### PR TITLE
Fix multi-image tapbacks, add `group` content type and `space.getMessage` API

### DIFF
--- a/packages/spectrum-ts/src/content/group.ts
+++ b/packages/spectrum-ts/src/content/group.ts
@@ -1,0 +1,52 @@
+import z from "zod";
+import type { Message } from "../types/message";
+import { resolveContents } from "./resolve";
+import type { Content, ContentBuilder, ContentInput } from "./types";
+
+const isMessage = (v: unknown): v is Message =>
+  typeof v === "object" && v !== null && "id" in v && "content" in v;
+
+/**
+ * A `group` bundles multiple messages into one logical unit (e.g. an album
+ * of images sent together). Each item is a full `Message` — addressable by
+ * id, reactable via `.react()`, replyable via `.reply()`.
+ *
+ * Groups do not nest, and reactions cannot be group members. Enforced by the
+ * `group()` builder; platforms may additionally reject unsupported item
+ * content types at send time.
+ */
+export const groupSchema = z.object({
+  type: z.literal("group"),
+  items: z.array(z.custom<Message>(isMessage)).min(2),
+});
+
+export type Group = z.infer<typeof groupSchema>;
+
+export const asGroup = (input: { items: Message[] }): Group =>
+  groupSchema.parse({ type: "group", items: input.items });
+
+// For outbound groups built via `group(attachment(...), ...)` the group items
+// are not real Messages yet — they have no id, space, or methods until the
+// provider's send path dispatches each one natively. We wrap the resolved
+// content in a minimal shape that satisfies the `isMessage` guard and the
+// providers read `item.content` directly.
+const stubOutboundMessage = (content: Content): Message =>
+  ({ id: "", content }) as unknown as Message;
+
+export function group(
+  ...items: [ContentInput, ContentInput, ...ContentInput[]]
+): ContentBuilder {
+  return {
+    build: async () => {
+      const resolved = await resolveContents(items);
+      const members: Message[] = [];
+      for (const item of resolved) {
+        if (item.type === "group" || item.type === "reaction") {
+          throw new Error(`group() cannot contain "${item.type}" items`);
+        }
+        members.push(stubOutboundMessage(item));
+      }
+      return asGroup({ items: members });
+    },
+  };
+}

--- a/packages/spectrum-ts/src/content/reaction.ts
+++ b/packages/spectrum-ts/src/content/reaction.ts
@@ -2,31 +2,34 @@ import z from "zod";
 import type { Message } from "../types/message";
 import type { ContentBuilder } from "./types";
 
+const isMessage = (v: unknown): v is Message =>
+  typeof v === "object" && v !== null && "id" in v && "content" in v;
+
 export const reactionSchema = z.object({
   type: z.literal("reaction"),
   emoji: z.string().min(1),
-  target: z.string().min(1),
+  target: z.custom<Message>(isMessage, {
+    message: "reaction target must be a Message",
+  }),
 });
 
 export type Reaction = z.infer<typeof reactionSchema>;
 
 export const asReaction = (input: {
   emoji: string;
-  target: string;
+  target: Message;
 }): Reaction => reactionSchema.parse({ type: "reaction", ...input });
 
 /**
- * Construct a `reaction` content value. Passing a `Message` extracts its id;
- * a string is treated as the target message id directly.
+ * Construct a `reaction` content value targeting the given message.
  *
  * `space.send(reaction(emoji, message))` is sugar for `message.react(emoji)`.
  * Reactions are fire-and-forget — the returned `OutboundMessage` will be
  * `undefined` because platforms do not surface a message id for reactions.
+ *
+ * To react to a message known only by id, resolve it first via
+ * `space.getMessage(id)`.
  */
-export function reaction(
-  emoji: string,
-  target: Message | string
-): ContentBuilder {
-  const targetId = typeof target === "string" ? target : target.id;
-  return { build: async () => asReaction({ emoji, target: targetId }) };
+export function reaction(emoji: string, target: Message): ContentBuilder {
+  return { build: async () => asReaction({ emoji, target }) };
 }

--- a/packages/spectrum-ts/src/content/types.ts
+++ b/packages/spectrum-ts/src/content/types.ts
@@ -2,6 +2,7 @@ import z from "zod";
 import { attachmentSchema } from "./attachment";
 import { contactSchema } from "./contact";
 import { customSchema } from "./custom";
+import { groupSchema } from "./group";
 import { reactionSchema } from "./reaction";
 import { richlinkSchema } from "./richlink";
 import { textSchema } from "./text";
@@ -15,6 +16,7 @@ export const contentSchema = z.discriminatedUnion("type", [
   voiceSchema,
   richlinkSchema,
   reactionSchema,
+  groupSchema,
 ]);
 
 export type Content = z.infer<typeof contentSchema>;

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -11,6 +11,7 @@ export {
   contact,
 } from "./content/contact";
 export { custom } from "./content/custom";
+export { type Group, group } from "./content/group";
 export { type Reaction, reaction } from "./content/reaction";
 export { resolveContents } from "./content/resolve";
 export { type Richlink, richlink } from "./content/richlink";

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -227,9 +227,41 @@ export function buildSpace(params: BuildSpaceParams): Space {
         `Platform "${definition.name}" send did not return a message id`
       );
     }
