### PR TITLE
Update `@photon-ai/imessage-kit` to 3.0.0-rc.2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
       "version": "0.3.0",
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.4.2",
-        "@photon-ai/imessage-kit": "^3.0.0-rc.1",
+        "@photon-ai/imessage-kit": "^3.0.0-rc.2",
         "@photon-ai/whatsapp-business": "^0.1.1",
         "@repeaterjs/repeater": "^3.0.6",
         "better-grpc": "^0.3.2",
@@ -141,7 +141,7 @@
 
     "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.4.2", "", { "dependencies": { "@grpc/grpc-js": "^1.12.6", "long": "^5.2.4", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2", "protobufjs": "^7.4.0" } }, "sha512-w66rA8vnAYcZWJHFbahERt0WkwxPnRbg8B1SmKlScNk4jO0jx9nsuaj2wuh8mtoPnT+LFwkB5Zd2avHLC8eIKQ=="],
 
-    "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0-rc.1", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" }, "os": "darwin" }, "sha512-PX9Fx8mQ+QuFd0JrUaCR3nk0c25dK0NKskX6ZxVmHVMj+kS9tJJiha/RL4/AyJyTLKQYpTcLvFa7cZCiY6PViQ=="],
+    "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0-rc.2", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-AlhogO/WEZNTMR0h+UsvtMkjdkuFI2WGnY8+gIVVusA6onzOuJwZpxQ70quc2Y+O0HsUV0JnLy+A0ZcudvuSXA=="],
 
     "@photon-ai/whatsapp-business": ["@photon-ai/whatsapp-business@0.1.1", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "long": "^5.3.2", "nice-grpc": "^2.1.15", "nice-grpc-common": "^2.0.3", "protobufjs": "^8.0.1" } }, "sha512-JAf/gHh92+H6h/7AMOQ6l+WFYBWdeRH5fZ+tvOUYJJnX1C4aJPDFa23VTH4ndhKPgA5bK/h++cxUZx2lMubvYQ=="],
 

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@photon-ai/advanced-imessage": "^0.4.2",
     "@photon-ai/whatsapp-business": "^0.1.1",
-    "@photon-ai/imessage-kit": "^3.0.0-rc.1",
+    "@photon-ai/imessage-kit": "^3.0.0-rc.2",
     "@repeaterjs/repeater": "^3.0.6",
     "better-grpc": "^0.3.2",
     "mime-types": "^3.0.1",


### PR DESCRIPTION
## Summary

- Bump `@photon-ai/imessage-kit` from `^3.0.0-rc.1` to `^3.0.0-rc.2` in `packages/spectrum-ts/package.json`.
- rc.2 also drops the `os: darwin` install restriction that was present in rc.1, so the package can now be installed on non-macOS hosts (e.g. CI runners and containers that build but don't run the local iMessage provider). Runtime usage is still macOS-only; only the install-time platform gate is relaxed.

No API changes on our side — the provider code in `packages/spectrum-ts/src/providers/imessage/{index,local,types}.ts` compiles cleanly against rc.2 without edits.

## Changes

| File | Change |
|------|--------|
| `packages/spectrum-ts/package.json` | Bump `@photon-ai/imessage-kit` to `^3.0.0-rc.2` |
| `bun.lock` | Updated lockfile entry (resolved `3.0.0-rc.2`, `os: darwin` constraint removed) |

## Test plan

- [x] `bun install` resolves cleanly against rc.2
- [x] `bun run build` succeeds for `packages/spectrum-ts`
- [ ] Smoke test: run the iMessage local provider on macOS and confirm incoming/outgoing messages still flow
- [ ] Confirm `bun install` succeeds on a Linux host now that the `os: darwin` gate is gone


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency version to resolve compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->