### PR TITLE
Enable npm publishing in CI release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,5 +15,5 @@ jobs:
       service-name: spectrum-ts
       working-directory: packages/spectrum-ts
       build-command: "bun run build"
-      dry-run: true
+      dry-run: false
     secrets: inherit


### PR DESCRIPTION
## Summary

- Disable `dry-run` in the release workflow so that CI actually publishes the package to npm
- The published npm package is stuck at `0.0.1` because the workflow has been running in dry-run mode since it was set up

## Changes

- `.github/workflows/release.yaml`: Set `dry-run: false` (was `true`)

## Test plan

- [ ] Merge this PR and verify the release workflow runs on `main`
- [ ] Confirm the new version is published to npm: `npm view spectrum-ts versions`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release workflow configuration.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal infrastructure and build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->