### PR TITLE
Lazy attachment content for inbound iMessage/WhatsApp messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,20 @@ await space.send(attachment(buffer, {
 }));
 ```
 
+Incoming attachments arrive with metadata up front and fetch bytes on demand, so text messages aren't stalled behind slow downloads:
+
+```typescript
+if (message.content.type === "attachment") {
+  const { name, mimeType, size } = message.content;
+
+  // Fetch bytes when you actually need them (memoized across calls)
+  const bytes = await message.content.read();
+
+  // Or stream for large files (fresh stream per call)
+  const stream = await message.content.stream();
+}
+```
+
 ### Custom
 
 Send platform-specific structured data as JSON. Use this when a platform supports rich content types that don't map to text or attachments.

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,6 @@
     "": {
       "name": "specturm-ts",
       "dependencies": {
-        "@photon-ai/advanced-imessage": "^0.4.3",
         "@types/node": "^25.6.0",
       },
       "devDependencies": {
@@ -24,7 +23,7 @@
       "name": "spectrum-ts",
       "version": "0.3.1",
       "dependencies": {
-        "@photon-ai/advanced-imessage": "^0.4.2",
+        "@photon-ai/advanced-imessage": "^0.4.3",
         "@photon-ai/imessage-kit": "^3.0.0-rc.2",
         "@photon-ai/whatsapp-business": "^0.1.1",
         "@repeaterjs/repeater": "^3.0.6",

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "specturm-ts",
       "dependencies": {
+        "@photon-ai/advanced-imessage": "^0.4.3",
         "@types/node": "^25.6.0",
       },
       "devDependencies": {
@@ -21,7 +22,7 @@
     },
     "packages/spectrum-ts": {
       "name": "spectrum-ts",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.4.2",
         "@photon-ai/imessage-kit": "^3.0.0-rc.2",
@@ -139,7 +140,7 @@
 
     "@parseaple/typedstream": ["@parseaple/typedstream@2.0.2", "", { "dependencies": { "@parseaple/bplist": "1.0.1" } }, "sha512-bzKNZjiBtZN2T2U7Nqq/hhv+EezkPnaWoB5WvPuBwNpQvOr3EI0XrDTkFnAzsA9DKdu57es/gcb1d2ctd1u8xw=="],
 
-    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.4.2", "", { "dependencies": { "@grpc/grpc-js": "^1.12.6", "long": "^5.2.4", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2", "protobufjs": "^7.4.0" } }, "sha512-w66rA8vnAYcZWJHFbahERt0WkwxPnRbg8B1SmKlScNk4jO0jx9nsuaj2wuh8mtoPnT+LFwkB5Zd2avHLC8eIKQ=="],
+    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.4.3", "", { "dependencies": { "@grpc/grpc-js": "^1.12.6", "long": "^5.2.4", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2", "protobufjs": "^7.4.0" } }, "sha512-/mZJi/13hp8f4nejIjarP8W3NMVpXGuC2ar+hozw00iU/CjW1nMEdpAFWTaeMeI+YHwMDc+xglHdZhkgFr3OcA=="],
 
     "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0-rc.2", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-AlhogO/WEZNTMR0h+UsvtMkjdkuFI2WGnY8+gIVVusA6onzOuJwZpxQ70quc2Y+O0HsUV0JnLy+A0ZcudvuSXA=="],
 

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -4,8 +4,8 @@ import { imessage } from "spectrum-ts/providers/imessage";
 // import { terminal } from "spectrum-ts/providers/terminal";
 
 const app = await Spectrum({
-  projectId: "2df5638a-b51b-47a9-848e-0557368354a0",
-  projectSecret: "uguGq3CQCIEZR7BA_NlBxkK-__drGuVtwbO7i0jUEdU",
+  projectId: "",
+  projectSecret: "",
   providers: [
     imessage.config(),
     // terminal.config({}),

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -4,10 +4,10 @@ import { imessage } from "spectrum-ts/providers/imessage";
 // import { terminal } from "spectrum-ts/providers/terminal";
 
 const app = await Spectrum({
-  projectId: "project-id",
-  projectSecret: "project-secret",
+  projectId: "2df5638a-b51b-47a9-848e-0557368354a0",
+  projectSecret: "uguGq3CQCIEZR7BA_NlBxkK-__drGuVtwbO7i0jUEdU",
   providers: [
-    imessage.config({ local: true }),
+    imessage.config(),
     // terminal.config({}),
   ],
 });
@@ -24,6 +24,7 @@ for await (const [space, message] of app.messages) {
     }
     case "attachment":
       console.log(`[attachment] ${message.content.name}`);
+      message.content.data;
       break;
     case "custom":
       console.log("[custom]", message.content.raw);

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -22,10 +22,13 @@ for await (const [space, message] of app.messages) {
       });
       break;
     }
-    case "attachment":
-      console.log(`[attachment] ${message.content.name}`);
-      message.content.data;
+    case "attachment": {
+      const bytes = await message.content.read();
+      console.log(
+        `[attachment] ${message.content.name} (${bytes.length} bytes)`
+      );
       break;
+    }
     case "custom":
       console.log("[custom]", message.content.raw);
       break;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "fix": "ultracite fix"
   },
   "dependencies": {
-    "@photon-ai/advanced-imessage": "^0.4.3",
     "@types/node": "^25.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "fix": "ultracite fix"
   },
   "dependencies": {
+    "@photon-ai/advanced-imessage": "^0.4.3",
     "@types/node": "^25.6.0"
   }
 }

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -37,7 +37,7 @@
     "dev": "tsup --watch"
   },
   "dependencies": {
-    "@photon-ai/advanced-imessage": "^0.4.2",
+    "@photon-ai/advanced-imessage": "^0.4.3",
     "@photon-ai/whatsapp-business": "^0.1.1",
     "@photon-ai/imessage-kit": "^3.0.0-rc.2",
     "@repeaterjs/repeater": "^3.0.6",

--- a/packages/spectrum-ts/src/content/attachment.ts
+++ b/packages/spectrum-ts/src/content/attachment.ts
@@ -65,7 +65,10 @@ export const asAttachment = (input: {
 }): Attachment => {
   let cached: Promise<Buffer> | undefined;
   const read = (): Promise<Buffer> => {
-    cached ??= input.read();
+    cached ??= input.read().catch((err: unknown) => {
+      cached = undefined;
+      throw err;
+    });
     return cached;
   };
 

--- a/packages/spectrum-ts/src/content/attachment.ts
+++ b/packages/spectrum-ts/src/content/attachment.ts
@@ -1,17 +1,33 @@
-import { readFile } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { readFile, stat } from "node:fs/promises";
 import { basename } from "node:path";
+import { Readable } from "node:stream";
 import { lookup as lookupMimeType } from "mime-types";
 import z from "zod";
 import type { ContentBuilder } from "./types";
 
 const DEFAULT_ATTACHMENT_NAME = "attachment";
 
+const readSchema = z.function({
+  input: [],
+  output: z.promise(z.instanceof(Buffer)),
+});
+
+const streamSchema = z.function({
+  input: [],
+  output: z.promise(z.instanceof(ReadableStream)),
+});
+
 export const attachmentSchema = z.object({
   type: z.literal("attachment"),
-  data: z.instanceof(Buffer),
-  mimeType: z.string().nonempty(),
   name: z.string().nonempty(),
+  mimeType: z.string().nonempty(),
+  size: z.number().int().nonnegative().optional(),
+  read: readSchema,
+  stream: streamSchema,
 });
+
+export type Attachment = z.infer<typeof attachmentSchema>;
 
 const resolveAttachmentName = (input: string | Buffer, name?: string): string =>
   name ||
@@ -32,12 +48,38 @@ const resolveAttachmentMimeType = (name: string, mimeType?: string): string => {
   return resolvedMimeType;
 };
 
+const bufferToStream = (buf: Buffer): ReadableStream<Uint8Array> =>
+  new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(buf);
+      controller.close();
+    },
+  });
+
 export const asAttachment = (input: {
-  data: Buffer;
-  mimeType: string;
   name: string;
-}): z.infer<typeof attachmentSchema> =>
-  attachmentSchema.parse({ type: "attachment", ...input });
+  mimeType: string;
+  size?: number;
+  read: () => Promise<Buffer>;
+  stream?: () => Promise<ReadableStream<Uint8Array>>;
+}): Attachment => {
+  let cached: Promise<Buffer> | undefined;
+  const read = (): Promise<Buffer> => {
+    cached ??= input.read();
+    return cached;
+  };
+
+  const stream = input.stream ?? (async () => bufferToStream(await read()));
+
+  return attachmentSchema.parse({
+    type: "attachment",
+    name: input.name,
+    mimeType: input.mimeType,
+    size: input.size,
+    read,
+    stream,
+  });
+};
 
 export function attachment(
   input: string | Buffer,
@@ -45,12 +87,29 @@ export function attachment(
 ): ContentBuilder {
   return {
     build: async () => {
-      const data = typeof input === "string" ? await readFile(input) : input;
       const name = resolveAttachmentName(input, options?.name);
+      const mimeType = resolveAttachmentMimeType(name, options?.mimeType);
+
+      if (typeof input === "string") {
+        const stats = await stat(input);
+        return asAttachment({
+          name,
+          mimeType,
+          size: stats.size,
+          read: () => readFile(input),
+          stream: async () =>
+            Readable.toWeb(
+              createReadStream(input)
+            ) as ReadableStream<Uint8Array>,
+        });
+      }
+
       return asAttachment({
-        data,
-        mimeType: resolveAttachmentMimeType(name, options?.mimeType),
         name,
+        mimeType,
+        size: input.byteLength,
+        read: async () => input,
+        stream: async () => bufferToStream(input),
       });
     },
   };

--- a/packages/spectrum-ts/src/providers/imessage/local.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local.ts
@@ -1,31 +1,67 @@
 import { unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type {
-  IMessageSDK,
-  Message as LocalIMessage,
+import {
+  type IMessageSDK,
+  type Message as LocalIMessage,
+  readAttachmentBytes,
 } from "@photon-ai/imessage-kit";
+import { asAttachment } from "../../content/attachment";
 import type { Content } from "../../content/types";
 import { type ManagedStream, stream } from "../../utils/stream";
 import type { IMessageMessage } from "./types";
+
+const DEFAULT_ATTACHMENT_NAME = "attachment";
 
 const toSpace = (message: LocalIMessage): IMessageMessage["space"] => ({
   id: message.chatId,
   type: message.chatKind === "group" ? "group" : "dm",
 });
 
-const toMessage = (message: LocalIMessage): IMessageMessage => ({
-  id: message.id,
-  content: { type: "text", text: message.text ?? "" },
-  sender: { id: message.participant ?? "" },
-  space: toSpace(message),
-  timestamp: message.createdAt,
-});
+const toMessages = async (
+  message: LocalIMessage
+): Promise<IMessageMessage[]> => {
+  const base = {
+    sender: { id: message.participant ?? "" },
+    space: toSpace(message),
+    timestamp: message.createdAt,
+  };
+
+  if (message.attachments.length > 0) {
+    return await Promise.all(
+      message.attachments.map(async (att) => ({
+        ...base,
+        id: `${message.id}:${att.id}`,
+        content: asAttachment({
+          data: await readAttachmentBytes(att),
+          mimeType: att.mimeType,
+          name: att.fileName ?? DEFAULT_ATTACHMENT_NAME,
+        }),
+      }))
+    );
+  }
+
+  return [
+    {
+      ...base,
+      id: message.id,
+      content: { type: "text", text: message.text ?? "" },
+    },
+  ];
+};
 
 export const messages = (client: IMessageSDK): ManagedStream<IMessageMessage> =>
-  stream((emit) => {
+  stream((emit, end) => {
     client.startWatching({
-      onMessage: (message) => emit(toMessage(message)),
+      onMessage: async (message) => {
+        try {
+          for (const m of await toMessages(message)) {
+            emit(m);
+          }
+        } catch (error) {
+          end(error);
+        }
+      },
     });
     return () => client.stopWatching();
   });

--- a/packages/spectrum-ts/src/providers/imessage/local.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local.ts
@@ -1,6 +1,8 @@
+import { createReadStream } from "node:fs";
 import { unlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { Readable } from "node:stream";
 import {
   type IMessageSDK,
   type Message as LocalIMessage,
@@ -18,9 +20,7 @@ const toSpace = (message: LocalIMessage): IMessageMessage["space"] => ({
   type: message.chatKind === "group" ? "group" : "dm",
 });
 
-const toMessages = async (
-  message: LocalIMessage
-): Promise<IMessageMessage[]> => {
+const toMessages = (message: LocalIMessage): IMessageMessage[] => {
   const base = {
     sender: { id: message.participant ?? "" },
     space: toSpace(message),
@@ -28,17 +28,25 @@ const toMessages = async (
   };
 
   if (message.attachments.length > 0) {
-    return await Promise.all(
-      message.attachments.map(async (att) => ({
+    return message.attachments.map((att) => {
+      const { localPath } = att;
+      return {
         ...base,
         id: `${message.id}:${att.id}`,
         content: asAttachment({
-          data: await readAttachmentBytes(att),
-          mimeType: att.mimeType,
           name: att.fileName ?? DEFAULT_ATTACHMENT_NAME,
+          mimeType: att.mimeType,
+          size: att.sizeBytes,
+          read: () => readAttachmentBytes(att),
+          stream: localPath
+            ? async () =>
+                Readable.toWeb(
+                  createReadStream(localPath)
+                ) as ReadableStream<Uint8Array>
+            : undefined,
         }),
-      }))
-    );
+      };
+    });
   }
 
   return [
@@ -53,9 +61,9 @@ const toMessages = async (
 export const messages = (client: IMessageSDK): ManagedStream<IMessageMessage> =>
   stream((emit, end) => {
     client.startWatching({
-      onMessage: async (message) => {
+      onMessage: (message) => {
         try {
-          for (const m of await toMessages(message)) {
+          for (const m of toMessages(message)) {
             emit(m);
           }
         } catch (error) {
@@ -77,7 +85,7 @@ export const send = async (
       break;
     case "attachment": {
       const tmp = join(tmpdir(), `spectrum-${Date.now()}-${content.name}`);
-      await writeFile(tmp, content.data);
+      await writeFile(tmp, await content.read());
       try {
         await client.send(spaceId, { attachments: [tmp] });
       } finally {

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -29,25 +29,26 @@ const baseMessage = (
   timestamp: event.timestamp,
 });
 
-const toMessages = async (
+const toMessages = (
   client: AdvancedIMessage,
   event: ReceivedEvent
-): Promise<IMessageMessage[]> => {
+): IMessageMessage[] => {
   const base = baseMessage(event);
   const messageGuidStr = event.message.guid as string;
 
   if (event.message.attachments.length > 0) {
-    return await Promise.all(
-      event.message.attachments.map(async (info) => ({
-        ...base,
-        id: `${messageGuidStr}:${info.guid as string}`,
-        content: asAttachment({
-          data: Buffer.from(await client.attachments.downloadBuffer(info.guid)),
-          mimeType: info.mimeType,
-          name: info.fileName,
-        }),
-      }))
-    );
+    return event.message.attachments.map((info) => ({
+      ...base,
+      id: `${messageGuidStr}:${info.guid as string}`,
+      content: asAttachment({
+        name: info.fileName,
+        mimeType: info.mimeType,
+        size: info.totalBytes,
+        read: async () =>
+          Buffer.from(await client.attachments.downloadBuffer(info.guid)),
+        stream: async () => client.attachments.download(info.guid).stream,
+      }),
+    }));
   }
 
   const text = event.message.text;
@@ -68,8 +69,7 @@ const clientStream = (
     (async () => {
       try {
         for await (const event of sub) {
-          const messages = await toMessages(client, event);
-          for (const message of messages) {
+          for (const message of toMessages(client, event)) {
             emit(message);
           }
         }
@@ -123,7 +123,7 @@ export const send = async (
       break;
     case "attachment": {
       const attachment = await remote.attachments.upload({
-        data: content.data,
+        data: await content.read(),
         fileName: content.name,
         mimeType: content.mimeType,
       });
@@ -157,7 +157,7 @@ export const replyToMessage = async (
       break;
     case "attachment": {
       const attachment = await remote.attachments.upload({
-        data: content.data,
+        data: await content.read(),
         fileName: content.name,
         mimeType: content.mimeType,
       });

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -5,6 +5,7 @@ import {
   messageGuid,
   Reaction,
 } from "@photon-ai/advanced-imessage";
+import { asAttachment } from "../../content/attachment";
 import { asCustom } from "../../content/custom";
 import { asText } from "../../content/text";
 import type { Content } from "../../content/types";
@@ -17,18 +18,46 @@ const TAPBACK_NAMES: ReadonlySet<string> = new Set(
   Object.values(Reaction).filter((r) => r !== "emoji" && r !== "sticker")
 );
 
-const toMessage = (event: ReceivedEvent): IMessageMessage => {
+const baseMessage = (
+  event: ReceivedEvent
+): Omit<IMessageMessage, "id" | "content"> => ({
+  sender: { id: event.message.sender?.address ?? "" },
+  space: {
+    id: event.chatGuid,
+    type: event.chatGuid.includes(";+;") ? "group" : "dm",
+  },
+  timestamp: event.timestamp,
+});
+
+const toMessages = async (
+  client: AdvancedIMessage,
+  event: ReceivedEvent
+): Promise<IMessageMessage[]> => {
+  const base = baseMessage(event);
+  const messageGuidStr = event.message.guid as string;
+
+  if (event.message.attachments.length > 0) {
+    return await Promise.all(
+      event.message.attachments.map(async (info) => ({
+        ...base,
+        id: `${messageGuidStr}:${info.guid as string}`,
+        content: asAttachment({
+          data: Buffer.from(await client.attachments.downloadBuffer(info.guid)),
+          mimeType: info.mimeType,
+          name: info.fileName,
+        }),
+      }))
+    );
+  }
+
   const text = event.message.text;
-  return {
-    id: event.message.guid as string,
-    content: text ? asText(text) : asCustom(event.message),
-    sender: { id: event.message.sender?.address ?? "" },
-    space: {
-      id: event.chatGuid,
-      type: event.chatGuid.includes(";+;") ? "group" : "dm",
+  return [
+    {
+      ...base,
+      id: messageGuidStr,
+      content: text ? asText(text) : asCustom(event.message),
     },
-    timestamp: event.timestamp,
-  };
+  ];
 };
 
 const clientStream = (
@@ -39,7 +68,10 @@ const clientStream = (
     (async () => {
       try {
         for await (const event of sub) {
-          emit(toMessage(event));
+          const messages = await toMessages(client, event);
+          for (const message of messages) {
+            emit(message);
+          }
         }
         end();
       } catch (e) {

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -9,24 +9,21 @@ import type { Content } from "../../content/types";
 import { type ManagedStream, stream } from "../../utils/stream";
 import type { WhatsAppMessage } from "./types";
 
-const toMessage = async (
+const toMessage = (
   client: WhatsAppClient,
   msg: InboundMessage
-): Promise<WhatsAppMessage> => {
-  const content = await mapContent(client, msg.content);
-  return {
-    id: msg.id,
-    content,
-    sender: { id: msg.from },
-    space: { id: msg.from },
-    timestamp: msg.timestamp,
-  };
-};
+): WhatsAppMessage => ({
+  id: msg.id,
+  content: mapContent(client, msg.content),
+  sender: { id: msg.from },
+  space: { id: msg.from },
+  timestamp: msg.timestamp,
+});
 
-const mapContent = async (
+const mapContent = (
   client: WhatsAppClient,
   content: InboundMessage["content"]
-): Promise<Content> => {
+): Content => {
   switch (content.type) {
     case "text":
       return asText(content.body);
@@ -34,7 +31,7 @@ const mapContent = async (
     case "video":
     case "audio":
     case "document":
-      return downloadMedia(client, content.media);
+      return lazyMedia(client, content.media);
     case "sticker":
       return asCustom({ whatsapp_type: "sticker", ...content.sticker });
     case "location":
@@ -59,30 +56,35 @@ const mapContent = async (
   }
 };
 
-const downloadMedia = async (
+const fetchMedia = async (
+  client: WhatsAppClient,
+  mediaId: string
+): Promise<Response> => {
+  const { url } = await client.media.getUrl(mediaId);
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Media download failed: ${response.status}`);
+  }
+  return response;
+};
+
+const lazyMedia = (
   client: WhatsAppClient,
   media: { id: string; mimeType: string; filename?: string }
-): Promise<Content> => {
-  try {
-    const { url } = await client.media.getUrl(media.id);
-    const response = await fetch(url);
-    if (!response.ok) {
-      throw new Error(`Media download failed: ${response.status}`);
-    }
-    const data = Buffer.from(await response.arrayBuffer());
-    return asAttachment({
-      data,
-      mimeType: media.mimeType,
-      name: media.filename ?? `media-${media.id}`,
-    });
-  } catch {
-    return asCustom({
-      whatsapp_type: "media_error",
-      mediaId: media.id,
-      mimeType: media.mimeType,
-    });
-  }
-};
+): Content =>
+  asAttachment({
+    name: media.filename ?? `media-${media.id}`,
+    mimeType: media.mimeType,
+    read: async () =>
+      Buffer.from(await (await fetchMedia(client, media.id)).arrayBuffer()),
+    stream: async () => {
+      const response = await fetchMedia(client, media.id);
+      if (!response.body) {
+        throw new Error("Media response missing body");
+      }
+      return response.body;
+    },
+  });
 
 const mimeToMediaType = (
   mimeType: string
@@ -112,8 +114,7 @@ export const messages = (
     (async () => {
       try {
         for await (const event of eventStream) {
-          const msg = await toMessage(client, event.message);
-          emit(msg);
+          emit(toMessage(client, event.message));
         }
         end();
       } catch (e) {
@@ -135,7 +136,7 @@ export const send = async (
       break;
     case "attachment": {
       const { mediaId } = await client.media.upload({
-        file: content.data,
+        file: await content.read(),
         mimeType: content.mimeType,
         filename: content.name,
       });
@@ -183,7 +184,7 @@ export const replyToMessage = async (
       break;
     case "attachment": {
       const { mediaId } = await client.media.upload({
-        file: content.data,
+        file: await content.read(),
         mimeType: content.mimeType,
         filename: content.name,
       });


### PR DESCRIPTION
## Summary

- Fix: incoming images were silently classified as `text` because providers never inspected `message.attachments`. Both iMessage providers (remote + local) and WhatsApp Business now emit `attachment`-typed content when the underlying message carries attachments.
- Refactor: attachment content is now **lazy**. Receiving a message no longer downloads bytes — consumers call `await content.read()` (memoized) or `await content.stream()` (fresh per call) when they actually want the data. Metadata (`name`, `mimeType`, `size?`) is available synchronously.
- A slow image download no longer stalls subsequent text messages in the stream.

## Breaking change

`attachment` content shape changed (pre-1.0, so this is fair game):

```ts
// before
{ type: "attachment", data: Buffer, mimeType, name }

// after
{ type: "attachment", name, mimeType, size?, read(): Promise<Buffer>, stream(): Promise<ReadableStream<Uint8Array>> }
```

Consumers that read `content.data` must switch to `await content.read()`. Outbound uses of the `attachment(path | buffer, options)` builder are unchanged at the call site.

## Usage

```ts
for await (const [space, message] of app.messages) {
  if (message.content.type === "attachment") {
    const { name, mimeType, size } = message.content;
    const bytes = await message.content.read();    // memoized
    // or: const stream = await message.content.stream(); // fresh per call
  }
}
```

## Changes

| File | What changed |
|---|---|
| `packages/spectrum-ts/src/content/attachment.ts` | New `attachmentSchema` with `z.function({ input, output })` for `read` / `stream` (zod v4 runtime contract via `.implement`). `asAttachment` memoizes `read()` and defaults `stream()` to a single-chunk ReadableStream. `attachment()` builder reads paths via `createReadStream` for native streaming. |
| `packages/spectrum-ts/src/providers/imessage/remote.ts` | `toMessages` now inspects `event.message.attachments` and emits one spectrum message per attachment. `read` uses `client.attachments.downloadBuffer`, `stream` uses `client.attachments.download(guid).stream`. Outbound `send`/`replyToMessage` switched to `await content.read()`. |
| `packages/spectrum-ts/src/providers/imessage/local.ts` | Same split for inbound attachments, using `readAttachmentBytes` + `Readable.toWeb(createReadStream(localPath))`. Outbound temp-file write switched to `await content.read()`. |
| `packages/spectrum-ts/src/providers/whatsapp-business/messages.ts` | Removed the eager `downloadMedia` (and its `asCustom` media-error fallback). New `lazyMedia` wraps `client.media.getUrl` + `fetch` behind `read()` / `stream()`. Receive path is now fully sync. |
| `examples/basic/index.ts` | Demonstrates `await message.content.read()` and logs byte count. |
| `package.json` / `bun.lock` | Bumped `@photon-ai/advanced-imessage` from `0.4.2` → `0.4.3`. |
| `README.md` | Documents the new receive-side attachment shape. |

## Behavioral notes

- Emitting N attachments produces N spectrum messages with ids `${messageGuid}:${attachmentGuid}`.
- For messages with **both** caption + attachment, the caption is dropped (per user direction: "prefer attachment, drop the text").
- WhatsApp media fetch errors now surface at `read()`/`stream()` call time rather than silently turning into a `custom` content; metadata is still delivered regardless.

## Test plan

- [x] `bun x tsc --noEmit -p packages/spectrum-ts` passes
- [x] `bun x ultracite check` passes on all touched files
- [ ] Manual: iMessage remote — send image, confirm `[attachment] <name> (<N> bytes)` prints
- [ ] Manual: iMessage remote — send a huge image followed by text, confirm text echoes before image finishes downloading
- [ ] Manual: iMessage remote outbound — send via `attachment("/path/to/img.jpeg")`
- [ ] Manual: iMessage local — flip `local: true` and repeat
- [ ] Regression: text-only messages still hit `case "text"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Attachments now load lazily—metadata (name, mimeType, size) is available immediately while bytes defer until requested.
  * Added content.read() (memoized) and content.stream() (fresh stream) interfaces for attachments.
  * Incoming message events that contain multiple attachments now emit one message per attachment for clearer handling.
* **Documentation**
  * README updated with an attachment handling guide and TypeScript examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->