### PR TITLE
feat(provider/terminal)!: use tuichat

### DIFF
--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -5,8 +5,15 @@ const app = await Spectrum({
   providers: [terminal.config()],
 });
 
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
 for await (const [space, message] of app.messages) {
-  if (message.content.type === "text") {
-    await space.send(text(`echo: ${message.content.text}`));
+  if (message.content.type !== "text") {
+    continue;
   }
+  const incoming = message.content.text;
+  await space.responding(async () => {
+    await sleep(600);
+    await space.send(text(`echo: ${incoming}`));
+  });
 }

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -1,10 +1,275 @@
-import { createInterface } from "node:readline";
+// The `terminal` Spectrum provider. On every createClient, spawns the
+// standalone tuichat binary (auto-downloaded from GitHub Releases on first
+// use) and drives it via JSON-RPC. The binary itself chooses between its
+// rich TUI and a non-TTY readline fallback, so this adapter is symmetric
+// and language-portable — any other SDK's adapter just has to spawn +
+// speak the protocol.
+//
+// Protocol: https://github.com/photon-hq/tuichat/blob/main/PROTOCOL.md
+
+import { type ChildProcess, spawn } from "node:child_process";
+import { createServer, type Socket } from "node:net";
 import z from "zod";
 import { definePlatform } from "../../platform/define";
-import { UnsupportedError } from "../../utils/errors";
+import {
+  type ProtocolContent,
+  type ProtocolMessageNotification,
+  RpcSession,
+} from "./protocol";
+import { resolveTuichatBinary } from "./resolve-binary";
+
+const commandSchema = z.object({
+  name: z.string().regex(/^\/[A-Za-z0-9_-]+$/, "command must start with /"),
+  description: z.string().optional(),
+});
+
+interface TerminalClient {
+  messages: AsyncIterable<ProtocolMessageNotification>;
+  proc: ChildProcess;
+  session: RpcSession;
+}
+
+async function spawnClient(options: {
+  commands?: { name: string; description?: string }[];
+}): Promise<TerminalClient> {
+  const binary = await resolveTuichatBinary();
+
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen({ host: "127.0.0.1", port: 0 }, () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const addr = server.address();
+  if (!addr || typeof addr === "string") {
+    server.close();
+    throw new Error("tuichat: failed to bind adapter listener");
+  }
+  const host = "127.0.0.1";
+  const port = addr.port;
+
+  const socketPromise = new Promise<Socket>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      server.close();
+      reject(new Error("tuichat: subprocess did not connect within 10s"));
+    }, 10_000);
+    server.once("connection", (sock) => {
+      clearTimeout(timeout);
+      server.close();
+      resolve(sock);
+    });
+    server.once("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+
+  const proc = spawn(binary, ["--connect", `${host}:${port}`], {
+    stdio: "inherit",
+  });
+  // Unref so the subprocess doesn't pin the parent event loop once all
+  // protocol work is done — the agent can exit cleanly and the OS cleans
+  // the child up via the socket close.
+  proc.unref();
+  proc.once("exit", (code) => {
+    if (code !== 0 && code !== null) {
+      process.stderr.write(`[tuichat] subprocess exited with code ${code}\n`);
+    }
+  });
+
+  const socket = await socketPromise;
+  const session = new RpcSession(socket);
+
+  const queue: ProtocolMessageNotification[] = [];
+  const waiters: Array<
+    (v: IteratorResult<ProtocolMessageNotification>) => void
+  > = [];
+  let closed = false;
+
+  const iter: AsyncIterable<ProtocolMessageNotification> = {
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<ProtocolMessageNotification>> {
+          if (closed && queue.length === 0) {
+            return Promise.resolve({ value: undefined, done: true });
+          }
+          const buffered = queue.shift();
+          if (buffered) {
+            return Promise.resolve({ value: buffered, done: false });
+          }
+          return new Promise((resolve) => waiters.push(resolve));
+        },
+      };
+    },
+  };
+
+  session.handleNotifications((method, params) => {
+    if (method === "streamEnd") {
+      closed = true;
+      while (waiters.length > 0) {
+        waiters.shift()?.({ value: undefined, done: true });
+      }
+      return;
+    }
+    if (method !== "message") {
+      return;
+    }
+    const msg = params as ProtocolMessageNotification;
+    const w = waiters.shift();
+    if (w) {
+      w({ value: msg, done: false });
+    } else {
+      queue.push(msg);
+    }
+  });
+  session.onClosed(() => {
+    closed = true;
+    while (waiters.length > 0) {
+      waiters.shift()?.({ value: undefined, done: true });
+    }
+  });
+
+  await session.request("initialize", {
+    commands: options.commands,
+    clientInfo: { name: "spectrum-ts", version: "terminal-provider" },
+  });
+
+  return { proc, session, messages: iter };
+}
+
+// ----- content conversion (Spectrum Content ↔ ProtocolContent) -----
+
+type SpectrumContent = z.infer<
+  typeof import("../../content/types").contentSchema
+>;
+
+async function spectrumToProtocol(
+  content: SpectrumContent
+): Promise<ProtocolContent> {
+  if (content.type === "text" || content.type === "custom") {
+    return content;
+  }
+  if (content.type === "attachment") {
+    const buf = await content.read();
+    return {
+      type: "attachment",
+      name: content.name,
+      mimeType: content.mimeType,
+      size: content.size,
+      bytes: buf.toString("base64"),
+    };
+  }
+  if (content.type === "voice") {
+    const buf = await content.read();
+    return {
+      type: "voice",
+      name: content.name,
+      mimeType: content.mimeType,
+      size: content.size,
+      bytes: buf.toString("base64"),
+    };
+  }
+  if (content.type === "contact") {
+    return {
+      type: "contact",
+      name: content.name
+        ? {
+            formatted: content.name.formatted,
+            first: content.name.first,
+            last: content.name.last,
+          }
+        : undefined,
+    };
+  }
+  throw new Error(
+    `terminal provider: unsupported content type: ${(content as { type: string }).type}`
+  );
+}
+
+function protocolToSpectrum(p: ProtocolContent): SpectrumContent {
+  if (p.type === "text" || p.type === "custom") {
+    return p as SpectrumContent;
+  }
+  if (p.type === "attachment" || p.type === "voice") {
+    const path = p.path;
+    let bufPromise: Promise<Buffer>;
+    if (p.bytes) {
+      bufPromise = Promise.resolve(Buffer.from(p.bytes, "base64") as Buffer);
+    } else if (path) {
+      bufPromise = import("node:fs/promises").then((m) => m.readFile(path));
+    } else {
+      bufPromise = Promise.reject(
+        new Error(`${p.type} has neither path nor bytes`)
+      );
+    }
+    const read = async (): Promise<Buffer> => bufPromise;
+    const stream = async (): Promise<ReadableStream<Uint8Array>> => {
+      if (path) {
+        const [{ createReadStream }, { Readable }] = await Promise.all([
+          import("node:fs"),
+          import("node:stream"),
+        ]);
+        return Readable.toWeb(
+          createReadStream(path)
+        ) as ReadableStream<Uint8Array>;
+      }
+      const buf = await bufPromise;
+      return new ReadableStream({
+        start(ctrl) {
+          ctrl.enqueue(new Uint8Array(buf));
+          ctrl.close();
+        },
+      });
+    };
+    const common = {
+      mimeType: p.mimeType,
+      size: p.size,
+      read,
+      stream,
+    };
+    if (p.type === "attachment") {
+      return {
+        type: "attachment",
+        name: p.name,
+        ...common,
+      } as SpectrumContent;
+    }
+    return {
+      type: "voice",
+      name: p.name,
+      ...common,
+    } as SpectrumContent;
+  }
+  if (p.type === "contact") {
+    return { type: "contact", name: p.name } as SpectrumContent;
+  }
+  // Fallback so unknown future shapes don't crash the agent.
+  return { type: "custom", raw: p } as SpectrumContent;
+}
+
+// ----- chat-id generation (adapter side) -----
+
+let nextChatIndex = 1;
+const knownChats = new Set<string>();
+
+function generateChatId(): string {
+  while (knownChats.has(`chat-${nextChatIndex}`)) {
+    nextChatIndex += 1;
+  }
+  const id = `chat-${nextChatIndex}`;
+  nextChatIndex += 1;
+  knownChats.add(id);
+  return id;
+}
+
+// ----- the provider -----
 
 export const terminal = definePlatform("terminal", {
-  config: z.object({}),
+  config: z.object({
+    commands: z.array(commandSchema).optional(),
+  }),
 
   user: {
     resolve: async ({ input }) => ({
@@ -13,52 +278,91 @@ export const terminal = definePlatform("terminal", {
   },
 
   space: {
-    resolve: async () => ({
-      id: "terminal",
-    }),
+    params: z.object({ id: z.string().optional() }),
+    resolve: async (ctx) => {
+      const client = ctx.client as TerminalClient;
+      const id = ctx.input.params?.id ?? generateChatId();
+      knownChats.add(id);
+      await client.session.request("ensureSpace", { id });
+      return { id };
+    },
   },
 
   lifecycle: {
-    createClient: async () => {
-      const client = createInterface({
-        input: process.stdin,
-        output: process.stdout,
-      });
-
-      client.on("SIGINT", () => {
-        client.close();
-        process.kill(process.pid, "SIGINT");
-      });
-
-      return client;
+    createClient: async ({ config }) => {
+      return await spawnClient({ commands: config.commands });
     },
 
     destroyClient: async ({ client }) => {
-      client.close();
-      process.stdin.unref();
+      const c = client as TerminalClient;
+      try {
+        await c.session.request("shutdown");
+      } catch {
+        // best-effort
+      }
+      c.session.close();
+      try {
+        c.proc.kill("SIGTERM");
+      } catch {
+        // best-effort
+      }
     },
   },
 
   events: {
-    async *messages({ client }) {
-      for await (const line of client) {
+    async *messages(ctx) {
+      const client = ctx.client as TerminalClient;
+      for await (const msg of client.messages) {
+        knownChats.add(msg.spaceId);
         yield {
-          id: crypto.randomUUID(),
-          content: { type: "text" as const, text: line },
-          sender: { id: "terminal-user" },
-          space: { id: "terminal" },
-          timestamp: new Date(),
+          id: msg.id,
+          content: protocolToSpectrum(msg.content),
+          sender: { id: msg.senderId },
+          space: { id: msg.spaceId },
+          timestamp: new Date(msg.timestamp),
         };
       }
     },
   },
 
   actions: {
-    send: async ({ content }) => {
-      if (content.type !== "text") {
-        throw UnsupportedError.content(content.type, "terminal");
-      }
-      console.log(content.text);
+    send: async ({ client, content, space }) => {
+      const c = client as TerminalClient;
+      const proto = await spectrumToProtocol(content);
+      await c.session.request("send", {
+        spaceId: space.id,
+        content: proto,
+      });
+      return { id: crypto.randomUUID(), timestamp: new Date() };
+    },
+
+    startTyping: async ({ client, space }) => {
+      const c = client as TerminalClient;
+      await c.session.request("startTyping", { spaceId: space.id });
+    },
+
+    stopTyping: async ({ client, space }) => {
+      const c = client as TerminalClient;
+      await c.session.request("stopTyping", { spaceId: space.id });
+    },
+
+    reactToMessage: async ({ client, space, messageId, reaction }) => {
+      const c = client as TerminalClient;
+      await c.session.request("reactToMessage", {
+        spaceId: space.id,
+        messageId,
+        reaction,
+      });
+    },
+
+    replyToMessage: async ({ client, space, messageId, content }) => {
+      const c = client as TerminalClient;
+      const proto = await spectrumToProtocol(content);
+      await c.session.request("replyToMessage", {
+        spaceId: space.id,
+        messageId,
+        content: proto,
+      });
       return { id: crypto.randomUUID(), timestamp: new Date() };
     },
   },

--- a/packages/spectrum-ts/src/providers/terminal/protocol.ts
+++ b/packages/spectrum-ts/src/providers/terminal/protocol.ts
@@ -1,0 +1,244 @@
+// JSON-RPC 2.0 over TCP with LSP-style Content-Length framing.
+// Speaks the protocol documented at https://github.com/photon-hq/tuichat/blob/main/PROTOCOL.md.
+//
+// Inlined into this provider rather than imported from an external package so
+// spectrum-ts takes no new runtime dependencies.
+
+import type { Socket } from "node:net";
+
+export const PROTOCOL_VERSION = "1" as const;
+
+export type ProtocolContent =
+  | { type: "text"; text: string }
+  | {
+      type: "attachment";
+      name: string;
+      mimeType: string;
+      size?: number;
+      bytes?: string;
+      path?: string;
+    }
+  | {
+      type: "voice";
+      name?: string;
+      mimeType: string;
+      size?: number;
+      bytes?: string;
+      path?: string;
+    }
+  | {
+      type: "contact";
+      name?: {
+        formatted?: string;
+        first?: string;
+        last?: string;
+      };
+      vcard?: string;
+    }
+  | { type: "custom"; raw: unknown };
+
+export interface ProtocolMessageNotification {
+  content: ProtocolContent;
+  id: string;
+  senderId: string;
+  spaceId: string;
+  timestamp: string;
+}
+
+interface RpcRequest {
+  id: number | string;
+  jsonrpc: "2.0";
+  method: string;
+  params?: unknown;
+}
+
+interface RpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: unknown;
+}
+
+interface RpcResponse {
+  error?: { code: number; message: string };
+  id: number | string;
+  jsonrpc: "2.0";
+  result?: unknown;
+}
+
+type RpcMessage = RpcRequest | RpcNotification | RpcResponse;
+
+// ----- codec -----
+
+const HEADER_TERMINATOR = Buffer.from("\r\n\r\n");
+const CONTENT_LENGTH = "content-length:";
+
+function encode(message: RpcMessage): Uint8Array {
+  const body = Buffer.from(JSON.stringify(message), "utf8");
+  const header = Buffer.from(`Content-Length: ${body.byteLength}\r\n\r\n`);
+  const out = new Uint8Array(header.byteLength + body.byteLength);
+  out.set(header, 0);
+  out.set(body, header.byteLength);
+  return out;
+}
+
+class Decoder {
+  private buf: Buffer = Buffer.alloc(0);
+
+  push(chunk: Buffer): RpcMessage[] {
+    if (this.buf.length === 0) {
+      this.buf = Buffer.from(chunk);
+    } else {
+      const merged = new Uint8Array(this.buf.byteLength + chunk.byteLength);
+      merged.set(this.buf, 0);
+      merged.set(chunk, this.buf.byteLength);
+      this.buf = Buffer.from(merged);
+    }
+    const out: RpcMessage[] = [];
+    for (;;) {
+      const msg = this.readOne();
+      if (!msg) {
+        break;
+      }
+      out.push(msg);
+    }
+    return out;
+  }
+
+  private readOne(): RpcMessage | null {
+    const end = this.buf.indexOf(HEADER_TERMINATOR);
+    if (end < 0) {
+      return null;
+    }
+    const header = this.buf.subarray(0, end).toString("utf8");
+    let len = -1;
+    for (const line of header.split("\r\n")) {
+      if (line.toLowerCase().startsWith(CONTENT_LENGTH)) {
+        const n = Number.parseInt(line.slice(CONTENT_LENGTH.length).trim(), 10);
+        if (!Number.isFinite(n) || n < 0) {
+          throw new Error("invalid Content-Length");
+        }
+        len = n;
+      }
+    }
+    if (len < 0) {
+      throw new Error("missing Content-Length header");
+    }
+    const bodyStart = end + HEADER_TERMINATOR.length;
+    const bodyEnd = bodyStart + len;
+    if (this.buf.length < bodyEnd) {
+      return null;
+    }
+    const body = this.buf.subarray(bodyStart, bodyEnd).toString("utf8");
+    this.buf = this.buf.subarray(bodyEnd);
+    return JSON.parse(body) as RpcMessage;
+  }
+}
+
+// ----- session -----
+
+export class RpcSession {
+  private readonly decoder = new Decoder();
+  private nextId = 1;
+  private readonly pending = new Map<
+    number | string,
+    { resolve: (v: unknown) => void; reject: (e: unknown) => void }
+  >();
+  private onNotify: ((method: string, params: unknown) => void) | null = null;
+  private onClose: (() => void) | null = null;
+  private closed = false;
+  private readonly socket: Socket;
+
+  constructor(socket: Socket) {
+    this.socket = socket;
+    socket.on("data", (chunk: Buffer) => this.handle(chunk));
+    socket.on("close", () => this.shutdown());
+    socket.on("error", () => this.shutdown());
+  }
+
+  handleNotifications(h: (method: string, params: unknown) => void): void {
+    this.onNotify = h;
+  }
+  onClosed(h: () => void): void {
+    this.onClose = h;
+  }
+
+  async request<T = unknown>(method: string, params?: unknown): Promise<T> {
+    if (this.closed) {
+      throw new Error("session closed");
+    }
+    const id = this.nextId++;
+    const msg: RpcRequest = { jsonrpc: "2.0", id, method, params };
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, {
+        resolve: (v) => resolve(v as T),
+        reject,
+      });
+      try {
+        this.socket.write(encode(msg));
+      } catch (err) {
+        this.pending.delete(id);
+        reject(err);
+      }
+    });
+  }
+
+  close(): void {
+    this.shutdown();
+  }
+
+  private handle(chunk: Buffer): void {
+    let msgs: RpcMessage[];
+    try {
+      msgs = this.decoder.push(chunk);
+    } catch {
+      this.shutdown();
+      return;
+    }
+    for (const m of msgs) {
+      if ("id" in m && "method" in m) {
+        // Server→client requests aren't part of our protocol; ignore.
+        continue;
+      }
+      if ("id" in m) {
+        const p = this.pending.get(m.id);
+        if (!p) {
+          continue;
+        }
+        this.pending.delete(m.id);
+        if (m.error) {
+          p.reject(new Error(m.error.message));
+        } else {
+          p.resolve(m.result);
+        }
+      } else if ("method" in m) {
+        try {
+          this.onNotify?.(m.method, m.params);
+        } catch {
+          // notifications have no response
+        }
+      }
+    }
+  }
+
+  private shutdown(): void {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    for (const p of this.pending.values()) {
+      p.reject(new Error("session closed"));
+    }
+    this.pending.clear();
+    try {
+      this.socket.end();
+    } catch {
+      // best-effort
+    }
+    try {
+      this.socket.destroy();
+    } catch {
+      // best-effort
+    }
+    this.onClose?.();
+  }
+}

--- a/packages/spectrum-ts/src/providers/terminal/resolve-binary.ts
+++ b/packages/spectrum-ts/src/providers/terminal/resolve-binary.ts
@@ -1,0 +1,134 @@
+// Resolves the tuichat binary on disk, downloading from GitHub Releases on
+// first use. Cache layout: <platform-cache>/tuichat/v<version>/tuichat-<target><ext>.
+//
+// Version precedence: TUICHAT_VERSION env → the value pinned in DEFAULT_VERSION.
+// Verification: fetch SHA256SUMS from the same release, check against download.
+//
+// No external deps — stdlib only.
+
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// Pinned default; bump on each certified tuichat release.
+export const DEFAULT_VERSION = "0.1.0";
+
+const REPO = "photon-hq/tuichat";
+
+type Target =
+  | "darwin-arm64"
+  | "darwin-x64"
+  | "linux-x64"
+  | "linux-arm64"
+  | "windows-x64";
+
+function targetSuffix(): Target {
+  const key = `${process.platform}-${process.arch}`;
+  const map: Record<string, Target> = {
+    "darwin-arm64": "darwin-arm64",
+    "darwin-x64": "darwin-x64",
+    "linux-x64": "linux-x64",
+    "linux-arm64": "linux-arm64",
+    "win32-x64": "windows-x64",
+  };
+  const t = map[key];
+  if (!t) {
+    throw new Error(`tuichat: unsupported platform/arch: ${key}`);
+  }
+  return t;
+}
+
+function cacheDir(version: string): string {
+  if (process.platform === "win32") {
+    const base =
+      process.env.LOCALAPPDATA ?? join(homedir(), "AppData", "Local");
+    return join(base, "tuichat", `v${version}`);
+  }
+  if (process.platform === "darwin") {
+    return join(homedir(), "Library", "Caches", "tuichat", `v${version}`);
+  }
+  const xdg = process.env.XDG_CACHE_HOME ?? join(homedir(), ".cache");
+  return join(xdg, "tuichat", `v${version}`);
+}
+
+const LINE_SPLIT = /\r?\n/;
+const CHECKSUM_LINE = /^([a-f0-9]{64})\s+\*?(\S+)$/;
+
+function parseChecksums(text: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const line of text.split(LINE_SPLIT)) {
+    const m = line.match(CHECKSUM_LINE);
+    if (m?.[1] && m[2]) {
+      out[m[2]] = m[1];
+    }
+  }
+  return out;
+}
+
+export interface ResolveOptions {
+  /** Set to true to force re-download even if cached. */
+  force?: boolean;
+  /** Override the version (default: TUICHAT_VERSION env or DEFAULT_VERSION). */
+  version?: string;
+}
+
+export async function resolveTuichatBinary(
+  options: ResolveOptions = {}
+): Promise<string> {
+  // Dev/local override: skip download, use a local binary path directly.
+  const override = process.env.TUICHAT_BINARY;
+  if (override) {
+    if (!existsSync(override)) {
+      throw new Error(`tuichat: TUICHAT_BINARY=${override} does not exist`);
+    }
+    return override;
+  }
+
+  const version =
+    options.version ?? process.env.TUICHAT_VERSION ?? DEFAULT_VERSION;
+  const target = targetSuffix();
+  const ext = target.startsWith("windows") ? ".exe" : "";
+  const filename = `tuichat-${target}${ext}`;
+  const dir = cacheDir(version);
+  const path = join(dir, filename);
+
+  if (!options.force && existsSync(path)) {
+    return path;
+  }
+
+  const base = `https://github.com/${REPO}/releases/download/v${version}`;
+  const [sumsRes, binRes] = await Promise.all([
+    fetch(`${base}/SHA256SUMS`),
+    fetch(`${base}/${filename}`),
+  ]);
+  if (!sumsRes.ok) {
+    throw new Error(
+      `tuichat: failed to fetch SHA256SUMS (v${version}): HTTP ${sumsRes.status}`
+    );
+  }
+  if (!binRes.ok) {
+    throw new Error(
+      `tuichat: failed to fetch ${filename} (v${version}): HTTP ${binRes.status}`
+    );
+  }
+  const expected = parseChecksums(await sumsRes.text())[filename];
+  if (!expected) {
+    throw new Error(
+      `tuichat: no checksum for ${filename} in SHA256SUMS (v${version})`
+    );
+  }
+  const bytes = Buffer.from(await binRes.arrayBuffer());
+  const actual = createHash("sha256").update(bytes).digest("hex");
+  if (actual !== expected) {
+    throw new Error(
+      `tuichat: checksum mismatch for ${filename} (expected ${expected}, got ${actual})`
+    );
+  }
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(path, bytes);
+  if (process.platform !== "win32") {
+    chmodSync(path, 0o755);
+  }
+  return path;
+}


### PR DESCRIPTION
- uses a better interface written in golang at https://github.com/photon-hq/tuichat
- auto downloads & checksum verifies the latest supported release
- communicates with tuichat with JSON RPC on a tcp socket

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added typing status indicators and message reaction support.
  * Terminal provider now communicates with an external application via JSON-RPC protocol.
  * Enhanced message content handling with support for attachments and voice data.
  * Automatic platform-specific binary resolution and caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->