### PR TITLE
chore(deps): upgrade @photon-ai/imessage-kit to v3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,10 +21,10 @@
     },
     "packages/spectrum-ts": {
       "name": "spectrum-ts",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.4.3",
-        "@photon-ai/imessage-kit": "^3.0.0-rc.2",
+        "@photon-ai/imessage-kit": "^3.0.0",
         "@photon-ai/whatsapp-business": "^0.1.1",
         "@repeaterjs/repeater": "^3.0.6",
         "better-grpc": "^0.3.2",
@@ -147,7 +147,7 @@
 
     "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.4.3", "", { "dependencies": { "@grpc/grpc-js": "^1.12.6", "long": "^5.2.4", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2", "protobufjs": "^7.4.0" } }, "sha512-/mZJi/13hp8f4nejIjarP8W3NMVpXGuC2ar+hozw00iU/CjW1nMEdpAFWTaeMeI+YHwMDc+xglHdZhkgFr3OcA=="],
 
-    "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0-rc.2", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-AlhogO/WEZNTMR0h+UsvtMkjdkuFI2WGnY8+gIVVusA6onzOuJwZpxQ70quc2Y+O0HsUV0JnLy+A0ZcudvuSXA=="],
+    "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-GGDETlRbrPXP5eaRvswaead7MCBGQkm8f7d3aVbx8+rXhB4GEyPiw7Q1/yz5ix53rmxqKRevWywOfG7n+kZDBw=="],
 
     "@photon-ai/whatsapp-business": ["@photon-ai/whatsapp-business@0.1.1", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "long": "^5.3.2", "nice-grpc": "^2.1.15", "nice-grpc-common": "^2.0.3", "protobufjs": "^8.0.1" } }, "sha512-JAf/gHh92+H6h/7AMOQ6l+WFYBWdeRH5fZ+tvOUYJJnX1C4aJPDFa23VTH4ndhKPgA5bK/h++cxUZx2lMubvYQ=="],
 

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@photon-ai/advanced-imessage": "^0.4.3",
-    "@photon-ai/imessage-kit": "^3.0.0-rc.2",
+    "@photon-ai/imessage-kit": "^3.0.0",
     "@photon-ai/whatsapp-business": "^0.1.1",
     "@repeaterjs/repeater": "^3.0.6",
     "better-grpc": "^0.3.2",

--- a/packages/spectrum-ts/src/providers/imessage/local.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local.ts
@@ -1,12 +1,11 @@
 import { createReadStream } from "node:fs";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import { Readable } from "node:stream";
