### PR TITLE
fix: preserve backpressure in ManagedStream and await pump on teardown

### DIFF
--- a/packages/spectrum-ts/src/providers/imessage/local.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local.ts
@@ -139,9 +139,9 @@ export const messages = (client: IMessageSDK): ManagedStream<IMessageMessage> =>
         onIncomingMessage: (message) => {
           lastPromise = lastPromise
             .then(() => toMessages(message))
-            .then((ms) => {
+            .then(async (ms) => {
               for (const m of ms) {
-                emit(m);
+                await emit(m);
               }
             })
             .catch(end);

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -121,14 +121,14 @@ const clientStream = (
 ): ManagedStream<IMessageMessage> => {
   const sub = client.messages.subscribe("message.received");
   return stream<IMessageMessage>((emit, end) => {
-    (async () => {
+    const pump = (async () => {
       try {
         for await (const event of sub) {
           if (event.message.isFromMe) {
             continue;
           }
           for (const message of await toMessages(client, event)) {
-            emit(message);
+            await emit(message);
           }
         }
         end();
@@ -136,7 +136,10 @@ const clientStream = (
         end(e);
       }
     })();
-    return () => sub.close();
+    return async () => {
+      sub.close();
+      await pump;
+    };
   });
 };
 

--- a/packages/spectrum-ts/src/providers/whatsapp-business/auth.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/auth.ts
@@ -209,7 +209,7 @@ const buildClientProxy = (
 };
 
 interface ResubscribeContext {
-  emit: (event: WhatsAppEvent) => void;
+  emit: (event: WhatsAppEvent) => Promise<void>;
   getCurrent: () => WhatsAppClient;
   options?: SubscribeOptions;
   setActive: (stream: TypedEventStream<WhatsAppEvent> | undefined) => void;
@@ -220,7 +220,7 @@ const pumpOnce = async (ctx: ResubscribeContext): Promise<boolean> => {
   ctx.setActive(sub);
   try {
     for await (const event of sub) {
-      ctx.emit(event);
+      await ctx.emit(event);
     }
     return true;
   } catch {
@@ -249,7 +249,7 @@ const resubscribableStream = (
         active = s;
       },
     };
-    (async () => {
+    const pump = (async () => {
       while (!closed) {
         await pumpOnce(ctx);
         if (!closed) {
@@ -259,11 +259,12 @@ const resubscribableStream = (
       end();
     })();
 
-    return () => {
+    return async () => {
       closed = true;
       active?.close().catch(() => undefined);
       active = undefined;
       state.subscriptions.delete(subscription);
+      await pump;
     };
   });
 

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -393,11 +393,11 @@ const clientStream = (
     );
 
   return stream<WhatsAppMessage>((emit, end) => {
-    (async () => {
+    const pump = (async () => {
       try {
         for await (const event of eventStream) {
           for (const m of toMessages(client, event.message)) {
-            emit(m);
+            await emit(m);
           }
         }
         end();
@@ -405,7 +405,10 @@ const clientStream = (
         end(e);
       }
     })();
-    return () => eventStream.close();
+    return async () => {
+      await eventStream.close();
+      await pump;
+    };
   });
 };
 

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -122,11 +122,11 @@ export async function Spectrum<
     return stream<T>((emit, end) => {
       const iterator = iterable[Symbol.asyncIterator]();
 
-      (async () => {
+      const pump = (async () => {
         try {
           let result = await iterator.next();
           while (!result.done) {
-            emit(result.value);
+            await emit(result.value);
             result = await iterator.next();
           }
           end();
@@ -137,6 +137,7 @@ export async function Spectrum<
 
       return async () => {
         await iterator.return?.();
+        await pump;
       };
     });
   };
@@ -196,15 +197,15 @@ export async function Spectrum<
   };
 
   const createMessagesStream = (): ManagedStream<[Space, Message]> => {
-    return stream<[Space, Message]>(async (emit, end) => {
+    return stream<[Space, Message]>((emit, end) => {
       const merged = mergeStreams(
         Array.from(platformStates.values(), createProviderMessagesStream)
       );
 
-      (async () => {
+      const pump = (async () => {
         try {
           for await (const value of merged) {
-            emit(value);
+            await emit(value);
           }
           end();
         } catch (error) {
@@ -214,6 +215,7 @@ export async function Spectrum<
 
       return async () => {
         await merged.close();
+        await pump;
       };
     });
   };
@@ -221,7 +223,7 @@ export async function Spectrum<
   const createCustomEventStream = (
     eventName: string
   ): ManagedStream<unknown> => {
-    return stream<unknown>(async (emit, end) => {
+    return stream<unknown>((emit, end) => {
       const providerStreams = Array.from(platformStates.values(), (state) => {
         const { client, config, definition } = state;
         const producer = definition.events[eventName] as
@@ -248,10 +250,10 @@ export async function Spectrum<
 
       const merged = mergeStreams(providerStreams);
 
-      (async () => {
+      const pump = (async () => {
         try {
           for await (const value of merged) {
-            emit(value);
+            await emit(value);
           }
           end();
         } catch (error) {
@@ -261,6 +263,7 @@ export async function Spectrum<
 
       return async () => {
         await merged.close();
+        await pump;
       };
     });
   };

--- a/packages/spectrum-ts/src/utils/stream.ts
+++ b/packages/spectrum-ts/src/utils/stream.ts
@@ -8,16 +8,18 @@ type StreamCleanup = void | (() => void | Promise<void>);
 
 export function stream<T>(
   setup: (
-    emit: (value: T) => void,
+    emit: (value: T) => Promise<void>,
     end: (error?: unknown) => void
   ) => StreamCleanup | Promise<StreamCleanup>
 ): ManagedStream<T> {
   const repeater = new Repeater<T>(async (push, stop) => {
-    const emit = (value: T) => {
-      Promise.resolve(push(value)).catch((error) => {
+    const emit = async (value: T): Promise<void> => {
+      try {
+        await push(value);
+      } catch (error) {
         stop(error);
-        return undefined;
-      });
+        throw error;
+      }
     };
     const end = (error?: unknown) => {
       stop(error);
@@ -51,7 +53,7 @@ export function mergeStreams<T>(
     const workers = streams.map(async (source) => {
       try {
         for await (const value of source) {
-          emit(value);
+          await emit(value);
         }
       } catch (error) {
         end(error);


### PR DESCRIPTION
Closes #23.

## Summary

- `emit()` in the core `stream()` helper no longer fire-and-forgets `push(value)` — it now returns `Promise<void>` and awaits the downstream consumer, so slow consumers actually apply backpressure to producers.
- Every forwarding path that drives an `emit` (Spectrum's `adaptIterable`, merged `messages`, custom event streams, and the iMessage / WhatsApp Business provider pumps) now `await`s the emission instead of letting the producer outrun the consumer.
- Stream teardown now waits for the background pump to finish before resolving. Each affected provider/helper captures its pump promise and `await`s it inside the cleanup function, so `close()` doesn't return until in-flight forwarding has fully settled.
- `mergeStreams` propagates the same change — each worker `await`s `emit(value)` so merged streams inherit backpressure.

## Problem

In `packages/spectrum-ts/src/utils/stream.ts`, `emit()` wrapped `push(value)` in a floating `Promise.resolve(...).catch(...)` and returned `void`. Producers couldn't observe consumer slowness, so a fast producer with a slow `for await` consumer would race ahead, losing flow control. The same pattern was copied through every `stream(...)` call site in the repo, and several of those call sites also returned synchronous cleanups that didn't wait for their async pump to drain.

## Changes

| File | Change |
|---|---|
| `packages/spectrum-ts/src/utils/stream.ts` | `emit` type is now `(value: T) => Promise<void>`; it awaits `push(value)` and rethrows after stopping. `mergeStreams` workers await each forwarded `emit`. |
| `packages/spectrum-ts/src/spectrum.ts` | `adaptIterable`, `createMessagesStream`, and `createCustomEventStream` await each `emit(...)`; each captures its pump promise and awaits it in the cleanup function. |
| `packages/spectrum-ts/src/providers/imessage/local.ts` | `onIncomingMessage` chain awaits each emission in the inner forwarding loop. |
| `packages/spectrum-ts/src/providers/imessage/remote.ts` | Subscription pump is captured as `pump`; cleanup closes the subscription and awaits `pump`. Inner loop awaits each `emit`. |
| `packages/spectrum-ts/src/providers/whatsapp-business/auth.ts` | `ResubscribeContext.emit` is now `(event) => Promise<void>`; `pumpOnce` awaits it. The resubscribe driver captures its pump promise and cleanup awaits it after closing the active stream. |
| `packages/spectrum-ts/src/providers/whatsapp-business/messages.ts` | Client stream captures its pump; cleanup awaits `eventStream.close()` and the pump. Inner loop awaits each `emit`. |

## Test plan

- [ ] `bun x ultracite check` passes
- [ ] `bun x tsc --noEmit` passes across the workspace
- [ ] `bun run build` succeeds; no new type errors in `dist/`
- [ ] Backpressure regression check: connect a slow consumer (e.g. `await new Promise(r => setTimeout(r, 100))` per iteration) to `app.messages` against a fast synthetic producer and confirm the producer is paced by the consumer instead of buffering unboundedly
- [ ] Teardown check: call `close()` on a `createMessagesStream` / `createCustomEventStream` while a pump is mid-flight and confirm the returned promise does not resolve until the pump has actually stopped
- [ ] Regression: iMessage local + remote and WhatsApp Business still deliver inbound messages end-to-end; re-subscription across WhatsApp token renewal still works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message delivery reliability with better sequencing and error handling across iMessage and WhatsApp Business integrations.
  * Enhanced stream shutdown procedures for cleaner resource management.

* **Performance**
  * Optimized message emission handling to better manage message queuing and prevent overflow conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->