### PR TITLE
feat: contact content type with vCard support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ out
 dist
 *.tgz
 
+# local scratch work (ad-hoc scripts, debugging, real-account experiments)
+tmp
+
 # code coverage
 coverage
 *.lcov

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Messages carry their own context. You can reply to a message directly, react to 
 
 ## Content
 
-Spectrum provides three content builders for constructing outgoing messages. Plain strings are also accepted everywhere a content input is expected, as a shortcut for `text()`.
+Spectrum provides four content builders for constructing outgoing messages. Plain strings are also accepted everywhere a content input is expected, as a shortcut for `text()`.
 
 ### Text
 
@@ -214,9 +214,36 @@ if (message.content.type === "attachment") {
 }
 ```
 
+### Contact
+
+Send a contact card. Provide structured details, parse a vCard string, or reference an existing user.
+
+```typescript
+import { contact } from "spectrum-ts";
+
+// Structured details
+await space.send(contact({
+  name: { first: "Ada", last: "Lovelace", formatted: "Ada Lovelace" },
+  phones: [{ value: "+15551234567", type: "mobile" }],
+  emails: [{ value: "ada@example.com", type: "work" }],
+  org: { name: "Analytical Engines", title: "Mathematician" },
+}));
+
+// From a vCard string
+await space.send(contact(vcardString));
+
+// From a user — useful for sharing a contact you've already resolved
+const user = await imessage(app).user("+15551234567");
+await space.send(contact(user, { name: { formatted: "Ada Lovelace" } }));
+```
+
+Inbound contacts arrive as `message.content.type === "contact"` with parsed fields. iMessage delivers contacts as `.vcf` attachments, which Spectrum auto-detects and parses; WhatsApp Business contact cards are mapped natively.
+
+The `fromVCard` and `toVCard` utilities are exported for direct vCard interop.
+
 ### Custom
 
-Send platform-specific structured data as JSON. Use this when a platform supports rich content types that don't map to text or attachments.
+Send platform-specific structured data as JSON. Use this when a platform supports rich content types that don't map to text, attachments, or contacts.
 
 ```typescript
 import { custom } from "spectrum-ts";

