### PR TITLE
feat: edit support via OutboundMessage + typed send return values

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,9 +19,15 @@
         "spectrum-ts": "workspace:*",
       },
     },
+    "examples/edit-echo": {
+      "name": "@spectrum-ts/example-edit-echo",
+      "dependencies": {
+        "spectrum-ts": "workspace:*",
+      },
+    },
     "packages/spectrum-ts": {
       "name": "spectrum-ts",
-      "version": "0.4.0",
+      "version": "0.6.0",
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.4.3",
         "@photon-ai/imessage-kit": "^3.0.0-rc.2",
@@ -224,6 +230,8 @@
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ=="],
 
     "@spectrum-ts/example-basic": ["@spectrum-ts/example-basic@workspace:examples/basic"],
+
+    "@spectrum-ts/example-edit-echo": ["@spectrum-ts/example-edit-echo@workspace:examples/edit-echo"],
 
     "@turbo/darwin-64": ["@turbo/darwin-64@2.9.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-P8foouaP+y/p+hhEGBoZpzMbpVvUMwPjDpcy6wN7EYfvvyISD1USuV27qWkczecihwuPJzQ1lDBuL8ERcavTyg=="],
 

--- a/examples/edit-echo/index.ts
+++ b/examples/edit-echo/index.ts
@@ -1,0 +1,27 @@
+import { Spectrum, text } from "spectrum-ts";
+import { terminal } from "spectrum-ts/providers/terminal";
+
+const app = await Spectrum({
+  providers: [terminal.config()],
+});
+
+for await (const [space, message] of app.messages) {
+  // `message` is InboundMessage — has `reply`/`react`, but not `edit`.
+  // The next line would be a type error if uncommented:
+  //
+  //   await message.edit("nope");
+  //   // @ts-expect-error — edit does not exist on InboundMessage
+
+  if (message.content.type !== "text") {
+    continue;
+  }
+
+  // space.send returns the OutboundMessage we just sent, so we can chain.
+  const sent = await space.send(text(`echo: ${message.content.text}`));
+  console.log(`sent id=${sent.id} direction=${sent.direction}`);
+
+  // `sent` is OutboundMessage — edit typechecks. Terminal provider throws
+  // at runtime; iMessage remote will actually update the message:
+  
+  await sent.edit(`echo (edited): ${message.content.text}`);
+}

--- a/examples/edit-echo/index.ts
+++ b/examples/edit-echo/index.ts
@@ -21,7 +21,11 @@ for await (const [space, message] of app.messages) {
   console.log(`sent id=${sent.id} direction=${sent.direction}`);
 
   // `sent` is OutboundMessage — edit typechecks. Terminal provider throws
-  // at runtime; iMessage remote will actually update the message:
-  
-  await sent.edit(`echo (edited): ${message.content.text}`);
+  // at runtime; iMessage remote will actually update the message. Wrap so
+  // the loop keeps running on providers that don't support edit.
+  try {
+    await sent.edit(`echo (edited): ${message.content.text}`);
+  } catch (err) {
+    console.log(`edit not supported: ${(err as Error).message}`);
+  }
 }

--- a/examples/edit-echo/package.json
+++ b/examples/edit-echo/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@spectrum-ts/example-edit-echo",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun run index.ts"
+  },
+  "dependencies": {
+    "spectrum-ts": "workspace:*"
+  }
+}