-import {
-  type IMessageSDK,
-  type Message as LocalIMessage,
-  readAttachmentBytes,
+import type {
+  IMessageSDK,
+  Message as LocalIMessage,
 } from "@photon-ai/imessage-kit";
 import { asAttachment } from "../../content/attachment";
 import { asContact } from "../../content/contact";
@@ -38,12 +37,16 @@ const isVCardAttachment = (
   return Boolean(fileName?.toLowerCase().endsWith(".vcf"));
 };
 
-const toSpace = (message: LocalIMessage): IMessageMessage["space"] => ({
-  id: message.chatId,
-  type: message.chatKind === "group" ? "group" : "dm",
-});
-
 type LocalAttachment = LocalIMessage["attachments"][number];
+
+const readLocalAttachment = async (att: LocalAttachment): Promise<Buffer> => {
+  if (!att.localPath) {
+    throw new Error(
+      `iMessage attachment ${att.id} has no local file available on disk`
+    );
+  }
+  return readFile(att.localPath);
+};
 
 const toAttachmentContent = (att: LocalAttachment): Content => {
   const { localPath } = att;
@@ -51,7 +54,7 @@ const toAttachmentContent = (att: LocalAttachment): Content => {
     name: att.fileName ?? DEFAULT_ATTACHMENT_NAME,
     mimeType: att.mimeType,
     size: att.sizeBytes,
-    read: () => readAttachmentBytes(att),
+    read: () => readLocalAttachment(att),
     stream: localPath
       ? async () =>
           Readable.toWeb(
@@ -63,7 +66,7 @@ const toAttachmentContent = (att: LocalAttachment): Content => {
 
 const toVCardContent = async (att: LocalAttachment): Promise<Content> => {
   try {
-    const buf = await readAttachmentBytes(att);
+    const buf = await readLocalAttachment(att);
     return asContact(fromVCard(buf.toString("utf8")));
   } catch {
     return toAttachmentContent(att);
@@ -73,9 +76,25 @@ const toVCardContent = async (att: LocalAttachment): Promise<Content> => {
 const toMessages = async (
   message: LocalIMessage
 ): Promise<IMessageMessage[]> => {
-  const base = {
+  const { chatId, chatKind } = message;
+  if (!chatId || chatKind === "unknown") {
+    return [];
+  }
+
+  // Drop rows spectrum's Content union cannot faithfully represent —
+  // reactions, group events, and retracts would collapse to empty or
+  // Apple-generated pseudo-text otherwise.
+  if (
+    message.reaction !== null ||
+    message.kind !== "text" ||
+    message.retractedAt !== null
+  ) {
+    return [];
+  }
+
+  const base: Omit<IMessageMessage, "id" | "content"> = {
     sender: { id: message.participant ?? "" },
-    space: toSpace(message),
+    space: { id: chatId, type: chatKind === "group" ? "group" : "dm" },
     timestamp: message.createdAt,
   };
 
@@ -103,19 +122,27 @@ const toMessages = async (
 export const messages = (client: IMessageSDK): ManagedStream<IMessageMessage> =>
   stream((emit, end) => {
     let lastPromise: Promise<void> = Promise.resolve();
-    client.startWatching({
-      onMessage: (message) => {
-        lastPromise = lastPromise
-          .then(() => toMessages(message))
-          .then((ms) => {
-            for (const m of ms) {
-              emit(m);
-            }
-          })
-          .catch((error) => end(error));
-      },
-    });
-    return () => client.stopWatching();
+
+    const startPromise = client
+      .startWatching({
+        onIncomingMessage: (message) => {
+          lastPromise = lastPromise
+            .then(() => toMessages(message))
+            .then((ms) => {
+              for (const m of ms) {
+                emit(m);
+              }
+            })
+            .catch(end);
+        },
+        onError: end,
+      })
+      .catch(end);
+
+    return async () => {
+      await startPromise.catch(() => {});
+      await client.stopWatching();
+    };
   });
 
 const vcardFileName = (
@@ -136,7 +163,7 @@ const sendTempFile = async (
   const tmp = join(dir, safeName);
   await writeFile(tmp, data);
   try {
-    await client.send(spaceId, { attachments: [tmp] });
+    await client.send({ to: spaceId, attachments: [tmp] });
   } finally {
     await rm(dir, { recursive: true, force: true }).catch(() => {});
   }
@@ -149,7 +176,7 @@ export const send = async (
 ) => {
   switch (content.type) {
     case "text":
-      await client.send(spaceId, content.text);
+      await client.send({ to: spaceId, text: content.text });
       break;
     case "attachment":
       await sendTempFile(client, spaceId, content.name, await content.read());


### PR DESCRIPTION
### Summary

Upgrade the iMessage local provider to `@photon-ai/imessage-kit@3.0.0`. The v3 API reshapes the watcher event surface, tightens nullable contracts on `Message` and `Attachment`, collapses the send signature, and removes the exported `readAttachmentBytes` helper. This PR adapts the provider end-to-end and adds a small result-set filter so consumers only observe events the `Content` union can faithfully represent.

### Changes

**Dependency**
- `@photon-ai/imessage-kit`: `^3.0.0-rc.2` → `^3.0.0`
- `spectrum-ts`: `0.4.0` → `0.5.0`

**Imports** (`providers/imessage/local.ts`)
- Drop the removed `readAttachmentBytes` export; add `readFile` from `node:fs/promises` and re-implement the helper locally as `readLocalAttachment`.
- Convert the imessage-kit imports to `import type` — both symbols are used for types only.

**Attachment reads**
- New `readLocalAttachment(att)` throws a descriptive error when `att.localPath` is null (v3 marks it `string | null`; the null path is a real WAL race scenario). Two call sites updated.

**Watcher subscription**
- Switch from the removed single `onMessage` callback to `onIncomingMessage`, aligning semantics with the WhatsApp provider which already consumes only `message.received`.
- Subscribe to `onError` so watcher-internal failures surface through the stream rather than being silently dropped.
- `startWatching` is now `async`; capture the returned promise and route failures through `end`.
- Teardown awaits the start promise before calling `stopWatching` to avoid a start/stop race where stop would see `watchSource === null` and no-op.

**Send API**
- `client.send(spaceId, request)` → `client.send({ to: spaceId, ...request })` per the v3 `SendRequest` shape. Two call sites updated.

**Message mapping (`toMessages`)**
- Inline the former `toSpace` helper; it cannot express "drop this row" which is required under the new null contracts.
- Guard `!chatId || chatKind === "unknown"` and return `[]` — both are legitimate transient states the v3 watcher can emit (see the `Message.chatId` JSDoc: "Observable in rare WAL races... treat as chat unknown, skip routing").
- Guard `reaction !== null || kind !== "text" || retractedAt !== null` and return `[]`. Spectrum's `Content` union has no reaction or system-event type; without this filter these rows would collapse into `{ type: "text", text: "" }` or into Apple-generated pseudo-text such as `Loved "..."`, producing spurious echo loops and indistinguishable-from-real-text events. Matches the WhatsApp provider's `Extract<MessageEvent, { type: "message.received" }>` narrowing.
- Type `base` as `Omit<IMessageMessage, "id" | "content">` so the `"group" | "dm"` literal collapses via contextual typing, removing the previous `as const` annotations. Matches the pattern in `providers/imessage/remote.ts`.

### What the stream now produces

After this change, the local provider emits exactly three content shapes, all originating from real inbound user activity:

| `Content.type` | Source |
|----------------|--------|
| `text` | Real text message (no attachments, `kind === "text"`) |
| `attachment` | Media or file attachment |
| `contact` | `.vcf` / vCard attachment, decoded into a `Contact` |

Dropped at the provider boundary: reactions (tapback, emoji, sticker), member-change events, group-name changes, group actions, retracted messages, and rows with unresolved `chatId` / `chatKind`.

### Non-goals

- Exposing reactions or system events through `Content`. That requires extending the shared `Content` union across every provider and is deliberately out of scope here.
- Changing the remote (WhatsApp) provider. Its semantics are already "received-only" and unaffected.

### Verification

- `tsc --noEmit` clean against `@photon-ai/imessage-kit@3.0.0`.
- Every v3 contract touched in this PR was cross-checked against the published source (`domain/message.ts`, `domain/chat.ts`, `domain/reaction.ts`, `application/message-dispatcher.ts`, `infra/db/mapper.ts`, `sdk.ts`).
- No behavioral change for consumers of real text / media / contact messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment error handling in iMessage provider.
  * Prevented non-text, reaction-only, or retracted items from being surfaced as messages.
  * Stabilized message watcher lifecycle to avoid emits/reads after teardown.
  * Adjusted sending flow to ensure consistent send behavior and results.

* **Chores**
  * Updated imessage-kit dependency to stable v3.0.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->