### PR TITLE
Change imessage config local option to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ import { imessage } from "spectrum-ts/providers/imessage";
 
 const app = await Spectrum("your-project-id", "your-project-secret", {
   providers: [
-    imessage.config({ local: true }),
+    imessage.config({ local: false }),
   ],
 });
 ```

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ import { imessage } from "spectrum-ts/providers/imessage";
 async function main() {
   const app = await Spectrum("YOUR_PROJECT_ID", "YOUR_SECRET_KEY", {
     providers: [
-      imessage.config({}),
+      imessage.config(),
     ],
   });
 
@@ -123,7 +123,7 @@ main();
 
 ```typescript
 const app = await Spectrum("your-project-id", "your-project-secret", {
-  providers: [imessage.config({ })],
+  providers: [imessage.config()],
 });
 ```
 Creates your app and connects providers.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified the iMessage provider examples in Getting Started and Initialize: the documented initialization now uses a no-argument call instead of explicitly supplying a local:false option, aligning examples with the current recommended usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->