### PR TITLE
fix(provider/terminal): resolve reaction target to full provider record

### DIFF
--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -17,9 +17,9 @@ for await (const [space, message] of app.messages) {
 
   // Inbound reactions are now first-class `reaction` content (upstream
   // spectrum-ts PR #31) — no more custom-content wrapping.
-  if (message.content.type === "reaction") {
+  if (message.content.type === "reaction" && message.content.target.content.type === "text") {
     console.log(
-      `reaction ${message.content.emoji} on msg ${message.content.target.slice(0, 8)}…`
+      `reaction ${message.content.emoji} on msg ${message.content.target.content.text.slice(0, 8)}…`
     );
     continue;
   }

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -13,7 +13,10 @@ import { inspect } from "node:util";
 import z from "zod";
 import { asAttachment } from "../../content/attachment";
 import { asContact } from "../../content/contact";
+import { asCustom } from "../../content/custom";
+import { asReaction } from "../../content/reaction";
 import { asVoice } from "../../content/voice";
+import type { ProviderMessageRecord } from "../../platform/build";
 import { definePlatform } from "../../platform/define";
 import { UnsupportedError } from "../../utils/errors";
 import { fromVCard, toVCard } from "../../utils/vcard";
@@ -353,6 +356,7 @@ async function spawnClient(options: {
 type SpectrumContent = z.infer<
   typeof import("../../content/types").contentSchema
 >;
+type ReactionTarget = Parameters<typeof asReaction>[0]["target"];
 
 // parseTimestamp validates an ISO timestamp string returned by the server —
 // an invalid string silently becomes an Invalid Date object through `new
@@ -361,6 +365,23 @@ type SpectrumContent = z.infer<
 function parseTimestamp(s: string): Date {
   const t = Date.parse(s);
   return Number.isNaN(t) ? new Date() : new Date(t);
+}
+
+function reactionTargetFromProtocol(
+  reaction: ProtocolReactionNotification
+): ReactionTarget {
+  // The protocol only gives us the target id. Core accepts nested raw provider
+  // records in reaction content and wraps them into full Messages before users
+  // see the event.
+  const target = {
+    id: reaction.messageId,
+    content: asCustom({ terminal_type: "reaction-target", stub: true }),
+    sender: { id: "__unknown__" },
+    space: { id: reaction.spaceId },
+    timestamp: parseTimestamp(reaction.timestamp),
+  } satisfies ProviderMessageRecord;
+
+  return target as ReactionTarget;
 }
 
 async function spectrumToProtocol(
@@ -569,18 +590,16 @@ export const terminal = definePlatform("terminal", {
           continue;
         }
         // Reactions ride the messages stream as first-class `reaction`
-        // content (upstream spectrum-ts PR #31 added this variant to the
-        // Content union). Agents filter with `msg.content.type === "reaction"`
-        // and read `.emoji` + `.target` directly.
+        // content. The protocol only provides the target id, so synthesize a
+        // minimal raw target for core to wrap into a full Message at emit time.
         const r = evt.value;
         client.knownChats.add(r.spaceId);
         yield {
           id: `reaction:${r.messageId}:${r.reaction}:${r.timestamp}`,
-          content: {
-            type: "reaction" as const,
+          content: asReaction({
             emoji: r.reaction,
-            target: r.messageId,
-          },
+            target: reactionTargetFromProtocol(r),
+          }),
           sender: { id: r.senderId },
           space: { id: r.spaceId },
           timestamp: parseTimestamp(r.timestamp),
@@ -610,11 +629,11 @@ export const terminal = definePlatform("terminal", {
       await c.session.request("stopTyping", { spaceId: space.id });
     },
 
-    reactToMessage: async ({ client, space, messageId, reaction }) => {
+    reactToMessage: async ({ client, space, target, reaction }) => {
       const c = client as TerminalClient;
       await c.session.request("reactToMessage", {
         spaceId: space.id,
-        messageId,
+        messageId: target.id,
         reaction,
       });
     },

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -14,7 +14,7 @@ import z from "zod";
 import { asAttachment } from "../../content/attachment";
 import { asContact } from "../../content/contact";
 import { asCustom } from "../../content/custom";
-import { asReaction } from "../../content/reaction";
+import { reactionSchema } from "../../content/reaction";
 import { asVoice } from "../../content/voice";
 import type { ProviderMessageRecord } from "../../platform/build";
 import { definePlatform } from "../../platform/define";
@@ -356,7 +356,6 @@ async function spawnClient(options: {
 type SpectrumContent = z.infer<
   typeof import("../../content/types").contentSchema
 >;
-type ReactionTarget = Parameters<typeof asReaction>[0]["target"];
 
 // parseTimestamp validates an ISO timestamp string returned by the server —
 // an invalid string silently becomes an Invalid Date object through `new
@@ -369,7 +368,7 @@ function parseTimestamp(s: string): Date {
 
 function reactionTargetFromProtocol(
   reaction: ProtocolReactionNotification
-): ReactionTarget {
+): ProviderMessageRecord {
   // The protocol only gives us the target id. Core accepts nested raw provider
   // records in reaction content and wraps them into full Messages before users
   // see the event.
@@ -381,7 +380,17 @@ function reactionTargetFromProtocol(
     timestamp: parseTimestamp(reaction.timestamp),
   } satisfies ProviderMessageRecord;
 
-  return target as ReactionTarget;
+  return target;
+}
+
+function reactionContentFromProtocol(
+  reaction: ProtocolReactionNotification
+): SpectrumContent {
+  return reactionSchema.parse({
+    type: "reaction",
+    emoji: reaction.reaction,
+    target: reactionTargetFromProtocol(reaction),
+  });
 }
 
 async function spectrumToProtocol(
@@ -596,10 +605,7 @@ export const terminal = definePlatform("terminal", {
         client.knownChats.add(r.spaceId);
         yield {
           id: `reaction:${r.messageId}:${r.reaction}:${r.timestamp}`,
-          content: asReaction({
-            emoji: r.reaction,
-            target: reactionTargetFromProtocol(r),
-          }),
+          content: reactionContentFromProtocol(r),
           sender: { id: r.senderId },
           space: { id: r.spaceId },
           timestamp: parseTimestamp(r.timestamp),


### PR DESCRIPTION
## Summary

- Fixes the terminal provider to emit reactions with a full provider message record as `target` instead of a bare id string, matching the new reaction contract introduced in #33 where core's `wrapProviderMessage` inflates nested raw targets into real `Message`s before agents see them.
- Updates the outbound `reactToMessage` action signature from `messageId: string` to `target: Message` so it lines up with the core platform action type.
- Fixes the basic example to read `.target.content` as a full message rather than treating `.target` as a string.

## Why

After #33 landed, `reaction` content carries a `Message` in `target` (not a bare id). The terminal provider still synthesized `{ type: "reaction", target: r.messageId }` and declared `reactToMessage` with `messageId: string`, which broke typecheck against the updated platform contract. The protocol only gives us the target id, so we synthesize a minimal raw provider record (stubbed `custom` content, unknown sender) and let core's wrapping path inflate it at emit time — same approach the WhatsApp Business adapter uses.

## Changes

| File | Change |
|---|---|
| `packages/spectrum-ts/src/providers/terminal/index.ts` | Add `reactionTargetFromProtocol` helper that builds a `ProviderMessageRecord` stub from the protocol notification; route inbound reactions through `asReaction({ emoji, target })`; update `reactToMessage` to accept `target: Message` and forward `target.id` to the SDK. |
| `examples/basic/index.ts` | Narrow on `target.content.type === "text"` and read `target.content.text` when logging inbound reactions. |

## Test plan

- [ ] `bun x ultracite check` passes
- [ ] `bun x tsc --noEmit` clean across the workspace
- [ ] Terminal provider: inbound reaction arrives with `content.type === "reaction"` and a hydrated `target` `Message` (with `.react`/`.reply` available)
- [ ] Terminal provider: `message.react("👍")` round-trips through `reactToMessage` and the SDK receives the correct `messageId`
- [ ] Basic example: reactions against text messages log the expected preview string; non-text targets are skipped without throwing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reaction processing now only triggers for text targets, stopping reactions from firing on non-text content.

* **Improvements**
  * Reaction events are emitted more reliably with improved handling.
  * Reaction action interface updated for more consistent and predictable reaction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->