### PR TITLE
Update default cloud and iMessage endpoints to production domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,15 +579,6 @@ export const myPlatform = definePlatform("my-platform", {
 
 ---
 
-## Environment Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `SPECTRUM_CLOUD_URL` | `spectrum-cloud.photon.codes` | Spectrum Cloud API endpoint for authentication. |
-| `SPECTRUM_IMESSAGE_ADDRESS` | `spectrum-imessage.photon.codes:443` | Default gRPC address for cloud-mode iMessage connections. |
-
----
-
 ## Development
 
 ### Prerequisites

--- a/bun.lock
+++ b/bun.lock
@@ -18,9 +18,9 @@
     },
     "packages/spectrum-ts": {
       "name": "spectrum-ts",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
-        "@photon-ai/advanced-imessage": "^0.1.0",
+        "@photon-ai/advanced-imessage": "^0.4.2",
         "@photon-ai/imessage-kit": "^2.1.2",
         "@photon-ai/whatsapp-business": "^0.1.1",
         "@repeaterjs/repeater": "^3.0.6",
@@ -131,7 +131,7 @@
 
     "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 
-    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.1.0", "", { "dependencies": { "@grpc/grpc-js": "^1.12.6", "long": "^5.2.4", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2", "protobufjs": "^7.4.0" } }, "sha512-/EzcSzu2LeAr+DVcr+mFZYlA2/i5ChW6UyuB0qT7SBGfCeJ1whVyidjE1vPv7xAPldY9U2+3ZekPEfZW196EJg=="],
+    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.4.2", "", { "dependencies": { "@grpc/grpc-js": "^1.12.6", "long": "^5.2.4", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2", "protobufjs": "^7.4.0" } }, "sha512-w66rA8vnAYcZWJHFbahERt0WkwxPnRbg8B1SmKlScNk4jO0jx9nsuaj2wuh8mtoPnT+LFwkB5Zd2avHLC8eIKQ=="],
 
     "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@2.1.2", "", { "dependencies": { "node-typedstream": "^1.4.1" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-xteMkPqqWkPLv40M9gA1HJGS/fHXIWzzXNCwRfnC4+bj120KMXMacT9zOSoEcGk4MA0pGXcUMQPE16MdB+Bf/g=="],
 
@@ -231,7 +231,7 @@
 
     "@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
-    "abort-controller-x": ["abort-controller-x@0.4.3", "", {}, "sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA=="],
+    "abort-controller-x": ["abort-controller-x@0.5.0", "", {}, "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -385,9 +385,9 @@
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
-    "nice-grpc": ["nice-grpc@2.1.14", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.4.0", "nice-grpc-common": "^2.0.2" } }, "sha512-GK9pKNxlvnU5FAdaw7i2FFuR9CqBspcE+if2tqnKXBcE0R8525wj4BZvfcwj7FjvqbssqKxRHt2nwedalbJlww=="],
+    "nice-grpc": ["nice-grpc@2.1.15", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.5.0", "nice-grpc-common": "^2.0.3" } }, "sha512-agPIt7dtQASnN5p1X3c2S5amDhWRWRT0Jp62trmpMBKSbkm87l8bG2slqxSthlrGa4AnRPG8+lFf4y8nn+Pogw=="],
 
-    "nice-grpc-common": ["nice-grpc-common@2.0.2", "", { "dependencies": { "ts-error": "^1.0.6" } }, "sha512-7RNWbls5kAL1QVUOXvBsv1uO0wPQK3lHv+cY1gwkTzirnG1Nop4cBJZubpgziNbaVc/bl9QJcyvsf/NQxa3rjQ=="],
+    "nice-grpc-common": ["nice-grpc-common@2.0.3", "", { "dependencies": { "ts-error": "^1.0.6" } }, "sha512-MEhnD3JMah0mgyivpb9hpRDbOBuXBxI/TVO+OK1h6rC97WM42HsPMR+zzRNQ0C5BqYJTw1nyWiQRD0DucO+pjQ=="],
 
     "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
 
@@ -517,16 +517,16 @@
 
     "zod": ["zod@4.2.1", "", {}, "sha512-0wZ1IRqGGhMP76gLqz8EyfBXKk0J2qo2+H3fi4mcUP/KtTocoX08nmIAHl1Z2kJIZbZee8KOpBCSNPRgauucjw=="],
 
-    "@photon-ai/whatsapp-business/nice-grpc": ["nice-grpc@2.1.15", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.5.0", "nice-grpc-common": "^2.0.3" } }, "sha512-agPIt7dtQASnN5p1X3c2S5amDhWRWRT0Jp62trmpMBKSbkm87l8bG2slqxSthlrGa4AnRPG8+lFf4y8nn+Pogw=="],
-
-    "@photon-ai/whatsapp-business/nice-grpc-common": ["nice-grpc-common@2.0.3", "", { "dependencies": { "ts-error": "^1.0.6" } }, "sha512-MEhnD3JMah0mgyivpb9hpRDbOBuXBxI/TVO+OK1h6rC97WM42HsPMR+zzRNQ0C5BqYJTw1nyWiQRD0DucO+pjQ=="],
-
     "@photon-ai/whatsapp-business/protobufjs": ["protobufjs@8.0.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w=="],
+
+    "better-grpc/nice-grpc": ["nice-grpc@2.1.14", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.4.0", "nice-grpc-common": "^2.0.2" } }, "sha512-GK9pKNxlvnU5FAdaw7i2FFuR9CqBspcE+if2tqnKXBcE0R8525wj4BZvfcwj7FjvqbssqKxRHt2nwedalbJlww=="],
 
     "nypm/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
-    "@photon-ai/whatsapp-business/nice-grpc/abort-controller-x": ["abort-controller-x@0.5.0", "", {}, "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ=="],
+    "better-grpc/nice-grpc/abort-controller-x": ["abort-controller-x@0.4.3", "", {}, "sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA=="],
+
+    "better-grpc/nice-grpc/nice-grpc-common": ["nice-grpc-common@2.0.2", "", { "dependencies": { "ts-error": "^1.0.6" } }, "sha512-7RNWbls5kAL1QVUOXvBsv1uO0wPQK3lHv+cY1gwkTzirnG1Nop4cBJZubpgziNbaVc/bl9QJcyvsf/NQxa3rjQ=="],
   }
 }

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -36,7 +36,7 @@
     "dev": "tsup --watch"
   },
   "dependencies": {
-    "@photon-ai/advanced-imessage": "^0.1.0",
+    "@photon-ai/advanced-imessage": "^0.4.2",
     "@photon-ai/whatsapp-business": "^0.1.1",
     "@photon-ai/imessage-kit": "^2.1.2",
     "@repeaterjs/repeater": "^3.0.6",

--- a/packages/spectrum-ts/src/providers/imessage/auth.ts
+++ b/packages/spectrum-ts/src/providers/imessage/auth.ts
@@ -62,7 +62,7 @@ export async function createCloudClients(
     if (tokenData.type === "shared") {
       const address =
         process.env.SPECTRUM_IMESSAGE_ADDRESS ??
-        "spectrum-imessage.photon.codes:443";
+        "imessage.spectrum.photon.codes:443";
 
       return [
         createClient({

--- a/packages/spectrum-ts/src/utils/cloud.ts
+++ b/packages/spectrum-ts/src/utils/cloud.ts
@@ -1,4 +1,4 @@
-export const SPECTRUM_CLOUD_URL = `https://${process.env.SPECTRUM_CLOUD_URL ?? "spectrum-cloud.photon.codes"}`;
+export const SPECTRUM_CLOUD_URL = `https://${process.env.SPECTRUM_CLOUD_URL ?? "spectrum.photon.codes"}`;
 
 // ---------------------------------------------------------------------------
 // API response types (aligned with OpenAPI spec)


### PR DESCRIPTION
## Summary

- Update default Spectrum Cloud URL from `spectrum-cloud.photon.codes` to `spectrum.photon.codes`
- Update default iMessage shared gRPC address from `spectrum-imessage.photon.codes:443` to `imessage.spectrum.photon.codes:443`
- Bump `@photon-ai/advanced-imessage` from `0.1.0` to `0.4.2`
- Remove environment variables section from README

## Changes

| File | Change |
|------|--------|
| `packages/spectrum-ts/src/utils/cloud.ts` | Default cloud URL → `spectrum.photon.codes` |
| `packages/spectrum-ts/src/providers/imessage/auth.ts` | Default shared gRPC address → `imessage.spectrum.photon.codes:443` |
| `packages/spectrum-ts/package.json` | Bump `@photon-ai/advanced-imessage` to `^0.4.2` |
| `bun.lock` | Updated lockfile |
| `README.md` | Removed environment variables table |

## Test plan

- [x] Verified `imessage.spectrum.photon.codes:443` is reachable via TLS (valid cert, TLSv1.3)
- [x] Verified `spectrum.photon.codes` returns HTTP 200
- [ ] Smoke test cloud auth flow end-to-end with updated endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed environment variables reference section from README.

* **Chores**
  * Updated advanced iMessage package dependency to latest version.
  * Updated default service endpoint addresses for Spectrum Cloud API and iMessage services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->