### PR TITLE
Make projectId and projectSecret optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ import { Spectrum, text } from "spectrum-ts";
 import { imessage } from "spectrum-ts/providers/imessage";
 import { terminal } from "spectrum-ts/providers/terminal";
 
-const app = await Spectrum("project-id", "project-secret", {
+const app = await Spectrum({
   providers: [
     imessage.config({ local: true }),
     terminal.config(),
@@ -90,7 +90,7 @@ The `Spectrum()` factory initializes all platform providers, authenticates with 
 import { Spectrum } from "spectrum-ts";
 import { imessage } from "spectrum-ts/providers/imessage";
 
-const app = await Spectrum("your-project-id", "your-project-secret", {
+const app = await Spectrum({
   providers: [
     imessage.config({ local: true }),
   ],
@@ -540,7 +540,7 @@ export const myPlatform = definePlatform("my-platform", {
 | `space.resolve` | Yes | Resolves or creates a conversation. Receives an array of users and optional params. |
 | `space.schema` | No | A Zod schema for validating and typing the resolved space. |
 | `space.params` | No | A Zod schema for additional space creation parameters. |
-| `lifecycle.createClient` | Yes | Creates the platform client. Receives config, project ID, and project secret. |
+| `lifecycle.createClient` | Yes | Creates the platform client. Receives config and optionally project ID and secret (`string \| undefined`). |
 | `lifecycle.destroyClient` | Yes | Tears down the client on shutdown. |
 | `events.messages` | Yes | An async generator that yields incoming messages. |
 | `events.[custom]` | No | Additional async generators for platform-specific events. |

--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ export const myPlatform = definePlatform("my-platform", {
 | `space.resolve` | Yes | Resolves or creates a conversation. Receives an array of users and optional params. |
 | `space.schema` | No | A Zod schema for validating and typing the resolved space. |
 | `space.params` | No | A Zod schema for additional space creation parameters. |
-| `lifecycle.createClient` | Yes | Creates the platform client. Receives config and optionally project ID and secret (`string \| undefined`). |
+| `lifecycle.createClient` | Yes | Creates the platform client. Receives config and optionally project ID and secret (`string` \| `undefined`). |
 | `lifecycle.destroyClient` | Yes | Tears down the client on shutdown. |
 | `events.messages` | Yes | An async generator that yields incoming messages. |
 | `events.[custom]` | No | Additional async generators for platform-specific events. |

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -3,7 +3,9 @@ import { imessage } from "spectrum-ts/providers/imessage";
 
 // import { terminal } from "spectrum-ts/providers/terminal";
 
-const app = await Spectrum("project-id", "project-secret", {
+const app = await Spectrum({
+  projectId: "project-id",
+  projectSecret: "project-secret",
   providers: [
     imessage.config(),
     // terminal.config({}),

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -140,8 +140,8 @@ export interface PlatformDef<
   lifecycle: {
     createClient: (ctx: {
       config: z.infer<_ConfigSchema>;
-      projectId: string;
-      projectSecret: string;
+      projectId: string | undefined;
+      projectSecret: string | undefined;
     }) => Promise<_Client>;
     destroyClient: (ctx: { client: _Client }) => Promise<void>;
   };

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -87,6 +87,14 @@ export const imessage = definePlatform("iMessage", {
         );
       }
 
+      if (!(projectId && projectSecret)) {
+        throw new Error(
+          "iMessage requires projectId and projectSecret. " +
+            "Either pass credentials to Spectrum(), use local mode: imessage.config({ local: true }), " +
+            "or provide explicit client config: imessage.config({ clients: [...] })"
+        );
+      }
+
       return await createCloudClients(projectId, projectSecret);
     },
 

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -47,11 +47,18 @@ export type SpectrumInstance<
 // Config validation
 // ---------------------------------------------------------------------------
 
-const spectrumConfigSchema = z.object({
-  projectId: z.string().min(1),
-  projectSecret: z.string().min(1),
-  providers: z.array(z.custom<PlatformProviderConfig>()),
-});
+const spectrumConfigSchema = z.union([
+  z.object({
+    projectId: z.string().min(1),
+    projectSecret: z.string().min(1),
+    providers: z.array(z.custom<PlatformProviderConfig>()),
+  }),
+  z.object({
+    projectId: z.undefined().optional(),
+    projectSecret: z.undefined().optional(),
+    providers: z.array(z.custom<PlatformProviderConfig>()),
+  }),
+]);
 
 // ---------------------------------------------------------------------------
 // Spectrum() factory
@@ -60,15 +67,21 @@ const spectrumConfigSchema = z.object({
 export async function Spectrum<
   const Providers extends PlatformProviderConfig[],
 >(
-  projectId: string,
-  projectSecret: string,
-  options: { providers: [...Providers] }
+  options:
+    | {
+        projectId: string;
+        projectSecret: string;
+        providers: [...Providers];
+      }
+    | {
+        projectId?: never;
+        projectSecret?: never;
+        providers: [...Providers];
+      }
 ): Promise<SpectrumInstance<Providers>> {
-  spectrumConfigSchema.parse({
-    projectId,
-    projectSecret,
-    providers: options.providers,
-  });
+  spectrumConfigSchema.parse(options);
+
+  const { projectId, projectSecret, providers } = options;
 
   const platformStates = new Map<
     string,
@@ -81,7 +94,7 @@ export async function Spectrum<
   let stopped = false;
 
   // Initialize all provider clients eagerly
-  for (const provider of options.providers) {
+  for (const provider of providers) {
     const providerConfig = provider as PlatformProviderConfig;
     const def = providerConfig.__definition;
     const userConfig = def.config.parse(providerConfig.config);
@@ -344,7 +357,7 @@ export async function Spectrum<
   );
 
   const base = {
-    __providers: options.providers,
+    __providers: providers,
     __internal: { platforms: platformStates },
     messages,
     stop: stopOnce,


### PR DESCRIPTION
## Summary

- **Remove `projectId` and `projectSecret` as required positional arguments** from `Spectrum()`. They are now optional fields in a single options object.
- Users can use Spectrum without creating a project — credentials are only needed when a provider requires them (e.g., iMessage cloud mode).
- TypeScript union type enforces that both credentials must be provided together or both omitted (compile-time safety).
- Zod union schema provides the same enforcement at runtime.

## Usage

```typescript
// Without credentials (e.g., terminal-only)
const app = await Spectrum({
  providers: [terminal.config()],
});

// With credentials (e.g., iMessage cloud mode)
const app = await Spectrum({
  projectId: "your-project-id",
  projectSecret: "your-project-secret",
  providers: [imessage.config()],
});
```

Passing only one of `projectId`/`projectSecret` is a compile-time error.

## Changes

| File | Change |
|------|--------|
| `packages/spectrum-ts/src/spectrum.ts` | Changed `Spectrum()` from 3-arg to single options object. Replaced Zod `.refine()` with `z.union()`. Added TypeScript union type with `never` for compile-time enforcement. |
| `packages/spectrum-ts/src/platform/types.ts` | Changed `projectId` and `projectSecret` from `string` to `string \| undefined` in `PlatformDef.lifecycle.createClient` context. |
| `packages/spectrum-ts/src/providers/imessage/index.ts` | Added guard in `createClient` that throws a descriptive error when cloud mode is used without credentials. |
| `examples/basic/index.ts` | Updated to new API. |
| `README.md` | Updated all code examples and platform provider anatomy table. |

## Test plan

- [x] `bun run build` passes with no type errors
- [x] `bun x ultracite check` passes with no lint issues
- [ ] Verify terminal provider works without credentials
- [ ] Verify iMessage cloud mode throws clear error without credentials
- [ ] Verify iMessage local/dedicated modes work without credentials

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client initialization now accepts a single options object, allowing credentials to be provided or omitted for more flexible setup.

* **Bug Fixes**
  * Added runtime validation to require credentials for cloud-based configurations and fail early when missing.

* **Documentation**
  * Updated README and examples to demonstrate the new initialization pattern and clarify credential requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->