### PR TITLE
feat: Early alpha support for WhatsApp Business provider

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.1.0",
         "@photon-ai/imessage-kit": "^2.1.2",
-        "@photon-ai/whatsapp-business": "^0.1.0",
+        "@photon-ai/whatsapp-business": "^0.1.1",
         "@repeaterjs/repeater": "^3.0.6",
         "better-grpc": "^0.3.2",
         "mime-types": "^3.0.1",
@@ -135,7 +135,7 @@
 
     "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@2.1.2", "", { "dependencies": { "node-typedstream": "^1.4.1" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-xteMkPqqWkPLv40M9gA1HJGS/fHXIWzzXNCwRfnC4+bj120KMXMacT9zOSoEcGk4MA0pGXcUMQPE16MdB+Bf/g=="],
 
-    "@photon-ai/whatsapp-business": ["@photon-ai/whatsapp-business@0.1.0", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "long": "^5.3.2", "nice-grpc": "^2.1.15", "nice-grpc-common": "^2.0.3", "protobufjs": "^8.0.1" } }, "sha512-vEZUrsSPbDW3O7LA2BJO4YxewDhnJ89r3yvMG67ZuAuIdLl9y13BGEcQp8zZS9Wp6u6si2NHSIm51qQagBQzEA=="],
+    "@photon-ai/whatsapp-business": ["@photon-ai/whatsapp-business@0.1.1", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "long": "^5.3.2", "nice-grpc": "^2.1.15", "nice-grpc-common": "^2.0.3", "protobufjs": "^8.0.1" } }, "sha512-JAf/gHh92+H6h/7AMOQ6l+WFYBWdeRH5fZ+tvOUYJJnX1C4aJPDFa23VTH4ndhKPgA5bK/h++cxUZx2lMubvYQ=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,10 +18,11 @@
     },
     "packages/spectrum-ts": {
       "name": "spectrum-ts",
-      "version": "0.0.1",
+      "version": "0.1.1",
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.1.0",
         "@photon-ai/imessage-kit": "^2.1.2",
+        "@photon-ai/whatsapp-business": "^0.1.0",
         "@repeaterjs/repeater": "^3.0.6",
         "better-grpc": "^0.3.2",
         "mime-types": "^3.0.1",
@@ -133,6 +134,8 @@
     "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.1.0", "", { "dependencies": { "@grpc/grpc-js": "^1.12.6", "long": "^5.2.4", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2", "protobufjs": "^7.4.0" } }, "sha512-/EzcSzu2LeAr+DVcr+mFZYlA2/i5ChW6UyuB0qT7SBGfCeJ1whVyidjE1vPv7xAPldY9U2+3ZekPEfZW196EJg=="],
 
     "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@2.1.2", "", { "dependencies": { "node-typedstream": "^1.4.1" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-xteMkPqqWkPLv40M9gA1HJGS/fHXIWzzXNCwRfnC4+bj120KMXMacT9zOSoEcGk4MA0pGXcUMQPE16MdB+Bf/g=="],
+
+    "@photon-ai/whatsapp-business": ["@photon-ai/whatsapp-business@0.1.0", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "long": "^5.3.2", "nice-grpc": "^2.1.15", "nice-grpc-common": "^2.0.3", "protobufjs": "^8.0.1" } }, "sha512-vEZUrsSPbDW3O7LA2BJO4YxewDhnJ89r3yvMG67ZuAuIdLl9y13BGEcQp8zZS9Wp6u6si2NHSIm51qQagBQzEA=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -514,8 +517,16 @@
 
     "zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
+    "@photon-ai/whatsapp-business/nice-grpc": ["nice-grpc@2.1.15", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.5.0", "nice-grpc-common": "^2.0.3" } }, "sha512-agPIt7dtQASnN5p1X3c2S5amDhWRWRT0Jp62trmpMBKSbkm87l8bG2slqxSthlrGa4AnRPG8+lFf4y8nn+Pogw=="],
+
+    "@photon-ai/whatsapp-business/nice-grpc-common": ["nice-grpc-common@2.0.3", "", { "dependencies": { "ts-error": "^1.0.6" } }, "sha512-MEhnD3JMah0mgyivpb9hpRDbOBuXBxI/TVO+OK1h6rC97WM42HsPMR+zzRNQ0C5BqYJTw1nyWiQRD0DucO+pjQ=="],
+
+    "@photon-ai/whatsapp-business/protobufjs": ["protobufjs@8.0.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w=="],
+
     "nypm/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+
+    "@photon-ai/whatsapp-business/nice-grpc/abort-controller-x": ["abort-controller-x@0.5.0", "", {}, "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ=="],
   }
 }

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -1,5 +1,4 @@
 import { Spectrum, text } from "spectrum-ts";
-import { imessage } from "spectrum-ts/providers/imessage";
 import { whatsappBusiness } from "spectrum-ts/providers/whatsapp-business";
 
 // import { terminal } from "spectrum-ts/providers/terminal";
@@ -9,7 +8,12 @@ const app = await Spectrum({
   projectSecret: "project-secret",
   providers: [
     // imessage.config(),
-    whatsappBusiness.config(),
+    whatsappBusiness.config({
+      phoneNumberId: "992752977264292",
+      accessToken:
+        "EAAMaxentpjkBRMZBIft4NT6Fh4yY6Wz78ZBvyDWepruHmDphuTvcHhb5aGYN8d0ZAxUacwxsBu5zrfIfxebRaBeDtWVfPcPdvlHQ6p2l61PjPxooUXZAZBXr9TlKbZBHj5m19yy5b2TByvzudcH1KYNB29gbrQZCf8Se2ABCpGwNYEEBQ2vDYhyESQcyMZA5HPdau3kwtDzSzVQDU0xPATl6X1TJTZAq5foH2lzBS6lQ2L3P8Uv10hCyOkZCaZCyBTPdO7Hh2wecIJlaFhXNE1zhS4SzcoZD",
+      appSecret: "c4fe7015331dbccc92363d15f5bb8531",
+    }),
     // terminal.config({}),
   ],
 });
@@ -20,13 +24,15 @@ for await (const [space, message] of app.messages) {
     .map((c) => c.text)
     .join(" ");
 
-  console.log(imessage(space));
+  console.log(incoming);
+
+  // console.log(imessage(space));
 
   await space.responding(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    // await new Promise((resolve) => setTimeout(resolve, 1000));
 
-    await message.react(imessage.tapbacks.laugh);
-    await message.reply(text(`echo: ${incoming}`), text("111"));
+    // await message.react(imessage.tapbacks.laugh);
+    await message.reply(text(`echo: ${incoming}`));
 
     // await space.send(text(`echo: ${incoming}`));
   });

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -1,5 +1,6 @@
 import { Spectrum, text } from "spectrum-ts";
 import { imessage } from "spectrum-ts/providers/imessage";
+import { whatsappBusiness } from "spectrum-ts/providers/whatsapp-business";
 
 // import { terminal } from "spectrum-ts/providers/terminal";
 
@@ -7,7 +8,8 @@ const app = await Spectrum({
   projectId: "project-id",
   projectSecret: "project-secret",
   providers: [
-    imessage.config(),
+    // imessage.config(),
+    whatsappBusiness.config(),
     // terminal.config({}),
   ],
 });

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -24,6 +24,11 @@
       "types": "./dist/providers/terminal/index.d.ts",
       "bun": "./src/providers/terminal/index.ts",
       "default": "./dist/providers/terminal/index.js"
+    },
+    "./providers/whatsapp-business": {
+      "types": "./dist/providers/whatsapp-business/index.d.ts",
+      "bun": "./src/providers/whatsapp-business/index.ts",
+      "default": "./dist/providers/whatsapp-business/index.js"
     }
   },
   "scripts": {
@@ -32,6 +37,7 @@
   },
   "dependencies": {
     "@photon-ai/advanced-imessage": "^0.1.0",
+    "@photon-ai/whatsapp-business": "^0.1.0",
     "@photon-ai/imessage-kit": "^2.1.2",
     "@repeaterjs/repeater": "^3.0.6",
     "better-grpc": "^0.3.2",

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -37,7 +37,7 @@
   },
   "dependencies": {
     "@photon-ai/advanced-imessage": "^0.1.0",
-    "@photon-ai/whatsapp-business": "^0.1.0",
+    "@photon-ai/whatsapp-business": "^0.1.1",
     "@photon-ai/imessage-kit": "^2.1.2",
     "@repeaterjs/repeater": "^3.0.6",
     "better-grpc": "^0.3.2",

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -23,4 +23,16 @@ export {
 export type { Message } from "./types/message";
 export type { Space } from "./types/space";
 export type { User } from "./types/user";
+export type {
+  CloudPlatform,
+  DedicatedTokenData,
+  ImessageInfoData,
+  PlatformStatus,
+  PlatformsData,
+  SharedTokenData,
+  SubscriptionData,
+  SubscriptionStatus,
+  TokenData,
+} from "./utils/cloud";
+export { cloud, SpectrumCloudError } from "./utils/cloud";
 export { type ManagedStream, mergeStreams, stream } from "./utils/stream";

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -289,14 +289,13 @@ export function definePlatform<
     throw new Error("Invalid input to platform narrowing function");
   }) as Platform<Def>;
 
-  narrower.config = (
-    config: z.input<_ConfigSchema> = {} as z.input<_ConfigSchema>
-  ) => {
+  narrower.config = (config?: z.input<_ConfigSchema>) => {
+    const resolvedConfig = config ?? {};
     return {
       __tag: "PlatformProviderConfig" as const,
       __def: undefined as unknown as Def,
       __name: name,
-      config,
+      config: resolvedConfig,
       __definition: fullDef as AnyPlatformDef,
     } satisfies PlatformProviderConfig<Def> as PlatformProviderConfig<Def>;
   };

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -423,7 +423,11 @@ export interface SpectrumLike<
 // ---------------------------------------------------------------------------
 
 export interface Platform<Def extends AnyPlatformDef> {
-  config(config?: z.input<Def["config"]>): PlatformProviderConfig<Def>;
+  config(
+    ...args: Record<string, never> extends z.input<Def["config"]>
+      ? [config?: z.input<Def["config"]>]
+      : [config: z.input<Def["config"]>]
+  ): PlatformProviderConfig<Def>;
   <Providers extends PlatformProviderConfig[]>(
     spectrum: SpectrumLike<Providers>
   ): HasProvider<Providers, Def["name"]> extends true

--- a/packages/spectrum-ts/src/providers/imessage/auth.ts
+++ b/packages/spectrum-ts/src/providers/imessage/auth.ts
@@ -2,30 +2,15 @@ import {
   type AdvancedIMessage,
   createClient,
 } from "@photon-ai/advanced-imessage";
-import { SPECTRUM_CLOUD_URL } from "../../utils/cloud";
+import {
+  cloud,
+  type DedicatedTokenData,
+  type SharedTokenData,
+} from "../../utils/cloud";
 
 const RENEWAL_RATIO = 0.8;
 const EXPIRY_BUFFER_MS = 30_000;
 const RETRY_DELAY_MS = 30_000;
-
-interface SharedTokenData {
-  expiresIn: number;
-  token: string;
-  type: "shared";
-}
-
-interface DedicatedTokenData {
-  auth: Record<string, string>;
-  expiresIn: number;
-  type: "dedicated";
-}
-
-type TokenData = SharedTokenData | DedicatedTokenData;
-
-interface TokenResponse {
-  data: TokenData;
-  succeed: boolean;
-}
 
 interface CloudAuth {
   dispose: () => void;
@@ -33,42 +18,11 @@ interface CloudAuth {
 
 const cloudAuthState = new WeakMap<AdvancedIMessage[], CloudAuth>();
 
-async function fetchTokens(
-  projectId: string,
-  projectSecret: string
-): Promise<TokenData> {
-  const url = `${SPECTRUM_CLOUD_URL}/${projectId}/imessage/tokens`;
-  const credentials = btoa(`${projectId}:${projectSecret}`);
-
-  const response = await fetch(url, {
-    method: "POST",
-    headers: {
-      Authorization: `Basic ${credentials}`,
-    },
-  });
-
-  if (!response.ok) {
-    const body = await response.text().catch(() => "");
-    throw new Error(
-      `Spectrum Cloud authentication failed (${response.status}): ${body || response.statusText}`
-    );
-  }
-
-  const json = (await response.json()) as TokenResponse;
-  if (!json.succeed) {
-    throw new Error(
-      "Spectrum Cloud authentication failed: server returned succeed=false"
-    );
-  }
-
-  return json.data;
-}
-
 export async function createCloudClients(
   projectId: string,
   projectSecret: string
 ): Promise<AdvancedIMessage[]> {
-  let tokenData = await fetchTokens(projectId, projectSecret);
+  let tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
   let tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
   let disposed = false;
   let renewalTimer: ReturnType<typeof setTimeout> | undefined;
@@ -82,7 +36,7 @@ export async function createCloudClients(
 
     renewalTimer = setTimeout(async () => {
       try {
-        tokenData = await fetchTokens(projectId, projectSecret);
+        tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
         tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
         scheduleRenewal();
       } catch {
@@ -99,7 +53,7 @@ export async function createCloudClients(
     if (Date.now() < tokenExpiresAt - EXPIRY_BUFFER_MS) {
       return;
     }
-    tokenData = await fetchTokens(projectId, projectSecret);
+    tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
     tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
     scheduleRenewal();
   };

--- a/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
@@ -1,0 +1,77 @@
+import {
+  createClient,
+  type WhatsAppClient,
+} from "@photon-ai/whatsapp-business";
+import { definePlatform } from "../../platform/define";
+import { messages, reactToMessage, replyToMessage, send } from "./messages";
+import { configSchema, spaceSchema } from "./types";
+
+export const whatsappBusiness = definePlatform("WhatsApp Business", {
+  config: configSchema,
+
+  user: {
+    resolve: async ({ input }) => ({ id: input.userID }),
+  },
+
+  space: {
+    schema: spaceSchema,
+    resolve: async ({ input }) => {
+      if (input.users.length === 0) {
+        throw new Error("WhatsApp space creation requires at least one user");
+      }
+      if (input.users.length > 1) {
+        throw new Error(
+          "WhatsApp Business API only supports 1:1 conversations"
+        );
+      }
+      const user = input.users[0];
+      if (!user) {
+        throw new Error("WhatsApp space creation requires a user");
+      }
+      return { id: user.id };
+    },
+  },
+
+  lifecycle: {
+    createClient: async ({ config }): Promise<WhatsAppClient> => {
+      return createClient({
+        accessToken: config.accessToken,
+        phoneNumberId: config.phoneNumberId,
+        appSecret: config.appSecret ?? "",
+      });
+    },
+
+    destroyClient: async ({ client }: { client: WhatsAppClient }) => {
+      await client.close();
+    },
+  },
+
+  events: {
+    messages: ({ client }) => messages(client as WhatsAppClient),
+  },
+
+  actions: {
+    send: async ({ space, content, client }) => {
+      const wa = client as WhatsAppClient;
+      for (const item of content) {
+        await send(wa, space.id, item);
+      }
+    },
+
+    reactToMessage: async ({ space, messageId, reaction, client }) => {
+      await reactToMessage(
+        client as WhatsAppClient,
+        space.id,
+        messageId,
+        reaction
+      );
+    },
+
+    replyToMessage: async ({ space, messageId, content, client }) => {
+      const wa = client as WhatsAppClient;
+      for (const item of content) {
+        await replyToMessage(wa, space.id, messageId, item);
+      }
+    },
+  },
+});

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -1,0 +1,240 @@
+import type {
+  InboundMessage,
+  WhatsAppClient,
+} from "@photon-ai/whatsapp-business";
+import type { Content } from "../../types/content";
+import { type ManagedStream, stream } from "../../utils/stream";
+import type { WhatsAppMessage } from "./types";
+
+const toMessage = async (
+  client: WhatsAppClient,
+  msg: InboundMessage
+): Promise<WhatsAppMessage> => {
+  const content = await mapContent(client, msg.content);
+  return {
+    id: msg.id,
+    content,
+    sender: { id: msg.from },
+    space: { id: msg.from },
+    timestamp: msg.timestamp,
+  };
+};
+
+const mapContent = async (
+  client: WhatsAppClient,
+  content: InboundMessage["content"]
+): Promise<Content[]> => {
+  switch (content.type) {
+    case "text":
+      return [{ type: "plain_text", text: content.body }];
+    case "image":
+    case "video":
+    case "audio":
+    case "document":
+      return [await downloadMedia(client, content.media)];
+    case "sticker":
+      return [
+        {
+          type: "custom",
+          raw: { whatsapp_type: "sticker", ...content.sticker },
+        },
+      ];
+    case "location":
+      return [
+        {
+          type: "custom",
+          raw: { whatsapp_type: "location", ...content.location },
+        },
+      ];
+    case "contacts":
+      return [
+        {
+          type: "custom",
+          raw: { whatsapp_type: "contacts", contacts: content.contacts },
+        },
+      ];
+    case "reaction":
+      return [
+        {
+          type: "custom",
+          raw: { whatsapp_type: "reaction", ...content.reaction },
+        },
+      ];
+    case "interactive":
+      return [
+        {
+          type: "custom",
+          raw: { whatsapp_type: "interactive", ...content.interactive },
+        },
+      ];
+    case "button":
+      return [
+        {
+          type: "custom",
+          raw: { whatsapp_type: "button", ...content.button },
+        },
+      ];
+    case "order":
+      return [
+        { type: "custom", raw: { whatsapp_type: "order", ...content.order } },
+      ];
+    case "system":
+      return [
+        {
+          type: "custom",
+          raw: { whatsapp_type: "system", ...content.system },
+        },
+      ];
+    default:
+      return [{ type: "custom", raw: { whatsapp_type: "unknown" } }];
+  }
+};
+
+const downloadMedia = async (
+  client: WhatsAppClient,
+  media: { id: string; mimeType: string; filename?: string }
+): Promise<Content> => {
+  try {
+    const { url } = await client.media.getUrl(media.id);
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Media download failed: ${response.status}`);
+    }
+    const data = Buffer.from(await response.arrayBuffer());
+    return {
+      type: "attachment",
+      data,
+      mimeType: media.mimeType,
+      name: media.filename ?? `media-${media.id}`,
+    };
+  } catch {
+    return {
+      type: "custom",
+      raw: {
+        whatsapp_type: "media_error",
+        mediaId: media.id,
+        mimeType: media.mimeType,
+      },
+    };
+  }
+};
+
+const mimeToMediaType = (
+  mimeType: string
+): "image" | "video" | "audio" | "document" => {
+  if (mimeType.startsWith("image/")) {
+    return "image";
+  }
+  if (mimeType.startsWith("video/")) {
+    return "video";
+  }
+  if (mimeType.startsWith("audio/")) {
+    return "audio";
+  }
+  return "document";
+};
+
+export const messages = (
+  client: WhatsAppClient
+): ManagedStream<WhatsAppMessage> => {
+  const eventStream = client.events
+    .subscribe()
+    .filter(
+      (e): e is Extract<typeof e, { type: "message" }> => e.type === "message"
+    );
+
+  return stream<WhatsAppMessage>((emit, end) => {
+    (async () => {
+      try {
+        for await (const event of eventStream) {
+          const msg = await toMessage(client, event.message);
+          emit(msg);
+        }
+        end();
+      } catch (e) {
+        end(e);
+      }
+    })();
+    return () => eventStream.close();
+  });
+};
+
+export const send = async (
+  client: WhatsAppClient,
+  spaceId: string,
+  content: Content
+): Promise<void> => {
+  switch (content.type) {
+    case "plain_text":
+      await client.messages.send({ to: spaceId, text: content.text });
+      break;
+    case "attachment": {
+      const { mediaId } = await client.media.upload({
+        file: content.data,
+        mimeType: content.mimeType,
+        filename: content.name,
+      });
+      const mediaType = mimeToMediaType(content.mimeType);
+      const mediaPayload =
+        mediaType === "document"
+          ? { id: mediaId, filename: content.name }
+          : { id: mediaId };
+      await client.messages.send({
+        to: spaceId,
+        [mediaType]: mediaPayload,
+      } as Parameters<typeof client.messages.send>[0]);
+      break;
+    }
+    default:
+      break;
+  }
+};
+
+export const reactToMessage = async (
+  client: WhatsAppClient,
+  spaceId: string,
+  messageId: string,
+  reaction: string
+): Promise<void> => {
+  await client.messages.send({
+    to: spaceId,
+    reaction: { message_id: messageId, emoji: reaction },
+  });
+};
+
+export const replyToMessage = async (
+  client: WhatsAppClient,
+  spaceId: string,
+  messageId: string,
+  content: Content
+): Promise<void> => {
+  switch (content.type) {
+    case "plain_text":
+      await client.messages.send({
+        to: spaceId,
+        replyTo: messageId,
+        text: content.text,
+      });
+      break;
+    case "attachment": {
+      const { mediaId } = await client.media.upload({
+        file: content.data,
+        mimeType: content.mimeType,
+        filename: content.name,
+      });
+      const mediaType = mimeToMediaType(content.mimeType);
+      const mediaPayload =
+        mediaType === "document"
+          ? { id: mediaId, filename: content.name }
+          : { id: mediaId };
+      await client.messages.send({
+        to: spaceId,
+        replyTo: messageId,
+        [mediaType]: mediaPayload,
+      } as Parameters<typeof client.messages.send>[0]);
+      break;
+    }
+    default:
+      break;
+  }
+};

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -198,7 +198,7 @@ export const reactToMessage = async (
 ): Promise<void> => {
   await client.messages.send({
     to: spaceId,
-    reaction: { message_id: messageId, emoji: reaction },
+    reaction: { messageId, emoji: reaction },
   });
 };
 

--- a/packages/spectrum-ts/src/providers/whatsapp-business/types.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/types.ts
@@ -1,0 +1,19 @@
+import z from "zod";
+import type { SchemaMessage } from "../../platform/types";
+
+export const configSchema = z.object({
+  accessToken: z.string().min(1),
+  phoneNumberId: z.string().min(1),
+  appSecret: z.string().optional(),
+});
+
+export const userSchema = z.object({});
+
+export const spaceSchema = z.object({
+  id: z.string(),
+});
+
+export type WhatsAppMessage = SchemaMessage<
+  typeof userSchema,
+  typeof spaceSchema
+>;

--- a/packages/spectrum-ts/src/utils/cloud.ts
+++ b/packages/spectrum-ts/src/utils/cloud.ts
@@ -1,1 +1,147 @@
 export const SPECTRUM_CLOUD_URL = `https://${process.env.SPECTRUM_CLOUD_URL ?? "spectrum-cloud.photon.codes"}`;
+
+// ---------------------------------------------------------------------------
+// API response types (aligned with OpenAPI spec)
+// ---------------------------------------------------------------------------
+
+export type SubscriptionStatus = "active" | "canceled" | "past_due";
+
+export interface SubscriptionData {
+  status: SubscriptionStatus | null;
+  tier: string;
+}
+
+export interface SharedTokenData {
+  expiresIn: number;
+  token: string;
+  type: "shared";
+}
+
+export interface DedicatedTokenData {
+  auth: Record<string, string>;
+  expiresIn: number;
+  type: "dedicated";
+}
+
+export type TokenData = SharedTokenData | DedicatedTokenData;
+
+export type CloudPlatform = "imessage" | "whatsapp_business";
+
+export interface PlatformStatus {
+  enabled: boolean;
+}
+
+export type PlatformsData = Record<CloudPlatform, PlatformStatus>;
+
+export interface ImessageInfoData {
+  type: "shared" | "dedicated";
+}
+
+// ---------------------------------------------------------------------------
+// Error
+// ---------------------------------------------------------------------------
+
+export class SpectrumCloudError extends Error {
+  readonly status: number;
+  readonly code: string;
+
+  constructor(status: number, code: string, message: string) {
+    super(message);
+    this.name = "SpectrumCloudError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+interface SuccessResponse<T> {
+  data: T;
+  succeed: true;
+}
+
+interface ErrorBody {
+  code: string;
+  message: string;
+  succeed: false;
+}
+
+const request = async <T>(path: string, init?: RequestInit): Promise<T> => {
+  const response = await fetch(`${SPECTRUM_CLOUD_URL}${path}`, init);
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    try {
+      const parsed = JSON.parse(body) as ErrorBody;
+      throw new SpectrumCloudError(
+        response.status,
+        parsed.code,
+        parsed.message
+      );
+    } catch (error) {
+      if (error instanceof SpectrumCloudError) {
+        throw error;
+      }
+      throw new SpectrumCloudError(
+        response.status,
+        "UNKNOWN",
+        body || response.statusText
+      );
+    }
+  }
+
+  const json = (await response.json()) as SuccessResponse<T>;
+  if (!json.succeed) {
+    throw new SpectrumCloudError(
+      response.status,
+      "UNKNOWN",
+      "Server returned succeed=false"
+    );
+  }
+
+  return json.data;
+};
+
+const basicAuth = (projectId: string, projectSecret: string): string =>
+  `Basic ${btoa(`${projectId}:${projectSecret}`)}`;
+
+// ---------------------------------------------------------------------------
+// Cloud API client
+// ---------------------------------------------------------------------------
+
+export const cloud = {
+  getSubscription: (projectId: string): Promise<SubscriptionData> =>
+    request(`/projects/${projectId}/billing/subscription`),
+
+  issueImessageTokens: (
+    projectId: string,
+    projectSecret: string
+  ): Promise<TokenData> =>
+    request(`/projects/${projectId}/imessage/tokens`, {
+      method: "POST",
+      headers: { Authorization: basicAuth(projectId, projectSecret) },
+    }),
+
+  getImessageInfo: (projectId: string): Promise<ImessageInfoData> =>
+    request(`/projects/${projectId}/imessage/`),
+
+  getPlatforms: (projectId: string): Promise<PlatformsData> =>
+    request(`/projects/${projectId}/platforms/`),
+
+  togglePlatform: (
+    projectId: string,
+    projectSecret: string,
+    platform: CloudPlatform,
+    enabled: boolean
+  ): Promise<PlatformsData> =>
+    request(`/projects/${projectId}/platforms/`, {
+      method: "PATCH",
+      headers: {
+        Authorization: basicAuth(projectId, projectSecret),
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ platform, enabled }),
+    }),
+};

--- a/packages/spectrum-ts/tsup.config.ts
+++ b/packages/spectrum-ts/tsup.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
     index: "src/index.ts",
     "providers/imessage/index": "src/providers/imessage/index.ts",
     "providers/terminal/index": "src/providers/terminal/index.ts",
+    "providers/whatsapp-business/index":
+      "src/providers/whatsapp-business/index.ts",
   },
   format: ["esm"],
   dts: true,


### PR DESCRIPTION
## Summary

- **Very early/alpha** support for WhatsApp Business as a new messaging provider in spectrum-ts
- Adds a typed Cloud API client (`cloud`) and exports public types from `utils/cloud`
- Makes platform config optional when the schema allows an empty object (improves DX for providers with no required config)

> **Note:** This is an early alpha integration. The WhatsApp Business provider API surface may change significantly in future iterations.

## Changes

### New files
| File | Description |
|------|-------------|
| `src/providers/whatsapp-business/index.ts` | Provider definition using `definePlatform` — lifecycle, events, and actions |
| `src/providers/whatsapp-business/messages.ts` | Message mapping (inbound content → `Content[]`), media download, send/reply/react helpers |
| `src/providers/whatsapp-business/types.ts` | Zod schemas (`configSchema`, `spaceSchema`) and `WhatsAppMessage` type |

### Modified files
| File | Description |
|------|-------------|
| `src/utils/cloud.ts` | New typed Cloud API client with `SpectrumCloudError`, token/subscription/platform endpoints |
| `src/index.ts` | Re-export cloud client and public types |
| `src/providers/imessage/auth.ts` | Refactored to use the shared `cloud.issueImessageTokens()` instead of inline fetch logic |
| `src/platform/define.ts` | Config parameter is now optional when schema allows `{}` |
| `src/platform/types.ts` | Conditional tuple type so `.config()` requires args only when the schema demands it |
| `package.json` | Added `@photon-ai/whatsapp-business` dep and `./providers/whatsapp-business` export |
| `tsup.config.ts` | Added whatsapp-business entry point |
| `examples/basic/index.ts` | Updated example to demo the WhatsApp provider |

## Test plan

- [ ] `bun run build` succeeds with the new entry point
- [ ] `bun x ultracite check` passes
- [ ] Verify `whatsappBusiness.config({ ... })` requires `accessToken` and `phoneNumberId`
- [ ] Verify `imessage.config()` still works with no arguments
- [ ] End-to-end: send and receive a WhatsApp message through the provider

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WhatsApp Business messaging provider supporting message sending, media attachments, reactions, and message replies
  * Cloud platform API client for subscription management, token issuance, and platform configuration

* **Improvements**
  * Enhanced platform definition interface with refined type safety and configuration flexibility

* **Chores**
  * Updated library exports and build configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->