--- a/examples/edit-echo/tsconfig.json
+++ b/examples/edit-echo/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["."],
+  "compilerOptions": {
+    "strictNullChecks": true
+  }
+}

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -1,0 +1,230 @@
+import { resolveContents } from "../content/resolve";
+import type { Content, ContentInput } from "../content/types";
+import type {
+  InboundMessage,
+  Message,
+  OutboundMessage,
+} from "../types/message";
+import type { Space } from "../types/space";
+import type { AnyPlatformDef, SendResult } from "./types";
+
+export type SpaceRef = {
+  id: string;
+  __platform: string;
+} & Record<string, unknown>;
+
+interface BaseBuildParams {
+  client: unknown;
+  config: unknown;
+  content: Content;
+  definition: AnyPlatformDef;
+  extras: Record<string, unknown>;
+  id: string;
+  space: Space;
+  spaceRef: SpaceRef;
+  timestamp: Date;
+}
+
+type BuildInboundParams = BaseBuildParams & {
+  direction: "inbound";
+  sender: { id: string } & Record<string, unknown>;
+};
+
+type BuildOutboundParams = BaseBuildParams & {
+  direction: "outbound";
+  sender: ({ id: string } & Record<string, unknown>) | undefined;
+};
+
+export type BuildMessageParams = BuildInboundParams | BuildOutboundParams;
+
+export interface BuildSpaceParams {
+  client: unknown;
+  config: unknown;
+  definition: AnyPlatformDef;
+  extras: Record<string, unknown>;
+  spaceRef: SpaceRef;
+  typingCtx: { space: SpaceRef; client: unknown; config: unknown };
+}
+
+export function buildSpace(params: BuildSpaceParams): Space {
+  const { spaceRef, extras, typingCtx, definition, client, config } = params;
+  // Declared first so inner arrows can reference it after assignment.
+  let space: Space;
+
+  async function sendImpl(
+    ...content: [ContentInput, ...ContentInput[]]
+  ): Promise<OutboundMessage | OutboundMessage[]> {
+    const resolved = await resolveContents(content);
+    const results: OutboundMessage[] = [];
+    for (const item of resolved) {
+      const sendResult = (await definition.actions.send({
+        ...typingCtx,
+        content: item,
+      })) as SendResult | undefined;
+      if (!sendResult?.id) {
+        throw new Error(
+          `Platform "${definition.name}" send did not return a message id`
+        );
+      }
+      results.push(
+        buildMessage({
+          id: sendResult.id,
+          content: item,
+          sender: sendResult.sender,
+          timestamp: sendResult.timestamp ?? new Date(),
+          extras: {},
+          spaceRef,
+          space,
+          definition,
+          client,
+          config,
+          direction: "outbound",
+        })
+      );
+    }
+    return content.length === 1 && results[0] ? results[0] : results;
+  }
+
+  space = {
+    ...extras,
+    ...spaceRef,
+    send: sendImpl as Space["send"],
+    edit: async (
+      message: OutboundMessage,
+      newContent: ContentInput
+    ): Promise<void> => {
+      await message.edit(newContent);
+    },
+    startTyping: async () => {
+      await definition.actions.startTyping?.(typingCtx);
+    },
+    stopTyping: async () => {
+      await definition.actions.stopTyping?.(typingCtx);
+    },
+    responding: async <T>(fn: () => T | Promise<T>): Promise<T> => {
+      await definition.actions.startTyping?.(typingCtx);
+      try {
+        return await fn();
+      } finally {
+        await definition.actions.stopTyping?.(typingCtx).catch(() => {});
+      }
+    },
+  };
+  return space;
+}
+
+export function buildMessage(params: BuildInboundParams): InboundMessage;
+export function buildMessage(params: BuildOutboundParams): OutboundMessage;
+export function buildMessage(params: BuildMessageParams): Message {
+  const { definition, client, config, spaceRef, space } = params;
+
+  const react = async (reaction: string): Promise<void> => {
+    if (!definition.actions.reactToMessage) {
+      return;
+    }
+    await definition.actions.reactToMessage({
+      space: spaceRef,
+      messageId: params.id,
+      reaction,
+      client,
+      config,
+    });
+  };
+
+  async function reply(content: ContentInput): Promise<OutboundMessage>;
+  async function reply(
+    ...content: [ContentInput, ContentInput, ...ContentInput[]]
+  ): Promise<OutboundMessage[]>;
+  async function reply(
+    ...content: [ContentInput, ...ContentInput[]]
+  ): Promise<OutboundMessage | OutboundMessage[]> {
+    if (!definition.actions.replyToMessage) {
+      throw new Error(
+        `Platform "${definition.name}" does not support replying to messages`
+      );
+    }
+    const resolved = await resolveContents(content);
+    const results: OutboundMessage[] = [];
+    for (const item of resolved) {
+      const sendResult = (await definition.actions.replyToMessage({
+        space: spaceRef,
+        messageId: params.id,
+        content: item,
+        client,
+        config,
+      })) as SendResult | undefined;
+      if (!sendResult?.id) {
+        throw new Error(
+          `Platform "${definition.name}" reply did not return a message id`
+        );
+      }
+      results.push(
+        buildMessage({
+          id: sendResult.id,
+          content: item,
+          sender: sendResult.sender,
+          timestamp: sendResult.timestamp ?? new Date(),
+          extras: {},
+          spaceRef,
+          space,
+          definition,
+          client,
+          config,
+          direction: "outbound",
+        })
+      );
+    }
+    return content.length === 1 && results[0] ? results[0] : results;
+  }
+
+  const senderWithPlatform =
+    params.sender === undefined
+      ? undefined
+      : { ...params.sender, __platform: definition.name };
+
+  if (params.direction === "outbound") {
+    return {
+      ...params.extras,
+      id: params.id,
+      content: params.content,
+      direction: "outbound",
+      platform: definition.name,
+      react,
+      reply,
+      edit: async (newContent: ContentInput): Promise<void> => {
+        if (!definition.actions.editMessage) {
+          throw new Error(
+            `Platform "${definition.name}" does not support editing messages`
+          );
+        }
+        const [resolved] = await resolveContents([newContent]);
+        if (!resolved) {
+          return;
+        }
+        await definition.actions.editMessage({
+          space: spaceRef,
+          messageId: params.id,
+          content: resolved,
+          client,
+          config,
+        });
+      },
+      sender: senderWithPlatform,
+      space,
+      timestamp: params.timestamp,
+    } as OutboundMessage;
+  }
+
+  return {
+    ...params.extras,
+    id: params.id,
+    content: params.content,
+    direction: "inbound",
+    platform: definition.name,
+    react,
+    reply,
+    sender: senderWithPlatform as InboundMessage["sender"],
+    space,
+    timestamp: params.timestamp,
+  } as InboundMessage;
+}

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -1,8 +1,7 @@
 import type z from "zod";
-import { resolveContents } from "../content/resolve";
-import type { ContentInput } from "../content/types";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
+import { buildSpace } from "./build";
 import type {
   AnyPlatformDef,
   Platform,
@@ -105,39 +104,14 @@ function createPlatformInstance<
         client: runtime.client as _Client,
         config: runtime.config as z.infer<_ConfigSchema>,
       };
-      return {
-        ...parsedSpace,
-        ...spaceRef,
-        send: async (...content: [ContentInput, ...ContentInput[]]) => {
-          const built = await resolveContents(content);
-          for (const item of built) {
-            await def.actions.send({
-              ...typingCtx,
-              content: item,
-            });
-          }
-        },
-        edit: async (
-          message: Message,
-          newContent: ContentInput
-        ): Promise<void> => {
-          await message.edit(newContent);
-        },
-        startTyping: async () => {
-          await def.actions.startTyping?.(typingCtx);
-        },
-        stopTyping: async () => {
-          await def.actions.stopTyping?.(typingCtx);
-        },
-        responding: async <T>(fn: () => T | Promise<T>): Promise<T> => {
-          await def.actions.startTyping?.(typingCtx);
-          try {
-            return await fn();
-          } finally {
-            await def.actions.stopTyping?.(typingCtx).catch(() => {});
-          }
-        },
-      } as PlatformSpace<Def>;
+      return buildSpace({
+        spaceRef,
+        extras: parsedSpace as Record<string, unknown>,
+        typingCtx,
+        definition: def as unknown as AnyPlatformDef,
+        client: runtime.client,
+        config: runtime.config,
+      }) as PlatformSpace<Def>;
     },
   };
 

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -117,6 +117,12 @@ function createPlatformInstance<
             });
           }
         },
+        edit: async (
+          message: Message,
+          newContent: ContentInput
+        ): Promise<void> => {
+          await message.edit(newContent);
+        },
         startTyping: async () => {
           await def.actions.startTyping?.(typingCtx);
         },

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -44,6 +44,12 @@ export type ProviderMessage<
   timestamp?: Date;
 } & TExtra;
 
+export interface SendResult<TSender extends ResolvedUser = ResolvedUser> {
+  id: string;
+  sender?: TSender;
+  timestamp?: Date;
+}
+
 type MergeSchema<
   TSchema extends z.ZodType | undefined,
   TBase extends object,
@@ -106,7 +112,7 @@ export interface PlatformDef<
       content: Content;
       client: _Client;
       config: z.infer<_ConfigSchema>;
