### PR TITLE
fix: Relax text() parameter type from NonEmptyString to string

### DIFF
--- a/packages/spectrum-ts/src/types/content.ts
+++ b/packages/spectrum-ts/src/types/content.ts
@@ -29,8 +29,8 @@ export interface ContentBuilder {
   build(): Promise<Content>;
 }
 
-export function text<T extends string>(
-  text: NonEmptyString<T>
+export function text(
+  text: string
 ): ContentBuilder {
   return {
     build: (): Promise<Content> =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relaxed type constraints on the `text` function to accept any string value, improving API flexibility and reducing validation restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->