### PR TITLE
Switch Message.content from array to single item and upgrade imessage-kit to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const app = await Spectrum({
 
 for await (const [space, message] of app.messages) {
   await space.responding(async () => {
-    await message.reply(text("Hello from Spectrum."));
+    await message.reply("Hello from Spectrum.");
   });
 }
 ```
@@ -91,7 +91,7 @@ Find your `PROJECT_ID` and `SECRET_KEY` in your project **Settings** on the [das
 ### Run your first app
 
 ```typescript
-import { Spectrum, text } from "spectrum-ts";
+import { Spectrum } from "spectrum-ts";
 import { imessage } from "spectrum-ts/providers/imessage";
 
 async function main() {
@@ -104,14 +104,10 @@ async function main() {
   });
 
   for await (const [space, message] of app.messages) {
-    const incoming = message.content
-      .filter((c) => c.type === "plain_text")
-      .map((c) => c.text)
-      .join(" ");
-
-    console.log(`[${message.platform}] ${message.sender.id}: ${incoming}`);
-
-    await space.send(text("hello world"));
+    if (message.content.type === "text") {
+      console.log(`[${message.platform}] ${message.sender.id}: ${message.content.text}`);
+      await space.send("hello world");
+    }
   }
 }
 
@@ -140,7 +136,7 @@ Streams messages from all platforms in real time.
 
 ### Send replies
 ```typescript
-await space.send(text("hello world"));
+await space.send("hello world");
 ```
 Respond directly to the conversation.
 
@@ -156,25 +152,25 @@ Every incoming message conforms to the `Message` interface:
 ```typescript
 interface Message {
   readonly id: string;
-  content: Content[];
+  content: Content;
   sender: User;
   space: Space;
   platform: string;
   timestamp: Date;
   react(reaction: string): Promise<void>;
-  reply(...content: ContentBuilder[]): Promise<void>;
+  reply(...content: ContentInput[]): Promise<void>;
 }
 ```
 
 Messages carry their own context. You can reply to a message directly, react to it, or use its space to send new messages. The `platform` field identifies which platform provider delivered the message.
 
-Content is an array because a single message can contain multiple pieces — text and an image, for example.
+`Content` is a discriminated union on `type` — `"text"`, `"attachment"`, or `"custom"`. Narrow on `message.content.type` to access the corresponding fields.
 
 ---
 
 ## Content
 
-Spectrum provides three content builders for constructing outgoing messages:
+Spectrum provides three content builders for constructing outgoing messages. Plain strings are also accepted everywhere a content input is expected, as a shortcut for `text()`.
 
 ### Text
 
@@ -182,6 +178,9 @@ Spectrum provides three content builders for constructing outgoing messages:
 import { text } from "spectrum-ts";
 
 await space.send(text("Hello, world."));
+
+// Plain strings are equivalent:
+await space.send("Hello, world.");
 ```
 
 ### Attachments
@@ -213,11 +212,11 @@ await space.send(custom({ type: "card", title: "Order Confirmed" }));
 
 ### Composing multiple content items
 
-All send methods accept variadic content builders. Items are sent in order.
+All send methods accept a variadic list of content inputs (strings or builders). Items are sent in order as separate messages.
 
 ```typescript
 await space.send(
-  text("Here's the file you requested:"),
+  "Here's the file you requested:",
   attachment("/path/to/document.pdf")
 );
 ```
@@ -232,7 +231,7 @@ A space represents a conversation. Every message arrives with its originating sp
 interface Space {
   readonly id: string;
   readonly __platform: string;
-  send(...content: ContentBuilder[]): Promise<void>;
+  send(...content: ContentInput[]): Promise<void>;
   startTyping(): Promise<void>;
   stopTyping(): Promise<void>;
   responding<T>(fn: () => T | Promise<T>): Promise<T>;
@@ -527,7 +526,7 @@ export const myPlatform = definePlatform("my-platform", {
       for await (const msg of client.onMessage()) {
         yield {
           id: msg.id,
-          content: [{ type: "plain_text", text: msg.body }],
+          content: { type: "text", text: msg.body },
           sender: { id: msg.authorId },
           space: { id: msg.channelId },
           timestamp: new Date(msg.ts),
@@ -539,10 +538,8 @@ export const myPlatform = definePlatform("my-platform", {
   // Actions the platform supports
   actions: {
     send: async ({ space, content, client }) => {
-      for (const item of content) {
-        if (item.type === "plain_text") {
-          await client.send(space.id, item.text);
-        }
+      if (content.type === "text") {
+        await client.send(space.id, content.text);
       }
     },
     // Optional:
@@ -569,7 +566,7 @@ export const myPlatform = definePlatform("my-platform", {
 | `lifecycle.destroyClient` | Yes | Tears down the client on shutdown. |
 | `events.messages` | Yes | An async generator that yields incoming messages. |
 | `events.[custom]` | No | Additional async generators for platform-specific events. |
-| `actions.send` | Yes | Sends content to a space. |
+| `actions.send` | Yes | Sends a single content item to a space. Invoked once per item when multiple are passed. |
 | `actions.startTyping` | No | Shows a typing indicator in a space. |
 | `actions.stopTyping` | No | Hides a typing indicator in a space. |
 | `actions.reactToMessage` | No | Reacts to a specific message. |

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ interface Message {
   platform: string;
   timestamp: Date;
   react(reaction: string): Promise<void>;
-  reply(...content: ContentInput[]): Promise<void>;
+  reply(...content: [ContentInput, ...ContentInput[]]): Promise<void>;
 }
 ```
 

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -11,5 +11,17 @@
   },
   "files": {
     "includes": ["!!bun.lock"]
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["packages/*/src/index.ts"],
+      "linter": {
+        "rules": {
+          "performance": {
+            "noBarrelFile": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -14,7 +14,7 @@
   },
   "overrides": [
     {
-      "includes": ["packages/*/src/index.ts"],
+      "includes": ["packages/spectrum-ts/src/index.ts"],
       "linter": {
         "rules": {
           "performance": {

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
       "version": "0.2.2",
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.4.2",
-        "@photon-ai/imessage-kit": "^2.1.2",
+        "@photon-ai/imessage-kit": "^3.0.0-rc.1",
         "@photon-ai/whatsapp-business": "^0.1.1",
         "@repeaterjs/repeater": "^3.0.6",
         "better-grpc": "^0.3.2",
@@ -134,9 +134,13 @@
 
     "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 
+    "@parseaple/bplist": ["@parseaple/bplist@1.0.1", "", {}, "sha512-HHZKfvCaY8r5lwc6YCiAIhpAwH56YR29JPQa/9ZW0UqzjqdzFidGgoWVIhIF8tPXCwivIt93vbyT0O5bpC1Twg=="],
+
+    "@parseaple/typedstream": ["@parseaple/typedstream@2.0.2", "", { "dependencies": { "@parseaple/bplist": "1.0.1" } }, "sha512-bzKNZjiBtZN2T2U7Nqq/hhv+EezkPnaWoB5WvPuBwNpQvOr3EI0XrDTkFnAzsA9DKdu57es/gcb1d2ctd1u8xw=="],
+
     "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.4.2", "", { "dependencies": { "@grpc/grpc-js": "^1.12.6", "long": "^5.2.4", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2", "protobufjs": "^7.4.0" } }, "sha512-w66rA8vnAYcZWJHFbahERt0WkwxPnRbg8B1SmKlScNk4jO0jx9nsuaj2wuh8mtoPnT+LFwkB5Zd2avHLC8eIKQ=="],
 
-    "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@2.1.2", "", { "dependencies": { "node-typedstream": "^1.4.1" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-xteMkPqqWkPLv40M9gA1HJGS/fHXIWzzXNCwRfnC4+bj120KMXMacT9zOSoEcGk4MA0pGXcUMQPE16MdB+Bf/g=="],
+    "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0-rc.1", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" }, "os": "darwin" }, "sha512-PX9Fx8mQ+QuFd0JrUaCR3nk0c25dK0NKskX6ZxVmHVMj+kS9tJJiha/RL4/AyJyTLKQYpTcLvFa7cZCiY6PViQ=="],
 
     "@photon-ai/whatsapp-business": ["@photon-ai/whatsapp-business@0.1.1", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "long": "^5.3.2", "nice-grpc": "^2.1.15", "nice-grpc-common": "^2.0.3", "protobufjs": "^8.0.1" } }, "sha512-JAf/gHh92+H6h/7AMOQ6l+WFYBWdeRH5fZ+tvOUYJJnX1C4aJPDFa23VTH4ndhKPgA5bK/h++cxUZx2lMubvYQ=="],
 
@@ -254,13 +258,9 @@
 
     "better-sqlite3": ["better-sqlite3@12.8.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ=="],
 
-    "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
-
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
-
-    "bplist-parser": ["bplist-parser@0.3.2", "", { "dependencies": { "big-integer": "1.6.x" } }, "sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ=="],
 
     "brace-expansion": ["brace-expansion@5.0.3", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
 
@@ -393,8 +393,6 @@
     "nice-grpc-common": ["nice-grpc-common@2.0.3", "", { "dependencies": { "ts-error": "^1.0.6" } }, "sha512-MEhnD3JMah0mgyivpb9hpRDbOBuXBxI/TVO+OK1h6rC97WM42HsPMR+zzRNQ0C5BqYJTw1nyWiQRD0DucO+pjQ=="],
 
     "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
-
-    "node-typedstream": ["node-typedstream@1.4.1", "", { "dependencies": { "bplist-parser": "^0.3.2" } }, "sha512-W9zcPlI3RRPOmwaDjwRyr7aYLoJFbvLIIHluFM3I+KZjAlbyhG4L3jSTEJlQmDqrMRQlFVTmivgJWgFlvWXx2Q=="],
 
     "nypm": ["nypm@0.6.5", "", { "dependencies": { "citty": "^0.2.0", "pathe": "^2.0.3", "tinyexec": "^1.0.2" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ=="],
 

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -1,5 +1,4 @@
 import { Spectrum } from "spectrum-ts";
-import { whatsappBusiness } from "spectrum-ts/providers/whatsapp-business";
 
 // import { terminal } from "spectrum-ts/providers/terminal";
 
@@ -8,12 +7,6 @@ const app = await Spectrum({
   projectSecret: "project-secret",
   providers: [
     // imessage.config(),
-    whatsappBusiness.config({
-      phoneNumberId: "992752977264292",
-      accessToken:
-        "EAAMaxentpjkBRMZBIft4NT6Fh4yY6Wz78ZBvyDWepruHmDphuTvcHhb5aGYN8d0ZAxUacwxsBu5zrfIfxebRaBeDtWVfPcPdvlHQ6p2l61PjPxooUXZAZBXr9TlKbZBHj5m19yy5b2TByvzudcH1KYNB29gbrQZCf8Se2ABCpGwNYEEBQ2vDYhyESQcyMZA5HPdau3kwtDzSzVQDU0xPATl6X1TJTZAq5foH2lzBS6lQ2L3P8Uv10hCyOkZCaZCyBTPdO7Hh2wecIJlaFhXNE1zhS4SzcoZD",
-      appSecret: "c4fe7015331dbccc92363d15f5bb8531",
-    }),
     // terminal.config({}),
   ],
 });

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -1,4 +1,4 @@
-import { Spectrum, text } from "spectrum-ts";
+import { Spectrum } from "spectrum-ts";
 import { whatsappBusiness } from "spectrum-ts/providers/whatsapp-business";
 
 // import { terminal } from "spectrum-ts/providers/terminal";
@@ -19,23 +19,24 @@ const app = await Spectrum({
 });
 
 for await (const [space, message] of app.messages) {
-  const incoming = message.content
-    .filter((c) => c.type === "plain_text")
-    .map((c) => c.text)
-    .join(" ");
-
-  console.log(incoming);
-
-  // console.log(imessage(space));
-
-  await space.responding(async () => {
-    // await new Promise((resolve) => setTimeout(resolve, 1000));
-
-    // await message.react(imessage.tapbacks.laugh);
-    await message.reply(text(`echo: ${incoming}`));
-
-    // await space.send(text(`echo: ${incoming}`));
-  });
+  switch (message.content.type) {
+    case "text": {
+      const incoming = message.content.text;
+      console.log(incoming);
+      await space.responding(async () => {
+        await message.reply(`echo: ${incoming}`);
+      });
+      break;
+    }
+    case "attachment":
+      console.log(`[attachment] ${message.content.name}`);
+      break;
+    case "custom":
+      console.log("[custom]", message.content.raw);
+      break;
+    default:
+      break;
+  }
 }
 
 // const user1 = await imessage(app).user("+13322593374");

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -1,4 +1,5 @@
 import { Spectrum } from "spectrum-ts";
+import { imessage } from "spectrum-ts/providers/imessage";
 
 // import { terminal } from "spectrum-ts/providers/terminal";
 
@@ -6,7 +7,7 @@ const app = await Spectrum({
   projectId: "project-id",
   projectSecret: "project-secret",
   providers: [
-    // imessage.config(),
+    imessage.config({ local: true }),
     // terminal.config({}),
   ],
 });
@@ -17,7 +18,7 @@ for await (const [space, message] of app.messages) {
       const incoming = message.content.text;
       console.log(incoming);
       await space.responding(async () => {
-        await message.reply(`echo: ${incoming}`);
+        await space.send(`echo: ${incoming}`);
       });
       break;
     }

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -11,25 +11,30 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
       "bun": "./src/index.ts",
+      "types": "./src/index.ts",
       "default": "./dist/index.js"
     },
-    "./providers/imessage": {
-      "types": "./dist/providers/imessage/index.d.ts",
-      "bun": "./src/providers/imessage/index.ts",
-      "default": "./dist/providers/imessage/index.js"
-    },
-    "./providers/terminal": {
-      "types": "./dist/providers/terminal/index.d.ts",
-      "bun": "./src/providers/terminal/index.ts",
-      "default": "./dist/providers/terminal/index.js"
-    },
-    "./providers/whatsapp-business": {
-      "types": "./dist/providers/whatsapp-business/index.d.ts",
-      "bun": "./src/providers/whatsapp-business/index.ts",
-      "default": "./dist/providers/whatsapp-business/index.js"
+    "./providers/*": {
+      "bun": "./src/providers/*/index.ts",
+      "types": "./src/providers/*/index.ts",
+      "default": "./dist/providers/*/index.js"
     }
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "./providers/*": {
+        "types": "./dist/providers/*/index.d.ts",
+        "default": "./dist/providers/*/index.js"
+      }
+    },
+    "files": [
+      "dist"
+    ]
   },
   "scripts": {
     "build": "tsup",

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@photon-ai/advanced-imessage": "^0.4.2",
     "@photon-ai/whatsapp-business": "^0.1.1",
-    "@photon-ai/imessage-kit": "^2.1.2",
+    "@photon-ai/imessage-kit": "^3.0.0-rc.1",
     "@repeaterjs/repeater": "^3.0.6",
     "better-grpc": "^0.3.2",
     "mime-types": "^3.0.1",

--- a/packages/spectrum-ts/src/content/attachment.ts
+++ b/packages/spectrum-ts/src/content/attachment.ts
@@ -2,54 +2,16 @@ import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 import { lookup as lookupMimeType } from "mime-types";
 import z from "zod";
+import type { ContentBuilder } from "./types";
 
 const DEFAULT_ATTACHMENT_NAME = "attachment";
 
-const contentSchema = z.discriminatedUnion("type", [
-  z.object({
-    type: z.literal("text"),
-    text: z.string().nonempty(),
-  }),
-  z.object({
-    type: z.literal("custom"),
-    raw: z.json(),
-  }),
-  z.object({
-    type: z.literal("attachment"),
-    data: z.instanceof(Buffer),
-    mimeType: z.string().nonempty(),
-    name: z.string().nonempty(),
-  }),
-]);
-
-export type Content = z.infer<typeof contentSchema>;
-
-export interface ContentBuilder {
-  build(): Promise<Content>;
-}
-
-export function text(text: string): ContentBuilder {
-  return {
-    build: (): Promise<Content> => Promise.resolve({ type: "text", text }),
-  };
-}
-
-export type ContentInput = string | ContentBuilder;
-
-export const resolveContents = (
-  items: readonly ContentInput[]
-): Promise<Content[]> =>
-  Promise.all(
-    items.map((c) => (typeof c === "string" ? text(c).build() : c.build()))
-  );
-
-export function custom(
-  raw: z.infer<ReturnType<typeof z.json>>
-): ContentBuilder {
-  return {
-    build: (): Promise<Content> => Promise.resolve({ type: "custom", raw }),
-  };
-}
+export const attachmentSchema = z.object({
+  type: z.literal("attachment"),
+  data: z.instanceof(Buffer),
+  mimeType: z.string().nonempty(),
+  name: z.string().nonempty(),
+});
 
 const resolveAttachmentName = (input: string | Buffer, name?: string): string =>
   name ||
@@ -75,7 +37,7 @@ export function attachment(
   options?: { mimeType?: string; name?: string }
 ): ContentBuilder {
   return {
-    build: async (): Promise<Content> => {
+    build: async () => {
       const data = typeof input === "string" ? await readFile(input) : input;
       const name = resolveAttachmentName(input, options?.name);
 

--- a/packages/spectrum-ts/src/content/attachment.ts
+++ b/packages/spectrum-ts/src/content/attachment.ts
@@ -32,6 +32,13 @@ const resolveAttachmentMimeType = (name: string, mimeType?: string): string => {
   return resolvedMimeType;
 };
 
+export const asAttachment = (input: {
+  data: Buffer;
+  mimeType: string;
+  name: string;
+}): z.infer<typeof attachmentSchema> =>
+  attachmentSchema.parse({ type: "attachment", ...input });
+
 export function attachment(
   input: string | Buffer,
   options?: { mimeType?: string; name?: string }
@@ -40,13 +47,11 @@ export function attachment(
     build: async () => {
       const data = typeof input === "string" ? await readFile(input) : input;
       const name = resolveAttachmentName(input, options?.name);
-
-      return {
+      return asAttachment({
         data,
         mimeType: resolveAttachmentMimeType(name, options?.mimeType),
         name,
-        type: "attachment",
-      };
+      });
     },
   };
 }

--- a/packages/spectrum-ts/src/content/custom.ts
+++ b/packages/spectrum-ts/src/content/custom.ts
@@ -1,0 +1,15 @@
+import z from "zod";
+import type { ContentBuilder } from "./types";
+
+export const customSchema = z.object({
+  type: z.literal("custom"),
+  raw: z.json(),
+});
+
+export function custom(
+  raw: z.infer<ReturnType<typeof z.json>>
+): ContentBuilder {
+  return {
+    build: () => Promise.resolve({ type: "custom", raw }),
+  };
+}

--- a/packages/spectrum-ts/src/content/custom.ts
+++ b/packages/spectrum-ts/src/content/custom.ts
@@ -3,12 +3,10 @@ import type { ContentBuilder } from "./types";
 
 export const customSchema = z.object({
   type: z.literal("custom"),
-  raw: z.json(),
+  raw: z.unknown(),
 });
 
-export function custom(
-  raw: z.infer<ReturnType<typeof z.json>>
-): ContentBuilder {
+export function custom(raw: unknown): ContentBuilder {
   return {
     build: () => Promise.resolve({ type: "custom", raw }),
   };

--- a/packages/spectrum-ts/src/content/custom.ts
+++ b/packages/spectrum-ts/src/content/custom.ts
@@ -6,8 +6,11 @@ export const customSchema = z.object({
   raw: z.unknown(),
 });
 
+export const asCustom = (raw: unknown): z.infer<typeof customSchema> =>
+  customSchema.parse({ type: "custom", raw });
+
 export function custom(raw: unknown): ContentBuilder {
   return {
-    build: () => Promise.resolve({ type: "custom", raw }),
+    build: async () => asCustom(raw),
   };
 }

--- a/packages/spectrum-ts/src/content/resolve.ts
+++ b/packages/spectrum-ts/src/content/resolve.ts
@@ -1,0 +1,9 @@
+import { text } from "./text";
+import type { Content, ContentInput } from "./types";
+
+export const resolveContents = (
+  items: readonly ContentInput[]
+): Promise<Content[]> =>
+  Promise.all(
+    items.map((c) => (typeof c === "string" ? text(c).build() : c.build()))
+  );

--- a/packages/spectrum-ts/src/content/text.ts
+++ b/packages/spectrum-ts/src/content/text.ts
@@ -6,8 +6,11 @@ export const textSchema = z.object({
   text: z.string().nonempty(),
 });
 
+export const asText = (text: string): z.infer<typeof textSchema> =>
+  textSchema.parse({ type: "text", text });
+
 export function text(text: string): ContentBuilder {
   return {
-    build: () => Promise.resolve({ type: "text", text }),
+    build: async () => asText(text),
   };
 }

--- a/packages/spectrum-ts/src/content/text.ts
+++ b/packages/spectrum-ts/src/content/text.ts
@@ -1,0 +1,13 @@
+import z from "zod";
+import type { ContentBuilder } from "./types";
+
+export const textSchema = z.object({
+  type: z.literal("text"),
+  text: z.string().nonempty(),
+});
+
+export function text(text: string): ContentBuilder {
+  return {
+    build: () => Promise.resolve({ type: "text", text }),
+  };
+}

--- a/packages/spectrum-ts/src/content/types.ts
+++ b/packages/spectrum-ts/src/content/types.ts
@@ -1,0 +1,18 @@
+import z from "zod";
+import { attachmentSchema } from "./attachment";
+import { customSchema } from "./custom";
+import { textSchema } from "./text";
+
+export const contentSchema = z.discriminatedUnion("type", [
+  textSchema,
+  customSchema,
+  attachmentSchema,
+]);
+
+export type Content = z.infer<typeof contentSchema>;
+
+export interface ContentBuilder {
+  build(): Promise<Content>;
+}
+
+export type ContentInput = string | ContentBuilder;

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -1,4 +1,3 @@
-// biome-ignore lint/performance/noBarrelFile: library entry point
 export { attachment } from "./content/attachment";
 export { custom } from "./content/custom";
 export { resolveContents } from "./content/resolve";

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -17,7 +17,9 @@ export {
   attachment,
   type Content,
   type ContentBuilder,
+  type ContentInput,
   custom,
+  resolveContents,
   text,
 } from "./types/content";
 export type { Message } from "./types/message";

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -1,4 +1,9 @@
 // biome-ignore lint/performance/noBarrelFile: library entry point
+export { attachment } from "./content/attachment";
+export { custom } from "./content/custom";
+export { resolveContents } from "./content/resolve";
+export { text } from "./content/text";
+export type { Content, ContentBuilder, ContentInput } from "./content/types";
 export { definePlatform } from "./platform/define";
 export type {
   AnyPlatformDef,
@@ -13,15 +18,6 @@ export type {
   SchemaMessage,
 } from "./platform/types";
 export { Spectrum, type SpectrumInstance } from "./spectrum";
-export {
-  attachment,
-  type Content,
-  type ContentBuilder,
-  type ContentInput,
-  custom,
-  resolveContents,
-  text,
-} from "./types/content";
 export type { Message } from "./types/message";
 export type { Space } from "./types/space";
 export type { User } from "./types/user";

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -1,5 +1,5 @@
 import type z from "zod";
-import type { ContentBuilder } from "../types/content";
+import { type ContentInput, resolveContents } from "../types/content";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
 import type {
@@ -107,12 +107,14 @@ function createPlatformInstance<
       return {
         ...parsedSpace,
         ...spaceRef,
-        send: async (...content: [ContentBuilder, ...ContentBuilder[]]) => {
-          const built = await Promise.all(content.map((c) => c.build()));
-          await def.actions.send({
-            ...typingCtx,
-            content: built,
-          });
+        send: async (...content: [ContentInput, ...ContentInput[]]) => {
+          const built = await resolveContents(content);
+          for (const item of built) {
+            await def.actions.send({
+              ...typingCtx,
+              content: item,
+            });
+          }
         },
         startTyping: async () => {
           await def.actions.startTyping?.(typingCtx);

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -1,5 +1,6 @@
 import type z from "zod";
-import { type ContentInput, resolveContents } from "../types/content";
+import { resolveContents } from "../content/resolve";
+import type { ContentInput } from "../content/types";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
 import type {

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -38,7 +38,7 @@ export type ProviderMessage<
   TExtra extends object = Record<never, never>,
 > = {
   id: string;
-  content: Content[];
+  content: Content;
   sender: TSender;
   space: TSpace;
   timestamp?: Date;
@@ -103,7 +103,7 @@ export interface PlatformDef<
   actions: {
     send: (_: {
       space: _ResolvedSpace & SpaceRef;
-      content: Content[];
+      content: Content;
       client: _Client;
       config: z.infer<_ConfigSchema>;
     }) => Promise<void>;
@@ -127,7 +127,7 @@ export interface PlatformDef<
     replyToMessage?: (_: {
       space: _ResolvedSpace & SpaceRef;
       messageId: string;
-      content: Content[];
+      content: Content;
       client: _Client;
       config: z.infer<_ConfigSchema>;
     }) => Promise<void>;

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -1,6 +1,6 @@
 import type { Fn, Pipe, Tuples } from "hotscript";
 import type z from "zod";
-import type { Content } from "../types/content";
+import type { Content } from "../content/types";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
 import type { User } from "../types/user";

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -115,12 +115,10 @@ export const imessage = definePlatform("iMessage", {
 
   actions: {
     send: async ({ space, content, client }) => {
-      for (const item of content) {
-        if (isLocal(client)) {
-          await localSend(client, space.id, item);
-        } else {
-          await remoteSend(client, space.id, item);
-        }
+      if (isLocal(client)) {
+        await localSend(client, space.id, content);
+      } else {
+        await remoteSend(client, space.id, content);
       }
     },
     startTyping: async ({ space, client }) => {
@@ -145,9 +143,7 @@ export const imessage = definePlatform("iMessage", {
       if (isLocal(client)) {
         return;
       }
-      for (const item of content) {
-        await remoteReplyToMessage(client, space.id, messageId, item);
-      }
+      await remoteReplyToMessage(client, space.id, messageId, content);
     },
   },
 });

--- a/packages/spectrum-ts/src/providers/imessage/local.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local.ts
@@ -10,16 +10,16 @@ import { type ManagedStream, stream } from "../../utils/stream";
 import type { IMessageMessage } from "./types";
 
 const toSpace = (message: LocalIMessage): IMessageMessage["space"] => ({
-  id: `${message.isGroupChat ? "any;+;" : "any;-;"}${message.chatId}`,
-  type: message.isGroupChat ? "group" : "dm",
+  id: message.chatId,
+  type: message.chatKind === "group" ? "group" : "dm",
 });
 
 const toMessage = (message: LocalIMessage): IMessageMessage => ({
-  id: message.guid,
+  id: message.id,
   content: { type: "text", text: message.text ?? "" },
-  sender: { id: message.sender ?? "" },
+  sender: { id: message.participant ?? "" },
   space: toSpace(message),
-  timestamp: message.date ?? new Date(),
+  timestamp: message.createdAt,
 });
 
 export const messages = (client: IMessageSDK): ManagedStream<IMessageMessage> =>
@@ -43,7 +43,7 @@ export const send = async (
       const tmp = join(tmpdir(), `spectrum-${Date.now()}-${content.name}`);
       await writeFile(tmp, content.data);
       try {
-        await client.send(spaceId, { files: [tmp] });
+        await client.send(spaceId, { attachments: [tmp] });
       } finally {
         await unlink(tmp).catch(() => {});
       }

--- a/packages/spectrum-ts/src/providers/imessage/local.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local.ts
@@ -5,7 +5,7 @@ import type {
   IMessageSDK,
   Message as LocalIMessage,
 } from "@photon-ai/imessage-kit";
-import type { Content } from "../../types/content";
+import type { Content } from "../../content/types";
 import { type ManagedStream, stream } from "../../utils/stream";
 import type { IMessageMessage } from "./types";
 

--- a/packages/spectrum-ts/src/providers/imessage/local.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local.ts
@@ -16,7 +16,7 @@ const toSpace = (message: LocalIMessage): IMessageMessage["space"] => ({
 
 const toMessage = (message: LocalIMessage): IMessageMessage => ({
   id: message.guid,
-  content: [{ type: "plain_text", text: message.text ?? "" }],
+  content: { type: "text", text: message.text ?? "" },
   sender: { id: message.sender ?? "" },
   space: toSpace(message),
   timestamp: message.date ?? new Date(),
@@ -36,7 +36,7 @@ export const send = async (
   content: Content
 ) => {
   switch (content.type) {
-    case "plain_text":
+    case "text":
       await client.send(spaceId, content.text);
       break;
     case "attachment": {

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -17,7 +17,7 @@ const TAPBACK_NAMES: ReadonlySet<string> = new Set(
 
 const toMessage = (event: ReceivedEvent): IMessageMessage => ({
   id: event.message.guid as string,
-  content: [{ type: "plain_text", text: event.message.text ?? "" }],
+  content: { type: "text", text: event.message.text ?? "" },
   sender: { id: event.message.sender?.address ?? "" },
   space: {
     id: event.chatGuid,
@@ -81,7 +81,7 @@ export const send = async (
     return;
   }
   switch (content.type) {
-    case "plain_text":
+    case "text":
       await remote.messages.send(chatGuid(spaceId), content.text);
       break;
     case "attachment": {
@@ -115,7 +115,7 @@ export const replyToMessage = async (
   const replyTo = messageGuid(msgId);
 
   switch (content.type) {
-    case "plain_text":
+    case "text":
       await remote.messages.send(chat, content.text, { replyTo });
       break;
     case "attachment": {

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -5,6 +5,8 @@ import {
   messageGuid,
   Reaction,
 } from "@photon-ai/advanced-imessage";
+import { asCustom } from "../../content/custom";
+import { asText } from "../../content/text";
 import type { Content } from "../../content/types";
 import { type ManagedStream, mergeStreams, stream } from "../../utils/stream";
 import type { IMessageMessage } from "./types";
@@ -15,16 +17,19 @@ const TAPBACK_NAMES: ReadonlySet<string> = new Set(
   Object.values(Reaction).filter((r) => r !== "emoji" && r !== "sticker")
 );
 
-const toMessage = (event: ReceivedEvent): IMessageMessage => ({
-  id: event.message.guid as string,
-  content: { type: "text", text: event.message.text ?? "" },
-  sender: { id: event.message.sender?.address ?? "" },
-  space: {
-    id: event.chatGuid,
-    type: event.chatGuid.includes(";+;") ? "group" : "dm",
-  },
-  timestamp: event.timestamp,
-});
+const toMessage = (event: ReceivedEvent): IMessageMessage => {
+  const text = event.message.text;
+  return {
+    id: event.message.guid as string,
+    content: text ? asText(text) : asCustom(event.message),
+    sender: { id: event.message.sender?.address ?? "" },
+    space: {
+      id: event.chatGuid,
+      type: event.chatGuid.includes(";+;") ? "group" : "dm",
+    },
+    timestamp: event.timestamp,
+  };
+};
 
 const clientStream = (
   client: AdvancedIMessage
@@ -96,7 +101,7 @@ export const send = async (
       break;
     }
     default:
-      break;
+      throw new Error(`Unsupported iMessage content type: ${content.type}`);
   }
 };
 
@@ -131,7 +136,7 @@ export const replyToMessage = async (
       break;
     }
     default:
-      break;
+      throw new Error(`Unsupported iMessage content type: ${content.type}`);
   }
 };
 

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -5,7 +5,7 @@ import {
   messageGuid,
   Reaction,
 } from "@photon-ai/advanced-imessage";
-import type { Content } from "../../types/content";
+import type { Content } from "../../content/types";
 import { type ManagedStream, mergeStreams, stream } from "../../utils/stream";
 import type { IMessageMessage } from "./types";
 

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -43,7 +43,7 @@ export const terminal = definePlatform("terminal", {
       for await (const line of client) {
         yield {
           id: crypto.randomUUID(),
-          content: [{ type: "plain_text" as const, text: line }],
+          content: { type: "text" as const, text: line },
           sender: { id: "terminal-user" },
           space: { id: "terminal" },
           timestamp: new Date(),
@@ -54,12 +54,8 @@ export const terminal = definePlatform("terminal", {
 
   actions: {
     send: async ({ content }) => {
-      const outputs = content
-        .filter((c) => c.type === "plain_text")
-        .map((c) => c.text);
-
-      for (const output of outputs) {
-        console.log(output);
+      if (content.type === "text") {
+        console.log(content.text);
       }
     },
   },

--- a/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
@@ -52,10 +52,7 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
 
   actions: {
     send: async ({ space, content, client }) => {
-      const wa = client as WhatsAppClient;
-      for (const item of content) {
-        await send(wa, space.id, item);
-      }
+      await send(client as WhatsAppClient, space.id, content);
     },
 
     reactToMessage: async ({ space, messageId, reaction, client }) => {
@@ -68,10 +65,12 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
     },
 
     replyToMessage: async ({ space, messageId, content, client }) => {
-      const wa = client as WhatsAppClient;
-      for (const item of content) {
-        await replyToMessage(wa, space.id, messageId, item);
-      }
+      await replyToMessage(
+        client as WhatsAppClient,
+        space.id,
+        messageId,
+        content
+      );
     },
   },
 });

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -2,7 +2,7 @@ import type {
   InboundMessage,
   WhatsAppClient,
 } from "@photon-ai/whatsapp-business";
-import type { Content } from "../../types/content";
+import type { Content } from "../../content/types";
 import { type ManagedStream, stream } from "../../utils/stream";
 import type { WhatsAppMessage } from "./types";
 

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -2,6 +2,9 @@ import type {
   InboundMessage,
   WhatsAppClient,
 } from "@photon-ai/whatsapp-business";
+import { asAttachment } from "../../content/attachment";
+import { asCustom } from "../../content/custom";
+import { asText } from "../../content/text";
 import type { Content } from "../../content/types";
 import { type ManagedStream, stream } from "../../utils/stream";
 import type { WhatsAppMessage } from "./types";
@@ -26,54 +29,33 @@ const mapContent = async (
 ): Promise<Content> => {
   switch (content.type) {
     case "text":
-      return { type: "text", text: content.body };
+      return asText(content.body);
     case "image":
     case "video":
     case "audio":
     case "document":
-      return await downloadMedia(client, content.media);
+      return downloadMedia(client, content.media);
     case "sticker":
-      return {
-        type: "custom",
-        raw: { whatsapp_type: "sticker", ...content.sticker },
-      };
+      return asCustom({ whatsapp_type: "sticker", ...content.sticker });
     case "location":
-      return {
-        type: "custom",
-        raw: { whatsapp_type: "location", ...content.location },
-      };
+      return asCustom({ whatsapp_type: "location", ...content.location });
     case "contacts":
-      return {
-        type: "custom",
-        raw: { whatsapp_type: "contacts", contacts: content.contacts },
-      };
+      return asCustom({
+        whatsapp_type: "contacts",
+        contacts: content.contacts,
+      });
     case "reaction":
-      return {
-        type: "custom",
-        raw: { whatsapp_type: "reaction", ...content.reaction },
-      };
+      return asCustom({ whatsapp_type: "reaction", ...content.reaction });
     case "interactive":
-      return {
-        type: "custom",
-        raw: { whatsapp_type: "interactive", ...content.interactive },
-      };
+      return asCustom({ whatsapp_type: "interactive", ...content.interactive });
     case "button":
-      return {
-        type: "custom",
-        raw: { whatsapp_type: "button", ...content.button },
-      };
+      return asCustom({ whatsapp_type: "button", ...content.button });
     case "order":
-      return {
-        type: "custom",
-        raw: { whatsapp_type: "order", ...content.order },
-      };
+      return asCustom({ whatsapp_type: "order", ...content.order });
     case "system":
-      return {
-        type: "custom",
-        raw: { whatsapp_type: "system", ...content.system },
-      };
+      return asCustom({ whatsapp_type: "system", ...content.system });
     default:
-      return { type: "custom", raw: { whatsapp_type: "unknown" } };
+      return asCustom({ whatsapp_type: "unknown" });
   }
 };
 
@@ -88,21 +70,17 @@ const downloadMedia = async (
       throw new Error(`Media download failed: ${response.status}`);
     }
     const data = Buffer.from(await response.arrayBuffer());
-    return {
-      type: "attachment",
+    return asAttachment({
       data,
       mimeType: media.mimeType,
       name: media.filename ?? `media-${media.id}`,
-    };
+    });
   } catch {
-    return {
-      type: "custom",
-      raw: {
-        whatsapp_type: "media_error",
-        mediaId: media.id,
-        mimeType: media.mimeType,
-      },
-    };
+    return asCustom({
+      whatsapp_type: "media_error",
+      mediaId: media.id,
+      mimeType: media.mimeType,
+    });
   }
 };
 

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -23,70 +23,57 @@ const toMessage = async (
 const mapContent = async (
   client: WhatsAppClient,
   content: InboundMessage["content"]
-): Promise<Content[]> => {
+): Promise<Content> => {
   switch (content.type) {
     case "text":
-      return [{ type: "plain_text", text: content.body }];
+      return { type: "text", text: content.body };
     case "image":
     case "video":
     case "audio":
     case "document":
-      return [await downloadMedia(client, content.media)];
+      return await downloadMedia(client, content.media);
     case "sticker":
-      return [
-        {
-          type: "custom",
-          raw: { whatsapp_type: "sticker", ...content.sticker },
-        },
-      ];
+      return {
+        type: "custom",
+        raw: { whatsapp_type: "sticker", ...content.sticker },
+      };
     case "location":
-      return [
-        {
-          type: "custom",
-          raw: { whatsapp_type: "location", ...content.location },
-        },
-      ];
+      return {
+        type: "custom",
+        raw: { whatsapp_type: "location", ...content.location },
+      };
     case "contacts":
-      return [
-        {
-          type: "custom",
-          raw: { whatsapp_type: "contacts", contacts: content.contacts },
-        },
-      ];
+      return {
+        type: "custom",
+        raw: { whatsapp_type: "contacts", contacts: content.contacts },
+      };
     case "reaction":
-      return [
-        {
-          type: "custom",
-          raw: { whatsapp_type: "reaction", ...content.reaction },
-        },
-      ];
+      return {
+        type: "custom",
+        raw: { whatsapp_type: "reaction", ...content.reaction },
+      };
     case "interactive":
-      return [
-        {
-          type: "custom",
-          raw: { whatsapp_type: "interactive", ...content.interactive },
-        },
-      ];
+      return {
+        type: "custom",
+        raw: { whatsapp_type: "interactive", ...content.interactive },
+      };
     case "button":
-      return [
-        {
-          type: "custom",
-          raw: { whatsapp_type: "button", ...content.button },
-        },
-      ];
+      return {
+        type: "custom",
+        raw: { whatsapp_type: "button", ...content.button },
+      };
     case "order":
-      return [
-        { type: "custom", raw: { whatsapp_type: "order", ...content.order } },
-      ];
+      return {
+        type: "custom",
+        raw: { whatsapp_type: "order", ...content.order },
+      };
     case "system":
-      return [
-        {
-          type: "custom",
-          raw: { whatsapp_type: "system", ...content.system },
-        },
-      ];
+      return {
+        type: "custom",
+        raw: { whatsapp_type: "system", ...content.system },
+      };
     default:
-      return [{ type: "custom", raw: { whatsapp_type: "unknown" } }];
+      return { type: "custom", raw: { whatsapp_type: "unknown" } };
   }
 };
 
@@ -165,7 +152,7 @@ export const send = async (
   content: Content
 ): Promise<void> => {
   switch (content.type) {
-    case "plain_text":
+    case "text":
       await client.messages.send({ to: spaceId, text: content.text });
       break;
     case "attachment": {
@@ -209,7 +196,7 @@ export const replyToMessage = async (
   content: Content
 ): Promise<void> => {
   switch (content.type) {
-    case "plain_text":
+    case "text":
       await client.messages.send({
         to: spaceId,
         replyTo: messageId,

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -1,15 +1,12 @@
 import z from "zod";
+import { resolveContents } from "./content/resolve";
+import type { Content, ContentInput } from "./content/types";
 import type {
   AnyPlatformDef,
   CustomEventStreams,
   PlatformProviderConfig,
   SpectrumLike,
 } from "./platform/types";
-import {
-  type Content,
-  type ContentInput,
-  resolveContents,
-} from "./types/content";
 import type { Message } from "./types/message";
 import type { Space } from "./types/space";
 import { type ManagedStream, mergeStreams, stream } from "./utils/stream";

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -5,14 +5,18 @@ import type {
   PlatformProviderConfig,
   SpectrumLike,
 } from "./platform/types";
-import type { Content, ContentBuilder } from "./types/content";
+import {
+  type Content,
+  type ContentInput,
+  resolveContents,
+} from "./types/content";
 import type { Message } from "./types/message";
 import type { Space } from "./types/space";
 import { type ManagedStream, mergeStreams, stream } from "./utils/stream";
 
 type ProviderMessageRecord = {
   id: string;
-  content: Content[];
+  content: Content;
   sender: { id: string } & Record<string, unknown>;
   space: { id: string } & Record<string, unknown>;
   timestamp?: Date;
@@ -38,7 +42,7 @@ export type SpectrumInstance<
     stop(): Promise<void>;
     send(
       space: Space,
-      ...content: [ContentBuilder, ...ContentBuilder[]]
+      ...content: [ContentInput, ...ContentInput[]]
     ): Promise<void>;
     responding<T>(space: Space, fn: () => T | Promise<T>): Promise<T>;
   };
@@ -162,12 +166,14 @@ export async function Spectrum<
         const typingCtx = { space: spaceRef, client, config };
         const space = {
           ...spaceRef,
-          send: async (...content: [ContentBuilder, ...ContentBuilder[]]) => {
-            const resolved = await Promise.all(content.map((c) => c.build()));
-            await definition.actions.send({
-              ...typingCtx,
-              content: resolved,
-            });
+          send: async (...content: [ContentInput, ...ContentInput[]]) => {
+            const resolved = await resolveContents(content);
+            for (const item of resolved) {
+              await definition.actions.send({
+                ...typingCtx,
+                content: item,
+              });
+            }
           },
           startTyping: async () => {
             await definition.actions.startTyping?.(typingCtx);
@@ -202,19 +208,21 @@ export async function Spectrum<
             });
           },
           reply: async (
-            ...content: [ContentBuilder, ...ContentBuilder[]]
+            ...content: [ContentInput, ...ContentInput[]]
           ): Promise<void> => {
             if (!definition.actions.replyToMessage) {
               return;
             }
-            const resolved = await Promise.all(content.map((c) => c.build()));
-            await definition.actions.replyToMessage({
-              space: spaceRef,
-              messageId: msg.id,
-              content: resolved,
-              client,
-              config,
-            });
+            const resolved = await resolveContents(content);
+            for (const item of resolved) {
+              await definition.actions.replyToMessage({
+                space: spaceRef,
+                messageId: msg.id,
+                content: item,
+                client,
+                config,
+              });
+            }
           },
           sender: {
             ...msg.sender,
@@ -363,7 +371,7 @@ export async function Spectrum<
     stop: stopOnce,
     send: async (
       space: Space,
-      ...content: [ContentBuilder, ...ContentBuilder[]]
+      ...content: [ContentInput, ...ContentInput[]]
     ) => {
       await space.send(...content);
     },

--- a/packages/spectrum-ts/src/types/content.ts
+++ b/packages/spectrum-ts/src/types/content.ts
@@ -7,7 +7,7 @@ const DEFAULT_ATTACHMENT_NAME = "attachment";
 
 const contentSchema = z.discriminatedUnion("type", [
   z.object({
-    type: z.literal("plain_text"),
+    type: z.literal("text"),
     text: z.string().nonempty(),
   }),
   z.object({
@@ -30,10 +30,18 @@ export interface ContentBuilder {
 
 export function text(text: string): ContentBuilder {
   return {
-    build: (): Promise<Content> =>
-      Promise.resolve({ type: "plain_text", text }),
+    build: (): Promise<Content> => Promise.resolve({ type: "text", text }),
   };
 }
+
+export type ContentInput = string | ContentBuilder;
+
+export const resolveContents = (
+  items: readonly ContentInput[]
+): Promise<Content[]> =>
+  Promise.all(
+    items.map((c) => (typeof c === "string" ? text(c).build() : c.build()))
+  );
 
 export function custom(
   raw: z.infer<ReturnType<typeof z.json>>

--- a/packages/spectrum-ts/src/types/message.ts
+++ b/packages/spectrum-ts/src/types/message.ts
@@ -1,4 +1,4 @@
-import type { Content, ContentBuilder } from "./content";
+import type { Content, ContentInput } from "./content";
 import type { Space } from "./space";
 import type { User } from "./user";
 
@@ -7,11 +7,11 @@ export interface Message<
   TSender extends User = User,
   TSpace extends Space = Space,
 > {
-  content: Content[];
+  content: Content;
   readonly id: string;
   platform: TPlatform;
   react(reaction: string): Promise<void>;
-  reply(...content: [ContentBuilder, ...ContentBuilder[]]): Promise<void>;
+  reply(...content: [ContentInput, ...ContentInput[]]): Promise<void>;
   sender: TSender;
   space: TSpace;
   timestamp: Date;

--- a/packages/spectrum-ts/src/types/message.ts
+++ b/packages/spectrum-ts/src/types/message.ts
@@ -1,4 +1,4 @@
-import type { Content, ContentInput } from "./content";
+import type { Content, ContentInput } from "../content/types";
 import type { Space } from "./space";
 import type { User } from "./user";
 

--- a/packages/spectrum-ts/src/types/space.ts
+++ b/packages/spectrum-ts/src/types/space.ts
@@ -1,10 +1,10 @@
-import type { ContentBuilder } from "./content";
+import type { ContentInput } from "./content";
 
 export interface Space<_Def = unknown> {
   readonly __platform: string;
   readonly id: string;
   responding<T>(fn: () => T | Promise<T>): Promise<T>;
-  send(...content: [ContentBuilder, ...ContentBuilder[]]): Promise<void>;
+  send(...content: [ContentInput, ...ContentInput[]]): Promise<void>;
   startTyping(): Promise<void>;
   stopTyping(): Promise<void>;
 }

--- a/packages/spectrum-ts/src/types/space.ts
+++ b/packages/spectrum-ts/src/types/space.ts
@@ -1,4 +1,4 @@
-import type { ContentInput } from "./content";
+import type { ContentInput } from "../content/types";
 
 export interface Space<_Def = unknown> {
   readonly __platform: string;

--- a/packages/spectrum-ts/tsconfig.json
+++ b/packages/spectrum-ts/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.json",
   "include": ["src"],
   "compilerOptions": {
-    "strictNullChecks": true,
-    "types": ["bun"]
+    "strictNullChecks": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,9 @@
     "verbatimModuleSyntax": true,
     "noEmit": true,
 
+    // Runtime types (monorepo-wide default; override per workspace if needed)
+    "types": ["bun"],
+
     // Best practices
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

- Switch `Message.content` from `Content[]` to a single `Content` so consumers can `switch` on `content.type` directly instead of iterating + filtering an array.
- Rename the text content type from `"plain_text"` to `"text"` to align with the builder name and reduce surface area.
- Accept plain strings anywhere a content input is expected (`ContentInput = string | ContentBuilder`) — `space.send("hi")` is now equivalent to `space.send(text("hi"))`.
- Split the monolithic `src/types/content.ts` into a dedicated `src/content/` module (`text`, `attachment`, `custom`, `resolve`, `types`) and re-export from the package entry.
- Upgrade `@photon-ai/imessage-kit` to `^3.0.0-rc.1` and update the local provider for the new field names (`chatKind`, `participant`, `createdAt`, `id`) and `attachments: [...]` payload.
- Use `z.unknown()` instead of `z.json()` for the `custom` content `raw` field so arbitrary platform payloads pass through without re-validation.
- Hoist the `bun` runtime types to root `tsconfig.json` so all workspaces inherit them, and disable `noBarrelFile` for package `src/index.ts` entry points via a Biome override.

## Usage

```typescript
for await (const [space, message] of app.messages) {
  switch (message.content.type) {
    case "text":
      await space.send(`echo: ${message.content.text}`);
      break;
    case "attachment":
      console.log(`[attachment] ${message.content.name}`);
      break;
    case "custom":
      console.log("[custom]", message.content.raw);
      break;
  }
}
```

## Changes

- `packages/spectrum-ts/src/content/{text,attachment,custom,types,resolve}.ts` — extract content into a dedicated module; each type has its own Zod schema, and `resolveContents` normalizes strings into text builders.
- `packages/spectrum-ts/src/index.ts` — re-export content builders, `ContentInput`, and keep the barrel file (allowed via Biome override).
- `packages/spectrum-ts/src/platform/{define,types}.ts`, `src/spectrum.ts`, `src/types/{message,space}.ts` — type `content` as `Content` (not `Content[]`), accept `ContentInput`, and invoke `actions.send` / `actions.replyToMessage` once per item from the variadic input.
- `packages/spectrum-ts/src/providers/imessage/{index,local,remote}.ts` — drop the inner `for` loop, adopt v3 field names, and use `attachments` for local sends.
- `packages/spectrum-ts/src/providers/whatsapp-business/{index,messages}.ts` — `mapContent` returns a single `Content`; action handlers no longer iterate.
- `packages/spectrum-ts/src/providers/terminal/index.ts` — single-content send, `plain_text` → `text`.
- `packages/spectrum-ts/package.json` — exports use the `./providers/*` pattern, `publishConfig.exports` maps to `dist/*`, and the `files` field lives under `publishConfig`. Bumps `@photon-ai/imessage-kit` to `^3.0.0-rc.1`.
- `packages/spectrum-ts/tsconfig.json` — drop per-package `types: ["bun"]` (now inherited from the monorepo root).
- `tsconfig.json` — set `types: ["bun"]` as the monorepo-wide default.
- `biome.jsonc` — override `performance/noBarrelFile` off for `packages/*/src/index.ts`.
- `examples/basic/index.ts` — rewrite around the new `switch` on `message.content.type`; drop the hardcoded WhatsApp Business credentials in favor of the iMessage local provider.
- `README.md` — update every sample to reflect the single-`Content` model, the `text` type name, and plain-string sends.

## Test plan

- [ ] `bun install` resolves cleanly (lockfile now pins imessage-kit v3 + `@parseaple/*` transitive deps).
- [ ] `bun run build` succeeds for `packages/spectrum-ts`.
- [ ] `bun x ultracite check` passes.
- [ ] `bun run examples/basic/index.ts` receives an incoming iMessage (local mode) and echoes it back.
- [ ] Narrowing works end-to-end: `message.content.type === "text"` exposes `.text`; `"attachment"` exposes `.data` / `.name`; `"custom"` exposes `.raw`.
- [ ] `space.send("string")` and `space.send(text("string"))` produce identical outgoing messages.
- [ ] Passing multiple content inputs (`space.send("a", attachment(...))`) results in two provider `send` invocations in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Messages now carry a single content object (text/attachment/custom).
  * Send/reply accept plain strings or content inputs and deliver each content item as its own message.
  * Examples updated to demonstrate content.type-based handling (e.g., "text", "attachment", "custom").

* **Documentation**
  * README and provider docs updated to reflect the new content shape and updated send/reply usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->