-    }) => Promise<void>;
+    }) => Promise<SendResult<_ResolvedUser>>;
     startTyping?: (_: {
       space: _ResolvedSpace & SpaceRef;
       client: _Client;
@@ -130,7 +136,7 @@ export interface PlatformDef<
       content: Content;
       client: _Client;
       config: z.infer<_ConfigSchema>;
-    }) => Promise<void>;
+    }) => Promise<SendResult<_ResolvedUser>>;
     editMessage?: (_: {
       space: _ResolvedSpace & SpaceRef;
       messageId: string;
@@ -190,7 +196,7 @@ export interface PlatformDef<
 export interface AnyPlatformDef {
   actions: {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
-    send: (_: any) => Promise<void>;
+    send: (_: any) => Promise<SendResult>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     startTyping?: (_: any) => Promise<void>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
@@ -198,7 +204,7 @@ export interface AnyPlatformDef {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     reactToMessage?: (_: any) => Promise<void>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
-    replyToMessage?: (_: any) => Promise<void>;
+    replyToMessage?: (_: any) => Promise<SendResult>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     editMessage?: (_: any) => Promise<void>;
   };

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -131,6 +131,13 @@ export interface PlatformDef<
       client: _Client;
       config: z.infer<_ConfigSchema>;
     }) => Promise<void>;
+    editMessage?: (_: {
+      space: _ResolvedSpace & SpaceRef;
+      messageId: string;
+      content: Content;
+      client: _Client;
+      config: z.infer<_ConfigSchema>;
+    }) => Promise<void>;
   };
 
   config: _ConfigSchema;
@@ -192,6 +199,8 @@ export interface AnyPlatformDef {
     reactToMessage?: (_: any) => Promise<void>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     replyToMessage?: (_: any) => Promise<void>;
+    // biome-ignore lint/suspicious/noExplicitAny: wildcard action
+    editMessage?: (_: any) => Promise<void>;
   };
   config: z.ZodType<object>;
   events: {

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -4,6 +4,7 @@ import { definePlatform } from "../../platform/define";
 import { createCloudClients, disposeCloudAuth } from "./auth";
 import { messages as localMessages, send as localSend } from "./local";
 import {
+  editMessage as remoteEditMessage,
   messages as remoteMessages,
   reactToMessage as remoteReactToMessage,
   replyToMessage as remoteReplyToMessage,
@@ -144,6 +145,14 @@ export const imessage = definePlatform("iMessage", {
         return;
       }
       await remoteReplyToMessage(client, space.id, messageId, content);
+    },
+    editMessage: async ({ space, messageId, content, client }) => {
+      if (isLocal(client)) {
+        throw new Error(
+          "iMessage local mode does not support editing messages"
+        );
+      }
+      await remoteEditMessage(client, space.id, messageId, content);
     },
   },
 });

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -117,10 +117,9 @@ export const imessage = definePlatform("iMessage", {
   actions: {
     send: async ({ space, content, client }) => {
       if (isLocal(client)) {
-        await localSend(client, space.id, content);
-      } else {
-        await remoteSend(client, space.id, content);
+        return await localSend(client, space.id, content);
       }
+      return await remoteSend(client, space.id, content);
     },
     startTyping: async ({ space, client }) => {
       if (isLocal(client)) {
@@ -142,9 +141,11 @@ export const imessage = definePlatform("iMessage", {
     },
     replyToMessage: async ({ space, messageId, content, client }) => {
       if (isLocal(client)) {
-        return;
+        throw new Error(
+          "iMessage local mode does not support replying to messages"
+        );
       }
-      await remoteReplyToMessage(client, space.id, messageId, content);
+      return await remoteReplyToMessage(client, space.id, messageId, content);
     },
     editMessage: async ({ space, messageId, content, client }) => {
       if (isLocal(client)) {

--- a/packages/spectrum-ts/src/providers/imessage/local.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local.ts
@@ -11,9 +11,21 @@ import {
 import { asAttachment } from "../../content/attachment";
 import { asContact } from "../../content/contact";
 import type { Content } from "../../content/types";
+import type { SendResult } from "../../platform/types";
 import { type ManagedStream, stream } from "../../utils/stream";
 import { fromVCard, toVCard } from "../../utils/vcard";
 import type { IMessageMessage } from "./types";
+
+type LocalSendResult = Awaited<ReturnType<IMessageSDK["send"]>>;
+
+const toSendResult = (result: LocalSendResult): SendResult => {
+  if (!result.message?.id) {
+    throw new Error(
+      "iMessage local send did not return a message id — track upstream in @photon-ai/imessage-kit"
+    );
+  }
+  return { id: result.message.id, timestamp: result.sentAt };
+};
 
 const DEFAULT_ATTACHMENT_NAME = "attachment";
 
@@ -105,6 +117,9 @@ export const messages = (client: IMessageSDK): ManagedStream<IMessageMessage> =>
     let lastPromise: Promise<void> = Promise.resolve();
     client.startWatching({
       onMessage: (message) => {
+        if (message.isFromMe) {
+          return;
+        }
         lastPromise = lastPromise
           .then(() => toMessages(message))
           .then((ms) => {
@@ -130,13 +145,13 @@ const sendTempFile = async (
   spaceId: string,
   name: string,
   data: Buffer
-): Promise<void> => {
+): Promise<LocalSendResult> => {
   const safeName = basename(name) || DEFAULT_ATTACHMENT_NAME;
   const dir = await mkdtemp(join(tmpdir(), "spectrum-"));
   const tmp = join(dir, safeName);
   await writeFile(tmp, data);
   try {
-    await client.send(spaceId, { attachments: [tmp] });
+    return await client.send(spaceId, { attachments: [tmp] });
   } finally {
     await rm(dir, { recursive: true, force: true }).catch(() => {});
   }
@@ -146,25 +161,28 @@ export const send = async (
   client: IMessageSDK,
   spaceId: string,
   content: Content
-) => {
+): Promise<SendResult> => {
   switch (content.type) {
     case "text":
-      await client.send(spaceId, content.text);
-      break;
+      return toSendResult(await client.send(spaceId, content.text));
     case "attachment":
-      await sendTempFile(client, spaceId, content.name, await content.read());
-      break;
+      return toSendResult(
+        await sendTempFile(client, spaceId, content.name, await content.read())
+      );
     case "contact": {
       const vcf = await toVCard(content);
-      await sendTempFile(
-        client,
-        spaceId,
-        vcardFileName(content),
-        Buffer.from(vcf, "utf8")
+      return toSendResult(
+        await sendTempFile(
+          client,
+          spaceId,
+          vcardFileName(content),
+          Buffer.from(vcf, "utf8")
+        )
       );
-      break;
     }
     default:
-      break;
+      throw new Error(
+        `Unsupported iMessage local content type: ${content.type}`
+      );
   }
 };

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -10,10 +10,16 @@ import { asContact } from "../../content/contact";
 import { asCustom } from "../../content/custom";
 import { asText } from "../../content/text";
 import type { Content } from "../../content/types";
+import type { SendResult } from "../../platform/types";
 import { ensureM4a } from "../../utils/audio";
 import { type ManagedStream, mergeStreams, stream } from "../../utils/stream";
 import { fromVCard, toVCard } from "../../utils/vcard";
 import type { IMessageMessage } from "./types";
+
+const toSendResult = (receipt: { guid: unknown }): SendResult => ({
+  id: receipt.guid as string,
+  timestamp: new Date(),
+});
 
 const VCARD_MIME_TYPES: ReadonlySet<string> = new Set([
   "text/vcard",
@@ -112,6 +118,9 @@ const clientStream = (
     (async () => {
       try {
         for await (const event of sub) {
+          if (event.message.isFromMe) {
+            continue;
+          }
           for (const message of await toMessages(client, event)) {
             emit(message);
           }
@@ -182,30 +191,30 @@ export const send = async (
   clients: AdvancedIMessage[],
   spaceId: string,
   content: Content
-) => {
+): Promise<SendResult> => {
   const remote = clients[0];
   if (!remote) {
-    return;
+    throw new Error("No remote iMessage client available");
   }
+  const chat = chatGuid(spaceId);
   switch (content.type) {
     case "text":
-      await remote.messages.send(chatGuid(spaceId), content.text);
-      break;
+      return toSendResult(await remote.messages.send(chat, content.text));
     case "attachment": {
       const attachment = await remote.attachments.upload({
         data: await content.read(),
         fileName: content.name,
         mimeType: content.mimeType,
       });
-      await remote.messages.send(chatGuid(spaceId), "", {
-        attachment: attachment.guid,
-      });
-      break;
+      return toSendResult(
+        await remote.messages.send(chat, "", {
+          attachment: attachment.guid,
+        })
+      );
     }
     case "contact": {
       const attachment = await sendContactAttachment(remote, content);
-      await remote.messages.send(chatGuid(spaceId), "", { attachment });
-      break;
+      return toSendResult(await remote.messages.send(chat, "", { attachment }));
     }
     case "voice": {
       const { buffer } = await ensureM4a(
@@ -217,11 +226,12 @@ export const send = async (
         fileName: content.name ?? "voice.m4a",
         mimeType: "audio/x-m4a",
       });
-      await remote.messages.send(chatGuid(spaceId), "", {
-        attachment: attachment.guid,
-        audioMessage: true,
-      });
-      break;
+      return toSendResult(
+        await remote.messages.send(chat, "", {
+          attachment: attachment.guid,
+          audioMessage: true,
+        })
+      );
     }
     default:
       throw new Error(`Unsupported iMessage content type: ${content.type}`);
@@ -233,10 +243,10 @@ export const replyToMessage = async (
   spaceId: string,
   msgId: string,
   content: Content
-) => {
+): Promise<SendResult> => {
   const remote = clients[0];
   if (!remote) {
-    return;
+    throw new Error("No remote iMessage client available");
   }
 
   const chat = chatGuid(spaceId);
@@ -244,24 +254,27 @@ export const replyToMessage = async (
 
   switch (content.type) {
     case "text":
-      await remote.messages.send(chat, content.text, { replyTo });
-      break;
+      return toSendResult(
+        await remote.messages.send(chat, content.text, { replyTo })
+      );
     case "attachment": {
       const attachment = await remote.attachments.upload({
         data: await content.read(),
         fileName: content.name,
         mimeType: content.mimeType,
       });
-      await remote.messages.send(chat, "", {
-        attachment: attachment.guid,
-        replyTo,
-      });
-      break;
+      return toSendResult(
+        await remote.messages.send(chat, "", {
+          attachment: attachment.guid,
+          replyTo,
+        })
+      );
     }
     case "contact": {
       const attachment = await sendContactAttachment(remote, content);
-      await remote.messages.send(chat, "", { attachment, replyTo });
-      break;
+      return toSendResult(
+        await remote.messages.send(chat, "", { attachment, replyTo })
+      );
     }
     case "voice": {
       const { buffer } = await ensureM4a(
@@ -273,12 +286,13 @@ export const replyToMessage = async (
         fileName: content.name ?? "voice.m4a",
         mimeType: "audio/x-m4a",
       });
-      await remote.messages.send(chat, "", {
-        attachment: attachment.guid,
-        audioMessage: true,
-        replyTo,
-      });
-      break;
+      return toSendResult(
+        await remote.messages.send(chat, "", {
+          attachment: attachment.guid,
+          audioMessage: true,
+          replyTo,
+        })
+      );
     }
     default:
       throw new Error(`Unsupported iMessage content type: ${content.type}`);

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -285,6 +285,26 @@ export const replyToMessage = async (
   }
 };
 
+export const editMessage = async (
+  clients: AdvancedIMessage[],
+  spaceId: string,
+  msgId: string,
+  content: Content
+) => {
+  if (content.type !== "text") {
+    throw new Error("iMessage only supports editing text content");
+  }
+  const remote = clients[0];
+  if (!remote) {
+    return;
+  }
+  await remote.messages.edit(
+    chatGuid(spaceId),
+    messageGuid(msgId),
+    content.text
+  );
+};
+
 export const reactToMessage = async (
   clients: AdvancedIMessage[],
   spaceId: string,

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -310,7 +310,7 @@ export const editMessage = async (
   }
   const remote = clients[0];
   if (!remote) {
-    return;
+    throw new Error("No remote iMessage client available");
   }
   await remote.messages.edit(
     chatGuid(spaceId),

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -57,6 +57,7 @@ export const terminal = definePlatform("terminal", {
       if (content.type === "text") {
         console.log(content.text);
       }
+      return { id: crypto.randomUUID(), timestamp: new Date() };
     },
   },
 });

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -54,9 +54,12 @@ export const terminal = definePlatform("terminal", {
 
   actions: {
     send: async ({ content }) => {
-      if (content.type === "text") {
-        console.log(content.text);
+      if (content.type !== "text") {
+        throw new Error(
+          `Terminal provider only supports text content, got "${content.type}"`
+        );
       }
+      console.log(content.text);
       return { id: crypto.randomUUID(), timestamp: new Date() };
     },
   },

--- a/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
@@ -52,7 +52,7 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
 
   actions: {
     send: async ({ space, content, client }) => {
-      await send(client as WhatsAppClient, space.id, content);
+      return await send(client as WhatsAppClient, space.id, content);
     },
 
     reactToMessage: async ({ space, messageId, reaction, client }) => {
@@ -65,7 +65,7 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
     },
 
     replyToMessage: async ({ space, messageId, content, client }) => {
-      await replyToMessage(
+      return await replyToMessage(
         client as WhatsAppClient,
         space.id,
         messageId,

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -18,8 +18,15 @@ import {
 import { asCustom } from "../../content/custom";
 import { asText } from "../../content/text";
 import type { Content } from "../../content/types";
+import type { SendResult } from "../../platform/types";
 import { type ManagedStream, stream } from "../../utils/stream";
 import type { WhatsAppMessage } from "./types";
+
+type WaSendResult = Awaited<ReturnType<WhatsAppClient["messages"]["send"]>>;
+
+const toSendResult = (result: WaSendResult): SendResult => ({
+  id: result.messageId,
+});
 
 type WaContactName = ContactCard["name"];
 type WaContactPhone = ContactCard["phones"][number];
@@ -394,11 +401,12 @@ export const send = async (
   client: WhatsAppClient,
   spaceId: string,
   content: Content
-): Promise<void> => {
+): Promise<SendResult> => {
   switch (content.type) {
     case "text":
-      await client.messages.send({ to: spaceId, text: content.text });
-      break;
+      return toSendResult(
+        await client.messages.send({ to: spaceId, text: content.text })
+      );
     case "attachment": {
       const { mediaId } = await client.media.upload({
         file: await content.read(),
@@ -410,32 +418,35 @@ export const send = async (
         mediaType === "document"
           ? { id: mediaId, filename: content.name }
           : { id: mediaId };
-      await client.messages.send({
-        to: spaceId,
-        [mediaType]: mediaPayload,
-      } as Parameters<typeof client.messages.send>[0]);
-      break;
+      return toSendResult(
+        await client.messages.send({
+          to: spaceId,
+          [mediaType]: mediaPayload,
+        } as Parameters<typeof client.messages.send>[0])
+      );
     }
     case "contact":
-      await client.messages.send({
-        to: spaceId,
-        contacts: [contactToWa(content)],
-      });
-      break;
+      return toSendResult(
+        await client.messages.send({
+          to: spaceId,
+          contacts: [contactToWa(content)],
+        })
+      );
     case "voice": {
       const { mediaId } = await client.media.upload({
         file: await content.read(),
         mimeType: content.mimeType,
         filename: voiceFilename(content),
       });
-      await client.messages.send({
-        to: spaceId,
-        audio: { id: mediaId },
-      } as Parameters<typeof client.messages.send>[0]);
-      break;
+      return toSendResult(
+        await client.messages.send({
+          to: spaceId,
+          audio: { id: mediaId },
+        } as Parameters<typeof client.messages.send>[0])
+      );
     }
     default:
-      break;
+      throw new Error(`Unsupported WhatsApp content type: ${content.type}`);
   }
 };
 
@@ -456,15 +467,16 @@ export const replyToMessage = async (
   spaceId: string,
   messageId: string,
   content: Content
-): Promise<void> => {
+): Promise<SendResult> => {
   switch (content.type) {
     case "text":
-      await client.messages.send({
-        to: spaceId,
-        replyTo: messageId,
-        text: content.text,
-      });
-      break;
+      return toSendResult(
+        await client.messages.send({
+          to: spaceId,
+          replyTo: messageId,
+          text: content.text,
+        })
+      );
     case "attachment": {
       const { mediaId } = await client.media.upload({
         file: await content.read(),
@@ -476,34 +488,37 @@ export const replyToMessage = async (
         mediaType === "document"
           ? { id: mediaId, filename: content.name }
           : { id: mediaId };
-      await client.messages.send({
-        to: spaceId,
-        replyTo: messageId,
-        [mediaType]: mediaPayload,
-      } as Parameters<typeof client.messages.send>[0]);
-      break;
+      return toSendResult(
+        await client.messages.send({
+          to: spaceId,
+          replyTo: messageId,
+          [mediaType]: mediaPayload,
+        } as Parameters<typeof client.messages.send>[0])
+      );
     }
     case "contact":
-      await client.messages.send({
-        to: spaceId,
-        replyTo: messageId,
-        contacts: [contactToWa(content)],
-      });
-      break;
+      return toSendResult(
+        await client.messages.send({
+          to: spaceId,
+          replyTo: messageId,
+          contacts: [contactToWa(content)],
+        })
+      );
     case "voice": {
       const { mediaId } = await client.media.upload({
         file: await content.read(),
         mimeType: content.mimeType,
         filename: voiceFilename(content),
       });
-      await client.messages.send({
-        to: spaceId,
-        replyTo: messageId,
-        audio: { id: mediaId },
-      } as Parameters<typeof client.messages.send>[0]);
-      break;
+      return toSendResult(
+        await client.messages.send({
+          to: spaceId,
+          replyTo: messageId,
+          audio: { id: mediaId },
+        } as Parameters<typeof client.messages.send>[0])
+      );
     }
     default:
-      break;
+      throw new Error(`Unsupported WhatsApp content type: ${content.type}`);
   }
 };

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -41,6 +41,7 @@ export type SpectrumInstance<
       space: Space,
       ...content: [ContentInput, ...ContentInput[]]
     ): Promise<void>;
+    edit(message: Message, newContent: ContentInput): Promise<void>;
     responding<T>(space: Space, fn: () => T | Promise<T>): Promise<T>;
   };
 
@@ -172,6 +173,12 @@ export async function Spectrum<
               });
             }
           },
+          edit: async (
+            targetMessage: Message,
+            newContent: ContentInput
+          ): Promise<void> => {
+            await targetMessage.edit(newContent);
+          },
           startTyping: async () => {
             await definition.actions.startTyping?.(typingCtx);
           },
@@ -220,6 +227,24 @@ export async function Spectrum<
                 config,
               });
             }
+          },
+          edit: async (newContent: ContentInput): Promise<void> => {
+            if (!definition.actions.editMessage) {
+              throw new Error(
+                `Platform "${definition.name}" does not support editing messages`
+              );
+            }
+            const [resolved] = await resolveContents([newContent]);
+            if (!resolved) {
+              return;
+            }
+            await definition.actions.editMessage({
+              space: spaceRef,
+              messageId: msg.id,
+              content: resolved,
+              client,
+              config,
+            });
           },
           sender: {
             ...msg.sender,
@@ -371,6 +396,9 @@ export async function Spectrum<
       ...content: [ContentInput, ...ContentInput[]]
     ) => {
       await space.send(...content);
+    },
+    edit: async (message: Message, newContent: ContentInput) => {
+      await message.edit(newContent);
     },
     responding: async <T>(
       space: Space,

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -1,13 +1,13 @@
 import z from "zod";
-import { resolveContents } from "./content/resolve";
 import type { Content, ContentInput } from "./content/types";
+import { buildMessage, buildSpace } from "./platform/build";
 import type {
   AnyPlatformDef,
   CustomEventStreams,
   PlatformProviderConfig,
   SpectrumLike,
 } from "./platform/types";
-import type { Message } from "./types/message";
+import type { InboundMessage, Message, OutboundMessage } from "./types/message";
 import type { Space } from "./types/space";
 import { type ManagedStream, mergeStreams, stream } from "./utils/stream";
 
@@ -35,13 +35,14 @@ export type SpectrumInstance<
   Providers extends PlatformProviderConfig[] = PlatformProviderConfig[],
 > = SpectrumLike<Providers> &
   CustomEventStreams<Providers> & {
-    readonly messages: AsyncIterable<[Space, Message]>;
+    readonly messages: AsyncIterable<[Space, InboundMessage]>;
     stop(): Promise<void>;
+    send(space: Space, content: ContentInput): Promise<OutboundMessage>;
     send(
       space: Space,
-      ...content: [ContentInput, ...ContentInput[]]
-    ): Promise<void>;
-    edit(message: Message, newContent: ContentInput): Promise<void>;
+      ...content: [ContentInput, ContentInput, ...ContentInput[]]
+    ): Promise<OutboundMessage[]>;
+    edit(message: OutboundMessage, newContent: ContentInput): Promise<void>;
     responding<T>(space: Space, fn: () => T | Promise<T>): Promise<T>;
   };
 
@@ -162,97 +163,27 @@ export async function Spectrum<
           __platform: definition.name,
         };
         const typingCtx = { space: spaceRef, client, config };
-        const space = {
-          ...spaceRef,
-          send: async (...content: [ContentInput, ...ContentInput[]]) => {
-            const resolved = await resolveContents(content);
-            for (const item of resolved) {
-              await definition.actions.send({
-                ...typingCtx,
-                content: item,
-              });
-            }
-          },
-          edit: async (
-            targetMessage: Message,
-            newContent: ContentInput
-          ): Promise<void> => {
-            await targetMessage.edit(newContent);
-          },
-          startTyping: async () => {
-            await definition.actions.startTyping?.(typingCtx);
-          },
-          stopTyping: async () => {
-            await definition.actions.stopTyping?.(typingCtx);
-          },
-          responding: async <T>(fn: () => T | Promise<T>): Promise<T> => {
-            await definition.actions.startTyping?.(typingCtx);
-            try {
-              return await fn();
-            } finally {
-              await definition.actions.stopTyping?.(typingCtx).catch(() => {});
-            }
-          },
-        };
-        const normalizedMessage = {
-          ...parsedExtra,
+        const space = buildSpace({
+          spaceRef,
+          extras: {},
+          typingCtx,
+          definition,
+          client,
+          config,
+        });
+        const normalizedMessage = buildMessage({
           id: msg.id,
           content: msg.content,
-          platform: definition.name,
-          react: async (reaction: string): Promise<void> => {
-            if (!definition.actions.reactToMessage) {
-              return;
-            }
-            await definition.actions.reactToMessage({
-              space: spaceRef,
-              messageId: msg.id,
-              reaction,
-              client,
-              config,
-            });
-          },
-          reply: async (
-            ...content: [ContentInput, ...ContentInput[]]
-          ): Promise<void> => {
-            if (!definition.actions.replyToMessage) {
-              return;
-            }
-            const resolved = await resolveContents(content);
-            for (const item of resolved) {
-              await definition.actions.replyToMessage({
-                space: spaceRef,
-                messageId: msg.id,
-                content: item,
-                client,
-                config,
-              });
-            }
-          },
-          edit: async (newContent: ContentInput): Promise<void> => {
-            if (!definition.actions.editMessage) {
-              throw new Error(
-                `Platform "${definition.name}" does not support editing messages`
-              );
-            }
-            const [resolved] = await resolveContents([newContent]);
-            if (!resolved) {
-              return;
-            }
-            await definition.actions.editMessage({
-              space: spaceRef,
-              messageId: msg.id,
-              content: resolved,
-              client,
-              config,
-            });
-          },
-          sender: {
-            ...msg.sender,
-            __platform: definition.name,
-          },
-          space,
+          sender: msg.sender,
           timestamp: msg.timestamp ?? new Date(),
-        };
+          extras: parsedExtra as Record<string, unknown>,
+          spaceRef,
+          space,
+          definition,
+          client,
+          config,
+          direction: "inbound",
+        });
 
         yield [space, normalizedMessage];
       }
@@ -369,7 +300,7 @@ export async function Spectrum<
   process.on("SIGINT", handleSignal);
   process.on("SIGTERM", handleSignal);
 
-  const messages = messagesStream as AsyncIterable<[Space, Message]>;
+  const messages = messagesStream as AsyncIterable<[Space, InboundMessage]>;
 
   // Proxy for flat custom event access (app.typing, app.readReceipt, etc.)
   const customEventProxy = new Proxy(
@@ -391,13 +322,17 @@ export async function Spectrum<
     __internal: { platforms: platformStates },
     messages,
     stop: stopOnce,
-    send: async (
+    send: (async (
       space: Space,
       ...content: [ContentInput, ...ContentInput[]]
-    ) => {
-      await space.send(...content);
-    },
-    edit: async (message: Message, newContent: ContentInput) => {
+    ): Promise<OutboundMessage | OutboundMessage[]> => {
+      return content.length === 1
+        ? await space.send(content[0])
+        : await space.send(
+            ...(content as [ContentInput, ContentInput, ...ContentInput[]])
+          );
+    }) as SpectrumInstance["send"],
+    edit: async (message: OutboundMessage, newContent: ContentInput) => {
       await message.edit(newContent);
     },
     responding: async <T>(

--- a/packages/spectrum-ts/src/types/message.ts
+++ b/packages/spectrum-ts/src/types/message.ts
@@ -2,18 +2,48 @@ import type { Content, ContentInput } from "../content/types";
 import type { Space } from "./space";
 import type { User } from "./user";
 
-export interface Message<
+interface BaseMessage<
   TPlatform extends string = string,
   TSender extends User = User,
   TSpace extends Space = Space,
 > {
   content: Content;
-  edit(newContent: ContentInput): Promise<void>;
   readonly id: string;
   platform: TPlatform;
   react(reaction: string): Promise<void>;
-  reply(...content: [ContentInput, ...ContentInput[]]): Promise<void>;
-  sender: TSender;
+  reply(
+    content: ContentInput
+  ): Promise<OutboundMessage<TPlatform, TSender, TSpace>>;
+  reply(
+    ...content: [ContentInput, ContentInput, ...ContentInput[]]
+  ): Promise<OutboundMessage<TPlatform, TSender, TSpace>[]>;
   space: TSpace;
   timestamp: Date;
 }
+
+export interface InboundMessage<
+  TPlatform extends string = string,
+  TSender extends User = User,
+  TSpace extends Space = Space,
+> extends BaseMessage<TPlatform, TSender, TSpace> {
+  direction: "inbound";
+  sender: TSender;
+}
+
+export interface OutboundMessage<
+  TPlatform extends string = string,
+  TSender extends User = User,
+  TSpace extends Space = Space,
+> extends BaseMessage<TPlatform, TSender, TSpace> {
+  direction: "outbound";
+  edit(newContent: ContentInput): Promise<void>;
+  sender: TSender | undefined;
+}
+
+export type Message<
+  TPlatform extends string = string,
+  TSender extends User = User,
+  TSpace extends Space = Space,
+> =
+  | InboundMessage<TPlatform, TSender, TSpace>
+  | OutboundMessage<TPlatform, TSender, TSpace>;

--- a/packages/spectrum-ts/src/types/message.ts
+++ b/packages/spectrum-ts/src/types/message.ts
@@ -8,6 +8,7 @@ export interface Message<
   TSpace extends Space = Space,
 > {
   content: Content;
+  edit(newContent: ContentInput): Promise<void>;
   readonly id: string;
   platform: TPlatform;
   react(reaction: string): Promise<void>;

--- a/packages/spectrum-ts/src/types/space.ts
+++ b/packages/spectrum-ts/src/types/space.ts
@@ -1,12 +1,15 @@
 import type { ContentInput } from "../content/types";
-import type { Message } from "./message";
+import type { OutboundMessage } from "./message";
 
 export interface Space<_Def = unknown> {
   readonly __platform: string;
-  edit(message: Message, newContent: ContentInput): Promise<void>;
+  edit(message: OutboundMessage, newContent: ContentInput): Promise<void>;
   readonly id: string;
   responding<T>(fn: () => T | Promise<T>): Promise<T>;
-  send(...content: [ContentInput, ...ContentInput[]]): Promise<void>;
+  send(content: ContentInput): Promise<OutboundMessage>;
+  send(
+    ...content: [ContentInput, ContentInput, ...ContentInput[]]
+  ): Promise<OutboundMessage[]>;
   startTyping(): Promise<void>;
   stopTyping(): Promise<void>;
 }

--- a/packages/spectrum-ts/src/types/space.ts
+++ b/packages/spectrum-ts/src/types/space.ts
@@ -1,7 +1,9 @@
 import type { ContentInput } from "../content/types";
+import type { Message } from "./message";
 
 export interface Space<_Def = unknown> {
   readonly __platform: string;
+  edit(message: Message, newContent: ContentInput): Promise<void>;
   readonly id: string;
   responding<T>(fn: () => T | Promise<T>): Promise<T>;
   send(...content: [ContentInput, ...ContentInput[]]): Promise<void>;


### PR DESCRIPTION
## Summary

- Splits `Message` into a discriminated union of `InboundMessage` (what the `app.messages` stream yields) and `OutboundMessage` (what `space.send` / `message.reply` now return). Only `OutboundMessage` carries `edit()`, so editing an inbound message is a type error at the call site.
- `space.send` / `message.reply` now **return** the `OutboundMessage` they sent (or an array, for variadic sends), enabling `const sent = await space.send(text("..."))`, then `await sent.edit("...")`.
- Platform `send` / `replyToMessage` actions now return a `SendResult { id, sender?, timestamp? }` so the SDK can construct a real `OutboundMessage` around the provider's message id — previously they all returned `void`.
- Wires `edit` through remote iMessage (uses `remote.messages.edit`, text-only per iMessage constraints). Local iMessage + WhatsApp Business + terminal throw a descriptive "not supported" error at runtime; terminal returns a synthetic UUID from `send` so outbound chaining still typechecks.
- Extracts the duplicated `space` / `message` factories out of `spectrum.ts` and `platform/define.ts` into a single `platform/build.ts` (`buildSpace`, `buildMessage`). Both entry points were constructing nearly identical objects — this collapses them and is where the new `OutboundMessage` construction + `edit` wiring lives.
- Inbound streams on both iMessage transports now drop `isFromMe` events so the user's own outbound edits don't loop back through `app.messages`.
- New `examples/edit-echo` demonstrates the send-then-edit flow and the type-level guarantee that inbound messages don't expose `edit`.
- Bumps `packages/spectrum-ts` to `0.6.0` (breaking: `Message` is now a union; consumers that did `msg.reply(...)` and discarded the result are unchanged, but anything typing variables as `Message` and touching `sender` needs to narrow on `direction`).

## Usage

```ts
for await (const [space, message] of app.messages) {
  // `message` is InboundMessage — has reply/react, NOT edit
  if (message.content.type !== "text") continue;

  const sent = await space.send(text(`echo: ${message.content.text}`));
  // `sent` is OutboundMessage — edit typechecks
  await sent.edit(`echo (edited): ${message.content.text}`);
}
```

Variadic send returns an array:

```ts
const [a, b] = await space.send(text("one"), text("two"));
await a.edit("uno");
```

Reply also returns the outbound message:

```ts
const reply = await message.reply(text("hello"));
await reply.edit("hi");
```

## Why split `Message` into inbound/outbound

Editing is fundamentally a sender-side operation — you can only edit messages *you* sent. Modeling this as a runtime capability (a method that sometimes throws) would push the check to the call site. Encoding it in the type system means the compiler rejects `incomingMessage.edit(...)` before it ever ships, and provider implementations don't need runtime guards for the "edit an inbound message" case. `direction: "inbound" | "outbound"` is the discriminant.

## Why platform actions now return `SendResult`

To construct an `OutboundMessage` the SDK needs the platform-assigned message id (iMessage `guid`, WhatsApp `messageId`, …). Previously those were thrown away. `SendResult` is a thin `{ id, sender?, timestamp? }` shape — optional sender/timestamp because not every provider surfaces them on send ack. Actions that can't realistically produce an id (iMessage local `replyToMessage`, edit on non-text content, etc.) now throw a descriptive error instead of silently no-oping.

## Changes

| File | Notes |
|------|-------|
| `packages/spectrum-ts/src/types/message.ts` | `Message` is now a union of `InboundMessage` (requires `sender`) and `OutboundMessage` (`sender?`, adds `edit(newContent)`). `reply()` now returns `OutboundMessage` (single) or `OutboundMessage[]` (variadic) via overloads. |
| `packages/spectrum-ts/src/types/space.ts` | `send()` now returns `OutboundMessage` / `OutboundMessage[]` via overloads. Adds top-level `edit(message, newContent)` delegating to `message.edit`. |
| `packages/spectrum-ts/src/platform/build.ts` | **New.** Extracts `buildSpace` and `buildMessage` from the two places in the SDK that previously built them by hand. Contains the new `OutboundMessage` construction (with `edit` wiring) and the shared `send`/`reply` loops that now return built outbound messages. |
| `packages/spectrum-ts/src/platform/define.ts` | `createPlatformInstance` now delegates to `buildSpace` instead of inlining the space object. |
| `packages/spectrum-ts/src/platform/types.ts` | Adds `SendResult<TSender>`. `send` / `replyToMessage` action return types changed from `Promise<void>` to `Promise<SendResult<...>>`. Adds optional `editMessage` action. `AnyPlatformDef` mirrors the changes. |
| `packages/spectrum-ts/src/spectrum.ts` | Uses `buildSpace` / `buildMessage`. `messages` is typed as `AsyncIterable<[Space, InboundMessage]>`. Top-level `send` / `edit` overloads mirror `Space`. |
| `packages/spectrum-ts/src/providers/imessage/remote.ts` | `send` and `replyToMessage` return `SendResult` (carrying `guid`). New `editMessage` calls `remote.messages.edit` (text-only). Inbound stream filters `event.message.isFromMe` so the agent's own sends/edits don't loop. |
| `packages/spectrum-ts/src/providers/imessage/local.ts` | `send` returns `SendResult` built from `client.send(...).message.id`. Inbound watcher filters `message.isFromMe`. `sendTempFile` now returns the underlying send result so it can be wrapped. |
| `packages/spectrum-ts/src/providers/imessage/index.ts` | `send` returns the result from local/remote. `replyToMessage` throws on local (previously no-op). New `editMessage` delegates to remote and throws on local. |
| `packages/spectrum-ts/src/providers/whatsapp-business/messages.ts` | `send` and `replyToMessage` return `SendResult` carrying `messageId`. Unknown content types now throw instead of silently no-oping. |
| `packages/spectrum-ts/src/providers/whatsapp-business/index.ts` | Propagates the new return values. |
| `packages/spectrum-ts/src/providers/terminal/index.ts` | `send` now returns `{ id: crypto.randomUUID(), timestamp }` so outbound chaining compiles; `edit` is left unimplemented and throws at runtime (terminal has no concept of editing a printed line). |
| `examples/edit-echo/*` | New example — echoes each inbound text, then edits the echo. Comments call out that `message.edit` is a type error. |
| `bun.lock`, `packages/spectrum-ts/package.json` | Version bump to `0.6.0`, lockfile entry for the new workspace. |

## Provider support matrix

| Provider | `send` returns id | `reply` returns id | `edit` |
|---|---|---|---|
| Remote iMessage | ✅ (guid) | ✅ (guid) | ✅ text only (via `remote.messages.edit`) |
| Local iMessage | ✅ (message.id) | ❌ (throws: not supported) | ❌ (throws: not supported) |
| WhatsApp Business | ✅ (messageId) | ✅ (messageId) | ❌ (not implemented) |
| Terminal | ✅ (synthetic UUID) | n/a | ❌ (throws) |

## Breaking changes

- `Message` is now `InboundMessage | OutboundMessage`. Code that types a variable as `Message` and reads `.sender` unconditionally needs to narrow on `direction` (or switch to `InboundMessage`, which is what `app.messages` actually yields).
- Platform authors implementing `send` / `replyToMessage` must return `SendResult` instead of `void`. The compiler will flag this.
- `reply(...)` / `space.send(...)` now return `OutboundMessage` / `OutboundMessage[]` instead of `void`. Call sites that discarded the result are unaffected; call sites that explicitly typed the result as `void` will need to update.

## Test plan

- [x] `bun x tsc --noEmit` passes across the workspace
- [x] `bun x ultracite check` passes
- [x] `bun run build` succeeds; `dist/index.d.ts` exposes `InboundMessage`, `OutboundMessage`, and `SendResult`
- [x] `examples/edit-echo` typechecks; the commented-out `message.edit(...)` line surfaces as a TS error when uncommented
- [ ] Manual: remote iMessage — send text, edit within the allowed window, confirm recipient sees the edited bubble
- [ ] Manual: remote iMessage — send non-text (attachment/voice) and confirm `edit()` throws with the descriptive error
- [ ] Manual: local iMessage — confirm `reply()` and `edit()` throw with clear "not supported" errors
- [ ] Manual: WhatsApp Business — confirm `space.send(text(...))` returns an `OutboundMessage` with `messageId` populated
- [ ] Manual: remote iMessage — confirm the agent's own outbound message does **not** appear in `app.messages` (isFromMe filter)
- [ ] Regression: existing reply/react flows across all providers still work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added message editing for outbound messages across platforms and a new "edit-echo" example demonstrating edits.
* **Behavior Changes**
  * Send and reply now return message send results (id/timestamp) instead of being fire-and-forget.
  * Providers now validate/throw on unsupported content types and skip self-originated inbound events.
* **API Updates**
  * Messages are distinguished as inbound or outbound with outbound-only edit capability; new send/edit methods expose these behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->