### PR TITLE
feat: WhatsApp Business cloud auth + UnsupportedError fallbacks

### DIFF
--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -44,5 +44,6 @@ export type {
   TokenData,
 } from "./utils/cloud";
 export { cloud, SpectrumCloudError } from "./utils/cloud";
+export { UnsupportedError, type UnsupportedKind } from "./utils/errors";
 export { type ManagedStream, mergeStreams, stream } from "./utils/stream";
 export { fromVCard, toVCard } from "./utils/vcard";

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -6,7 +6,37 @@ import type {
   OutboundMessage,
 } from "../types/message";
 import type { Space } from "../types/space";
+import { UnsupportedError } from "../utils/errors";
 import type { AnyPlatformDef, SendResult } from "./types";
+
+const ANSI_YELLOW = "\x1b[33m";
+const ANSI_RESET = "\x1b[0m";
+
+const supportsAnsiColor = (): boolean => {
+  if (typeof process === "undefined") {
+    return false;
+  }
+  if (process.env.NO_COLOR) {
+    return false;
+  }
+  if (process.env.FORCE_COLOR) {
+    return true;
+  }
+  return Boolean(process.stderr?.isTTY);
+};
+
+const warnUnsupported = (err: UnsupportedError, fallbackPlatform: string) => {
+  const platform = err.platform ?? fallbackPlatform;
+  const subject =
+    err.kind === "content"
+      ? `content type "${err.contentType ?? "unknown"}"`
+      : `action "${err.action ?? "unknown"}"`;
+  const detail = err.detail ? `: ${err.detail}` : "";
+  const body = `[spectrum-ts] ${platform} does not support ${subject}${detail}; skipping.`;
+  console.warn(
+    supportsAnsiColor() ? `${ANSI_YELLOW}${body}${ANSI_RESET}` : body
+  );
+};
 
 export type SpaceRef = {
   id: string;
@@ -53,14 +83,23 @@ export function buildSpace(params: BuildSpaceParams): Space {
 
   async function sendImpl(
     ...content: [ContentInput, ...ContentInput[]]
-  ): Promise<OutboundMessage | OutboundMessage[]> {
+  ): Promise<OutboundMessage | OutboundMessage[] | undefined> {
     const resolved = await resolveContents(content);
     const results: OutboundMessage[] = [];
     for (const item of resolved) {
-      const sendResult = (await definition.actions.send({
-        ...typingCtx,
-        content: item,
-      })) as SendResult | undefined;
+      let sendResult: SendResult | undefined;
+      try {
+        sendResult = (await definition.actions.send({
+          ...typingCtx,
+          content: item,
+        })) as SendResult | undefined;
+      } catch (err) {
+        if (err instanceof UnsupportedError) {
+          warnUnsupported(err, definition.name);
+          continue;
+        }
+        throw err;
+      }
       if (!sendResult?.id) {
         throw new Error(
           `Platform "${definition.name}" send did not return a message id`
@@ -82,7 +121,10 @@ export function buildSpace(params: BuildSpaceParams): Space {
         })
       );
     }
-    return content.length === 1 && results[0] ? results[0] : results;
+    if (content.length === 1) {
+      return results[0];
+    }
+    return results;
   }
 
   space = {
@@ -120,6 +162,10 @@ export function buildMessage(params: BuildMessageParams): Message {
 
   const react = async (reaction: string): Promise<void> => {
     if (!definition.actions.reactToMessage) {
+      warnUnsupported(
+        UnsupportedError.action("react", definition.name),
+        definition.name
+      );
       return;
     }
     await definition.actions.reactToMessage({
@@ -137,22 +183,33 @@ export function buildMessage(params: BuildMessageParams): Message {
   ): Promise<OutboundMessage[]>;
   async function reply(
     ...content: [ContentInput, ...ContentInput[]]
-  ): Promise<OutboundMessage | OutboundMessage[]> {
+  ): Promise<OutboundMessage | OutboundMessage[] | undefined> {
     if (!definition.actions.replyToMessage) {
-      throw new Error(
-        `Platform "${definition.name}" does not support replying to messages`
+      warnUnsupported(
+        UnsupportedError.action("reply", definition.name),
+        definition.name
       );
+      return content.length === 1 ? undefined : [];
     }
     const resolved = await resolveContents(content);
     const results: OutboundMessage[] = [];
     for (const item of resolved) {
-      const sendResult = (await definition.actions.replyToMessage({
-        space: spaceRef,
-        messageId: params.id,
-        content: item,
-        client,
-        config,
-      })) as SendResult | undefined;
+      let sendResult: SendResult | undefined;
+      try {
+        sendResult = (await definition.actions.replyToMessage({
+          space: spaceRef,
+          messageId: params.id,
+          content: item,
+          client,
+          config,
+        })) as SendResult | undefined;
+      } catch (err) {
+        if (err instanceof UnsupportedError) {
+          warnUnsupported(err, definition.name);
+          continue;
+        }
+        throw err;
+      }
       if (!sendResult?.id) {
         throw new Error(
           `Platform "${definition.name}" reply did not return a message id`
@@ -174,7 +231,10 @@ export function buildMessage(params: BuildMessageParams): Message {
         })
       );
     }
-    return content.length === 1 && results[0] ? results[0] : results;
+    if (content.length === 1) {
+      return results[0];
+    }
+    return results;
   }
 
   const senderWithPlatform =
@@ -193,21 +253,31 @@ export function buildMessage(params: BuildMessageParams): Message {
       reply,
       edit: async (newContent: ContentInput): Promise<void> => {
         if (!definition.actions.editMessage) {
-          throw new Error(
-            `Platform "${definition.name}" does not support editing messages`
+          warnUnsupported(
+            UnsupportedError.action("edit", definition.name),
+            definition.name
           );
+          return;
         }
         const [resolved] = await resolveContents([newContent]);
         if (!resolved) {
           return;
         }
-        await definition.actions.editMessage({
-          space: spaceRef,
-          messageId: params.id,
-          content: resolved,
-          client,
-          config,
-        });
+        try {
+          await definition.actions.editMessage({
+            space: spaceRef,
+            messageId: params.id,
+            content: resolved,
+            client,
+            config,
+          });
+        } catch (err) {
+          if (err instanceof UnsupportedError) {
+            warnUnsupported(err, definition.name);
+            return;
+          }
+          throw err;
+        }
       },
       sender: senderWithPlatform,
       space,

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -19,8 +19,9 @@ const supportsAnsiColor = (): boolean => {
   if (process.env.NO_COLOR) {
     return false;
   }
-  if (process.env.FORCE_COLOR) {
-    return true;
+  const force = process.env.FORCE_COLOR;
+  if (force !== undefined) {
+    return force !== "" && force !== "0" && force !== "false";
   }
   return Boolean(process.stderr?.isTTY);
 };
@@ -177,7 +178,9 @@ export function buildMessage(params: BuildMessageParams): Message {
     });
   };
 
-  async function reply(content: ContentInput): Promise<OutboundMessage>;
+  async function reply(
+    content: ContentInput
+  ): Promise<OutboundMessage | undefined>;
   async function reply(
     ...content: [ContentInput, ContentInput, ...ContentInput[]]
   ): Promise<OutboundMessage[]>;

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -1,6 +1,7 @@
 import { createClient, directChat } from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
 import { definePlatform } from "../../platform/define";
+import { UnsupportedError } from "../../utils/errors";
 import { createCloudClients, disposeCloudAuth } from "./auth";
 import { messages as localMessages, send as localSend } from "./local";
 import {
@@ -41,8 +42,10 @@ export const imessage = definePlatform("iMessage", {
     schema: spaceSchema,
     resolve: async ({ input, client }) => {
       if (isLocal(client)) {
-        throw new Error(
-          "Space creation is not supported in local mode. Local mode only supports replying to messages."
+        throw UnsupportedError.action(
+          "createSpace",
+          "iMessage (local mode)",
+          "local mode only supports replying to existing messages"
         );
       }
 
@@ -141,17 +144,13 @@ export const imessage = definePlatform("iMessage", {
     },
     replyToMessage: async ({ space, messageId, content, client }) => {
       if (isLocal(client)) {
-        throw new Error(
-          "iMessage local mode does not support replying to messages"
-        );
+        throw UnsupportedError.action("reply", "iMessage (local mode)");
       }
       return await remoteReplyToMessage(client, space.id, messageId, content);
     },
     editMessage: async ({ space, messageId, content, client }) => {
       if (isLocal(client)) {
-        throw new Error(
-          "iMessage local mode does not support editing messages"
-        );
+        throw UnsupportedError.action("edit", "iMessage (local mode)");
       }
       await remoteEditMessage(client, space.id, messageId, content);
     },

--- a/packages/spectrum-ts/src/providers/imessage/local.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local.ts
@@ -11,6 +11,7 @@ import { asAttachment } from "../../content/attachment";
 import { asContact } from "../../content/contact";
 import type { Content } from "../../content/types";
 import type { SendResult } from "../../platform/types";
+import { UnsupportedError } from "../../utils/errors";
 import { type ManagedStream, stream } from "../../utils/stream";
 import { fromVCard, toVCard } from "../../utils/vcard";
 import type { IMessageMessage } from "./types";
@@ -206,8 +207,6 @@ export const send = async (
       return synthSendResult();
     }
     default:
-      throw new Error(
-        `Unsupported iMessage local content type: ${content.type}`
-      );
+      throw UnsupportedError.content(content.type, "iMessage (local mode)");
   }
 };

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -12,9 +12,15 @@ import { asText } from "../../content/text";
 import type { Content } from "../../content/types";
 import type { SendResult } from "../../platform/types";
 import { ensureM4a } from "../../utils/audio";
+import { UnsupportedError } from "../../utils/errors";
 import { type ManagedStream, mergeStreams, stream } from "../../utils/stream";
 import { fromVCard, toVCard } from "../../utils/vcard";
 import type { IMessageMessage } from "./types";
+
+const PLATFORM = "iMessage";
+
+const unsupportedContent = (type: string): UnsupportedError =>
+  UnsupportedError.content(type, PLATFORM);
 
 const toSendResult = (receipt: { guid: unknown }): SendResult => ({
   id: receipt.guid as string,
@@ -234,7 +240,7 @@ export const send = async (
       );
     }
     default:
-      throw new Error(`Unsupported iMessage content type: ${content.type}`);
+      throw unsupportedContent(content.type);
   }
 };
 
@@ -295,7 +301,7 @@ export const replyToMessage = async (
       );
     }
     default:
-      throw new Error(`Unsupported iMessage content type: ${content.type}`);
+      throw unsupportedContent(content.type);
   }
 };
 
@@ -306,7 +312,11 @@ export const editMessage = async (
   content: Content
 ) => {
   if (content.type !== "text") {
-    throw new Error("iMessage only supports editing text content");
+    throw UnsupportedError.content(
+      content.type,
+      PLATFORM,
+      "only text content can be edited"
+    );
   }
   const remote = clients[0];
   if (!remote) {

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -1,6 +1,7 @@
 import { createInterface } from "node:readline";
 import z from "zod";
 import { definePlatform } from "../../platform/define";
+import { UnsupportedError } from "../../utils/errors";
 
 export const terminal = definePlatform("terminal", {
   config: z.object({}),
@@ -55,9 +56,7 @@ export const terminal = definePlatform("terminal", {
   actions: {
     send: async ({ content }) => {
       if (content.type !== "text") {
-        throw new Error(
-          `Terminal provider only supports text content, got "${content.type}"`
-        );
+        throw UnsupportedError.content(content.type, "terminal");
       }
       console.log(content.text);
       return { id: crypto.randomUUID(), timestamp: new Date() };

--- a/packages/spectrum-ts/src/providers/whatsapp-business/auth.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/auth.ts
@@ -87,7 +87,11 @@ export async function createCloudClients(
       try {
         await refreshTokens();
         scheduleRenewal();
-      } catch {
+      } catch (err) {
+        console.warn(
+          `[spectrum-ts] WhatsApp Business token refresh failed; retrying in ${RETRY_DELAY_MS}ms.`,
+          err
+        );
         renewalTimer = setTimeout(() => scheduleRenewal(), RETRY_DELAY_MS);
         renewalTimer?.unref?.();
       }

--- a/packages/spectrum-ts/src/providers/whatsapp-business/auth.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/auth.ts
@@ -76,10 +76,18 @@ export async function createCloudClients(
     }
   };
 
+  const clearRenewalTimer = () => {
+    if (renewalTimer !== undefined) {
+      clearTimeout(renewalTimer);
+      renewalTimer = undefined;
+    }
+  };
+
   const scheduleRenewal = () => {
     if (disposed) {
       return;
     }
+    clearRenewalTimer();
     const ttlMs = tokenData.expiresIn * 1000;
     const renewInMs = Math.max(ttlMs * RENEWAL_RATIO, 5000);
 
@@ -92,6 +100,7 @@ export async function createCloudClients(
           `[spectrum-ts] WhatsApp Business token refresh failed; retrying in ${RETRY_DELAY_MS}ms.`,
           err
         );
+        clearRenewalTimer();
         renewalTimer = setTimeout(() => scheduleRenewal(), RETRY_DELAY_MS);
         renewalTimer?.unref?.();
       }
@@ -123,10 +132,7 @@ export async function createCloudClients(
   cloudAuthState.set(clients, {
     dispose: async () => {
       disposed = true;
-      if (renewalTimer !== undefined) {
-        clearTimeout(renewalTimer);
-        renewalTimer = undefined;
-      }
+      clearRenewalTimer();
       for (const state of lines.values()) {
         for (const sub of state.subscriptions) {
           sub.close();

--- a/packages/spectrum-ts/src/providers/whatsapp-business/auth.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/auth.ts
@@ -1,0 +1,278 @@
+import {
+  createClient,
+  type SubscribeOptions,
+  TypedEventStream,
+  type WhatsAppClient,
+  type WhatsAppEvent,
+} from "@photon-ai/whatsapp-business";
+import { cloud } from "../../utils/cloud";
+import { stream } from "../../utils/stream";
+
+const RENEWAL_RATIO = 0.8;
+const EXPIRY_BUFFER_MS = 30_000;
+const RETRY_DELAY_MS = 30_000;
+const RESUBSCRIBE_BACKOFF_MS = 500;
+
+interface CloudAuth {
+  dispose: () => Promise<void>;
+}
+
+interface LineSubscription {
+  close: () => void;
+  swap: () => void;
+}
+
+interface LineState {
+  current: WhatsAppClient;
+  subscriptions: Set<LineSubscription>;
+}
+
+const cloudAuthState = new WeakMap<WhatsAppClient[], CloudAuth>();
+
+// `@photon-ai/whatsapp-business` 0.1.x does not accept a token callback, so we
+// recreate the underlying client before each RPC when the token is near expiry,
+// and transparently re-subscribe long-lived event streams across swaps.
+export async function createCloudClients(
+  projectId: string,
+  projectSecret: string
+): Promise<WhatsAppClient[]> {
+  let tokenData = await cloud.issueWhatsappBusinessTokens(
+    projectId,
+    projectSecret
+  );
+  let tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
+  let disposed = false;
+  let renewalTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const lines = new Map<string, LineState>();
+
+  const buildRawClient = (phoneNumberId: string): WhatsAppClient => {
+    const accessToken = tokenData.auth[phoneNumberId];
+    if (!accessToken) {
+      throw new Error(
+        `WhatsApp Business line ${phoneNumberId} missing from token response`
+      );
+    }
+    return createClient({ accessToken, appSecret: "", phoneNumberId });
+  };
+
+  const refreshTokens = async (): Promise<void> => {
+    tokenData = await cloud.issueWhatsappBusinessTokens(
+      projectId,
+      projectSecret
+    );
+    tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
+
+    for (const [phoneNumberId, state] of lines) {
+      if (!tokenData.auth[phoneNumberId]) {
+        continue;
+      }
+      const old = state.current;
+      state.current = buildRawClient(phoneNumberId);
+      for (const sub of state.subscriptions) {
+        sub.swap();
+      }
+      await old.close().catch(() => undefined);
+    }
+  };
+
+  const scheduleRenewal = () => {
+    if (disposed) {
+      return;
+    }
+    const ttlMs = tokenData.expiresIn * 1000;
+    const renewInMs = Math.max(ttlMs * RENEWAL_RATIO, 5000);
+
+    renewalTimer = setTimeout(async () => {
+      try {
+        await refreshTokens();
+        scheduleRenewal();
+      } catch {
+        renewalTimer = setTimeout(() => scheduleRenewal(), RETRY_DELAY_MS);
+        renewalTimer?.unref?.();
+      }
+    }, renewInMs);
+    renewalTimer?.unref?.();
+  };
+
+  const refreshIfNeeded = async (): Promise<void> => {
+    if (Date.now() < tokenExpiresAt - EXPIRY_BUFFER_MS) {
+      return;
+    }
+    await refreshTokens();
+    scheduleRenewal();
+  };
+
+  scheduleRenewal();
+
+  const clients: WhatsAppClient[] = Object.keys(tokenData.auth).map(
+    (phoneNumberId) => {
+      const state: LineState = {
+        current: buildRawClient(phoneNumberId),
+        subscriptions: new Set(),
+      };
+      lines.set(phoneNumberId, state);
+      return buildClientProxy(state, refreshIfNeeded);
+    }
+  );
+
+  cloudAuthState.set(clients, {
+    dispose: async () => {
+      disposed = true;
+      if (renewalTimer !== undefined) {
+        clearTimeout(renewalTimer);
+        renewalTimer = undefined;
+      }
+      for (const state of lines.values()) {
+        for (const sub of state.subscriptions) {
+          sub.close();
+        }
+      }
+      await Promise.allSettled(
+        Array.from(lines.values()).map((s) => s.current.close())
+      );
+      lines.clear();
+    },
+  });
+
+  return clients;
+}
+
+export async function disposeCloudAuth(
+  clients: WhatsAppClient[]
+): Promise<void> {
+  const auth = cloudAuthState.get(clients);
+  if (!auth) {
+    return;
+  }
+  await auth.dispose();
+  cloudAuthState.delete(clients);
+}
+
+const buildClientProxy = (
+  state: LineState,
+  refresh: () => Promise<void>
+): WhatsAppClient => {
+  const forwarder = <T extends object>(pick: (c: WhatsAppClient) => T): T =>
+    new Proxy({} as T, {
+      get: (_, prop: string | symbol) => {
+        return async (...args: unknown[]) => {
+          await refresh();
+          const target = pick(state.current) as Record<
+            string | symbol,
+            unknown
+          >;
+          const fn = target[prop] as (...a: unknown[]) => unknown;
+          return Reflect.apply(fn, pick(state.current), args);
+        };
+      },
+    });
+
+  const events = {
+    fetchMissed: async (
+      opts: Parameters<WhatsAppClient["events"]["fetchMissed"]>[0]
+    ) => {
+      await refresh();
+      return state.current.events.fetchMissed(opts);
+    },
+    subscribe: (options?: SubscribeOptions) =>
+      resubscribableStream(state, options),
+  } as unknown as WhatsAppClient["events"];
+
+  return {
+    events,
+    media: forwarder((c) => c.media),
+    messages: forwarder((c) => c.messages),
+    close: async () => {
+      for (const sub of state.subscriptions) {
+        sub.close();
+      }
+      await state.current.close();
+    },
+    [Symbol.asyncDispose]: async () => {
+      for (const sub of state.subscriptions) {
+        sub.close();
+      }
+      await state.current.close();
+    },
+  };
+};
+
+interface ResubscribeContext {
+  emit: (event: WhatsAppEvent) => void;
+  getCurrent: () => WhatsAppClient;
+  options?: SubscribeOptions;
+  setActive: (stream: TypedEventStream<WhatsAppEvent> | undefined) => void;
+}
+
+const pumpOnce = async (ctx: ResubscribeContext): Promise<boolean> => {
+  const sub = ctx.getCurrent().events.subscribe(ctx.options);
+  ctx.setActive(sub);
+  try {
+    for await (const event of sub) {
+      ctx.emit(event);
+    }
+    return true;
+  } catch {
+    return false;
+  } finally {
+    ctx.setActive(undefined);
+  }
+};
+
+// Returns a TypedEventStream that stays open across client swaps: on swap we
+// close the underlying subscription and the worker loop re-subscribes against
+// `state.current`.
+const resubscribableStream = (
+  state: LineState,
+  options?: SubscribeOptions
+): TypedEventStream<WhatsAppEvent> => {
+  let closed = false;
+  let active: TypedEventStream<WhatsAppEvent> | undefined;
+
+  const source = stream<WhatsAppEvent>((emit, end) => {
+    const ctx: ResubscribeContext = {
+      emit,
+      getCurrent: () => state.current,
+      options,
+      setActive: (s) => {
+        active = s;
+      },
+    };
+    (async () => {
+      while (!closed) {
+        await pumpOnce(ctx);
+        if (!closed) {
+          await new Promise((r) => setTimeout(r, RESUBSCRIBE_BACKOFF_MS));
+        }
+      }
+      end();
+    })();
+
+    return () => {
+      closed = true;
+      active?.close().catch(() => undefined);
+      active = undefined;
+      state.subscriptions.delete(subscription);
+    };
+  });
+
+  const subscription: LineSubscription = {
+    close: () => {
+      closed = true;
+      active?.close().catch(() => undefined);
+    },
+    swap: () => {
+      // Force the inner for-await to end; worker loop re-subscribes to state.current.
+      active?.close().catch(() => undefined);
+    },
+  };
+  state.subscriptions.add(subscription);
+
+  return new TypedEventStream<WhatsAppEvent>(source, async () => {
+    closed = true;
+    active?.close().catch(() => undefined);
+    state.subscriptions.delete(subscription);
+    await source.close();
+  });
+};

--- a/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
@@ -1,5 +1,6 @@
 import { createClient } from "@photon-ai/whatsapp-business";
 import { definePlatform } from "../../platform/define";
+import { UnsupportedError } from "../../utils/errors";
 import { createCloudClients, disposeCloudAuth } from "./auth";
 import { messages, reactToMessage, replyToMessage, send } from "./messages";
 import {
@@ -23,8 +24,10 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
         throw new Error("WhatsApp space creation requires at least one user");
       }
       if (input.users.length > 1) {
-        throw new Error(
-          "WhatsApp Business API only supports 1:1 conversations"
+        throw UnsupportedError.action(
+          "createSpace",
+          "WhatsApp Business",
+          "only 1:1 conversations are supported"
         );
       }
       const user = input.users[0];

--- a/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
@@ -1,10 +1,13 @@
-import {
-  createClient,
-  type WhatsAppClient,
-} from "@photon-ai/whatsapp-business";
+import { createClient } from "@photon-ai/whatsapp-business";
 import { definePlatform } from "../../platform/define";
+import { createCloudClients, disposeCloudAuth } from "./auth";
 import { messages, reactToMessage, replyToMessage, send } from "./messages";
-import { configSchema, spaceSchema } from "./types";
+import {
+  configSchema,
+  isCloudConfig,
+  spaceSchema,
+  type WhatsAppClients,
+} from "./types";
 
 export const whatsappBusiness = definePlatform("WhatsApp Business", {
   config: configSchema,
@@ -33,31 +36,50 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
   },
 
   lifecycle: {
-    createClient: async ({ config }): Promise<WhatsAppClient> => {
-      return createClient({
-        accessToken: config.accessToken,
-        phoneNumberId: config.phoneNumberId,
-        appSecret: config.appSecret ?? "",
-      });
+    createClient: async ({
+      config,
+      projectId,
+      projectSecret,
+    }): Promise<WhatsAppClients> => {
+      if (!isCloudConfig(config)) {
+        return [
+          createClient({
+            accessToken: config.accessToken,
+            appSecret: config.appSecret ?? "",
+            phoneNumberId: config.phoneNumberId,
+          }),
+        ];
+      }
+
+      if (!(projectId && projectSecret)) {
+        throw new Error(
+          "WhatsApp Business cloud mode requires projectId and projectSecret. " +
+            "Either pass credentials to Spectrum(), or provide direct credentials: " +
+            "whatsappBusiness.config({ accessToken, phoneNumberId })"
+        );
+      }
+
+      return await createCloudClients(projectId, projectSecret);
     },
 
-    destroyClient: async ({ client }: { client: WhatsAppClient }) => {
-      await client.close();
+    destroyClient: async ({ client }: { client: WhatsAppClients }) => {
+      await disposeCloudAuth(client);
+      await Promise.all(client.map((c) => c.close()));
     },
   },
 
   events: {
-    messages: ({ client }) => messages(client as WhatsAppClient),
+    messages: ({ client }) => messages(client as WhatsAppClients),
   },
 
   actions: {
     send: async ({ space, content, client }) => {
-      return await send(client as WhatsAppClient, space.id, content);
+      return await send(client as WhatsAppClients, space.id, content);
     },
 
     reactToMessage: async ({ space, messageId, reaction, client }) => {
       await reactToMessage(
-        client as WhatsAppClient,
+        client as WhatsAppClients,
         space.id,
         messageId,
         reaction
@@ -66,7 +88,7 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
 
     replyToMessage: async ({ space, messageId, content, client }) => {
       return await replyToMessage(
-        client as WhatsAppClient,
+        client as WhatsAppClients,
         space.id,
         messageId,
         content

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -19,6 +19,7 @@ import { asCustom } from "../../content/custom";
 import { asText } from "../../content/text";
 import type { Content } from "../../content/types";
 import type { SendResult } from "../../platform/types";
+import { UnsupportedError } from "../../utils/errors";
 import { type ManagedStream, mergeStreams, stream } from "../../utils/stream";
 import type { WhatsAppClients, WhatsAppMessage } from "./types";
 
@@ -462,7 +463,7 @@ export const send = async (
       );
     }
     default:
-      throw new Error(`Unsupported WhatsApp content type: ${content.type}`);
+      throw UnsupportedError.content(content.type);
   }
 };
 
@@ -536,6 +537,6 @@ export const replyToMessage = async (
       );
     }
     default:
-      throw new Error(`Unsupported WhatsApp content type: ${content.type}`);
+      throw UnsupportedError.content(content.type);
   }
 };

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -19,8 +19,19 @@ import { asCustom } from "../../content/custom";
 import { asText } from "../../content/text";
 import type { Content } from "../../content/types";
 import type { SendResult } from "../../platform/types";
-import { type ManagedStream, stream } from "../../utils/stream";
-import type { WhatsAppMessage } from "./types";
+import { type ManagedStream, mergeStreams, stream } from "../../utils/stream";
+import type { WhatsAppClients, WhatsAppMessage } from "./types";
+
+// v1 routes outbound traffic to the first line. When multi-line send becomes a
+// requirement, extend spaceSchema with an optional `line` (phoneNumberId) and
+// pick the matching client here.
+const primary = (clients: WhatsAppClients): WhatsAppClient => {
+  const client = clients[0];
+  if (!client) {
+    throw new Error("No WhatsApp Business client available");
+  }
+  return client;
+};
 
 type WaSendResult = Awaited<ReturnType<WhatsAppClient["messages"]["send"]>>;
 
@@ -371,7 +382,7 @@ const contactToWa = (contact: Contact): ContactCardInput => {
   return card;
 };
 
-export const messages = (
+const clientStream = (
   client: WhatsAppClient
 ): ManagedStream<WhatsAppMessage> => {
   const eventStream = client.events
@@ -397,11 +408,16 @@ export const messages = (
   });
 };
 
+export const messages = (
+  clients: WhatsAppClients
+): ManagedStream<WhatsAppMessage> => mergeStreams(clients.map(clientStream));
+
 export const send = async (
-  client: WhatsAppClient,
+  clients: WhatsAppClients,
   spaceId: string,
   content: Content
 ): Promise<SendResult> => {
+  const client = primary(clients);
   switch (content.type) {
     case "text":
       return toSendResult(
@@ -451,23 +467,24 @@ export const send = async (
 };
 
 export const reactToMessage = async (
-  client: WhatsAppClient,
+  clients: WhatsAppClients,
   spaceId: string,
   messageId: string,
   reaction: string
 ): Promise<void> => {
-  await client.messages.send({
+  await primary(clients).messages.send({
     to: spaceId,
     reaction: { messageId, emoji: reaction },
   });
 };
 
 export const replyToMessage = async (
-  client: WhatsAppClient,
+  clients: WhatsAppClients,
   spaceId: string,
   messageId: string,
   content: Content
 ): Promise<SendResult> => {
+  const client = primary(clients);
   switch (content.type) {
     case "text":
       return toSendResult(

--- a/packages/spectrum-ts/src/providers/whatsapp-business/types.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/types.ts
@@ -1,11 +1,23 @@
+import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
 import z from "zod";
 import type { SchemaMessage } from "../../platform/types";
 
-export const configSchema = z.object({
+const directConfig = z.object({
   accessToken: z.string().min(1),
-  phoneNumberId: z.string().min(1),
   appSecret: z.string().optional(),
+  phoneNumberId: z.string().min(1),
 });
+
+const cloudConfig = z.object({}).strict();
+
+export const configSchema = z.union([directConfig, cloudConfig]);
+
+export type WhatsAppConfig = z.infer<typeof configSchema>;
+export type WhatsAppClients = WhatsAppClient[];
+
+export const isCloudConfig = (
+  config: WhatsAppConfig
+): config is z.infer<typeof cloudConfig> => !("accessToken" in config);
 
 export const userSchema = z.object({});
 

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -37,7 +37,10 @@ export type SpectrumInstance<
   CustomEventStreams<Providers> & {
     readonly messages: AsyncIterable<[Space, InboundMessage]>;
     stop(): Promise<void>;
-    send(space: Space, content: ContentInput): Promise<OutboundMessage>;
+    send(
+      space: Space,
+      content: ContentInput
+    ): Promise<OutboundMessage | undefined>;
     send(
       space: Space,
       ...content: [ContentInput, ContentInput, ...ContentInput[]]
@@ -325,7 +328,7 @@ export async function Spectrum<
     send: (async (
       space: Space,
       ...content: [ContentInput, ...ContentInput[]]
-    ): Promise<OutboundMessage | OutboundMessage[]> => {
+    ): Promise<OutboundMessage | OutboundMessage[] | undefined> => {
       return content.length === 1
         ? await space.send(content[0])
         : await space.send(

--- a/packages/spectrum-ts/src/types/message.ts
+++ b/packages/spectrum-ts/src/types/message.ts
@@ -13,7 +13,7 @@ interface BaseMessage<
   react(reaction: string): Promise<void>;
   reply(
     content: ContentInput
-  ): Promise<OutboundMessage<TPlatform, TSender, TSpace>>;
+  ): Promise<OutboundMessage<TPlatform, TSender, TSpace> | undefined>;
   reply(
     ...content: [ContentInput, ContentInput, ...ContentInput[]]
   ): Promise<OutboundMessage<TPlatform, TSender, TSpace>[]>;

--- a/packages/spectrum-ts/src/types/space.ts
+++ b/packages/spectrum-ts/src/types/space.ts
@@ -6,7 +6,7 @@ export interface Space<_Def = unknown> {
   edit(message: OutboundMessage, newContent: ContentInput): Promise<void>;
   readonly id: string;
   responding<T>(fn: () => T | Promise<T>): Promise<T>;
-  send(content: ContentInput): Promise<OutboundMessage>;
+  send(content: ContentInput): Promise<OutboundMessage | undefined>;
   send(
     ...content: [ContentInput, ContentInput, ...ContentInput[]]
   ): Promise<OutboundMessage[]>;

--- a/packages/spectrum-ts/src/utils/cloud.ts
+++ b/packages/spectrum-ts/src/utils/cloud.ts
@@ -37,6 +37,12 @@ export interface ImessageInfoData {
   type: "shared" | "dedicated";
 }
 
+export interface WhatsappBusinessTokenData {
+  auth: Record<string, string>;
+  expiresIn: number;
+  numbers: Record<string, string | null>;
+}
+
 // ---------------------------------------------------------------------------
 // Error
 // ---------------------------------------------------------------------------
@@ -126,6 +132,15 @@ export const cloud = {
 
   getImessageInfo: (projectId: string): Promise<ImessageInfoData> =>
     request(`/projects/${projectId}/imessage/`),
+
+  issueWhatsappBusinessTokens: (
+    projectId: string,
+    projectSecret: string
+  ): Promise<WhatsappBusinessTokenData> =>
+    request(`/projects/${projectId}/whatsapp-business/tokens`, {
+      method: "POST",
+      headers: { Authorization: basicAuth(projectId, projectSecret) },
+    }),
 
   getPlatforms: (projectId: string): Promise<PlatformsData> =>
     request(`/projects/${projectId}/platforms/`),

--- a/packages/spectrum-ts/src/utils/errors.ts
+++ b/packages/spectrum-ts/src/utils/errors.ts
@@ -1,0 +1,71 @@
+export type UnsupportedKind = "content" | "action";
+
+interface UnsupportedErrorOptions {
+  action?: string;
+  contentType?: string;
+  detail?: string;
+  kind: UnsupportedKind;
+  platform?: string;
+}
+
+const composeMessage = (opts: UnsupportedErrorOptions): string => {
+  const platform = opts.platform ?? "platform";
+  const subject =
+    opts.kind === "content"
+      ? `content type "${opts.contentType ?? "unknown"}"`
+      : `action "${opts.action ?? "unknown"}"`;
+  const detail = opts.detail ? `: ${opts.detail}` : "";
+  return `${platform} does not support ${subject}${detail}`;
+};
+
+export class UnsupportedError extends Error {
+  readonly kind: UnsupportedKind;
+  readonly platform?: string;
+  readonly contentType?: string;
+  readonly action?: string;
+  readonly detail?: string;
+
+  constructor(opts: UnsupportedErrorOptions) {
+    super(composeMessage(opts));
+    this.name = "UnsupportedError";
+    this.kind = opts.kind;
+    this.platform = opts.platform;
+    this.contentType = opts.contentType;
+    this.action = opts.action;
+    this.detail = opts.detail;
+  }
+
+  static content(
+    contentType: string,
+    platform?: string,
+    detail?: string
+  ): UnsupportedError {
+    return new UnsupportedError({
+      kind: "content",
+      contentType,
+      platform,
+      detail,
+    });
+  }
+
+  static action(
+    action: string,
+    platform?: string,
+    detail?: string
+  ): UnsupportedError {
+    return new UnsupportedError({ kind: "action", action, platform, detail });
+  }
+
+  withPlatform(platform: string): UnsupportedError {
+    if (this.platform) {
+      return this;
+    }
+    return new UnsupportedError({
+      kind: this.kind,
+      platform,
+      contentType: this.contentType,
+      action: this.action,
+      detail: this.detail,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a Spectrum Cloud auth path for the WhatsApp Business provider: omitting direct credentials triggers `cloud.issueWhatsappBusinessTokens`, which returns one access token per phone-number line. Tokens auto-renew before expiry, clients get swapped in place, and long-lived `events.subscribe()` streams re-subscribe transparently across swaps.
- Introduces multi-line support end-to-end: `createClient` now returns `WhatsAppClient[]`, inbound message streams are merged across lines via `mergeStreams`, and outbound traffic routes to the primary line for now (with a comment marking the extension point).
- Adds `UnsupportedError` (and `UnsupportedKind` type) as a first-class way for providers to signal that a content type or action isn't available. Providers throw it; the platform runtime catches it and emits a yellow stderr warning instead of crashing the send/reply/edit loop. `react()` and `edit()` on unsupported platforms now no-op with a warning, and `send`/`reply` return `undefined` (single) or skip the item (batch) rather than throwing.
- Converts existing provider-specific "not supported" `Error`s to `UnsupportedError` across iMessage (local/remote), terminal, and WhatsApp.

## Usage

Cloud mode — no credentials required beyond the Spectrum project:

```typescript
import { Spectrum } from "spectrum-ts";
import { whatsappBusiness } from "spectrum-ts/providers/whatsapp-business";

const app = await Spectrum({
  projectId: process.env.PROJECT_ID,
  projectSecret: process.env.PROJECT_SECRET,
  providers: [whatsappBusiness.config({})],
});
```

Direct mode still works unchanged:

```typescript
whatsappBusiness.config({
  accessToken: process.env.WA_TOKEN,
  phoneNumberId: process.env.WA_PHONE_NUMBER_ID,
});
```

Unsupported-op handling — callers can opt into strict behavior by checking the return value:

```typescript
const sent = await space.send(voiceClip); // may be undefined on terminal
if (!sent) return;
await sent.react("👍"); // no-ops with a warning on providers that don't support reactions
```

## Changes

| File | Change |
|---|---|
| `utils/errors.ts` | New `UnsupportedError` with `content()` / `action()` / `withPlatform()` factories |
| `utils/cloud.ts` | New `issueWhatsappBusinessTokens` + `WhatsappBusinessTokenData` type |
| `platform/build.ts` | `sendImpl`/`reply`/`edit`/`react` catch `UnsupportedError` → warn + skip; single-item returns allow `undefined` |
| `types/message.ts`, `types/space.ts`, `spectrum.ts` | Single-content `send`/`reply` return types widened to `… \| undefined` |
| `providers/whatsapp-business/auth.ts` | New — cloud token lifecycle, client proxy, resubscribable event stream |
| `providers/whatsapp-business/index.ts` | Routes cloud vs direct config; client is now `WhatsAppClients` |
| `providers/whatsapp-business/messages.ts` | `messages()` merges per-line streams; send/reply route through `primary()` |
| `providers/whatsapp-business/types.ts` | `configSchema` becomes a union of direct + cloud; `isCloudConfig` helper |
| `providers/imessage/*`, `providers/terminal/index.ts` | Replace `throw new Error(...)` for unsupported ops with `UnsupportedError` |
| `index.ts` | Export `UnsupportedError` + `UnsupportedKind` |

## Test plan

- [ ] Build cleanly: `bun x ultracite check` and `bun run build`
- [ ] WhatsApp cloud mode end-to-end: `whatsappBusiness.config({})` + `projectId`/`projectSecret` issues tokens, receives inbound messages across all lines, and sends outbound successfully
- [ ] Token renewal: force a short expiry and confirm the client swaps without dropping an active `events.subscribe()` stream
- [ ] Direct mode regression: `whatsappBusiness.config({ accessToken, phoneNumberId })` still works
- [ ] Unsupported-op warnings: send a non-text content to the terminal provider, call `react()` on a WhatsApp message, and call `edit()` on iMessage local — each should log a single yellow stderr warning and continue instead of throwing
- [ ] `NO_COLOR=1` suppresses ANSI colors; non-TTY stderr also prints plain text


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cloud-auth support for WhatsApp Business with multi-client handling and token refresh.

* **Bug Fixes**
  * Provider operations now emit warnings for unsupported actions/content instead of crashing.
  * Single-item send/reply may resolve to no result when an operation is unsupported.

* **Refactors**
  * Unified, structured handling of unsupported operations across platforms and provider implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->