### PR TITLE
feat: richlink content type + accept user IDs in `space()`

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,12 +4,9 @@
   "workspaces": {
     "": {
       "name": "specturm-ts",
-      "dependencies": {
-        "@types/node": "^25.6.0",
-        "open-graph-scraper": "^6.11.0",
-      },
       "devDependencies": {
         "@biomejs/biome": "^2.4.12",
+        "@types/node": "^25.6.0",
         "turbo": "^2",
         "ultracite": "7.4.3",
       },
@@ -36,6 +33,7 @@
         "@repeaterjs/repeater": "^3.0.6",
         "better-grpc": "^0.3.2",
         "mime-types": "^3.0.1",
+        "open-graph-scraper": "^6.11.0",
         "type-fest": "^5.4.1",
         "vcf": "^2.1.2",
         "zod": "^4.2.1",
@@ -246,7 +244,7 @@
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-/08CwpKJl3oRY8nOlh2YgilZVJDHsr60XTNxRhuDeuFXONpUZ5X+Nv65izbG/xBew9qxcJFbDX9/sAmAX+ITcQ=="],
 
-    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -286,7 +284,7 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
-    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
@@ -594,8 +592,6 @@
 
     "better-grpc/nice-grpc": ["nice-grpc@2.1.14", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.4.0", "nice-grpc-common": "^2.0.2" } }, "sha512-GK9pKNxlvnU5FAdaw7i2FFuR9CqBspcE+if2tqnKXBcE0R8525wj4BZvfcwj7FjvqbssqKxRHt2nwedalbJlww=="],
 
-    "bun-types/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
-
     "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
@@ -617,8 +613,6 @@
     "better-grpc/nice-grpc/abort-controller-x": ["abort-controller-x@0.4.3", "", {}, "sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA=="],
 
     "better-grpc/nice-grpc/nice-grpc-common": ["nice-grpc-common@2.0.2", "", { "dependencies": { "ts-error": "^1.0.6" } }, "sha512-7RNWbls5kAL1QVUOXvBsv1uO0wPQK3lHv+cY1gwkTzirnG1Nop4cBJZubpgziNbaVc/bl9QJcyvsf/NQxa3rjQ=="],
-
-    "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "specturm-ts",
       "dependencies": {
         "@types/node": "^25.6.0",
+        "open-graph-scraper": "^6.11.0",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.12",
@@ -27,7 +28,7 @@
     },
     "packages/spectrum-ts": {
       "name": "spectrum-ts",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.4.3",
         "@photon-ai/imessage-kit": "^3.0.0",
@@ -279,6 +280,8 @@
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
+    "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
+
     "brace-expansion": ["brace-expansion@5.0.3", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
@@ -290,6 +293,12 @@
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
+    "chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
+
+    "cheerio": ["cheerio@1.2.0", "", { "dependencies": { "cheerio-select": "^2.1.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "encoding-sniffer": "^0.2.1", "htmlparser2": "^10.1.0", "parse5": "^7.3.0", "parse5-htmlparser2-tree-adapter": "^7.1.0", "parse5-parser-stream": "^7.1.2", "undici": "^7.19.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg=="],
+
+    "cheerio-select": ["cheerio-select@2.1.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-select": "^5.1.0", "css-what": "^6.1.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1" } }, "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
@@ -313,6 +322,10 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decompress-response": ["decompress-response@6.0.0", "", { "dependencies": { "mimic-response": "^3.1.0" } }, "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ=="],
@@ -323,9 +336,21 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
+
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
@@ -358,6 +383,10 @@
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
     "hotscript": ["hotscript@1.0.13", "", {}, "sha512-C++tTF1GqkGYecL+2S1wJTfoH6APGAsbb7PAWQ3iVIwgG/EFseAfEVOKFgAFq4yK3+6j1EjUD4UQ9dRJHX/sSQ=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -417,13 +446,23 @@
 
     "node-abi": ["node-abi@3.89.0", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA=="],
 
+    "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
+
     "nypm": ["nypm@0.6.5", "", { "dependencies": { "citty": "^0.2.0", "pathe": "^2.0.3", "tinyexec": "^1.0.2" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "open-graph-scraper": ["open-graph-scraper@6.11.0", "", { "dependencies": { "chardet": "^2.1.1", "cheerio": "^1.1.2", "iconv-lite": "^0.7.0", "undici": "^7.16.0" } }, "sha512-KkO3qMMzJj9KYGtCl19dRtncb+RuBiG/P9BgukcAG4p2w9wSAWTE90vL6/xqth1K9ThkYF/+xfTGrVvU79TJtQ=="],
+
     "p-defer": ["p-defer@4.0.1", "", {}, "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@7.1.0", "", { "dependencies": { "domhandler": "^5.0.3", "parse5": "^7.0.0" } }, "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g=="],
+
+    "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -460,6 +499,8 @@
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -523,11 +564,17 @@
 
     "ultracite": ["ultracite@7.4.3", "", { "dependencies": { "@clack/prompts": "^1.1.0", "commander": "^14.0.3", "cross-spawn": "^7.0.6", "deepmerge": "^4.3.1", "glob": "^13.0.6", "jsonc-parser": "^3.3.1", "nypm": "^0.6.5" }, "peerDependencies": { "oxlint": "^1.0.0" }, "optionalPeers": ["oxlint"], "bin": { "ultracite": "dist/index.js" } }, "sha512-HMnd21OpSSwi/YtNqXUP/798dlTQ2GlXh0wR+8rIVY9uCTTQiOiRthdLlRaAo6IqUT0l29hiRl+ShsO0r81LtQ=="],
 
+    "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
+
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "vcf": ["vcf@2.1.2", "", { "dependencies": { "camelcase": "^5.0.0", "foldline": "^1.1.0" } }, "sha512-oLYtZ+GJPjpKS950fw70+HavdP7ZO2Q+xMCMeCyiUKuXkJJJG1/wUjCKTagPryS1gApYjZOWW/khmdLsch8jxg=="],
+
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -549,13 +596,21 @@
 
     "bun-types/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
+    "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "nypm/tinyexec": ["tinyexec@1.0.2", "", {}, "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "protobufjs/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "tsup/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "@photon-ai/whatsapp-business/protobufjs/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 

--- a/examples/edit-echo/index.ts
+++ b/examples/edit-echo/index.ts
@@ -18,6 +18,9 @@ for await (const [space, message] of app.messages) {
 
   // space.send returns the OutboundMessage we just sent, so we can chain.
   const sent = await space.send(text(`echo: ${message.content.text}`));
+  if (!sent) {
+    continue;
+  }
   console.log(`sent id=${sent.id} direction=${sent.direction}`);
 
   // `sent` is OutboundMessage — edit typechecks. Terminal provider throws

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "fix": "ultracite fix"
   },
   "dependencies": {
-    "@types/node": "^25.6.0"
+    "@types/node": "^25.6.0",
+    "open-graph-scraper": "^6.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,23 +1,20 @@
 {
-  "private": true,
-  "packageManager": "bun@1.3.5",
-  "workspaces": [
-    "packages/*",
-    "examples/*"
-  ],
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",
+    "@types/node": "^25.6.0",
     "turbo": "^2",
     "ultracite": "7.4.3"
   },
+  "packageManager": "bun@1.3.5",
+  "private": true,
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev",
     "check": "ultracite check",
     "fix": "ultracite fix"
   },
-  "dependencies": {
-    "@types/node": "^25.6.0",
-    "open-graph-scraper": "^6.11.0"
-  }
+  "workspaces": [
+    "packages/*",
+    "examples/*"
+  ]
 }

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -43,6 +43,7 @@
     "@repeaterjs/repeater": "^3.0.6",
     "better-grpc": "^0.3.2",
     "mime-types": "^3.0.1",
+    "open-graph-scraper": "^6.11.0",
     "type-fest": "^5.4.1",
     "vcf": "^2.1.2",
     "zod": "^4.2.1"

--- a/packages/spectrum-ts/src/content/richlink.ts
+++ b/packages/spectrum-ts/src/content/richlink.ts
@@ -1,0 +1,93 @@
+import z from "zod";
+import { bufferToStream, readSchema, streamSchema } from "../utils/io";
+import {
+  fetchImage,
+  fetchLinkMetadata,
+  type LinkMetadata,
+} from "../utils/link-metadata";
+import type { ContentBuilder } from "./types";
+
+const richlinkCoverSchema = z.object({
+  mimeType: z.string().nonempty().optional(),
+  read: readSchema,
+  stream: streamSchema,
+});
+
+const optionalStringAccessor = z.function({
+  input: [],
+  output: z.promise(z.string().nonempty().optional()),
+});
+
+const coverAccessor = z.function({
+  input: [],
+  output: z.promise(richlinkCoverSchema.optional()),
+});
+
+export const richlinkSchema = z.object({
+  type: z.literal("richlink"),
+  url: z.url(),
+  title: optionalStringAccessor,
+  summary: optionalStringAccessor,
+  cover: coverAccessor,
+});
+
+export type Richlink = z.infer<typeof richlinkSchema>;
+export type RichlinkCover = z.infer<typeof richlinkCoverSchema>;
+
+const memoize = <T>(factory: () => Promise<T>): (() => Promise<T>) => {
+  let cached: Promise<T> | undefined;
+  return () => {
+    cached ??= factory();
+    return cached;
+  };
+};
+
+const buildCover = (
+  image: NonNullable<LinkMetadata["image"]>
+): RichlinkCover => {
+  const read = memoize(() =>
+    fetchImage(image.url)
+      .then((r) => r.data)
+      .catch(() => Buffer.alloc(0))
+  );
+  return {
+    mimeType: image.mimeType,
+    read,
+    stream: async () => bufferToStream(await read()),
+  };
+};
+
+/**
+ * Construct a `richlink` content value.
+ *
+ * Accessors (`title`, `summary`, `cover`) are async and lazy: the first call
+ * issues a single network request to the URL; subsequent calls share the
+ * cached result. Network / parse failures resolve to `undefined` and are
+ * cached — no retries. Callers who only need `title` / `summary` never
+ * trigger an image download; calling `cover.read()` triggers one additional
+ * request to fetch the image bytes.
+ */
+export const asRichlink = (input: { url: string }): Richlink => {
+  const getMetadata = memoize(() => fetchLinkMetadata(input.url));
+
+  const title = async () => (await getMetadata()).title;
+  const summary = async () => (await getMetadata()).summary;
+  const cover = async (): Promise<RichlinkCover | undefined> => {
+    const { image } = await getMetadata();
+    return image ? buildCover(image) : undefined;
+  };
+
+  return richlinkSchema.parse({
+    type: "richlink",
+    url: input.url,
+    title,
+    summary,
+    cover,
+  });
+};
+
+export function richlink(url: string): ContentBuilder {
+  return {
+    build: async () => asRichlink({ url }),
+  };
+}

--- a/packages/spectrum-ts/src/content/richlink.ts
+++ b/packages/spectrum-ts/src/content/richlink.ts
@@ -8,14 +8,14 @@ import {
 import type { ContentBuilder } from "./types";
 
 const richlinkCoverSchema = z.object({
-  mimeType: z.string().nonempty().optional(),
+  mimeType: z.string().min(1).optional(),
   read: readSchema,
   stream: streamSchema,
 });
 
 const optionalStringAccessor = z.function({
   input: [],
-  output: z.promise(z.string().nonempty().optional()),
+  output: z.promise(z.string().min(1).optional()),
 });
 
 const coverAccessor = z.function({
@@ -69,20 +69,20 @@ const buildCover = (
  */
 export const asRichlink = (input: { url: string }): Richlink => {
   const getMetadata = memoize(() => fetchLinkMetadata(input.url));
+  const getCover = memoize(async (): Promise<RichlinkCover | undefined> => {
+    const { image } = await getMetadata();
+    return image ? buildCover(image) : undefined;
+  });
 
   const title = async () => (await getMetadata()).title;
   const summary = async () => (await getMetadata()).summary;
-  const cover = async (): Promise<RichlinkCover | undefined> => {
-    const { image } = await getMetadata();
-    return image ? buildCover(image) : undefined;
-  };
 
   return richlinkSchema.parse({
     type: "richlink",
     url: input.url,
     title,
     summary,
-    cover,
+    cover: getCover,
   });
 };
 

--- a/packages/spectrum-ts/src/content/types.ts
+++ b/packages/spectrum-ts/src/content/types.ts
@@ -2,6 +2,7 @@ import z from "zod";
 import { attachmentSchema } from "./attachment";
 import { contactSchema } from "./contact";
 import { customSchema } from "./custom";
+import { richlinkSchema } from "./richlink";
 import { textSchema } from "./text";
 import { voiceSchema } from "./voice";
 
@@ -11,6 +12,7 @@ export const contentSchema = z.discriminatedUnion("type", [
   attachmentSchema,
   contactSchema,
   voiceSchema,
+  richlinkSchema,
 ]);
 
 export type Content = z.infer<typeof contentSchema>;

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -12,6 +12,7 @@ export {
 } from "./content/contact";
 export { custom } from "./content/custom";
 export { resolveContents } from "./content/resolve";
+export { type Richlink, richlink } from "./content/richlink";
 export { text } from "./content/text";
 export type { Content, ContentBuilder, ContentInput } from "./content/types";
 export { type Voice, voice } from "./content/voice";

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -32,6 +32,31 @@ function createPlatformInstance<
     );
   };
 
+  const resolveUserID = async (userID: string): Promise<PlatformUser<Def>> => {
+    const resolved = await def.user.resolve({
+      input: { userID },
+      client: runtime.client as _Client,
+      config: runtime.config as z.infer<_ConfigSchema>,
+    });
+    return {
+      ...resolved,
+      __platform: def.name,
+    } as PlatformUser<Def>;
+  };
+
+  const resolveStringUsers = async (args: unknown[]): Promise<unknown[]> => {
+    const convertArg = async (arg: unknown): Promise<unknown> => {
+      if (typeof arg === "string") {
+        return await resolveUserID(arg);
+      }
+      if (Array.isArray(arg)) {
+        return await Promise.all(arg.map(convertArg));
+      }
+      return arg;
+    };
+    return await Promise.all(args.map(convertArg));
+  };
+
   const normalizeSpaceArgs = (
     args: unknown[]
   ): { users: PlatformUser<Def>[]; params: unknown } => {
@@ -82,7 +107,8 @@ function createPlatformInstance<
     },
 
     async space(...args: unknown[]) {
-      const { users, params } = normalizeSpaceArgs(args);
+      const convertedArgs = await resolveStringUsers(args);
+      const { users, params } = normalizeSpaceArgs(convertedArgs);
       let parsedParams = params;
       if (params !== undefined && def.space.params) {
         parsedParams = def.space.params.parse(params);

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -364,20 +364,22 @@ type SpaceParamsInputOf<Def extends AnyPlatformDef> = InputSchema<
   Def["space"]["params"]
 >;
 
+type SpaceUserLike<Def extends AnyPlatformDef> = PlatformUser<Def> | string;
+
 type SpaceArrayArgs<Def extends AnyPlatformDef> = [
   SpaceParamsInputOf<Def>,
 ] extends [never]
-  ? [users: PlatformUser<Def>[]]
+  ? [users: SpaceUserLike<Def>[]]
   :
-      | [users: PlatformUser<Def>[]]
-      | [users: PlatformUser<Def>[], params: SpaceParamsInputOf<Def>]
+      | [users: SpaceUserLike<Def>[]]
+      | [users: SpaceUserLike<Def>[], params: SpaceParamsInputOf<Def>]
       | [params: SpaceParamsInputOf<Def>];
 
 type SpaceVarargArgs<Def extends AnyPlatformDef> = [
   SpaceParamsInputOf<Def>,
 ] extends [never]
-  ? PlatformUser<Def>[]
-  : PlatformUser<Def>[] | [...PlatformUser<Def>[], SpaceParamsInputOf<Def>];
+  ? SpaceUserLike<Def>[]
+  : SpaceUserLike<Def>[] | [...SpaceUserLike<Def>[], SpaceParamsInputOf<Def>];
 
 type SpaceArgs<Def extends AnyPlatformDef> =
   | SpaceArrayArgs<Def>

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -8,6 +8,7 @@ import {
 import { asAttachment } from "../../content/attachment";
 import { asContact } from "../../content/contact";
 import { asCustom } from "../../content/custom";
+import { asRichlink } from "../../content/richlink";
 import { asText } from "../../content/text";
 import type { Content } from "../../content/types";
 import type { SendResult } from "../../platform/types";
@@ -18,6 +19,13 @@ import { fromVCard, toVCard } from "../../utils/vcard";
 import type { IMessageMessage } from "./types";
 
 const PLATFORM = "iMessage";
+
+// The balloonBundleId Apple stamps on messages whose sole purpose is to
+// render a URL preview card. Lives on the proto-level message only —
+// the public `Message$1` type does not expose it, so we reach through
+// `_raw`. Other plugin bundles (Find My, Digital Touch, Apple Pay) use
+// different ids and are intentionally not matched here.
+const URL_BALLOON_BUNDLE_ID = "com.apple.messages.URLBalloonProvider";
 
 const unsupportedContent = (type: string): UnsupportedError =>
   UnsupportedError.content(type, PLATFORM);
@@ -87,12 +95,41 @@ const toVCardContent = async (
   }
 };
 
+const getBalloonBundleId = (
+  message: ReceivedEvent["message"]
+): string | undefined => {
+  const raw = (message as { _raw?: { balloonBundleId?: unknown } })._raw;
+  const id = raw?.balloonBundleId;
+  return typeof id === "string" ? id : undefined;
+};
+
+const toRichlinkMessage = (
+  event: ReceivedEvent,
+  base: Omit<IMessageMessage, "id" | "content">,
+  id: string
+): IMessageMessage => {
+  const url = event.message.text ?? "";
+  try {
+    return { ...base, id, content: asRichlink({ url }) };
+  } catch {
+    return {
+      ...base,
+      id,
+      content: url ? asText(url) : asCustom(event.message),
+    };
+  }
+};
+
 const toMessages = async (
   client: AdvancedIMessage,
   event: ReceivedEvent
 ): Promise<IMessageMessage[]> => {
   const base = baseMessage(event);
   const messageGuidStr = event.message.guid as string;
+
+  if (getBalloonBundleId(event.message) === URL_BALLOON_BUNDLE_ID) {
+    return [toRichlinkMessage(event, base, messageGuidStr)];
+  }
 
   if (event.message.attachments.length > 0) {
     return Promise.all(
@@ -209,6 +246,10 @@ export const send = async (
   switch (content.type) {
     case "text":
       return toSendResult(await remote.messages.send(chat, content.text));
+    case "richlink":
+      return toSendResult(
+        await remote.messages.send(chat, content.url, { richLink: true })
+      );
     case "attachment": {
       const attachment = await remote.attachments.upload({
         data: await content.read(),
@@ -265,6 +306,13 @@ export const replyToMessage = async (
     case "text":
       return toSendResult(
         await remote.messages.send(chat, content.text, { replyTo })
+      );
+    case "richlink":
+      return toSendResult(
+        await remote.messages.send(chat, content.url, {
+          richLink: true,
+          replyTo,
+        })
       );
     case "attachment": {
       const attachment = await remote.attachments.upload({

--- a/packages/spectrum-ts/src/utils/link-metadata.ts
+++ b/packages/spectrum-ts/src/utils/link-metadata.ts
@@ -24,6 +24,14 @@ const normaliseImageUrl = (raw: string, base: string): string | undefined => {
   }
 };
 
+const cleanString = (v: string | undefined): string | undefined => {
+  if (typeof v !== "string") {
+    return;
+  }
+  const trimmed = v.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+};
+
 export const fetchLinkMetadata = async (url: string): Promise<LinkMetadata> => {
   try {
     const result = await ogs({
@@ -43,23 +51,25 @@ export const fetchLinkMetadata = async (url: string): Promise<LinkMetadata> => {
       twitterImage,
     } = result.result;
 
-    const title = ogTitle ?? twitterTitle;
-    const summary = ogDescription ?? twitterDescription;
+    const title = cleanString(ogTitle) ?? cleanString(twitterTitle);
+    const summary =
+      cleanString(ogDescription) ?? cleanString(twitterDescription);
 
     const imageCandidate = ogImage?.[0] ?? twitterImage?.[0];
-    const image = imageCandidate
-      ? (() => {
-          const resolved = normaliseImageUrl(imageCandidate.url, url);
-          if (!resolved) {
-            return;
-          }
-          const mimeType =
-            "type" in imageCandidate && typeof imageCandidate.type === "string"
-              ? imageCandidate.type
-              : undefined;
-          return { url: resolved, mimeType };
-        })()
+    const resolved = imageCandidate
+      ? normaliseImageUrl(imageCandidate.url, url)
       : undefined;
+    const image =
+      imageCandidate && resolved
+        ? {
+            url: resolved,
+            mimeType:
+              "type" in imageCandidate &&
+              typeof imageCandidate.type === "string"
+                ? imageCandidate.type
+                : undefined,
+          }
+        : undefined;
 
     return { title, summary, image };
   } catch {

--- a/packages/spectrum-ts/src/utils/link-metadata.ts
+++ b/packages/spectrum-ts/src/utils/link-metadata.ts
@@ -1,0 +1,87 @@
+import ogs from "open-graph-scraper";
+
+export interface LinkMetadata {
+  image?: { mimeType?: string; url: string };
+  summary?: string;
+  title?: string;
+}
+
+export interface FetchedImage {
+  data: Buffer;
+  mimeType?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0) AppleWebKit/605.1.15 " +
+  "(KHTML, like Gecko) Version/17.0 Safari/605.1.15 spectrum-ts/richlink";
+
+const normaliseImageUrl = (raw: string, base: string): string | undefined => {
+  try {
+    return new URL(raw, base).toString();
+  } catch {
+    return;
+  }
+};
+
+export const fetchLinkMetadata = async (url: string): Promise<LinkMetadata> => {
+  try {
+    const result = await ogs({
+      url,
+      timeout: DEFAULT_TIMEOUT_MS,
+      fetchOptions: { headers: { "User-Agent": USER_AGENT } },
+    });
+    if (result.error) {
+      return {};
+    }
+    const {
+      ogTitle,
+      ogDescription,
+      ogImage,
+      twitterTitle,
+      twitterDescription,
+      twitterImage,
+    } = result.result;
+
+    const title = ogTitle ?? twitterTitle;
+    const summary = ogDescription ?? twitterDescription;
+
+    const imageCandidate = ogImage?.[0] ?? twitterImage?.[0];
+    const image = imageCandidate
+      ? (() => {
+          const resolved = normaliseImageUrl(imageCandidate.url, url);
+          if (!resolved) {
+            return;
+          }
+          const mimeType =
+            "type" in imageCandidate && typeof imageCandidate.type === "string"
+              ? imageCandidate.type
+              : undefined;
+          return { url: resolved, mimeType };
+        })()
+      : undefined;
+
+    return { title, summary, image };
+  } catch {
+    return {};
+  }
+};
+
+export const fetchImage = async (url: string): Promise<FetchedImage> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: { "User-Agent": USER_AGENT },
+    });
+    if (!res.ok) {
+      throw new Error(`image fetch ${url} returned ${res.status}`);
+    }
+    const data = Buffer.from(await res.arrayBuffer());
+    const mimeType = res.headers.get("content-type") ?? undefined;
+    return { data, mimeType };
+  } finally {
+    clearTimeout(timer);
+  }
+};


### PR DESCRIPTION
## Summary

- Adds a new `richlink` content type that carries a URL plus lazily-fetched Open Graph metadata (title, summary, cover image). Accessors are async and memoized, and network/parse failures resolve to `undefined` rather than throwing.
- Teaches the iMessage remote provider to recognise Apple's URL-preview balloons (`com.apple.messages.URLBalloonProvider`) and surface them as `richlink` messages on the inbound side; outbound `send` / `replyToMessage` route `richlink` through imessage-kit with `richLink: true`.
- Widens `platform.space(...)` to accept raw user IDs as strings in addition to `PlatformUser` objects — the runtime resolves each string via `def.user.resolve` before normalising args, so callers no longer need to call `resolve` themselves for the common "I already have a user ID" case.
- Adds a small null guard in the `edit-echo` example: `space.send` is now `… | undefined` (from #24's `UnsupportedError` fallback), so the example guards before logging / editing.

## Usage

Build a richlink from a URL — all metadata is fetched on first access:

```typescript
import { richlink } from "spectrum-ts";

await space.send(richlink("https://photon.codes"));

// Inbound side (iMessage URL preview balloons):
for await (const [, message] of app.messages) {
  if (message.content.type === "richlink") {
    const title = await message.content.title();   // cached after first call
    const cover = await message.content.cover();   // undefined if no image
    if (cover) {
      const bytes = await cover.read();            // triggers image fetch
    }
  }
}
```

Pass user IDs directly to `space()`:

```typescript
// Before: await imessage.user.resolve(...) first
await app.imessage.space(["+15551234567"]).send(text("hi"));
```

## Changes

| File | Change |
|---|---|
| `packages/spectrum-ts/src/content/richlink.ts` | New — `richlinkSchema`, `asRichlink`, and the `richlink(url)` builder. Accessors are memoized; cover read failures resolve to an empty Buffer. |
| `packages/spectrum-ts/src/utils/link-metadata.ts` | New — `fetchLinkMetadata` (via `open-graph-scraper`) and `fetchImage` with 5s timeout + Safari-ish UA. |
| `packages/spectrum-ts/src/content/types.ts`, `src/index.ts` | Add `richlinkSchema` to the content union; export `richlink` + `Richlink`. |
| `packages/spectrum-ts/src/providers/imessage/remote.ts` | Detect `balloonBundleId === "com.apple.messages.URLBalloonProvider"` on inbound; emit a richlink message (falling back to `text` / `custom` if the URL is empty/invalid). Outbound `send` / `replyToMessage` handle `richlink` via `{ richLink: true }`. |
| `packages/spectrum-ts/src/platform/define.ts` | `space()` now resolves string args through `def.user.resolve` before normalising. |
| `packages/spectrum-ts/src/platform/types.ts` | `SpaceArrayArgs` / `SpaceVarargArgs` widened to `PlatformUser<Def> \| string`. |
| `examples/edit-echo/index.ts` | Guard against `send` returning `undefined` before logging / editing. |
| `package.json`, `bun.lock` | Adds `open-graph-scraper@^6.11.0` (pulls in `cheerio` and friends). |

## Test plan

- [ ] `bun x ultracite check` passes
- [ ] `bun x tsc --noEmit` clean across the workspace
- [ ] `bun run build` succeeds
- [ ] Inbound: send a URL from iMessage that renders as a preview card → message arrives as `content.type === "richlink"` with `title` / `summary` / `cover` accessors; non-preview URLs still arrive as `text`
- [ ] Outbound: `space.send(richlink("https://…"))` on iMessage renders as a rich preview on the receiving device
- [ ] Metadata laziness: `title()` / `summary()` alone fire exactly one OG fetch; `cover().read()` triggers a single additional image fetch; repeated calls reuse the cached promise
- [ ] Failure modes: unreachable URL / HTML without OG tags → accessors resolve to `undefined` (no throw); image fetch timeout → `cover.read()` resolves to an empty Buffer
- [ ] String user IDs: `app.<platform>.space(["user-id"]).send(...)` works without a prior `user.resolve` call; passing `PlatformUser` objects and mixed arrays still type-checks and works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added richlink content type with automatic metadata (title, summary) and cover image fetching for enhanced URL sharing
  * iMessage now supports URL previews/richlink messaging for improved link sharing
  * Space creation/API now accepts string user identifiers in addition to resolved user objects

* **Bug Fixes**
  * Prevented message-edit attempts when no outbound message is present, avoiding edit failures
<!-- end of auto-generated comment: release notes by coderabbit.ai -->