--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
     },
     "packages/spectrum-ts": {
       "name": "spectrum-ts",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.4.3",
         "@photon-ai/imessage-kit": "^3.0.0-rc.2",
@@ -30,11 +30,13 @@
         "better-grpc": "^0.3.2",
         "mime-types": "^3.0.1",
         "type-fest": "^5.4.1",
+        "vcf": "^2.1.2",
         "zod": "^4.2.1",
       },
       "devDependencies": {
         "@types/bun": "latest",
         "@types/mime-types": "^3.0.1",
+        "@types/vcf": "^2.0.7",
         "clean-publish": "^6.0.5",
         "hotscript": "^1.0.13",
         "tsup": "^8.4.0",
@@ -239,6 +241,8 @@
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@types/vcf": ["@types/vcf@2.0.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-PFZg6Ix/hMvURL4JpExCU3jTVEzGrfW+3RYSca+hlGsmW+PQGScc/vH6czR7tAxF01TZTLK8i3tPKE1EYvBOkg=="],
+
     "abort-controller-x": ["abort-controller-x@0.5.0", "", {}, "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
@@ -272,6 +276,8 @@
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
@@ -326,6 +332,8 @@
     "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
+
+    "foldline": ["foldline@1.1.0", "", {}, "sha512-9SheyADS50hjvFYjFJ3OB/GlDz2mD1T2CHd7auIk4Uto5YYWPBcw8iYo3F+gENJ+/SOeH9tT0loHZSqlUlumTA=="],
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
@@ -506,6 +514,8 @@
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "vcf": ["vcf@2.1.2", "", { "dependencies": { "camelcase": "^5.0.0", "foldline": "^1.1.0" } }, "sha512-oLYtZ+GJPjpKS950fw70+HavdP7ZO2Q+xMCMeCyiUKuXkJJJG1/wUjCKTagPryS1gApYjZOWW/khmdLsch8jxg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -1,46 +1,12 @@
-import { Spectrum } from "spectrum-ts";
-import { imessage } from "spectrum-ts/providers/imessage";
-
-// import { terminal } from "spectrum-ts/providers/terminal";
+import { Spectrum, text } from "spectrum-ts";
+import { terminal } from "spectrum-ts/providers/terminal";
 
 const app = await Spectrum({
-  projectId: "",
-  projectSecret: "",
-  providers: [
-    imessage.config(),
-    // terminal.config({}),
-  ],
+  providers: [terminal.config()],
 });
 
 for await (const [space, message] of app.messages) {
-  switch (message.content.type) {
-    case "text": {
-      const incoming = message.content.text;
-      console.log(incoming);
-      await space.responding(async () => {
-        await space.send(`echo: ${incoming}`);
-      });
-      break;
-    }
-    case "attachment": {
-      const bytes = await message.content.read();
-      console.log(
-        `[attachment] ${message.content.name} (${bytes.length} bytes)`
-      );
-      break;
-    }
-    case "custom":
-      console.log("[custom]", message.content.raw);
-      break;
-    default:
-      break;
+  if (message.content.type === "text") {
+    await space.send(text(`echo: ${message.content.text}`));
   }
 }
-
-// const user1 = await imessage(app).user("+13322593374");
-// // const user2 = await imessage(app).user("+15103658086");
-// const newSpace = await imessage(app).space(user1);
-// await newSpace.send(
-//   text("hello"),
-//   // attachment("/Users/ryanzhu/Downloads/Image.jpeg")
-// );

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -38,17 +38,19 @@
   },
   "dependencies": {
     "@photon-ai/advanced-imessage": "^0.4.3",
-    "@photon-ai/whatsapp-business": "^0.1.1",
     "@photon-ai/imessage-kit": "^3.0.0-rc.2",
+    "@photon-ai/whatsapp-business": "^0.1.1",
     "@repeaterjs/repeater": "^3.0.6",
     "better-grpc": "^0.3.2",
     "mime-types": "^3.0.1",
     "type-fest": "^5.4.1",
+    "vcf": "^2.1.2",
     "zod": "^4.2.1"
   },
   "devDependencies": {
     "@types/bun": "latest",
     "@types/mime-types": "^3.0.1",
+    "@types/vcf": "^2.0.7",
     "clean-publish": "^6.0.5",
     "hotscript": "^1.0.13",
     "tsup": "^8.4.0"

--- a/packages/spectrum-ts/src/content/contact.ts
+++ b/packages/spectrum-ts/src/content/contact.ts
@@ -1,0 +1,119 @@
+import vCard from "vcf";
+import z from "zod";
+import type { User } from "../types/user";
+import { fromVCard } from "../utils/vcard";
+import type { ContentBuilder } from "./types";
+
+const readSchema = z.function({
+  input: [],
+  output: z.promise(z.instanceof(Buffer)),
+});
+
+const userRefSchema = z.object({
+  __platform: z.string(),
+  id: z.string(),
+});
+
+const nameSchema = z.object({
+  formatted: z.string().optional(),
+  first: z.string().optional(),
+  last: z.string().optional(),
+  middle: z.string().optional(),
+  prefix: z.string().optional(),
+  suffix: z.string().optional(),
+});
+
+const phoneTypeSchema = z.enum(["mobile", "home", "work", "other"]);
+const emailTypeSchema = z.enum(["home", "work", "other"]);
+const addressTypeSchema = z.enum(["home", "work", "other"]);
+
+const phoneSchema = z.object({
+  value: z.string(),
+  type: phoneTypeSchema.optional(),
+});
+
+const emailSchema = z.object({
+  value: z.string(),
+  type: emailTypeSchema.optional(),
+});
+
+const addressSchema = z.object({
+  street: z.string().optional(),
+  city: z.string().optional(),
+  region: z.string().optional(),
+  postalCode: z.string().optional(),
+  country: z.string().optional(),
+  type: addressTypeSchema.optional(),
+});
+
+const orgSchema = z.object({
+  name: z.string().optional(),
+  title: z.string().optional(),
+  department: z.string().optional(),
+});
+
+const photoSchema = z.object({
+  mimeType: z.string(),
+  read: readSchema,
+});
+
+export const contactSchema = z.object({
+  type: z.literal("contact"),
+  user: userRefSchema.optional(),
+  name: nameSchema.optional(),
+  phones: z.array(phoneSchema).optional(),
+  emails: z.array(emailSchema).optional(),
+  addresses: z.array(addressSchema).optional(),
+  org: orgSchema.optional(),
+  urls: z.array(z.string()).optional(),
+  birthday: z.string().optional(),
+  note: z.string().optional(),
+  photo: photoSchema.optional(),
+  raw: z.unknown().optional(),
+});
+
+export type Contact = z.infer<typeof contactSchema>;
+export type ContactName = z.infer<typeof nameSchema>;
+export type ContactPhone = z.infer<typeof phoneSchema>;
+export type ContactEmail = z.infer<typeof emailSchema>;
+export type ContactAddress = z.infer<typeof addressSchema>;
+export type ContactOrg = z.infer<typeof orgSchema>;
+
+export type ContactInput = Omit<Contact, "type">;
+export type ContactDetails = Omit<ContactInput, "user">;
+
+export const asContact = (input: ContactInput): Contact =>
+  contactSchema.parse({ type: "contact", ...input });
+
+const isUser = (value: unknown): value is User =>
+  typeof value === "object" &&
+  value !== null &&
+  "__platform" in value &&
+  "id" in value &&
+  typeof (value as User).__platform === "string" &&
+  typeof (value as User).id === "string";
+
+export function contact(user: User, details?: ContactDetails): ContentBuilder;
+export function contact(input: string | ContactInput | vCard): ContentBuilder;
+export function contact(
+  input: User | ContactInput | string | vCard,
+  details?: ContactDetails
+): ContentBuilder {
+  return {
+    build: async () => {
+      if (typeof input === "string") {
+        return asContact(fromVCard(input));
+      }
+      if (input instanceof vCard) {
+        return asContact(fromVCard(input.toString()));
+      }
+      if (isUser(input)) {
+        return asContact({
+          user: { __platform: input.__platform, id: input.id },
+          ...details,
+        });
+      }
+      return asContact(input);
+    },
+  };
+}

--- a/packages/spectrum-ts/src/content/types.ts
+++ b/packages/spectrum-ts/src/content/types.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import { attachmentSchema } from "./attachment";
+import { contactSchema } from "./contact";
 import { customSchema } from "./custom";
 import { textSchema } from "./text";
 
@@ -7,6 +8,7 @@ export const contentSchema = z.discriminatedUnion("type", [
   textSchema,
   customSchema,
   attachmentSchema,
+  contactSchema,
 ]);
 
 export type Content = z.infer<typeof contentSchema>;

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -1,4 +1,15 @@
 export { attachment } from "./content/attachment";
+export {
+  type Contact,
+  type ContactAddress,
+  type ContactDetails,
+  type ContactEmail,
+  type ContactInput,
+  type ContactName,
+  type ContactOrg,
+  type ContactPhone,
+  contact,
+} from "./content/contact";
 export { custom } from "./content/custom";
 export { resolveContents } from "./content/resolve";
 export { text } from "./content/text";
@@ -33,3 +44,4 @@ export type {
 } from "./utils/cloud";
 export { cloud, SpectrumCloudError } from "./utils/cloud";
 export { type ManagedStream, mergeStreams, stream } from "./utils/stream";
+export { fromVCard, toVCard } from "./utils/vcard";

--- a/packages/spectrum-ts/src/providers/imessage/local.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local.ts
@@ -9,18 +9,67 @@ import {
   readAttachmentBytes,
 } from "@photon-ai/imessage-kit";
 import { asAttachment } from "../../content/attachment";
+import { asContact } from "../../content/contact";
 import type { Content } from "../../content/types";
 import { type ManagedStream, stream } from "../../utils/stream";
+import { fromVCard, toVCard } from "../../utils/vcard";
 import type { IMessageMessage } from "./types";
 
 const DEFAULT_ATTACHMENT_NAME = "attachment";
+
+const VCARD_MIME_TYPES: ReadonlySet<string> = new Set([
+  "text/vcard",
+  "text/x-vcard",
+  "text/directory",
+  "application/vcard",
+  "application/x-vcard",
+]);
+
+const isVCardAttachment = (
+  mimeType: string | null | undefined,
+  fileName: string | null | undefined
+): boolean => {
+  if (mimeType && VCARD_MIME_TYPES.has(mimeType.toLowerCase())) {
+    return true;
+  }
+  return Boolean(fileName?.toLowerCase().endsWith(".vcf"));
+};
 
 const toSpace = (message: LocalIMessage): IMessageMessage["space"] => ({
   id: message.chatId,
   type: message.chatKind === "group" ? "group" : "dm",
 });
 
-const toMessages = (message: LocalIMessage): IMessageMessage[] => {
+type LocalAttachment = LocalIMessage["attachments"][number];
+
+const toAttachmentContent = (att: LocalAttachment): Content => {
+  const { localPath } = att;
+  return asAttachment({
+    name: att.fileName ?? DEFAULT_ATTACHMENT_NAME,
+    mimeType: att.mimeType,
+    size: att.sizeBytes,
+    read: () => readAttachmentBytes(att),
+    stream: localPath
+      ? async () =>
+          Readable.toWeb(
+            createReadStream(localPath)
+          ) as ReadableStream<Uint8Array>
+      : undefined,
+  });
+};
+
+const toVCardContent = async (att: LocalAttachment): Promise<Content> => {
+  try {
+    const buf = await readAttachmentBytes(att);
+    return asContact(fromVCard(buf.toString("utf8")));
+  } catch {
+    return toAttachmentContent(att);
+  }
+};
+
+const toMessages = async (
+  message: LocalIMessage
+): Promise<IMessageMessage[]> => {
   const base = {
     sender: { id: message.participant ?? "" },
     space: toSpace(message),
@@ -28,25 +77,15 @@ const toMessages = (message: LocalIMessage): IMessageMessage[] => {
   };
 
   if (message.attachments.length > 0) {
-    return message.attachments.map((att) => {
-      const { localPath } = att;
-      return {
+    return Promise.all(
+      message.attachments.map(async (att) => ({
         ...base,
         id: `${message.id}:${att.id}`,
-        content: asAttachment({
-          name: att.fileName ?? DEFAULT_ATTACHMENT_NAME,
-          mimeType: att.mimeType,
-          size: att.sizeBytes,
-          read: () => readAttachmentBytes(att),
-          stream: localPath
-            ? async () =>
-                Readable.toWeb(
-                  createReadStream(localPath)
-                ) as ReadableStream<Uint8Array>
-            : undefined,
-        }),
-      };
-    });
+        content: isVCardAttachment(att.mimeType, att.fileName)
+          ? await toVCardContent(att)
+          : toAttachmentContent(att),
+      }))
+    );
   }
 
   return [
@@ -62,17 +101,41 @@ export const messages = (client: IMessageSDK): ManagedStream<IMessageMessage> =>
   stream((emit, end) => {
     client.startWatching({
       onMessage: (message) => {
-        try {
-          for (const m of toMessages(message)) {
-            emit(m);
+        (async () => {
+          try {
+            for (const m of await toMessages(message)) {
+              emit(m);
+            }
+          } catch (error) {
+            end(error);
           }
-        } catch (error) {
-          end(error);
-        }
+        })();
       },
     });
     return () => client.stopWatching();
   });
+
+const vcardFileName = (
+  content: Extract<Content, { type: "contact" }>
+): string => {
+  const base = content.name?.formatted ?? content.user?.id ?? "contact";
+  return `${base.replace(/[^a-zA-Z0-9_\-.]/g, "_")}.vcf`;
+};
+
+const sendTempFile = async (
+  client: IMessageSDK,
+  spaceId: string,
+  name: string,
+  data: Buffer
+): Promise<void> => {
+  const tmp = join(tmpdir(), `spectrum-${Date.now()}-${name}`);
+  await writeFile(tmp, data);
+  try {
+    await client.send(spaceId, { attachments: [tmp] });
+  } finally {
+    await unlink(tmp).catch(() => {});
+  }
+};
 
 export const send = async (
   client: IMessageSDK,
@@ -83,14 +146,17 @@ export const send = async (
     case "text":
       await client.send(spaceId, content.text);
       break;
-    case "attachment": {
-      const tmp = join(tmpdir(), `spectrum-${Date.now()}-${content.name}`);
-      await writeFile(tmp, await content.read());
-      try {
-        await client.send(spaceId, { attachments: [tmp] });
-      } finally {
-        await unlink(tmp).catch(() => {});
-      }
+    case "attachment":
+      await sendTempFile(client, spaceId, content.name, await content.read());
+      break;
+    case "contact": {
+      const vcf = await toVCard(content);
+      await sendTempFile(
+        client,
+        spaceId,
+        vcardFileName(content),
+        Buffer.from(vcf, "utf8")
+      );
       break;
     }
     default:

--- a/packages/spectrum-ts/src/providers/imessage/local.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local.ts
@@ -1,7 +1,7 @@
 import { createReadStream } from "node:fs";
-import { unlink, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { Readable } from "node:stream";
 import {
   type IMessageSDK,
@@ -25,11 +25,14 @@ const VCARD_MIME_TYPES: ReadonlySet<string> = new Set([
   "application/x-vcard",
 ]);
 
+const normalizeMimeType = (mimeType: string): string =>
+  (mimeType.split(";")[0] ?? "").trim().toLowerCase();
+
 const isVCardAttachment = (
   mimeType: string | null | undefined,
   fileName: string | null | undefined
 ): boolean => {
-  if (mimeType && VCARD_MIME_TYPES.has(mimeType.toLowerCase())) {
+  if (mimeType && VCARD_MIME_TYPES.has(normalizeMimeType(mimeType))) {
     return true;
   }
   return Boolean(fileName?.toLowerCase().endsWith(".vcf"));
@@ -99,17 +102,17 @@ const toMessages = async (
 
 export const messages = (client: IMessageSDK): ManagedStream<IMessageMessage> =>
   stream((emit, end) => {
+    let lastPromise: Promise<void> = Promise.resolve();
     client.startWatching({
       onMessage: (message) => {
-        (async () => {
-          try {
-            for (const m of await toMessages(message)) {
+        lastPromise = lastPromise
+          .then(() => toMessages(message))
+          .then((ms) => {
+            for (const m of ms) {
               emit(m);
             }
-          } catch (error) {
-            end(error);
-          }
-        })();
+          })
+          .catch((error) => end(error));
       },
     });
     return () => client.stopWatching();
@@ -128,12 +131,14 @@ const sendTempFile = async (
   name: string,
   data: Buffer
 ): Promise<void> => {
-  const tmp = join(tmpdir(), `spectrum-${Date.now()}-${name}`);
+  const safeName = basename(name) || DEFAULT_ATTACHMENT_NAME;
+  const dir = await mkdtemp(join(tmpdir(), "spectrum-"));
+  const tmp = join(dir, safeName);
   await writeFile(tmp, data);
   try {
     await client.send(spaceId, { attachments: [tmp] });
   } finally {
-    await unlink(tmp).catch(() => {});
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
   }
 };
 

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -6,11 +6,31 @@ import {
   Reaction,
 } from "@photon-ai/advanced-imessage";
 import { asAttachment } from "../../content/attachment";
+import { asContact } from "../../content/contact";
 import { asCustom } from "../../content/custom";
 import { asText } from "../../content/text";
 import type { Content } from "../../content/types";
 import { type ManagedStream, mergeStreams, stream } from "../../utils/stream";
+import { fromVCard, toVCard } from "../../utils/vcard";
 import type { IMessageMessage } from "./types";
+
+const VCARD_MIME_TYPES: ReadonlySet<string> = new Set([
+  "text/vcard",
+  "text/x-vcard",
+  "text/directory",
+  "application/vcard",
+  "application/x-vcard",
+]);
+
+const isVCardAttachment = (
+  mimeType: string | undefined,
+  fileName: string | undefined
+): boolean => {
+  if (mimeType && VCARD_MIME_TYPES.has(mimeType.toLowerCase())) {
+    return true;
+  }
+  return Boolean(fileName?.toLowerCase().endsWith(".vcf"));
+};
 
 type ReceivedEvent = Extract<MessageEvent, { type: "message.received" }>;
 
@@ -29,26 +49,48 @@ const baseMessage = (
   timestamp: event.timestamp,
 });
 
-const toMessages = (
+const toAttachmentContent = (
+  client: AdvancedIMessage,
+  info: ReceivedEvent["message"]["attachments"][number]
+): Content =>
+  asAttachment({
+    name: info.fileName,
+    mimeType: info.mimeType,
+    size: info.totalBytes,
+    read: async () =>
+      Buffer.from(await client.attachments.downloadBuffer(info.guid)),
+    stream: async () => client.attachments.download(info.guid).stream,
+  });
+
+const toVCardContent = async (
+  client: AdvancedIMessage,
+  info: ReceivedEvent["message"]["attachments"][number]
+): Promise<Content> => {
+  try {
+    const buf = Buffer.from(await client.attachments.downloadBuffer(info.guid));
+    return asContact(fromVCard(buf.toString("utf8")));
+  } catch {
+    return toAttachmentContent(client, info);
+  }
+};
+
+const toMessages = async (
   client: AdvancedIMessage,
   event: ReceivedEvent
-): IMessageMessage[] => {
+): Promise<IMessageMessage[]> => {
   const base = baseMessage(event);
   const messageGuidStr = event.message.guid as string;
 
   if (event.message.attachments.length > 0) {
-    return event.message.attachments.map((info) => ({
-      ...base,
-      id: `${messageGuidStr}:${info.guid as string}`,
-      content: asAttachment({
-        name: info.fileName,
-        mimeType: info.mimeType,
-        size: info.totalBytes,
-        read: async () =>
-          Buffer.from(await client.attachments.downloadBuffer(info.guid)),
-        stream: async () => client.attachments.download(info.guid).stream,
-      }),
-    }));
+    return Promise.all(
+      event.message.attachments.map(async (info) => ({
+        ...base,
+        id: `${messageGuidStr}:${info.guid as string}`,
+        content: isVCardAttachment(info.mimeType, info.fileName)
+          ? await toVCardContent(client, info)
+          : toAttachmentContent(client, info),
+      }))
+    );
   }
 
   const text = event.message.text;
@@ -69,7 +111,7 @@ const clientStream = (
     (async () => {
       try {
         for await (const event of sub) {
-          for (const message of toMessages(client, event)) {
+          for (const message of await toMessages(client, event)) {
             emit(message);
           }
         }
@@ -80,6 +122,24 @@ const clientStream = (
     })();
     return () => sub.close();
   });
+};
+
+const sendVCardAttachment = (
+  remote: AdvancedIMessage,
+  name: string,
+  vcf: string
+) =>
+  remote.attachments.upload({
+    data: Buffer.from(vcf, "utf8"),
+    fileName: name,
+    mimeType: "text/vcard",
+  });
+
+const vcardFileName = (
+  contact: Extract<Content, { type: "contact" }>
+): string => {
+  const base = contact.name?.formatted ?? contact.user?.id ?? "contact";
+  return `${base.replace(/[^a-zA-Z0-9_\-.]/g, "_")}.vcf`;
 };
 
 export const messages = (
@@ -132,6 +192,18 @@ export const send = async (
       });
       break;
     }
+    case "contact": {
+      const vcf = await toVCard(content);
+      const upload = await sendVCardAttachment(
+        remote,
+        vcardFileName(content),
+        vcf
+      );
+      await remote.messages.send(chatGuid(spaceId), "", {
+        attachment: upload.guid,
+      });
+      break;
+    }
     default:
       throw new Error(`Unsupported iMessage content type: ${content.type}`);
   }
@@ -163,6 +235,19 @@ export const replyToMessage = async (
       });
       await remote.messages.send(chat, "", {
         attachment: attachment.guid,
+        replyTo,
+      });
+      break;
+    }
+    case "contact": {
+      const vcf = await toVCard(content);
+      const upload = await sendVCardAttachment(
+        remote,
+        vcardFileName(content),
+        vcf
+      );
+      await remote.messages.send(chat, "", {
+        attachment: upload.guid,
         replyTo,
       });
       break;

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -142,6 +142,15 @@ const vcardFileName = (
   return `${base.replace(/[^a-zA-Z0-9_\-.]/g, "_")}.vcf`;
 };
 
+const sendContactAttachment = async (
+  remote: AdvancedIMessage,
+  content: Extract<Content, { type: "contact" }>
+) => {
+  const vcf = await toVCard(content);
+  const upload = await sendVCardAttachment(remote, vcardFileName(content), vcf);
+  return upload.guid;
+};
+
 export const messages = (
   clients: AdvancedIMessage[]
 ): ManagedStream<IMessageMessage> => mergeStreams(clients.map(clientStream));
@@ -193,15 +202,8 @@ export const send = async (
       break;
     }
     case "contact": {
-      const vcf = await toVCard(content);
-      const upload = await sendVCardAttachment(
-        remote,
-        vcardFileName(content),
-        vcf
-      );
-      await remote.messages.send(chatGuid(spaceId), "", {
-        attachment: upload.guid,
-      });
+      const attachment = await sendContactAttachment(remote, content);
+      await remote.messages.send(chatGuid(spaceId), "", { attachment });
       break;
     }
     default:
@@ -240,16 +242,8 @@ export const replyToMessage = async (
       break;
     }
     case "contact": {
-      const vcf = await toVCard(content);
-      const upload = await sendVCardAttachment(
-        remote,
-        vcardFileName(content),
-        vcf
-      );
-      await remote.messages.send(chat, "", {
-        attachment: upload.guid,
-        replyTo,
-      });
+      const attachment = await sendContactAttachment(remote, content);
+      await remote.messages.send(chat, "", { attachment, replyTo });
       break;
     }
     default:

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -296,9 +296,30 @@ const spectrumNameToWa = (name: Contact["name"]): WaContactName => ({
   suffix: name?.suffix,
 });
 
+const isWhatsAppContactCard = (value: unknown): value is ContactCardInput => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const raw = value as Record<string, unknown>;
+  const name = raw.name as Record<string, unknown> | undefined;
+  if (
+    !name ||
+    typeof name !== "object" ||
+    typeof name.formattedName !== "string"
+  ) {
+    return false;
+  }
+  return (
+    Array.isArray(raw.phones) &&
+    Array.isArray(raw.emails) &&
+    Array.isArray(raw.addresses) &&
+    Array.isArray(raw.urls)
+  );
+};
+
 const contactToWa = (contact: Contact): ContactCardInput => {
-  if (contact.raw && typeof contact.raw === "object" && "name" in contact.raw) {
-    return contact.raw as ContactCardInput;
+  if (isWhatsAppContactCard(contact.raw)) {
+    return contact.raw;
   }
   const card: ContactCardInput = {
     name: spectrumNameToWa(contact.name),

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -1,24 +1,194 @@
 import type {
+  ContactCard,
+  ContactCardInput,
   InboundMessage,
   WhatsAppClient,
 } from "@photon-ai/whatsapp-business";
 import { asAttachment } from "../../content/attachment";
+import {
+  asContact,
+  type Contact,
+  type ContactAddress as SpectrumContactAddress,
+  type ContactEmail as SpectrumContactEmail,
+  type ContactName as SpectrumContactName,
+  type ContactOrg as SpectrumContactOrg,
+  type ContactPhone as SpectrumContactPhone,
+} from "../../content/contact";
 import { asCustom } from "../../content/custom";
 import { asText } from "../../content/text";
 import type { Content } from "../../content/types";
 import { type ManagedStream, stream } from "../../utils/stream";
 import type { WhatsAppMessage } from "./types";
 
-const toMessage = (
+type WaContactName = ContactCard["name"];
+type WaContactPhone = ContactCard["phones"][number];
+type WaContactEmail = ContactCard["emails"][number];
+type WaContactAddress = ContactCard["addresses"][number];
+type WaContactOrg = NonNullable<ContactCard["org"]>;
+type WaContactUrl = ContactCard["urls"][number];
+
+const mapWaPhoneType = (
+  type: string | undefined
+): SpectrumContactPhone["type"] => {
+  if (!type) {
+    return undefined;
+  }
+  const upper = type.toUpperCase();
+  if (upper === "CELL" || upper === "MOBILE" || upper === "IPHONE") {
+    return "mobile";
+  }
+  if (upper === "HOME") {
+    return "home";
+  }
+  if (upper === "WORK" || upper === "BUSINESS") {
+    return "work";
+  }
+  return "other";
+};
+
+const mapWaSimpleType = (
+  type: string | undefined
+): "home" | "work" | "other" | undefined => {
+  if (!type) {
+    return undefined;
+  }
+  const upper = type.toUpperCase();
+  if (upper === "HOME") {
+    return "home";
+  }
+  if (upper === "WORK" || upper === "BUSINESS") {
+    return "work";
+  }
+  return "other";
+};
+
+const waNameToSpectrum = (name: WaContactName): SpectrumContactName => {
+  const result: SpectrumContactName = { formatted: name.formattedName };
+  if (name.firstName) {
+    result.first = name.firstName;
+  }
+  if (name.lastName) {
+    result.last = name.lastName;
+  }
+  if (name.middleName) {
+    result.middle = name.middleName;
+  }
+  if (name.prefix) {
+    result.prefix = name.prefix;
+  }
+  if (name.suffix) {
+    result.suffix = name.suffix;
+  }
+  return result;
+};
+
+const waPhoneToSpectrum = (phone: WaContactPhone): SpectrumContactPhone => {
+  const entry: SpectrumContactPhone = { value: phone.phone };
+  const type = mapWaPhoneType(phone.type);
+  if (type) {
+    entry.type = type;
+  }
+  return entry;
+};
+
+const waEmailToSpectrum = (email: WaContactEmail): SpectrumContactEmail => {
+  const entry: SpectrumContactEmail = { value: email.email };
+  const type = mapWaSimpleType(email.type);
+  if (type) {
+    entry.type = type;
+  }
+  return entry;
+};
+
+const waAddressToSpectrum = (
+  address: WaContactAddress
+): SpectrumContactAddress => {
+  const entry: SpectrumContactAddress = {};
+  if (address.street) {
+    entry.street = address.street;
+  }
+  if (address.city) {
+    entry.city = address.city;
+  }
+  if (address.state) {
+    entry.region = address.state;
+  }
+  if (address.zip) {
+    entry.postalCode = address.zip;
+  }
+  if (address.country) {
+    entry.country = address.country;
+  }
+  const type = mapWaSimpleType(address.type);
+  if (type) {
+    entry.type = type;
+  }
+  return entry;
+};
+
+const waOrgToSpectrum = (org: WaContactOrg): SpectrumContactOrg => {
+  const entry: SpectrumContactOrg = {};
+  if (org.company) {
+    entry.name = org.company;
+  }
+  if (org.title) {
+    entry.title = org.title;
+  }
+  if (org.department) {
+    entry.department = org.department;
+  }
+  return entry;
+};
+
+const waContactToSpectrum = (card: ContactCard): Content => {
+  const input: Parameters<typeof asContact>[0] = { raw: card };
+  input.name = waNameToSpectrum(card.name);
+  if (card.phones.length > 0) {
+    input.phones = card.phones.map(waPhoneToSpectrum);
+  }
+  if (card.emails.length > 0) {
+    input.emails = card.emails.map(waEmailToSpectrum);
+  }
+  if (card.addresses.length > 0) {
+    input.addresses = card.addresses.map(waAddressToSpectrum);
+  }
+  if (card.org) {
+    input.org = waOrgToSpectrum(card.org);
+  }
+  if (card.urls.length > 0) {
+    input.urls = card.urls.map((u: WaContactUrl) => u.url);
+  }
+  if (card.birthday) {
+    input.birthday = card.birthday;
+  }
+  return asContact(input);
+};
+
+const toMessages = (
   client: WhatsAppClient,
   msg: InboundMessage
-): WhatsAppMessage => ({
-  id: msg.id,
-  content: mapContent(client, msg.content),
-  sender: { id: msg.from },
-  space: { id: msg.from },
-  timestamp: msg.timestamp,
-});
+): WhatsAppMessage[] => {
+  const base = {
+    sender: { id: msg.from },
+    space: { id: msg.from },
+    timestamp: msg.timestamp,
+  };
+  if (msg.content.type === "contacts") {
+    const multi = msg.content.contacts.length > 1;
+    return msg.content.contacts.map((card, index) => ({
+      ...base,
+      id: multi ? `${msg.id}:${index}` : msg.id,
+      content: waContactToSpectrum(card),
+    }));
+  }
+  return [
+    {
+      ...base,
+      id: msg.id,
+      content: mapContent(client, msg.content),
+    },
+  ];
+};
 
 const mapContent = (
   client: WhatsAppClient,
@@ -36,11 +206,6 @@ const mapContent = (
       return asCustom({ whatsapp_type: "sticker", ...content.sticker });
     case "location":
       return asCustom({ whatsapp_type: "location", ...content.location });
-    case "contacts":
-      return asCustom({
-        whatsapp_type: "contacts",
-        contacts: content.contacts,
-      });
     case "reaction":
       return asCustom({ whatsapp_type: "reaction", ...content.reaction });
     case "interactive":
@@ -101,6 +266,72 @@ const mimeToMediaType = (
   return "document";
 };
 
+const spectrumPhoneTypeToWa = (
+  type: SpectrumContactPhone["type"]
+): string | undefined => {
+  if (type === "mobile") {
+    return "CELL";
+  }
+  if (type === "home" || type === "work" || type === "other") {
+    return type.toUpperCase();
+  }
+  return undefined;
+};
+
+const spectrumSimpleTypeToWa = (
+  type: "home" | "work" | "other" | undefined
+): string | undefined => (type ? type.toUpperCase() : undefined);
+
+const spectrumNameToWa = (name: Contact["name"]): WaContactName => ({
+  formattedName:
+    name?.formatted ??
+    ([name?.first, name?.middle, name?.last]
+      .filter((p): p is string => Boolean(p))
+      .join(" ") ||
+      "Unknown"),
+  firstName: name?.first,
+  lastName: name?.last,
+  middleName: name?.middle,
+  prefix: name?.prefix,
+  suffix: name?.suffix,
+});
+
+const contactToWa = (contact: Contact): ContactCardInput => {
+  if (contact.raw && typeof contact.raw === "object" && "name" in contact.raw) {
+    return contact.raw as ContactCardInput;
+  }
+  const card: ContactCardInput = {
+    name: spectrumNameToWa(contact.name),
+    phones: (contact.phones ?? []).map((p) => ({
+      phone: p.value,
+      type: spectrumPhoneTypeToWa(p.type),
+    })),
+    emails: (contact.emails ?? []).map((e) => ({
+      email: e.value,
+      type: spectrumSimpleTypeToWa(e.type),
+    })),
+    addresses: (contact.addresses ?? []).map((a) => ({
+      street: a.street,
+      city: a.city,
+      state: a.region,
+      zip: a.postalCode,
+      country: a.country,
+      type: spectrumSimpleTypeToWa(a.type),
+    })),
+    urls: (contact.urls ?? []).map((url) => ({ url })),
+    org:
+      contact.org?.name || contact.org?.department || contact.org?.title
+        ? {
+            company: contact.org.name,
+            department: contact.org.department,
+            title: contact.org.title,
+          }
+        : undefined,
+    birthday: contact.birthday,
+  };
+  return card;
+};
+
 export const messages = (
   client: WhatsAppClient
 ): ManagedStream<WhatsAppMessage> => {
@@ -114,7 +345,9 @@ export const messages = (
     (async () => {
       try {
         for await (const event of eventStream) {
-          emit(toMessage(client, event.message));
+          for (const m of toMessages(client, event.message)) {
+            emit(m);
+          }
         }
         end();
       } catch (e) {
@@ -151,6 +384,12 @@ export const send = async (
       } as Parameters<typeof client.messages.send>[0]);
       break;
     }
+    case "contact":
+      await client.messages.send({
+        to: spaceId,
+        contacts: [contactToWa(content)],
+      });
+      break;
     default:
       break;
   }
@@ -200,6 +439,13 @@ export const replyToMessage = async (
       } as Parameters<typeof client.messages.send>[0]);
       break;
     }
+    case "contact":
+      await client.messages.send({
+        to: spaceId,
+        replyTo: messageId,
+        contacts: [contactToWa(content)],
+      });
+      break;
     default:
       break;
   }

--- a/packages/spectrum-ts/src/utils/vcard.ts
+++ b/packages/spectrum-ts/src/utils/vcard.ts
@@ -1,0 +1,430 @@
+import vCard from "vcf";
+import type {
+  Contact,
+  ContactAddress,
+  ContactEmail,
+  ContactInput,
+  ContactName,
+  ContactOrg,
+  ContactPhone,
+} from "../content/contact";
+
+type VCardProperty = vCard.Property & {
+  type?: string | string[];
+  encoding?: string | string[];
+};
+
+const asPropertyArray = (
+  prop: vCard.Property | vCard.Property[] | undefined
+): VCardProperty[] => {
+  if (!prop) {
+    return [];
+  }
+  const arr = Array.isArray(prop) ? prop : [prop];
+  return arr as VCardProperty[];
+};
+
+const propString = (
+  prop: vCard.Property | vCard.Property[] | undefined
+): string | undefined => {
+  const [first] = asPropertyArray(prop);
+  const value = first?.valueOf().trim();
+  return value ? value : undefined;
+};
+
+const paramTypes = (prop: VCardProperty): string[] => {
+  const { type } = prop;
+  if (!type) {
+    return [];
+  }
+  return (Array.isArray(type) ? type : [type]).map((t) => t.toLowerCase());
+};
+
+const mapPhoneType = (prop: VCardProperty): ContactPhone["type"] => {
+  const types = paramTypes(prop);
+  if (types.some((t) => t === "cell" || t === "mobile" || t === "iphone")) {
+    return "mobile";
+  }
+  if (types.includes("home")) {
+    return "home";
+  }
+  if (types.includes("work")) {
+    return "work";
+  }
+  if (types.length > 0) {
+    return "other";
+  }
+  return undefined;
+};
+
+const mapSimpleType = (
+  prop: VCardProperty
+): "home" | "work" | "other" | undefined => {
+  const types = paramTypes(prop);
+  if (types.includes("home")) {
+    return "home";
+  }
+  if (types.includes("work")) {
+    return "work";
+  }
+  if (types.length > 0) {
+    return "other";
+  }
+  return undefined;
+};
+
+const splitStructured = (value: string): string[] =>
+  value.split(";").map((part) => part.trim());
+
+const extractName = (card: vCard): ContactName | undefined => {
+  const fn = propString(card.data.fn);
+  const n = propString(card.data.n);
+  if (!(fn || n)) {
+    return undefined;
+  }
+
+  const result: ContactName = {};
+  if (fn) {
+    result.formatted = fn;
+  }
+  if (n) {
+    const [last, first, middle, prefix, suffix] = splitStructured(n);
+    if (first) {
+      result.first = first;
+    }
+    if (last) {
+      result.last = last;
+    }
+    if (middle) {
+      result.middle = middle;
+    }
+    if (prefix) {
+      result.prefix = prefix;
+    }
+    if (suffix) {
+      result.suffix = suffix;
+    }
+  }
+  return result;
+};
+
+const extractPhones = (card: vCard): ContactPhone[] | undefined => {
+  const props = asPropertyArray(card.data.tel);
+  if (props.length === 0) {
+    return undefined;
+  }
+  return props.map((p) => {
+    const entry: ContactPhone = { value: p.valueOf().trim() };
+    const type = mapPhoneType(p);
+    if (type) {
+      entry.type = type;
+    }
+    return entry;
+  });
+};
+
+const extractEmails = (card: vCard): ContactEmail[] | undefined => {
+  const props = asPropertyArray(card.data.email);
+  if (props.length === 0) {
+    return undefined;
+  }
+  return props.map((p) => {
+    const entry: ContactEmail = { value: p.valueOf().trim() };
+    const type = mapSimpleType(p);
+    if (type) {
+      entry.type = type;
+    }
+    return entry;
+  });
+};
+
+const extractAddresses = (card: vCard): ContactAddress[] | undefined => {
+  const props = asPropertyArray(card.data.adr);
+  if (props.length === 0) {
+    return undefined;
+  }
+  return props.map((p) => {
+    // ADR fields: PO Box; extended; street; locality; region; postal code; country
+    const [, , street, city, region, postalCode, country] = splitStructured(
+      p.valueOf()
+    );
+    const entry: ContactAddress = {};
+    if (street) {
+      entry.street = street;
+    }
+    if (city) {
+      entry.city = city;
+    }
+    if (region) {
+      entry.region = region;
+    }
+    if (postalCode) {
+      entry.postalCode = postalCode;
+    }
+    if (country) {
+      entry.country = country;
+    }
+    const type = mapSimpleType(p);
+    if (type) {
+      entry.type = type;
+    }
+    return entry;
+  });
+};
+
+const extractOrg = (card: vCard): ContactOrg | undefined => {
+  const orgStr = propString(card.data.org);
+  const title = propString(card.data.title);
+  if (!(orgStr || title)) {
+    return undefined;
+  }
+  const result: ContactOrg = {};
+  if (orgStr) {
+    const [name, department] = splitStructured(orgStr);
+    if (name) {
+      result.name = name;
+    }
+    if (department) {
+      result.department = department;
+    }
+  }
+  if (title) {
+    result.title = title;
+  }
+  return result;
+};
+
+const extractUrls = (card: vCard): string[] | undefined => {
+  const props = asPropertyArray(card.data.url);
+  if (props.length === 0) {
+    return undefined;
+  }
+  return props.map((p) => p.valueOf().trim());
+};
+
+const photoMimeFromType = (type: string | undefined): string => {
+  if (!type) {
+    return "image/jpeg";
+  }
+  const lower = type.toLowerCase();
+  if (lower.startsWith("image/")) {
+    return lower;
+  }
+  return `image/${lower}`;
+};
+
+const DATA_URI_PATTERN = /^data:([^;,]+);base64,(.*)$/i;
+
+const extractPhoto = (card: vCard): Contact["photo"] | undefined => {
+  const [prop] = asPropertyArray(card.data.photo);
+  if (!prop) {
+    return undefined;
+  }
+  const value = prop.valueOf();
+  // vCard 4.0 can carry a data URI; 3.0 typically uses ENCODING=b with raw base64.
+  const dataUriMatch = DATA_URI_PATTERN.exec(value);
+  if (dataUriMatch) {
+    const [, mimeType, base64] = dataUriMatch;
+    const buf = Buffer.from(base64 ?? "", "base64");
+    return {
+      mimeType: mimeType ?? "image/jpeg",
+      read: async () => buf,
+    };
+  }
+  const type = Array.isArray(prop.type) ? prop.type[0] : prop.type;
+  const buf = Buffer.from(value, "base64");
+  return {
+    mimeType: photoMimeFromType(type),
+    read: async () => buf,
+  };
+};
+
+const normalizeVCardInput = (vcf: string): string => {
+  const withoutBom = vcf.charCodeAt(0) === 0xfe_ff ? vcf.slice(1) : vcf;
+  // RFC 6350 mandates CRLF; real-world .vcf files (notably from iMessage)
+  // ship with LF- or CR-only line endings, which breaks the `vcf` parser.
+  return withoutBom.replace(/\r\n|\r|\n/g, "\r\n");
+};
+
+export const fromVCard = (vcf: string): ContactInput => {
+  const [card] = vCard.parse(normalizeVCardInput(vcf));
+  if (!card) {
+    throw new Error("Invalid vCard: no cards parsed");
+  }
+  const input: ContactInput = { raw: vcf };
+  const name = extractName(card);
+  if (name) {
+    input.name = name;
+  }
+  const phones = extractPhones(card);
+  if (phones) {
+    input.phones = phones;
+  }
+  const emails = extractEmails(card);
+  if (emails) {
+    input.emails = emails;
+  }
+  const addresses = extractAddresses(card);
+  if (addresses) {
+    input.addresses = addresses;
+  }
+  const org = extractOrg(card);
+  if (org) {
+    input.org = org;
+  }
+  const urls = extractUrls(card);
+  if (urls) {
+    input.urls = urls;
+  }
+  const birthday = propString(card.data.bday);
+  if (birthday) {
+    input.birthday = birthday;
+  }
+  const note = propString(card.data.note);
+  if (note) {
+    input.note = note;
+  }
+  const photo = extractPhoto(card);
+  if (photo) {
+    input.photo = photo;
+  }
+  return input;
+};
+
+const formattedNameFor = (name: ContactName | undefined): string => {
+  if (name?.formatted) {
+    return name.formatted;
+  }
+  const parts = [name?.first, name?.middle, name?.last].filter(
+    (p): p is string => Boolean(p)
+  );
+  if (parts.length > 0) {
+    return parts.join(" ");
+  }
+  return "Unknown";
+};
+
+const phoneTypeParam = (type: ContactPhone["type"]): string | undefined => {
+  if (type === "mobile") {
+    return "CELL";
+  }
+  if (type === "home" || type === "work" || type === "other") {
+    return type.toUpperCase();
+  }
+  return undefined;
+};
+
+const simpleTypeParam = (
+  type: "home" | "work" | "other" | undefined
+): string | undefined => (type ? type.toUpperCase() : undefined);
+
+const photoTypeParam = (mimeType: string): string => {
+  const sub = mimeType.split("/")[1] ?? "jpeg";
+  return sub.toUpperCase();
+};
+
+const writeName = (card: vCard, name: Contact["name"]): void => {
+  card.set("fn", formattedNameFor(name));
+  if (!name) {
+    return;
+  }
+  if (name.first || name.last || name.middle || name.prefix || name.suffix) {
+    card.set(
+      "n",
+      [
+        name.last ?? "",
+        name.first ?? "",
+        name.middle ?? "",
+        name.prefix ?? "",
+        name.suffix ?? "",
+      ].join(";")
+    );
+  }
+};
+
+const writePhones = (card: vCard, phones: Contact["phones"]): void => {
+  for (const phone of phones ?? []) {
+    const type = phoneTypeParam(phone.type);
+    card.add("tel", phone.value, type ? { type } : undefined);
+  }
+};
+
+const writeEmails = (card: vCard, emails: Contact["emails"]): void => {
+  for (const email of emails ?? []) {
+    const type = simpleTypeParam(email.type);
+    card.add("email", email.value, type ? { type } : undefined);
+  }
+};
+
+const writeAddresses = (card: vCard, addresses: Contact["addresses"]): void => {
+  for (const addr of addresses ?? []) {
+    const value = [
+      "",
+      "",
+      addr.street ?? "",
+      addr.city ?? "",
+      addr.region ?? "",
+      addr.postalCode ?? "",
+      addr.country ?? "",
+    ].join(";");
+    const type = simpleTypeParam(addr.type);
+    card.add("adr", value, type ? { type } : undefined);
+  }
+};
+
+const writeOrg = (card: vCard, org: Contact["org"]): void => {
+  if (!org) {
+    return;
+  }
+  if (org.name || org.department) {
+    card.set("org", [org.name ?? "", org.department ?? ""].join(";"));
+  }
+  if (org.title) {
+    card.set("title", org.title);
+  }
+};
+
+const writeUrls = (card: vCard, urls: Contact["urls"]): void => {
+  for (const url of urls ?? []) {
+    card.add("url", url);
+  }
+};
+
+const writePhoto = async (
+  card: vCard,
+  photo: Contact["photo"]
+): Promise<void> => {
+  if (!photo) {
+    return;
+  }
+  const buf = await photo.read();
+  card.set("photo", buf.toString("base64"), {
+    encoding: "b",
+    type: photoTypeParam(photo.mimeType),
+  });
+};
+
+export const toVCard = async (contact: Contact): Promise<string> => {
+  if (
+    typeof contact.raw === "string" &&
+    contact.raw.startsWith("BEGIN:VCARD")
+  ) {
+    return contact.raw;
+  }
+
+  const card = new vCard();
+  writeName(card, contact.name);
+  writePhones(card, contact.phones);
+  writeEmails(card, contact.emails);
+  writeAddresses(card, contact.addresses);
+  writeOrg(card, contact.org);
+  writeUrls(card, contact.urls);
+  if (contact.birthday) {
+    card.set("bday", contact.birthday);
+  }
+  if (contact.note) {
+    card.set("note", contact.note);
+  }
+  await writePhoto(card, contact.photo);
+  return card.toString();
+};


### PR DESCRIPTION
## Summary

- Adds a new `contact` content type to Spectrum's discriminated content union, alongside `text`, `attachment`, and `custom`.
- Supports building contacts from structured details, a vCard string, a `vcf` instance, or a `User` reference.
- Wires the new content type through both iMessage transports (local + remote) and WhatsApp Business — including inbound parsing and outbound send/reply.
- Exposes `fromVCard` / `toVCard` utilities for direct vCard interop.

## Usage

```typescript
import { contact } from "spectrum-ts";

await space.send(contact({
  name: { first: "Ada", last: "Lovelace", formatted: "Ada Lovelace" },
  phones: [{ value: "+15551234567", type: "mobile" }],
  emails: [{ value: "ada@example.com", type: "work" }],
}));

// From an existing user
const user = await imessage(app).user("+15551234567");
await space.send(contact(user, { name: { formatted: "Ada Lovelace" } }));

// From a vCard string
await space.send(contact(vcardString));
```

Inbound:

```typescript
if (message.content.type === "contact") {
  console.log(message.content.name?.formatted, message.content.phones);
}
```

## Changes

| File | Notes |
|------|-------|
| `packages/spectrum-ts/src/content/contact.ts` | New content type. Defines the Zod schema, `Contact` types, and the `contact()` builder with three call signatures (User, ContactInput, string \| vCard). |
| `packages/spectrum-ts/src/content/types.ts` | Adds `contactSchema` to the discriminated union. |
| `packages/spectrum-ts/src/utils/vcard.ts` | New `fromVCard` / `toVCard` helpers — handles structured names, phones, emails, addresses, org, urls, birthday, photo, note. |
| `packages/spectrum-ts/src/index.ts` | Exports `contact`, related types, and the vCard utilities. |
| `packages/spectrum-ts/src/providers/imessage/local.ts` | Auto-detects `.vcf` / vCard MIME attachments on inbound messages and parses them into contacts. Outbound contacts are serialized to a temp `.vcf` and sent as an attachment. |
| `packages/spectrum-ts/src/providers/imessage/remote.ts` | Same inbound auto-detection over the gRPC transport; outbound contacts are uploaded as `text/vcard` attachments. |
| `packages/spectrum-ts/src/providers/whatsapp-business/messages.ts` | Maps inbound WhatsApp `contacts` payloads to Spectrum contacts (one Spectrum message per card). Outbound contacts (including `replyToMessage`) are converted back to WhatsApp's `ContactCardInput`. |
| `packages/spectrum-ts/package.json` | Adds `vcf@^2.1.2` and `@types/vcf@^2.0.7`. |
| `examples/basic/index.ts` | Simplified to a terminal-only echo example. |
| `README.md` | Documents the new `contact` content builder and the `fromVCard` / `toVCard` utilities. |

## Test plan

- [ ] `bun run build` succeeds.
- [ ] `bun x ultracite check` passes.
- [ ] Send a `contact()` over iMessage local mode and confirm the recipient sees a `.vcf` attachment that imports cleanly into Contacts.app.
- [ ] Send a `contact()` over iMessage cloud mode and confirm the same behavior.
- [ ] Receive an iMessage `.vcf` attachment and confirm it surfaces as `message.content.type === "contact"` with parsed fields.
- [ ] Send a `contact()` over WhatsApp Business and confirm the card renders natively in WhatsApp.
- [ ] Receive a WhatsApp contact card and confirm it surfaces as `message.content.type === "contact"`; verify multi-card payloads emit one message per card with stable IDs.
- [ ] Round-trip a contact via `toVCard` → `fromVCard` and confirm structured fields survive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a contact content builder and vCard import/export utilities; providers can send and receive contact cards across channels.

* **Documentation**
  * Updated docs to describe the new contact builder, vCard interop, and platform-specific inbound contact handling.

* **Chores**
  * Added tmp to ignore rules, updated package dependencies, and simplified the example implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->