### PR TITLE
Fix npm publish to ship only the built dist

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,5 +15,6 @@ jobs:
       service-name: spectrum-ts
       working-directory: packages/spectrum-ts
       build-command: "bun run build"
+      publish-command: "bunx clean-publish --package-manager npm"
       dry-run: false
     secrets: inherit

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
     },
     "packages/spectrum-ts": {
       "name": "spectrum-ts",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.4.2",
         "@photon-ai/imessage-kit": "^3.0.0-rc.1",
@@ -35,6 +35,7 @@
       "devDependencies": {
         "@types/bun": "latest",
         "@types/mime-types": "^3.0.1",
+        "clean-publish": "^6.0.5",
         "hotscript": "^1.0.13",
         "tsup": "^8.4.0",
       },
@@ -278,6 +279,8 @@
 
     "citty": ["citty@0.2.1", "", {}, "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="],
 
+    "clean-publish": ["clean-publish@6.0.5", "", { "dependencies": { "lilconfig": "^3.1.3", "picomatch": "^4.0.4", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15" }, "bin": { "clean-publish": "clean-publish.js", "clear-package-json": "clear-package-json.js" } }, "sha512-Iqm/EDPQFLY0I8kktg61Nt8V/5fiXYNkNR5UsHcLKmj4vp7a0a7EGZmNEbN2Hg77frQlHNljT/MruK5Wr/Rtog=="],
+
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
@@ -474,7 +477,7 @@
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
-    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+    "tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
@@ -529,6 +532,8 @@
     "protobufjs/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+
+    "tsup/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
     "@photon-ai/whatsapp-business/protobufjs/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -6,8 +6,7 @@
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "exports": {
     ".": {
@@ -31,10 +30,7 @@
         "types": "./dist/providers/*/index.d.ts",
         "default": "./dist/providers/*/index.js"
       }
-    },
-    "files": [
-      "dist"
-    ]
+    }
   },
   "scripts": {
     "build": "tsup",
@@ -53,6 +49,7 @@
   "devDependencies": {
     "@types/bun": "latest",
     "@types/mime-types": "^3.0.1",
+    "clean-publish": "^6.0.5",
     "hotscript": "^1.0.13",
     "tsup": "^8.4.0"
   },


### PR DESCRIPTION
## Summary

- Move `files: ["dist"]` to the top level of `packages/spectrum-ts/package.json`. npm silently ignores a `files` array nested inside `publishConfig`, so the prior manifest was shipping the full source tree (including `src/`) in every tarball.
- Add `clean-publish` as a devDependency and wire `bunx clean-publish --package-manager npm` as the BuildSpace `publish-command` in `.github/workflows/release.yaml`. `clean-publish` is what merges `publishConfig.exports` into the published manifest so tarball consumers only ever resolve dist paths.

Dev-mode resolution is unchanged: the top-level `exports` still maps the `bun` and `types` conditions to `./src/*`, which workspace consumers reach via symlinks.

## Dependency

Requires photon-hq/buildspace#72 to land first — the `publish-command` input on the reusable release workflow is new there.

## Changes

| File | Change |
|------|--------|
| `packages/spectrum-ts/package.json` | Hoist `files: ["dist"]` out of `publishConfig`; add `clean-publish` devDep |
| `.github/workflows/release.yaml` | Pass `publish-command: "bunx clean-publish --package-manager npm"` to the reusable release workflow |
| `bun.lock` | Lockfile updates for `clean-publish` and its transitive deps |

## Test plan

- [ ] Confirm photon-hq/buildspace#72 is merged before this lands
- [ ] Run the release workflow in dry-run mode and verify the published tarball contains only `dist/` (no `src/`)
- [ ] Verify the published `package.json` has the flattened `exports` from `publishConfig` and no `bun` condition
- [ ] Install the published tarball in a scratch project and confirm `import { Spectrum } from "spectrum-ts"` resolves to `dist/index.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized package distribution by reducing published files to only compiled output
  * Updated release workflow to streamline package publishing process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->