+
+    // If the provider reported per-item send receipts for a group, replace
+    // the placeholder items (produced by the `group()` builder, which cannot
+    // know ids before the send) with real outbound Messages carrying each
+    // native receipt. This is what lets consumers call
+    // `outMsg.content.items[i].react(...)` after a group send.
+    const outboundContent =
+      item.type === "group" && sendResult.groupMembers
+        ? {
+            ...item,
+            items: item.items.map((stub, idx) => {
+              const member = sendResult?.groupMembers?.[idx];
+              if (!member?.id) {
+                return stub;
+              }
+              return buildMessage({
+                id: member.id,
+                content: stub.content,
+                sender: member.sender,
+                timestamp: member.timestamp ?? new Date(),
+                extras: {},
+                spaceRef,
+                space,
+                definition,
+                client,
+                config,
+                direction: "outbound",
+              });
+            }),
+          }
+        : item;
+
     return buildMessage({
       id: sendResult.id,
-      content: item,
+      content: outboundContent,
       sender: sendResult.sender,
       timestamp: sendResult.timestamp ?? new Date(),
       extras: {},

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -77,6 +77,107 @@ export interface BuildSpaceParams {
   typingCtx: { space: SpaceRef; client: unknown; config: unknown };
 }
 
+// Raw provider message fields — everything else on a provider-emitted record
+// is platform-specific extras (e.g. `partIndex` for iMessage).
+export const providerMessageCoreKeys: ReadonlySet<string> = new Set([
+  "content",
+  "id",
+  "sender",
+  "space",
+  "timestamp",
+]);
+
+export type ProviderMessageRecord = {
+  id: string;
+  content: Content;
+  sender: { id: string } & Record<string, unknown>;
+  space: { id: string } & Record<string, unknown>;
+  timestamp?: Date;
+} & Record<string, unknown>;
+
+export interface WrapContext {
+  client: unknown;
+  config: unknown;
+  definition: AnyPlatformDef;
+  space: Space;
+  spaceRef: SpaceRef;
+}
+
+const extractExtras = (
+  raw: ProviderMessageRecord,
+  definition: AnyPlatformDef
+): Record<string, unknown> => {
+  const entries = Object.entries(raw).filter(
+    ([key]) => !providerMessageCoreKeys.has(key)
+  );
+  const extra = Object.fromEntries(entries);
+  return (
+    definition.message?.schema ? definition.message.schema.parse(extra) : extra
+  ) as Record<string, unknown>;
+};
+
+/**
+ * Wrap a raw provider message record (and any nested raw targets/items inside
+ * its content) into a fully-built inbound `Message`. The recursion handles
+ * reaction targets and group items, which arrive from providers as raw shapes.
+ */
+export function wrapProviderMessage(
+  raw: ProviderMessageRecord,
+  ctx: WrapContext
+): InboundMessage {
+  const wrappedContent = wrapNestedContent(raw.content, ctx);
+  return buildMessage({
+    id: raw.id,
+    content: wrappedContent,
+    sender: raw.sender,
+    timestamp: raw.timestamp ?? new Date(),
+    extras: extractExtras(raw, ctx.definition),
+    spaceRef: ctx.spaceRef,
+    space: ctx.space,
+    definition: ctx.definition,
+    client: ctx.client,
+    config: ctx.config,
+    direction: "inbound",
+  });
+}
+
+const wrapNestedContent = (content: Content, ctx: WrapContext): Content => {
+  if (content.type === "reaction") {
+    const target = content.target as unknown;
+    if (isRawProviderRecord(target)) {
+      return {
+        ...content,
+        target: wrapProviderMessage(target, ctx),
+      };
+    }
+    return content;
+  }
+  if (content.type === "group") {
+    const items = content.items.map((item) => {
+      const raw = item as unknown;
+      return isRawProviderRecord(raw) ? wrapProviderMessage(raw, ctx) : item;
+    });
+    return { ...content, items };
+  }
+  return content;
+};
+
+const isRawProviderRecord = (v: unknown): v is ProviderMessageRecord => {
+  if (typeof v !== "object" || v === null) {
+    return false;
+  }
+  const record = v as Record<string, unknown>;
+  // A built Message has `react` and `reply` methods; a raw provider record
+  // does not. We use that to distinguish the two when they both satisfy the
+  // `isMessage` guard used by Zod custom validators.
+  return (
+    "id" in record &&
+    "content" in record &&
+    typeof record.react !== "function" &&
+    typeof record.reply !== "function"
+  );
+};
+
 export function buildSpace(params: BuildSpaceParams): Space {
   const { spaceRef, extras, typingCtx, definition, client, config } = params;
   // Declared first so inner arrows can reference it after assignment.
@@ -91,7 +192,7 @@ export function buildSpace(params: BuildSpaceParams): Space {
       }
       await definition.actions.reactToMessage({
         space: spaceRef,
-        messageId: item.target,
+        target: item.target,
         reaction: item.emoji,
         client,
         config,
@@ -162,6 +263,41 @@ export function buildSpace(params: BuildSpaceParams): Space {
     return results;
   }
 
+  async function getMessageImpl(id: string): Promise<Message | undefined> {
+    if (!definition.actions.getMessage) {
+      warnUnsupported(
+        UnsupportedError.action("getMessage", definition.name),
+        definition.name
+      );
+      return;
+    }
+    let raw: ProviderMessageRecord | undefined;
+    try {
+      raw = (await definition.actions.getMessage({
+        space: spaceRef,
+        messageId: id,
+        client,
+        config,
+      })) as ProviderMessageRecord | undefined;
+    } catch (err) {
+      if (err instanceof UnsupportedError) {
+        warnUnsupported(err, definition.name);
+        return;
+      }
+      throw err;
+    }
+    if (!raw) {
+      return;
+    }
+    return wrapProviderMessage(raw, {
+      client,
+      config,
+      definition,
+      space,
+      spaceRef,
+    });
+  }
+
   space = {
     ...extras,
     ...spaceRef,
@@ -172,6 +308,7 @@ export function buildSpace(params: BuildSpaceParams): Space {
     ): Promise<void> => {
       await message.edit(newContent);
     },
+    getMessage: getMessageImpl,
     startTyping: async () => {
       await definition.actions.startTyping?.(typingCtx);
     },
@@ -195,6 +332,10 @@ export function buildMessage(params: BuildOutboundParams): OutboundMessage;
 export function buildMessage(params: BuildMessageParams): Message {
   const { definition, client, config, spaceRef, space } = params;
 
+  // Late-bound self reference so `react()` can pass the built Message as the
+  // reaction target.
+  let self: Message | undefined;
+
   const react = async (reaction: string): Promise<void> => {
     if (!definition.actions.reactToMessage) {
       warnUnsupported(
@@ -203,10 +344,15 @@ export function buildMessage(params: BuildMessageParams): Message {
       );
       return;
     }
+    if (!self) {
+      throw new Error(
+        "react() called before message construction completed (internal bug)"
+      );
+    }
     try {
       await definition.actions.reactToMessage({
         space: spaceRef,
-        messageId: params.id,
+        target: self,
         reaction,
         client,
         config,
@@ -288,7 +434,7 @@ export function buildMessage(params: BuildMessageParams): Message {
       : { ...params.sender, __platform: definition.name };
 
   if (params.direction === "outbound") {
-    return {
+    const outbound = {
       ...params.extras,
       id: params.id,
       content: params.content,
@@ -328,9 +474,11 @@ export function buildMessage(params: BuildMessageParams): Message {
       space,
       timestamp: params.timestamp,
     } as OutboundMessage;
+    self = outbound;
+    return outbound;
   }
 
-  return {
+  const inbound = {
     ...params.extras,
     id: params.id,
     content: params.content,
@@ -342,4 +490,6 @@ export function buildMessage(params: BuildMessageParams): Message {
     space,
     timestamp: params.timestamp,
   } as InboundMessage;
+  self = inbound;
+  return inbound;
 }

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -45,6 +45,14 @@ export type ProviderMessage<
 } & TExtra;
 
 export interface SendResult<TSender extends ResolvedUser = ResolvedUser> {
+  /**
+   * Per-item send receipts returned when the dispatched content was a
+   * `group`. Providers that iterate native sends to emulate a group
+   * (e.g. iMessage) populate this so the platform build layer can
+   * replace the outbound group's placeholder items with real Messages
+   * that carry each item's own id.
+   */
+  groupMembers?: SendResult<TSender>[];
   id: string;
   sender?: TSender;
   timestamp?: Date;

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -125,7 +125,7 @@ export interface PlatformDef<
     }) => Promise<void>;
     reactToMessage?: (_: {
       space: _ResolvedSpace & SpaceRef;
-      messageId: string;
+      target: _MessageType;
       reaction: string;
       client: _Client;
       config: z.infer<_ConfigSchema>;
@@ -144,6 +144,12 @@ export interface PlatformDef<
       client: _Client;
       config: z.infer<_ConfigSchema>;
     }) => Promise<void>;
+    getMessage?: (_: {
+      space: _ResolvedSpace & SpaceRef;
+      messageId: string;
+      client: _Client;
+      config: z.infer<_ConfigSchema>;
+    }) => Promise<_MessageType | undefined>;
   };
 
   config: _ConfigSchema;
@@ -207,6 +213,8 @@ export interface AnyPlatformDef {
     replyToMessage?: (_: any) => Promise<SendResult>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     editMessage?: (_: any) => Promise<void>;
+    // biome-ignore lint/suspicious/noExplicitAny: wildcard action
+    getMessage?: (_: any) => Promise<any>;
   };
   config: z.ZodType<object>;
   events: {

--- a/packages/spectrum-ts/src/providers/imessage/cache.ts
+++ b/packages/spectrum-ts/src/providers/imessage/cache.ts
@@ -1,0 +1,58 @@
+import type { IMessageMessage } from "./types";
+
+const DEFAULT_MAX = 1000;
+
+/**
+ * Bounded insertion-order cache of recently-seen iMessage messages, keyed by
+ * guid. Provides O(1) lookup for reaction target resolution. When capacity is
+ * exceeded, the oldest entry is evicted. Access does not promote recency —
+ * this is a bounded FIFO, not an LRU. The workload (reactions arriving shortly
+ * after the message they target) doesn't benefit from LRU semantics, and FIFO
+ * avoids a dependency.
+ */
+export class MessageCache {
+  private readonly map = new Map<string, IMessageMessage>();
+  private readonly max: number;
+
+  constructor(max = DEFAULT_MAX) {
+    this.max = max;
+  }
+
+  get(id: string): IMessageMessage | undefined {
+    return this.map.get(id);
+  }
+
+  set(id: string, message: IMessageMessage): void {
+    if (this.map.has(id)) {
+      this.map.delete(id);
+    }
+    this.map.set(id, message);
+    if (this.map.size > this.max) {
+      const first = this.map.keys().next().value;
+      if (first !== undefined) {
+        this.map.delete(first);
+      }
+    }
+  }
+
+  clear(): void {
+    this.map.clear();
+  }
+}
+
+const caches = new WeakMap<object, MessageCache>();
+
+/**
+ * Returns a per-client message cache. Keyed by an object (the client array
+ * for remote, or the IMessageSDK instance for local), so each iMessage
+ * provider instance has its own cache and multiple providers don't share
+ * state accidentally.
+ */
+export const getMessageCache = (owner: object): MessageCache => {
+  let cache = caches.get(owner);
+  if (!cache) {
+    cache = new MessageCache();
+    caches.set(owner, cache);
+  }
+  return cache;
+};

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -3,9 +3,14 @@ import { IMessageSDK } from "@photon-ai/imessage-kit";
 import { definePlatform } from "../../platform/define";
 import { UnsupportedError } from "../../utils/errors";
 import { createCloudClients, disposeCloudAuth } from "./auth";
-import { messages as localMessages, send as localSend } from "./local";
+import {
+  getMessage as localGetMessage,
+  messages as localMessages,
+  send as localSend,
+} from "./local";
 import {
   editMessage as remoteEditMessage,
+  getMessage as remoteGetMessage,
   messages as remoteMessages,
   reactToMessage as remoteReactToMessage,
   replyToMessage as remoteReplyToMessage,
@@ -16,7 +21,9 @@ import {
 import {
   configSchema,
   type IMessageClient,
+  type IMessageMessage,
   isLocal,
+  messageSchema,
   spaceSchema,
 } from "./types";
 
@@ -59,6 +66,10 @@ export const imessage = definePlatform("iMessage", {
       const { chat } = await remote.chats.create(addresses);
       return { id: chat.guid as string, type: "group" as const };
     },
+  },
+
+  message: {
+    schema: messageSchema,
   },
 
   lifecycle: {
@@ -125,11 +136,16 @@ export const imessage = definePlatform("iMessage", {
       }
       await remoteStopTyping(client, space.id);
     },
-    reactToMessage: async ({ space, messageId, reaction, client }) => {
+    reactToMessage: async ({ space, target, reaction, client }) => {
       if (isLocal(client)) {
         throw UnsupportedError.action("react", "iMessage (local mode)");
       }
-      await remoteReactToMessage(client, space.id, messageId, reaction);
+      await remoteReactToMessage(
+        client,
+        space.id,
+        target as IMessageMessage,
+        reaction
+      );
     },
     replyToMessage: async ({ space, messageId, content, client }) => {
       if (isLocal(client)) {
@@ -142,6 +158,12 @@ export const imessage = definePlatform("iMessage", {
         throw UnsupportedError.action("edit", "iMessage (local mode)");
       }
       await remoteEditMessage(client, space.id, messageId, content);
+    },
+    getMessage: async ({ space, messageId, client }) => {
+      if (isLocal(client)) {
+        return localGetMessage(client, messageId);
+      }
+      return remoteGetMessage(client, space.id, messageId);
     },
   },
 });

--- a/packages/spectrum-ts/src/providers/imessage/local.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local.ts
@@ -210,3 +210,12 @@ export const send = async (
       throw UnsupportedError.content(content.type, "iMessage (local mode)");
   }
 };
+
+// Local mode has no by-id SDK lookup and does not surface reactions, so it
+// has no cache to consult. `space.getMessage(id)` always resolves to
+// `undefined` on local — callers with only an id cannot materialize a Message
+// here.
+export const getMessage = async (
+  _client: IMessageSDK,
+  _id: string
+): Promise<IMessageMessage | undefined> => undefined;

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -249,7 +249,7 @@ const rebuildFromAppleMessage = async (
           client,
           base,
           info,
-          info.guid as string,
+          formatChildId(i, messageGuidStr),
           i,
           messageGuidStr
         )
@@ -312,9 +312,14 @@ const toRichlinkMessage = (
 };
 
 // Apple prefixes the target guid of a tapback with `p:<partIndex>/` to name a
-// specific part of a multi-part message. We keep the index so multi-image
-// reactions can resolve to the exact group sub-item.
+// specific part of a multi-part message. We reuse the same encoding as
+// spectrum-ts group child message ids so that a child id is round-trippable:
+// `remote.messages.get(parentGuid)` can always reconstruct the child by
+// parsing the index off the front.
 const PART_PREFIX = /^p:(\d+)\//;
+
+const formatChildId = (partIndex: number, parentGuid: string): string =>
+  `p:${partIndex}/${parentGuid}`;
 
 const parseTapbackTarget = (
   target: string
@@ -323,6 +328,19 @@ const parseTapbackTarget = (
   const guid = target.replace(PART_PREFIX, "");
   const partIndex = match ? Number(match[1]) : 0;
   return { guid, partIndex };
+};
+
+const parseChildId = (
+  id: string
+): { parentGuid: string; partIndex: number } | null => {
+  const match = id.match(PART_PREFIX);
+  if (!match) {
+    return null;
+  }
+  return {
+    parentGuid: id.replace(PART_PREFIX, ""),
+    partIndex: Number(match[1]),
+  };
 };
 
 const resolveReactionTarget = async (
@@ -435,7 +453,7 @@ const toMessages = async (
           client,
           base,
           info,
-          info.guid as string,
+          formatChildId(i, messageGuidStr),
           i,
           messageGuidStr
         )
@@ -612,15 +630,21 @@ export const send = async (
         );
       }
     }
-    let first: SendResult | undefined;
+    // The SDK has no single multi-attachment send with uploaded bytes
+    // (MessagePart requires server-side paths; upload returns guids only),
+    // so we fall back to N sequential sends. Return per-child receipts on
+    // `groupMembers` so the platform layer can build real outbound Messages
+    // for each group item. The outer `id` tracks the first child purely for
+    // OutboundMessage compatibility — prefer items[i].id for per-item ops.
+    const groupMembers: SendResult[] = [];
     for (const sub of content.items as unknown as IMessageMessage[]) {
-      const r = await sendSingle(remote, chat, sub.content);
-      first ??= r;
+      groupMembers.push(await sendSingle(remote, chat, sub.content));
     }
+    const first = groupMembers[0];
     if (!first) {
       throw new Error("Empty group");
     }
-    return first;
+    return { ...first, groupMembers };
   }
 
   return sendSingle(remote, chat, content);
@@ -762,6 +786,28 @@ export const getMessage = async (
   if (cached) {
     return cached;
   }
+
+  // Group-child ids use the `p:<partIndex>/<parentGuid>` format (same as
+  // Apple tapback targets). The SDK's `messages.get` only accepts parent
+  // guids, so decode the id and descend into the parent's items.
+  const childRef = parseChildId(msgId);
+  if (childRef) {
+    try {
+      const fetched = await remote.messages.get(
+        messageGuid(childRef.parentGuid)
+      );
+      const parent = await rebuildFromAppleMessage(remote, fetched, spaceId);
+      cacheMessage(cache, parent);
+      if (parent.content.type !== "group") {
+        return;
+      }
+      const items = parent.content.items as unknown as IMessageMessage[];
+      return items[childRef.partIndex];
+    } catch {
+      return;
+    }
+  }
+
   try {
     const fetched = await remote.messages.get(messageGuid(msgId));
     const rebuilt = await rebuildFromAppleMessage(remote, fetched, spaceId);

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -8,15 +8,18 @@ import {
 import { asAttachment } from "../../content/attachment";
 import { asContact } from "../../content/contact";
 import { asCustom } from "../../content/custom";
+import { asGroup } from "../../content/group";
 import { asReaction } from "../../content/reaction";
 import { asRichlink } from "../../content/richlink";
 import { asText } from "../../content/text";
 import type { Content } from "../../content/types";
 import type { SendResult } from "../../platform/types";
+import type { Message } from "../../types/message";
 import { ensureM4a } from "../../utils/audio";
 import { UnsupportedError } from "../../utils/errors";
 import { type ManagedStream, mergeStreams, stream } from "../../utils/stream";
 import { fromVCard, toVCard } from "../../utils/vcard";
+import { getMessageCache } from "./cache";
 import type { IMessageMessage } from "./types";
 
 const PLATFORM = "iMessage";
@@ -28,8 +31,17 @@ const PLATFORM = "iMessage";
 // different ids and are intentionally not matched here.
 const URL_BALLOON_BUNDLE_ID = "com.apple.messages.URLBalloonProvider";
 
-const unsupportedContent = (type: string): UnsupportedError =>
-  UnsupportedError.content(type, PLATFORM);
+// Attachment-shaped content types are the only members a group may contain
+// when sent via iMessage. Anything else surfaces as an UnsupportedError so the
+// platform build layer logs a clear warning.
+const GROUP_ITEM_ALLOWED: ReadonlySet<Content["type"]> = new Set([
+  "attachment",
+  "contact",
+  "voice",
+]);
+
+const unsupportedContent = (type: string, detail?: string): UnsupportedError =>
+  UnsupportedError.content(type, PLATFORM, detail);
 
 const toSendResult = (receipt: { guid: unknown }): SendResult => ({
   id: receipt.guid as string,
@@ -55,6 +67,8 @@ const isVCardAttachment = (
 };
 
 type ReceivedEvent = Extract<MessageEvent, { type: "message.received" }>;
+type AppleMessage = ReceivedEvent["message"];
+type AppleAttachment = AppleMessage["attachments"][number];
 
 // Emoji ↔ classic tapback (Apple's six fixed reactions). On send, these six
 // emoji use the native tapback API; anything else falls through to the
@@ -104,7 +118,7 @@ const resolveReactionEmoji = (
 };
 
 const getAssociatedMessageType = (
-  message: ReceivedEvent["message"]
+  message: AppleMessage
 ): string | undefined => {
   const direct = (message as { associatedMessageType?: unknown })
     .associatedMessageType;
@@ -116,20 +130,32 @@ const getAssociatedMessageType = (
   return typeof fromRaw === "string" ? fromRaw : undefined;
 };
 
-const baseMessage = (
-  event: ReceivedEvent
-): Omit<IMessageMessage, "id" | "content"> => ({
-  sender: { id: event.message.sender?.address ?? "" },
-  space: {
-    id: event.chatGuid,
-    type: event.chatGuid.includes(";+;") ? "group" : "dm",
-  },
-  timestamp: event.timestamp,
-});
+const getBalloonBundleId = (message: AppleMessage): string | undefined => {
+  const raw = (message as { _raw?: { balloonBundleId?: unknown } })._raw;
+  const id = raw?.balloonBundleId;
+  return typeof id === "string" ? id : undefined;
+};
+
+// `Message$1` from the SDK (fetched via `messages.get`) lacks the ambient
+// chatGuid that inbound events carry; fall back to the first chat the message
+// belongs to.
+const resolveChatGuid = (
+  message: AppleMessage,
+  hint: string | undefined
+): string => {
+  if (hint) {
+    return hint;
+  }
+  const first = message.chatGuids?.[0];
+  return (first as unknown as string | undefined) ?? "";
+};
+
+const resolveSenderId = (message: AppleMessage): string =>
+  message.sender?.address ?? "";
 
 const toAttachmentContent = (
   client: AdvancedIMessage,
-  info: ReceivedEvent["message"]["attachments"][number]
+  info: AppleAttachment
 ): Content =>
   asAttachment({
     name: info.fileName,
@@ -142,7 +168,7 @@ const toAttachmentContent = (
 
 const toVCardContent = async (
   client: AdvancedIMessage,
-  info: ReceivedEvent["message"]["attachments"][number]
+  info: AppleAttachment
 ): Promise<Content> => {
   try {
     const buf = Buffer.from(await client.attachments.downloadBuffer(info.guid));
@@ -152,12 +178,120 @@ const toVCardContent = async (
   }
 };
 
-const getBalloonBundleId = (
-  message: ReceivedEvent["message"]
-): string | undefined => {
-  const raw = (message as { _raw?: { balloonBundleId?: unknown } })._raw;
-  const id = raw?.balloonBundleId;
-  return typeof id === "string" ? id : undefined;
+const attachmentContent = async (
+  client: AdvancedIMessage,
+  info: AppleAttachment
+): Promise<Content> =>
+  isVCardAttachment(info.mimeType, info.fileName)
+    ? await toVCardContent(client, info)
+    : toAttachmentContent(client, info);
+
+const baseShape = (
+  message: AppleMessage,
+  chatGuidHint: string | undefined,
+  timestamp: Date
+): Omit<IMessageMessage, "id" | "content"> => {
+  const chat = resolveChatGuid(message, chatGuidHint);
+  return {
+    sender: { id: resolveSenderId(message) },
+    space: {
+      id: chat,
+      type: chat.includes(";+;") ? "group" : "dm",
+    },
+    timestamp,
+  };
+};
+
+const buildAttachmentMessage = async (
+  client: AdvancedIMessage,
+  base: Omit<IMessageMessage, "id" | "content">,
+  info: AppleAttachment,
+  id: string,
+  partIndex: number,
+  parentId?: string
+): Promise<IMessageMessage> => {
+  const content = await attachmentContent(client, info);
+  const msg: IMessageMessage = { ...base, id, content, partIndex };
+  if (parentId !== undefined) {
+    msg.parentId = parentId;
+  }
+  return msg;
+};
+
+// Rebuilds an `IMessageMessage` (or a group) from an Apple SDK message that
+// did not arrive via the live stream. Used on reaction cache miss.
+const rebuildFromAppleMessage = async (
+  client: AdvancedIMessage,
+  message: AppleMessage,
+  chatGuidHint?: string
+): Promise<IMessageMessage> => {
+  const messageGuidStr = message.guid as string;
+  const timestamp = message.dateCreated ?? new Date();
+  const base = baseShape(message, chatGuidHint, timestamp);
+
+  if (message.attachments.length === 1) {
+    const info = message.attachments[0];
+    if (!info) {
+      throw new Error("Unreachable: attachments.length === 1 but no element");
+    }
+    return buildAttachmentMessage(client, base, info, messageGuidStr, 0);
+  }
+
+  if (message.attachments.length > 1) {
+    const items: IMessageMessage[] = [];
+    for (let i = 0; i < message.attachments.length; i++) {
+      const info = message.attachments[i];
+      if (!info) {
+        continue;
+      }
+      items.push(
+        await buildAttachmentMessage(
+          client,
+          base,
+          info,
+          info.guid as string,
+          i,
+          messageGuidStr
+        )
+      );
+    }
+    return {
+      ...base,
+      id: messageGuidStr,
+      content: asGroup({ items: items as unknown as Message[] }),
+    };
+  }
+
+  const text = message.text;
+  if (getBalloonBundleId(message) === URL_BALLOON_BUNDLE_ID) {
+    const url = text ?? "";
+    try {
+      return { ...base, id: messageGuidStr, content: asRichlink({ url }) };
+    } catch {
+      return {
+        ...base,
+        id: messageGuidStr,
+        content: url ? asText(url) : asCustom(message),
+      };
+    }
+  }
+  return {
+    ...base,
+    id: messageGuidStr,
+    content: text ? asText(text) : asCustom(message),
+  };
+};
+
+const cacheMessage = (
+  cache: ReturnType<typeof getMessageCache>,
+  message: IMessageMessage
+): void => {
+  cache.set(message.id, message);
+  if (message.content.type === "group") {
+    for (const item of message.content.items as unknown as IMessageMessage[]) {
+      cache.set(item.id, item);
+    }
+  }
 };
 
 const toRichlinkMessage = (
@@ -178,16 +312,52 @@ const toRichlinkMessage = (
 };
 
 // Apple prefixes the target guid of a tapback with `p:<partIndex>/` to name a
-// specific part of a multi-part message. spectrum-ts surfaces message ids as
-// bare guids everywhere else, so strip the part prefix here for consistency.
-const PART_PREFIX = /^p:\d+\//;
+// specific part of a multi-part message. We keep the index so multi-image
+// reactions can resolve to the exact group sub-item.
+const PART_PREFIX = /^p:(\d+)\//;
 
-const toReactionMessage = (
+const parseTapbackTarget = (
+  target: string
+): { guid: string; partIndex: number } => {
+  const match = target.match(PART_PREFIX);
+  const guid = target.replace(PART_PREFIX, "");
+  const partIndex = match ? Number(match[1]) : 0;
+  return { guid, partIndex };
+};
+
+const resolveReactionTarget = async (
+  client: AdvancedIMessage,
+  cache: ReturnType<typeof getMessageCache>,
+  strippedGuid: string,
+  partIndex: number
+): Promise<IMessageMessage | undefined> => {
+  let candidate = cache.get(strippedGuid);
+  if (!candidate) {
+    try {
+      const fetched = await client.messages.get(messageGuid(strippedGuid));
+      candidate = await rebuildFromAppleMessage(client, fetched);
+      cacheMessage(cache, candidate);
+    } catch {
+      return;
+    }
+  }
+  if (candidate.content.type === "group") {
+    const item = (candidate.content.items as unknown as IMessageMessage[])[
+      partIndex
+    ];
+    return item ?? candidate;
+  }
+  return candidate;
+};
+
+const toReactionMessage = async (
+  client: AdvancedIMessage,
+  cache: ReturnType<typeof getMessageCache>,
   event: ReceivedEvent,
   base: Omit<IMessageMessage, "id" | "content">,
   id: string,
   target: string
-): IMessageMessage[] => {
+): Promise<IMessageMessage[]> => {
   const type = getAssociatedMessageType(event.message);
   if (type && isTapbackRemoval(type)) {
     return [];
@@ -199,54 +369,102 @@ const toReactionMessage = (
   if (!emoji) {
     return [];
   }
-  const normalizedTarget = target.replace(PART_PREFIX, "");
+  const { guid: strippedGuid, partIndex } = parseTapbackTarget(target);
+  const resolved = await resolveReactionTarget(
+    client,
+    cache,
+    strippedGuid,
+    partIndex
+  );
+  if (!resolved) {
+    return [];
+  }
   return [
-    { ...base, id, content: asReaction({ emoji, target: normalizedTarget }) },
+    {
+      ...base,
+      id,
+      content: asReaction({ emoji, target: resolved as unknown as Message }),
+    },
   ];
 };
 
 const toMessages = async (
   client: AdvancedIMessage,
+  cache: ReturnType<typeof getMessageCache>,
   event: ReceivedEvent
 ): Promise<IMessageMessage[]> => {
-  const base = baseMessage(event);
+  const base = baseShape(event.message, event.chatGuid, event.timestamp);
   const messageGuidStr = event.message.guid as string;
 
   const assoc = event.message.associatedMessageGuid as string | undefined;
   if (assoc) {
-    return toReactionMessage(event, base, messageGuidStr, assoc);
+    return toReactionMessage(client, cache, event, base, messageGuidStr, assoc);
   }
 
   if (getBalloonBundleId(event.message) === URL_BALLOON_BUNDLE_ID) {
-    return [toRichlinkMessage(event, base, messageGuidStr)];
+    const msg = toRichlinkMessage(event, base, messageGuidStr);
+    cacheMessage(cache, msg);
+    return [msg];
   }
 
-  if (event.message.attachments.length > 0) {
-    return Promise.all(
-      event.message.attachments.map(async (info) => ({
-        ...base,
-        id: `${messageGuidStr}:${info.guid as string}`,
-        content: isVCardAttachment(info.mimeType, info.fileName)
-          ? await toVCardContent(client, info)
-          : toAttachmentContent(client, info),
-      }))
+  if (event.message.attachments.length === 1) {
+    const info = event.message.attachments[0];
+    if (!info) {
+      throw new Error("Unreachable: attachments.length === 1 but no element");
+    }
+    const msg = await buildAttachmentMessage(
+      client,
+      base,
+      info,
+      messageGuidStr,
+      0
     );
+    cacheMessage(cache, msg);
+    return [msg];
+  }
+
+  if (event.message.attachments.length > 1) {
+    const items: IMessageMessage[] = [];
+    for (let i = 0; i < event.message.attachments.length; i++) {
+      const info = event.message.attachments[i];
+      if (!info) {
+        continue;
+      }
+      items.push(
+        await buildAttachmentMessage(
+          client,
+          base,
+          info,
+          info.guid as string,
+          i,
+          messageGuidStr
+        )
+      );
+    }
+    const parent: IMessageMessage = {
+      ...base,
+      id: messageGuidStr,
+      content: asGroup({ items: items as unknown as Message[] }),
+    };
+    cacheMessage(cache, parent);
+    return [parent];
   }
 
   const text = event.message.text;
-  return [
-    {
-      ...base,
-      id: messageGuidStr,
-      content: text ? asText(text) : asCustom(event.message),
-    },
-  ];
+  const msg: IMessageMessage = {
+    ...base,
+    id: messageGuidStr,
+    content: text ? asText(text) : asCustom(event.message),
+  };
+  cacheMessage(cache, msg);
+  return [msg];
 };
 
 const clientStream = (
   client: AdvancedIMessage
 ): ManagedStream<IMessageMessage> => {
   const sub = client.messages.subscribe("message.received");
+  const cache = getMessageCache(client);
   return stream<IMessageMessage>((emit, end) => {
     const pump = (async () => {
       try {
@@ -254,7 +472,7 @@ const clientStream = (
           if (event.message.isFromMe) {
             continue;
           }
-          for (const message of await toMessages(client, event)) {
+          for (const message of await toMessages(client, cache, event)) {
             await emit(message);
           }
         }
@@ -323,16 +541,11 @@ export const stopTyping = async (
   await remote.chats.stopTyping(chatGuid(spaceId));
 };
 
-export const send = async (
-  clients: AdvancedIMessage[],
-  spaceId: string,
+const sendSingle = async (
+  remote: AdvancedIMessage,
+  chat: ReturnType<typeof chatGuid>,
   content: Content
 ): Promise<SendResult> => {
-  const remote = clients[0];
-  if (!remote) {
-    throw new Error("No remote iMessage client available");
-  }
-  const chat = chatGuid(spaceId);
   switch (content.type) {
     case "text":
       return toSendResult(await remote.messages.send(chat, content.text));
@@ -347,9 +560,7 @@ export const send = async (
         mimeType: content.mimeType,
       });
       return toSendResult(
-        await remote.messages.send(chat, "", {
-          attachment: attachment.guid,
-        })
+        await remote.messages.send(chat, "", { attachment: attachment.guid })
       );
     }
     case "contact": {
@@ -376,6 +587,43 @@ export const send = async (
     default:
       throw unsupportedContent(content.type);
   }
+};
+
+export const send = async (
+  clients: AdvancedIMessage[],
+  spaceId: string,
+  content: Content
+): Promise<SendResult> => {
+  const remote = clients[0];
+  if (!remote) {
+    throw new Error("No remote iMessage client available");
+  }
+  const chat = chatGuid(spaceId);
+
+  if (content.type === "group") {
+    // Strict validation — fail before any native send when a group contains
+    // items iMessage cannot carry natively.
+    for (const sub of content.items as unknown as IMessageMessage[]) {
+      const itemType = sub.content.type;
+      if (!GROUP_ITEM_ALLOWED.has(itemType)) {
+        throw unsupportedContent(
+          "group",
+          `"${itemType}" items are not supported inside a group`
+        );
+      }
+    }
+    let first: SendResult | undefined;
+    for (const sub of content.items as unknown as IMessageMessage[]) {
+      const r = await sendSingle(remote, chat, sub.content);
+      first ??= r;
+    }
+    if (!first) {
+      throw new Error("Empty group");
+    }
+    return first;
+  }
+
+  return sendSingle(remote, chat, content);
 };
 
 export const replyToMessage = async (
@@ -473,7 +721,7 @@ export const editMessage = async (
 export const reactToMessage = async (
   clients: AdvancedIMessage[],
   spaceId: string,
-  msgId: string,
+  target: IMessageMessage,
   reaction: string
 ) => {
   const remote = clients[0];
@@ -482,12 +730,44 @@ export const reactToMessage = async (
   }
 
   const chat = chatGuid(spaceId);
-  const msg = messageGuid(msgId);
+  // A group sub-item carries the parent's guid in `parentId`; top-level
+  // messages reuse their own id. Apple's tapback API keys off the parent
+  // guid and disambiguates via `partIndex`.
+  const parentGuid = target.parentId ?? target.id;
+  const guid = messageGuid(parentGuid);
+  const opts =
+    typeof target.partIndex === "number"
+      ? { partIndex: target.partIndex }
+      : undefined;
 
   const native = EMOJI_TO_TAPBACK[reaction];
   if (native) {
-    await remote.messages.react(chat, msg, native);
+    await remote.messages.react(chat, guid, native, opts);
   } else {
-    await remote.messages.reactEmoji(chat, msg, reaction);
+    await remote.messages.reactEmoji(chat, guid, reaction, opts);
+  }
+};
+
+export const getMessage = async (
+  clients: AdvancedIMessage[],
+  spaceId: string,
+  msgId: string
+): Promise<IMessageMessage | undefined> => {
+  const remote = clients[0];
+  if (!remote) {
+    return;
+  }
+  const cache = getMessageCache(remote);
+  const cached = cache.get(msgId);
+  if (cached) {
+    return cached;
+  }
+  try {
+    const fetched = await remote.messages.get(messageGuid(msgId));
+    const rebuilt = await rebuildFromAppleMessage(remote, fetched, spaceId);
+    cacheMessage(cache, rebuilt);
+    return rebuilt;
+  } catch {
+    return;
   }
 };

--- a/packages/spectrum-ts/src/providers/imessage/types.ts
+++ b/packages/spectrum-ts/src/providers/imessage/types.ts
@@ -25,7 +25,22 @@ export const spaceSchema = z.object({
   type: z.enum(["dm", "group"]),
 });
 
+/**
+ * iMessage-specific per-message metadata surfaced on `IMessageMessage`.
+ * - `partIndex`: attachment index within a multi-part message (0 for bare
+ *   or single-attachment messages; 0..N-1 for a group's sub-items).
+ * - `parentId`: guid of the parent message for a group sub-item. Undefined
+ *   when the message itself is the parent.
+ */
+export const messageSchema = z.object({
+  partIndex: z.number().int().nonnegative().optional(),
+  parentId: z.string().optional(),
+});
+
 export type IMessageMessage = SchemaMessage<
   typeof userSchema,
   typeof spaceSchema
->;
+> & {
+  partIndex?: number;
+  parentId?: string;
+};

--- a/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
@@ -80,11 +80,11 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
       return await send(client as WhatsAppClients, space.id, content);
     },
 
-    reactToMessage: async ({ space, messageId, reaction, client }) => {
+    reactToMessage: async ({ space, target, reaction, client }) => {
       await reactToMessage(
         client as WhatsAppClients,
         space.id,
-        messageId,
+        target.id,
         reaction
       );
     },

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -227,11 +227,19 @@ const mapContent = (
       return asCustom({ whatsapp_type: "sticker", ...content.sticker });
     case "location":
       return asCustom({ whatsapp_type: "location", ...content.location });
-    case "reaction":
+    case "reaction": {
+      // WhatsApp reaction events carry only the target message id; synthesize
+      // a minimal target Message shape. Core's wrapProviderMessage inflates
+      // this into a full Message with react/reply methods at emit time.
+      const stubTarget = {
+        id: content.reaction.messageId,
+        content: asCustom({ whatsapp_type: "reaction-target", stub: true }),
+      };
       return asReaction({
         emoji: content.reaction.emoji,
-        target: content.reaction.messageId,
+        target: stubTarget as Parameters<typeof asReaction>[0]["target"],
       });
+    }
     case "interactive":
       return asCustom({ whatsapp_type: "interactive", ...content.interactive });
     case "button":

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -1,6 +1,10 @@
 import z from "zod";
-import type { Content, ContentInput } from "./content/types";
-import { buildMessage, buildSpace } from "./platform/build";
+import type { ContentInput } from "./content/types";
+import {
+  buildSpace,
+  type ProviderMessageRecord,
+  wrapProviderMessage,
+} from "./platform/build";
 import type {
   AnyPlatformDef,
   CustomEventStreams,
@@ -10,22 +14,6 @@ import type {
 import type { InboundMessage, Message, OutboundMessage } from "./types/message";
 import type { Space } from "./types/space";
 import { type ManagedStream, mergeStreams, stream } from "./utils/stream";
-
-type ProviderMessageRecord = {
-  id: string;
-  content: Content;
-  sender: { id: string } & Record<string, unknown>;
-  space: { id: string } & Record<string, unknown>;
-  timestamp?: Date;
-} & Record<string, unknown>;
-
-const providerMessageCoreKeys = new Set([
-  "content",
-  "id",
-  "sender",
-  "space",
-  "timestamp",
-]);
 
 // ---------------------------------------------------------------------------
 // SpectrumInstance — the typed return of Spectrum()
@@ -155,13 +143,6 @@ export async function Spectrum<
 
     const bindSend = async function* (): AsyncIterable<[Space, Message]> {
       for await (const msg of raw) {
-        const extraEntries = Object.entries(msg).filter(
-          ([key]) => !providerMessageCoreKeys.has(key)
-        );
-        const extra = Object.fromEntries(extraEntries);
-        const parsedExtra = definition.message?.schema
-          ? definition.message.schema.parse(extra)
-          : {};
         const spaceRef = {
           ...msg.space,
           __platform: definition.name,
@@ -175,20 +156,13 @@ export async function Spectrum<
           client,
           config,
         });
-        const normalizedMessage = buildMessage({
-          id: msg.id,
-          content: msg.content,
-          sender: msg.sender,
-          timestamp: msg.timestamp ?? new Date(),
-          extras: parsedExtra as Record<string, unknown>,
-          spaceRef,
-          space,
-          definition,
+        const normalizedMessage = wrapProviderMessage(msg, {
           client,
           config,
-          direction: "inbound",
+          definition,
+          space,
+          spaceRef,
         });
-
         yield [space, normalizedMessage];
       }
     };

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -38,19 +38,48 @@ export type SpectrumInstance<
   };
 
 // ---------------------------------------------------------------------------
+// Runtime options
+// ---------------------------------------------------------------------------
+
+/**
+ * Runtime behavior tweaks for a Spectrum instance.
+ */
+export interface SpectrumOptions {
+  /**
+   * When `true`, inbound `group` messages are never delivered whole. Instead,
+   * each group item is yielded from `spectrum.messages` as its own
+   * `[space, message]` tuple, in order. Items retain their individual
+   * `id`, `sender`, `timestamp`, and `.react()` / `.reply()` methods.
+   *
+   * Does not affect outbound `group(...)` sends or `space.getMessage(id)`.
+   *
+   * @default false
+   */
+  flattenGroups?: boolean;
+}
+
+// ---------------------------------------------------------------------------
 // Config validation
 // ---------------------------------------------------------------------------
+
+const spectrumOptionsSchema = z
+  .object({
+    flattenGroups: z.boolean().optional(),
+  })
+  .optional();
 
 const spectrumConfigSchema = z.union([
   z.object({
     projectId: z.string().min(1),
     projectSecret: z.string().min(1),
     providers: z.array(z.custom<PlatformProviderConfig>()),
+    options: spectrumOptionsSchema,
   }),
   z.object({
     projectId: z.undefined().optional(),
     projectSecret: z.undefined().optional(),
     providers: z.array(z.custom<PlatformProviderConfig>()),
+    options: spectrumOptionsSchema,
   }),
 ]);
 
@@ -66,16 +95,24 @@ export async function Spectrum<
         projectId: string;
         projectSecret: string;
         providers: [...Providers];
+        options?: SpectrumOptions;
       }
     | {
         projectId?: never;
         projectSecret?: never;
         providers: [...Providers];
+        options?: SpectrumOptions;
       }
 ): Promise<SpectrumInstance<Providers>> {
   spectrumConfigSchema.parse(options);
 
-  const { projectId, projectSecret, providers } = options;
+  const {
+    projectId,
+    projectSecret,
+    providers,
+    options: runtimeOptions,
+  } = options;
+  const flattenGroups = runtimeOptions?.flattenGroups ?? false;
 
   const platformStates = new Map<
     string,
@@ -163,6 +200,12 @@ export async function Spectrum<
           space,
           spaceRef,
         });
+        if (flattenGroups && normalizedMessage.content.type === "group") {
+          for (const item of normalizedMessage.content.items) {
+            yield [space, item];
+          }
+          continue;
+        }
         yield [space, normalizedMessage];
       }
     };

--- a/packages/spectrum-ts/src/types/space.ts
+++ b/packages/spectrum-ts/src/types/space.ts
@@ -1,9 +1,16 @@
 import type { ContentInput } from "../content/types";
-import type { OutboundMessage } from "./message";
+import type { Message, OutboundMessage } from "./message";
 
 export interface Space<_Def = unknown> {
   readonly __platform: string;
   edit(message: OutboundMessage, newContent: ContentInput): Promise<void>;
+  /**
+   * Look up a message in this space by its id. Returns `undefined` if the
+   * platform has no way to resolve the id (e.g. cache miss with no by-id
+   * SDK fallback). Used to materialize a `Message` for APIs that require one,
+   * such as `reaction()`.
+   */
+  getMessage(id: string): Promise<Message | undefined>;
   readonly id: string;
   responding<T>(fn: () => T | Promise<T>): Promise<T>;
   send(content: ContentInput): Promise<OutboundMessage | undefined>;


### PR DESCRIPTION
## Summary

- Fix iMessage reactions against a specific image in a multi-attachment message (tapbacks were previously dropped or mis-targeted because the `p:<partIndex>/` prefix was stripped and never routed back to a sub-item).
- Introduce a new `group` content type that bundles multiple messages into one logical unit (e.g. an iMessage album) and surfaces each item as a full addressable `Message`.
- Add `space.getMessage(id)` so callers can materialize a `Message` from an id — needed now that `reaction(emoji, target)` accepts a `Message` rather than a string.
- Refactor the inbound message wrapping path into `wrapProviderMessage` so nested raw provider records (reaction targets, group items) are inflated into real `Message`s with `react`/`reply` methods.

## Breaking changes

- `reaction(emoji, target)` now requires a `Message` — the string-id overload is removed. Migrate via `const target = await space.getMessage(id); space.send(reaction("🎉", target))`.
- The `reactToMessage` platform action receives `target: Message` instead of `messageId: string`. Providers that previously keyed off the string id should read `target.id` (and, on iMessage, `target.parentId` / `target.partIndex`).

## Changes

**New**
- `content/group.ts` — `group(...items)` builder and `Group` schema. Disallows nesting and reactions as members; enforces a minimum of two items.
- `providers/imessage/cache.ts` — bounded FIFO per-client message cache (default 1000) used to resolve reaction targets without a round-trip to the SDK.
- `platform/build.ts` — `wrapProviderMessage` recursively wraps reaction targets and group items. `buildMessage` now late-binds `self` so `react()` can pass the built `Message` to the platform action.
- `types/space.ts` — `Space.getMessage(id)` added; per-platform `getMessage` action threaded through `AnyPlatformDef`.

**iMessage**
- Multi-attachment inbound messages now surface as a `group` whose items are individual attachment `Message`s (each carries `partIndex` and `parentId`).
- Tapback parsing retains the `partIndex`; reaction targets resolve against the cache first, falling back to `client.messages.get` + `rebuildFromAppleMessage`.
- `reactToMessage` keys off `target.parentId ?? target.id` and forwards `partIndex` to the SDK so tapbacks land on the correct sub-item.
- Outbound `group` send dispatches each item natively; rejects non-attachment-shaped items with an `UnsupportedError`.
- Local mode returns `undefined` from `getMessage` (no by-id SDK lookup available).

**WhatsApp Business**
- `reactToMessage` adapter reads `target.id`.
- Inbound reactions synthesize a minimal stub target; core inflates it via `wrapProviderMessage`.

## Test plan

- [ ] iMessage: send an album of 3 images, tapback the 2nd image, confirm the reaction lands on the 2nd image (not the 1st or dropped).
- [ ] iMessage: receive an album inbound, assert the stream emits a single `group` message with 3 items; each item is individually reactable via `.react()`.
- [ ] iMessage: `space.getMessage(knownGuid)` returns a hydrated message; unknown guid returns `undefined`.
- [ ] iMessage local mode: `space.getMessage` returns `undefined` without throwing.
- [ ] WhatsApp Business: inbound reaction still emits a `reaction` content with a usable `target.id`.
- [ ] `reaction(emoji, message)` still works; passing a string now fails typecheck.
- [ ] `group(attachment(...), attachment(...))` sends both items on iMessage; `group(text(...), attachment(...))` rejects with an `UnsupportedError`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "group" content type to bundle multiple message items; exported builder and type.
  * Space.getMessage(id) API to materialize messages on demand.
  * iMessage: per-message caching, rebuilt message retrieval, and group send/receive support with per-item receipts.
  * Runtime option to flatten incoming groups into individual stream items.

* **Improvements**
  * Reworked reaction flow to target full message objects across platforms (incl. WhatsApp).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->