### PR TITLE
feat: poll content type for iMessage and WhatsApp Business

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,9 +19,9 @@
     },
     "packages/spectrum-ts": {
       "name": "spectrum-ts",
-      "version": "0.9.0",
+      "version": "1.0.1",
       "dependencies": {
-        "@photon-ai/advanced-imessage": "^0.4.3",
+        "@photon-ai/advanced-imessage": "^0.5.1",
         "@photon-ai/imessage-kit": "^3.0.0",
         "@photon-ai/whatsapp-business": "^0.1.1",
         "@repeaterjs/repeater": "^3.0.6",
@@ -145,7 +145,7 @@
 
     "@parseaple/typedstream": ["@parseaple/typedstream@2.0.2", "", { "dependencies": { "@parseaple/bplist": "1.0.1" } }, "sha512-bzKNZjiBtZN2T2U7Nqq/hhv+EezkPnaWoB5WvPuBwNpQvOr3EI0XrDTkFnAzsA9DKdu57es/gcb1d2ctd1u8xw=="],
 
-    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.4.3", "", { "dependencies": { "@grpc/grpc-js": "^1.12.6", "long": "^5.2.4", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2", "protobufjs": "^7.4.0" } }, "sha512-/mZJi/13hp8f4nejIjarP8W3NMVpXGuC2ar+hozw00iU/CjW1nMEdpAFWTaeMeI+YHwMDc+xglHdZhkgFr3OcA=="],
+    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.5.1", "", { "dependencies": { "@grpc/grpc-js": "^1.12.6", "long": "^5.2.4", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2", "protobufjs": "^7.4.0" } }, "sha512-LBohv663myuJ9WIGgUP/Ksw57PreD5BbpOO9aJTAiCBWFpgrkaaOjgFRW1kIBrN2/x0ghItc6Nn1DGPaYnxxew=="],
 
     "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-GGDETlRbrPXP5eaRvswaead7MCBGQkm8f7d3aVbx8+rXhB4GEyPiw7Q1/yz5ix53rmxqKRevWywOfG7n+kZDBw=="],
 

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -17,7 +17,10 @@ for await (const [space, message] of app.messages) {
 
   // Inbound reactions are now first-class `reaction` content (upstream
   // spectrum-ts PR #31) — no more custom-content wrapping.
-  if (message.content.type === "reaction" && message.content.target.content.type === "text") {
+  if (
+    message.content.type === "reaction" &&
+    message.content.target.content.type === "text"
+  ) {
     console.log(
       `reaction ${message.content.emoji} on msg ${message.content.target.content.text.slice(0, 8)}…`
     );

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -38,7 +38,7 @@
     "generate:emoji": "bun scripts/generate-emoji.ts"
   },
   "dependencies": {
-    "@photon-ai/advanced-imessage": "^0.4.3",
+    "@photon-ai/advanced-imessage": "^0.5.1",
     "@photon-ai/imessage-kit": "^3.0.0",
     "@photon-ai/whatsapp-business": "^0.1.1",
     "@repeaterjs/repeater": "^3.0.6",

--- a/packages/spectrum-ts/src/content/poll.ts
+++ b/packages/spectrum-ts/src/content/poll.ts
@@ -11,11 +11,34 @@ export const pollSchema = z.object({
   options: z.array(pollChoiceSchema).min(2).max(10),
 });
 
-export const pollOptionSchema = z.object({
-  type: z.literal("poll_option"),
-  title: z.string().nonempty(),
-  pollId: z.string().optional(),
-});
+export const pollOptionSchema = z
+  .object({
+    type: z.literal("poll_option"),
+    option: pollChoiceSchema,
+    poll: pollSchema,
+    selected: z.boolean(),
+    title: z.string().nonempty(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.title !== value.option.title) {
+      ctx.addIssue({
+        code: "custom",
+        message: "poll_option title must match option.title",
+        path: ["title"],
+      });
+    }
+    if (
+      !value.poll.options.some(
+        (pollOption) => pollOption.title === value.option.title
+      )
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "poll_option option must exist in poll.options",
+        path: ["option"],
+      });
+    }
+  });
 
 export type Poll = z.infer<typeof pollSchema>;
 export type PollChoice = z.infer<typeof pollChoiceSchema>;
@@ -32,9 +55,15 @@ export const asPoll = (input: PollInput): Poll =>
   pollSchema.parse({ type: "poll", ...input });
 
 export const asPollOption = (input: {
-  title: string;
-  pollId?: string;
-}): PollOption => pollOptionSchema.parse({ type: "poll_option", ...input });
+  option: PollChoice;
+  poll: Poll;
+  selected: boolean;
+}): PollOption =>
+  pollOptionSchema.parse({
+    type: "poll_option",
+    ...input,
+    title: input.option.title,
+  });
 
 export const option = (title: string): PollChoice => ({ title });
 

--- a/packages/spectrum-ts/src/content/poll.ts
+++ b/packages/spectrum-ts/src/content/poll.ts
@@ -1,0 +1,67 @@
+import z from "zod";
+import type { ContentBuilder } from "./types";
+
+export const pollChoiceSchema = z.object({
+  title: z.string().nonempty(),
+});
+
+export const pollSchema = z.object({
+  type: z.literal("poll"),
+  title: z.string().nonempty().max(300),
+  options: z.array(pollChoiceSchema).min(2).max(10),
+});
+
+export const pollOptionSchema = z.object({
+  type: z.literal("poll_option"),
+  title: z.string().nonempty(),
+  pollId: z.string().optional(),
+});
+
+export type Poll = z.infer<typeof pollSchema>;
+export type PollChoice = z.infer<typeof pollChoiceSchema>;
+export type PollOption = z.infer<typeof pollOptionSchema>;
+
+export type PollChoiceInput = string | { title: string };
+
+export interface PollInput {
+  options: PollChoice[];
+  title: string;
+}
+
+export const asPoll = (input: PollInput): Poll =>
+  pollSchema.parse({ type: "poll", ...input });
+
+export const asPollOption = (input: {
+  title: string;
+  pollId?: string;
+}): PollOption => pollOptionSchema.parse({ type: "poll_option", ...input });
+
+export const option = (title: string): PollChoice => ({ title });
+
+const normalize = (raw: PollChoiceInput): PollChoice =>
+  typeof raw === "string" ? { title: raw } : { title: raw.title };
+
+const collectOptions = (
+  args: readonly [PollChoiceInput[]] | readonly PollChoiceInput[]
+): PollChoiceInput[] => {
+  const [first] = args;
+  if (args.length === 1 && Array.isArray(first)) {
+    return first;
+  }
+  return args as PollChoiceInput[];
+};
+
+export function poll(title: string, options: PollChoiceInput[]): ContentBuilder;
+export function poll(
+  title: string,
+  ...options: PollChoiceInput[]
+): ContentBuilder;
+export function poll(
+  title: string,
+  ...rest: readonly [PollChoiceInput[]] | readonly PollChoiceInput[]
+): ContentBuilder {
+  return {
+    build: async () =>
+      asPoll({ title, options: collectOptions(rest).map(normalize) }),
+  };
+}

--- a/packages/spectrum-ts/src/content/types.ts
+++ b/packages/spectrum-ts/src/content/types.ts
@@ -3,6 +3,7 @@ import { attachmentSchema } from "./attachment";
 import { contactSchema } from "./contact";
 import { customSchema } from "./custom";
 import { groupSchema } from "./group";
+import { pollOptionSchema, pollSchema } from "./poll";
 import { reactionSchema } from "./reaction";
 import { richlinkSchema } from "./richlink";
 import { textSchema } from "./text";
@@ -17,6 +18,8 @@ export const contentSchema = z.discriminatedUnion("type", [
   richlinkSchema,
   reactionSchema,
   groupSchema,
+  pollSchema,
+  pollOptionSchema,
 ]);
 
 export type Content = z.infer<typeof contentSchema>;

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -12,6 +12,14 @@ export {
 } from "./content/contact";
 export { custom } from "./content/custom";
 export { type Group, group } from "./content/group";
+export {
+  option,
+  type Poll,
+  type PollChoice,
+  type PollChoiceInput,
+  type PollOption,
+  poll,
+} from "./content/poll";
 export { type Reaction, reaction } from "./content/reaction";
 export { resolveContents } from "./content/resolve";
 export { type Richlink, richlink } from "./content/richlink";

--- a/packages/spectrum-ts/src/providers/imessage/cache.ts
+++ b/packages/spectrum-ts/src/providers/imessage/cache.ts
@@ -1,6 +1,17 @@
+import type { Poll, PollChoice } from "../../content/poll";
 import type { IMessageMessage } from "./types";
 
 const DEFAULT_MAX = 1000;
+
+export interface CachedPoll {
+  readonly optionsByIdentifier: ReadonlyMap<string, PollChoice>;
+  readonly poll: Poll;
+}
+
+export interface PollSelectionDelta {
+  readonly optionId: string;
+  readonly selected: boolean;
+}
 
 /**
  * Bounded insertion-order cache of recently-seen iMessage messages, keyed by
@@ -40,7 +51,130 @@ export class MessageCache {
   }
 }
 
-const caches = new WeakMap<object, MessageCache>();
+/**
+ * Bounded insertion-order cache of recently-seen iMessage polls, keyed by
+ * poll message guid. The public poll shape deliberately hides provider ids;
+ * `optionsByIdentifier` keeps the private lookup table needed to correlate
+ * vote events back to public `PollChoice` objects.
+ */
+export class PollCache {
+  private readonly map = new Map<string, CachedPoll>();
+  private readonly max: number;
+  private readonly selectionEventTimesByPoll = new Map<
+    string,
+    Map<string, number>
+  >();
+  private readonly selectionsByPoll = new Map<
+    string,
+    Map<string, Set<string>>
+  >();
+
+  constructor(max = DEFAULT_MAX) {
+    this.max = max;
+  }
+
+  get(id: string): CachedPoll | undefined {
+    return this.map.get(id);
+  }
+
+  set(id: string, poll: CachedPoll): void {
+    if (this.map.has(id)) {
+      this.map.delete(id);
+    }
+    this.map.set(id, poll);
+    if (this.map.size > this.max) {
+      const first = this.map.keys().next().value;
+      if (first !== undefined) {
+        this.map.delete(first);
+        this.selectionEventTimesByPoll.delete(first);
+        this.selectionsByPoll.delete(first);
+      }
+    }
+  }
+
+  clear(): void {
+    this.map.clear();
+    this.selectionEventTimesByPoll.clear();
+    this.selectionsByPoll.clear();
+  }
+
+  actorSelectionDeltas(
+    pollId: string,
+    actorId: string,
+    optionIds: readonly string[]
+  ): PollSelectionDelta[] {
+    const previous = this.selectionsByPoll.get(pollId)?.get(actorId);
+    if (!previous) {
+      return optionIds.map((optionId) => ({ optionId, selected: true }));
+    }
+    const current = new Set(optionIds);
+    const selected = optionIds
+      .filter((optionId) => !previous.has(optionId))
+      .map((optionId) => ({ optionId, selected: true }));
+    const deselected = [...previous]
+      .filter((optionId) => !current.has(optionId))
+      .map((optionId) => ({ optionId, selected: false }));
+    return [...selected, ...deselected];
+  }
+
+  clearedActorSelectionDeltas(
+    pollId: string,
+    actorId: string
+  ): PollSelectionDelta[] {
+    const previous = this.selectionsByPoll.get(pollId)?.get(actorId);
+    if (!previous) {
+      return [];
+    }
+    return [...previous].map((optionId) => ({ optionId, selected: false }));
+  }
+
+  actorSelection(pollId: string, actorId: string): string[] | undefined {
+    const selection = this.selectionsByPoll.get(pollId)?.get(actorId);
+    return selection ? [...selection] : undefined;
+  }
+
+  commitActorSelection(
+    pollId: string,
+    actorId: string,
+    optionIds: readonly string[],
+    at?: Date
+  ): void {
+    let selections = this.selectionsByPoll.get(pollId);
+    if (!selections) {
+      selections = new Map<string, Set<string>>();
+      this.selectionsByPoll.set(pollId, selections);
+    }
+    selections.set(actorId, new Set(optionIds));
+
+    if (!at) {
+      return;
+    }
+    let eventTimes = this.selectionEventTimesByPoll.get(pollId);
+    if (!eventTimes) {
+      eventTimes = new Map<string, number>();
+      this.selectionEventTimesByPoll.set(pollId, eventTimes);
+    }
+    const eventTime = at.getTime();
+    const previousTime = eventTimes.get(actorId);
+    if (previousTime === undefined || eventTime >= previousTime) {
+      eventTimes.set(actorId, eventTime);
+    }
+  }
+
+  isStaleActorSelectionEvent(
+    pollId: string,
+    actorId: string,
+    at: Date
+  ): boolean {
+    const previousTime = this.selectionEventTimesByPoll
+      .get(pollId)
+      ?.get(actorId);
+    return previousTime !== undefined && at.getTime() < previousTime;
+  }
+}
+
+const messageCaches = new WeakMap<object, MessageCache>();
+const pollCaches = new WeakMap<object, PollCache>();
 
 /**
  * Returns a per-client message cache. Keyed by an object (the client array
@@ -49,10 +183,19 @@ const caches = new WeakMap<object, MessageCache>();
  * state accidentally.
  */
 export const getMessageCache = (owner: object): MessageCache => {
-  let cache = caches.get(owner);
+  let cache = messageCaches.get(owner);
   if (!cache) {
     cache = new MessageCache();
-    caches.set(owner, cache);
+    messageCaches.set(owner, cache);
+  }
+  return cache;
+};
+
+export const getPollCache = (owner: object): PollCache => {
+  let cache = pollCaches.get(owner);
+  if (!cache) {
+    cache = new PollCache();
+    pollCaches.set(owner, cache);
   }
   return cache;
 };

--- a/packages/spectrum-ts/src/providers/imessage/local.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local.ts
@@ -206,6 +206,8 @@ export const send = async (
       );
       return synthSendResult();
     }
+    case "poll":
+      throw UnsupportedError.content("poll", "iMessage (local mode)");
     default:
       throw UnsupportedError.content(content.type, "iMessage (local mode)");
   }

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -1,6 +1,8 @@
 import {
   type AdvancedIMessage,
   chatGuid,
+  type PollInfo as IMessagePollInfo,
+  type PollOption as IMessagePollOption,
   type MessageEvent,
   messageGuid,
   type PollChangeDelta,
@@ -11,7 +13,7 @@ import { asAttachment } from "../../content/attachment";
 import { asContact } from "../../content/contact";
 import { asCustom } from "../../content/custom";
 import { asGroup } from "../../content/group";
-import { asPollOption } from "../../content/poll";
+import { asPoll, asPollOption, type PollChoice } from "../../content/poll";
 import { asReaction } from "../../content/reaction";
 import { asRichlink } from "../../content/richlink";
 import { asText } from "../../content/text";
@@ -22,7 +24,12 @@ import { ensureM4a } from "../../utils/audio";
 import { UnsupportedError } from "../../utils/errors";
 import { type ManagedStream, mergeStreams, stream } from "../../utils/stream";
 import { fromVCard, toVCard } from "../../utils/vcard";
-import { getMessageCache } from "./cache";
+import {
+  type CachedPoll,
+  getMessageCache,
+  getPollCache,
+  type PollCache,
+} from "./cache";
 import type { IMessageMessage } from "./types";
 
 const PLATFORM = "iMessage";
@@ -485,43 +492,290 @@ type VotedPollEvent = PollEvent & {
   delta: Extract<PollChangeDelta, { type: "voted" }>;
 };
 
+type UnvotedPollEvent = PollEvent & {
+  delta: Extract<PollChangeDelta, { type: "unvoted" }>;
+};
+
+const toCachedPoll = (input: {
+  options: readonly IMessagePollOption[];
+  title: string;
+}): CachedPoll => {
+  const poll = asPoll({
+    title: input.title,
+    options: input.options.map((optionInfo) => ({
+      title: optionInfo.text,
+    })),
+  });
+  const optionsByIdentifier = new Map<string, PollChoice>();
+  for (const [index, optionInfo] of input.options.entries()) {
+    const option = poll.options[index];
+    if (option && optionInfo.optionIdentifier) {
+      optionsByIdentifier.set(optionInfo.optionIdentifier, option);
+    }
+  }
+  return { poll, optionsByIdentifier };
+};
+
+const cachePollInfo = (
+  cache: PollCache,
+  info: IMessagePollInfo
+): CachedPoll => {
+  const cached = toCachedPoll(info);
+  cache.set(info.messageGuid as string, cached);
+  return cached;
+};
+
+const cachePollEvent = (
+  cache: PollCache,
+  event: PollEvent
+): CachedPoll | undefined => {
+  if (event.delta.type === "created" || event.delta.type === "optionAdded") {
+    try {
+      const cached = toCachedPoll({
+        title: event.delta.title,
+        options: event.delta.options,
+      });
+      cache.set(event.pollMessageGuid as string, cached);
+      return cached;
+    } catch (e) {
+      console.error("[spectrum-ts][imessage][poll] failed to cache poll", e);
+    }
+  }
+};
+
+const fetchPollInfo = async (
+  client: AdvancedIMessage,
+  cache: PollCache,
+  event: PollEvent
+): Promise<IMessagePollInfo | undefined> => {
+  try {
+    const info = await client.polls.get(event.pollMessageGuid);
+    cachePollInfo(cache, info);
+    return info;
+  } catch (e) {
+    console.error("[spectrum-ts][imessage][poll] failed to fetch poll", e);
+    return;
+  }
+};
+
+const resolvePoll = async (
+  client: AdvancedIMessage,
+  cache: PollCache,
+  event: PollEvent
+): Promise<CachedPoll | undefined> => {
+  const pollId = event.pollMessageGuid as string;
+  const cached = cache.get(pollId);
+  if (cached) {
+    return cached;
+  }
+  try {
+    const info = await client.polls.get(event.pollMessageGuid);
+    return cachePollInfo(cache, info);
+  } catch (e) {
+    console.error("[spectrum-ts][imessage][poll] failed to resolve poll", e);
+    return;
+  }
+};
+
+const buildPollOptionMessage = (input: {
+  cached: CachedPoll;
+  chatGuid: string;
+  event: Pick<PollEvent, "at" | "pollMessageGuid">;
+  optionId: string;
+  selected: boolean;
+  senderAddress: string;
+}): IMessageMessage | undefined => {
+  const option = input.cached.optionsByIdentifier.get(input.optionId);
+  if (!option) {
+    return;
+  }
+  const action = input.selected ? "selected" : "deselected";
+  return {
+    id: `${input.event.pollMessageGuid}:${input.senderAddress}:${input.optionId}:${action}:${input.event.at.getTime()}`,
+    sender: { id: input.senderAddress },
+    space: {
+      id: input.chatGuid,
+      type: input.chatGuid.includes(";+;") ? "group" : "dm",
+    },
+    timestamp: input.event.at,
+    content: asPollOption({
+      option,
+      poll: input.cached.poll,
+      selected: input.selected,
+    }),
+  };
+};
+
+const buildPollOptionMessages = (input: {
+  cached: CachedPoll;
+  chatGuid: string;
+  deltas: readonly { optionId: string; selected: boolean }[];
+  event: Pick<PollEvent, "at" | "pollMessageGuid">;
+  senderAddress: string;
+}): IMessageMessage[] => {
+  const messages: IMessageMessage[] = [];
+  for (const delta of input.deltas) {
+    const message = buildPollOptionMessage({
+      cached: input.cached,
+      chatGuid: input.chatGuid,
+      event: input.event,
+      optionId: delta.optionId,
+      selected: delta.selected,
+      senderAddress: input.senderAddress,
+    });
+    if (message) {
+      messages.push(message);
+    }
+  }
+  return messages;
+};
+
+const allOptionIdsKnown = (
+  cached: CachedPoll,
+  optionIds: readonly string[]
+): boolean =>
+  optionIds.every((optionId) => cached.optionsByIdentifier.has(optionId));
+
+const refreshPollMetadata = async (
+  client: AdvancedIMessage,
+  pollCache: PollCache,
+  event: VotedPollEvent,
+  fallbackOptionIds: readonly string[]
+): Promise<{ optionIds: string[]; poll: CachedPoll } | undefined> => {
+  const info = await fetchPollInfo(client, pollCache, event);
+  if (!info) {
+    return;
+  }
+  const refreshed = pollCache.get(info.messageGuid as string);
+  if (!refreshed) {
+    return;
+  }
+  return {
+    optionIds: [...fallbackOptionIds],
+    poll: refreshed,
+  };
+};
+
 const toPollVoteMessages = async (
   client: AdvancedIMessage,
+  pollCache: PollCache,
   event: VotedPollEvent
 ): Promise<IMessageMessage[]> => {
   const senderAddress = event.actor.address;
   if (!senderAddress) {
     return [];
   }
-  const info = await client.polls.get(event.pollMessageGuid);
-  const titleFor = (id: string): string | undefined =>
-    info.options.find((o) => o.optionIdentifier === id)?.text;
-  const chatGuidStr = event.chatGuid as string;
-  const messages: IMessageMessage[] = [];
-  for (const optionId of event.delta.optionIdentifiers) {
-    const title = titleFor(optionId);
-    if (!title) {
-      continue;
-    }
-    messages.push({
-      id: `${event.pollMessageGuid}:${senderAddress}:${optionId}`,
-      sender: { id: senderAddress },
-      space: {
-        id: chatGuidStr,
-        type: chatGuidStr.includes(";+;") ? "group" : "dm",
-      },
-      timestamp: event.at,
-      content: asPollOption({
-        title,
-        pollId: event.pollMessageGuid as string,
-      }),
-    });
+  const pollId = event.pollMessageGuid as string;
+  if (pollCache.isStaleActorSelectionEvent(pollId, senderAddress, event.at)) {
+    return [];
   }
+  const cached = await resolvePoll(client, pollCache, event);
+  if (!cached) {
+    return [];
+  }
+  const chatGuidStr = event.chatGuid as string;
+  let currentOptionIds = [...event.delta.optionIdentifiers];
+  let resolvedPoll = cached;
+
+  if (
+    currentOptionIds.some(
+      (optionId) => !resolvedPoll.optionsByIdentifier.has(optionId)
+    )
+  ) {
+    const snapshot = await refreshPollMetadata(
+      client,
+      pollCache,
+      event,
+      currentOptionIds
+    );
+    if (snapshot) {
+      currentOptionIds = snapshot.optionIds;
+      resolvedPoll = snapshot.poll;
+    }
+  }
+
+  if (!allOptionIdsKnown(resolvedPoll, currentOptionIds)) {
+    return [];
+  }
+
+  const deltas = pollCache.actorSelectionDeltas(
+    pollId,
+    senderAddress,
+    currentOptionIds
+  );
+  const messages = buildPollOptionMessages({
+    cached: resolvedPoll,
+    chatGuid: chatGuidStr,
+    deltas,
+    event,
+    senderAddress,
+  });
+
+  pollCache.commitActorSelection(
+    pollId,
+    senderAddress,
+    currentOptionIds,
+    event.at
+  );
+
   return messages;
 };
 
+const toPollUnvoteMessages = async (
+  client: AdvancedIMessage,
+  pollCache: PollCache,
+  event: UnvotedPollEvent
+): Promise<IMessageMessage[]> => {
+  const senderAddress = event.actor.address;
+  if (!senderAddress) {
+    return [];
+  }
+  const pollId = event.pollMessageGuid as string;
+  if (pollCache.isStaleActorSelectionEvent(pollId, senderAddress, event.at)) {
+    return [];
+  }
+  const cached = await resolvePoll(client, pollCache, event);
+  if (!cached) {
+    return [];
+  }
+  const chatGuidStr = event.chatGuid as string;
+  const messages: IMessageMessage[] = [];
+  const deltas = pollCache.clearedActorSelectionDeltas(pollId, senderAddress);
+  for (const delta of deltas) {
+    const message = buildPollOptionMessage({
+      cached,
+      chatGuid: chatGuidStr,
+      event,
+      optionId: delta.optionId,
+      selected: delta.selected,
+      senderAddress,
+    });
+    if (message) {
+      messages.push(message);
+    }
+  }
+  pollCache.commitActorSelection(pollId, senderAddress, [], event.at);
+  return messages;
+};
+
+const toPollDeltaMessages = async (
+  client: AdvancedIMessage,
+  pollCache: PollCache,
+  event: PollEvent
+): Promise<IMessageMessage[]> => {
+  switch (event.delta.type) {
+    case "voted":
+      return toPollVoteMessages(client, pollCache, event);
+    case "unvoted":
+      return toPollUnvoteMessages(client, pollCache, event);
+    default:
+      return [];
+  }
+};
+
 const clientStream = (
-  client: AdvancedIMessage
+  client: AdvancedIMessage,
+  pollCache: PollCache
 ): ManagedStream<IMessageMessage> => {
   const messageSub = client.messages.subscribe("message.received");
   const pollSub = client.polls.subscribe();
@@ -544,14 +798,12 @@ const clientStream = (
     const pollPump = (async () => {
       try {
         for await (const event of pollSub) {
-          if (event.actor.isFromMe || event.delta.type !== "voted") {
+          cachePollEvent(pollCache, event);
+          if (event.actor.isFromMe) {
             continue;
           }
-          const votes = await toPollVoteMessages(
-            client,
-            event as VotedPollEvent
-          );
-          for (const vote of votes) {
+          const messages = await toPollDeltaMessages(client, pollCache, event);
+          for (const vote of messages) {
             await emit(vote);
           }
         }
@@ -599,7 +851,10 @@ const sendContactAttachment = async (
 
 export const messages = (
   clients: AdvancedIMessage[]
-): ManagedStream<IMessageMessage> => mergeStreams(clients.map(clientStream));
+): ManagedStream<IMessageMessage> => {
+  const pollCache = getPollCache(clients);
+  return mergeStreams(clients.map((client) => clientStream(client, pollCache)));
+};
 
 export const startTyping = async (
   clients: AdvancedIMessage[],

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -496,6 +496,12 @@ type UnvotedPollEvent = PollEvent & {
   delta: Extract<PollChangeDelta, { type: "unvoted" }>;
 };
 
+const isVotedPollEvent = (event: PollEvent): event is VotedPollEvent =>
+  event.delta.type === "voted";
+
+const isUnvotedPollEvent = (event: PollEvent): event is UnvotedPollEvent =>
+  event.delta.type === "unvoted";
+
 const toCachedPoll = (input: {
   options: readonly IMessagePollOption[];
   title: string;
@@ -763,14 +769,13 @@ const toPollDeltaMessages = async (
   pollCache: PollCache,
   event: PollEvent
 ): Promise<IMessageMessage[]> => {
-  switch (event.delta.type) {
-    case "voted":
-      return toPollVoteMessages(client, pollCache, event);
-    case "unvoted":
-      return toPollUnvoteMessages(client, pollCache, event);
-    default:
-      return [];
+  if (isVotedPollEvent(event)) {
+    return toPollVoteMessages(client, pollCache, event);
   }
+  if (isUnvotedPollEvent(event)) {
+    return toPollUnvoteMessages(client, pollCache, event);
+  }
+  return [];
 };
 
 const clientStream = (

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -9,6 +9,7 @@ import { asAttachment } from "../../content/attachment";
 import { asContact } from "../../content/contact";
 import { asCustom } from "../../content/custom";
 import { asGroup } from "../../content/group";
+import { asPollOption } from "../../content/poll";
 import { asReaction } from "../../content/reaction";
 import { asRichlink } from "../../content/richlink";
 import { asText } from "../../content/text";
@@ -469,6 +470,26 @@ const toMessages = async (
   }
 
   const text = event.message.text;
+  if (!text) {
+    const raw = (event.message as { _raw?: Record<string, unknown> })._raw;
+    console.log("[spectrum-ts][imessage][empty-text] _raw dump", {
+      guid: event.message.guid,
+      sender: event.message.sender?.address,
+      isFromMe: event.message.isFromMe,
+      balloonBundleId: raw?.balloonBundleId,
+      associatedMessageGuid: raw?.associatedMessageGuid,
+      associatedMessageType: raw?.associatedMessageType,
+      payloadDataLength:
+        raw?.payloadData instanceof Uint8Array
+          ? raw.payloadData.byteLength
+          : undefined,
+      messageSummaryInfoLength:
+        raw?.messageSummaryInfo instanceof Uint8Array
+          ? raw.messageSummaryInfo.byteLength
+          : undefined,
+      rawKeys: raw ? Object.keys(raw) : [],
+    });
+  }
   const msg: IMessageMessage = {
     ...base,
     id: messageGuidStr,
@@ -478,15 +499,77 @@ const toMessages = async (
   return [msg];
 };
 
+const toPollVoteMessage = async (
+  client: AdvancedIMessage,
+  pollMessageGuid: string,
+  chatGuid: string,
+  senderAddress: string,
+  timestamp: Date
+): Promise<IMessageMessage | null> => {
+  const info = await client.polls.get(pollMessageGuid as never);
+  console.log("[spectrum-ts][imessage][poll] fetched poll info", {
+    pollMessageGuid,
+    title: info.title,
+    options: info.options.map((o) => ({
+      id: o.optionIdentifier,
+      text: o.text,
+    })),
+    votes: info.votes.map((v) => ({
+      participant: v.participantAddress,
+      option: v.optionIdentifier,
+    })),
+    senderAddress,
+  });
+  const vote = info.votes.find((v) => v.participantAddress === senderAddress);
+  if (!vote) {
+    console.log(
+      "[spectrum-ts][imessage][poll] no vote from sender",
+      senderAddress
+    );
+    return null;
+  }
+  const chosen = info.options.find(
+    (o) => o.optionIdentifier === vote.optionIdentifier
+  );
+  if (!chosen) {
+    console.log(
+      "[spectrum-ts][imessage][poll] option not found",
+      vote.optionIdentifier
+    );
+    return null;
+  }
+  console.log(
+    "[spectrum-ts][imessage][poll] resolved vote",
+    senderAddress,
+    "->",
+    chosen.text
+  );
+  return {
+    id: `${pollMessageGuid}:${senderAddress}`,
+    sender: { id: senderAddress },
+    space: {
+      id: chatGuid,
+      type: chatGuid.includes(";+;") ? "group" : "dm",
+    },
+    timestamp,
+    content: asPollOption({
+      title: chosen.text,
+      pollId: pollMessageGuid,
+    }),
+  };
+};
+
 const clientStream = (
   client: AdvancedIMessage
 ): ManagedStream<IMessageMessage> => {
-  const sub = client.messages.subscribe("message.received");
+  const messageSub = client.messages.subscribe("message.received");
+  const updatedSub = client.messages.subscribe("message.updated");
+  const pollSub = client.polls.subscribe();
   const cache = getMessageCache(client);
   return stream<IMessageMessage>((emit, end) => {
-    const pump = (async () => {
+    const messagePump = (async () => {
       try {
-        for await (const event of sub) {
+        for await (const event of messageSub) {
           if (event.message.isFromMe) {
             continue;
           }
@@ -494,14 +577,69 @@ const clientStream = (
             await emit(message);
           }
         }
-        end();
       } catch (e) {
         end(e);
       }
     })();
+    const updatedPump = (async () => {
+      try {
+        for await (const event of updatedSub) {
+          console.log("[spectrum-ts][imessage][message.updated]", {
+            updateType: event.updateType,
+            isFromMe: event.message.isFromMe,
+            guid: event.message.guid,
+            sender: event.message.sender?.address,
+            text: event.message.text,
+          });
+        }
+      } catch (e) {
+        console.log("[spectrum-ts][imessage][message.updated] error", e);
+      }
+    })();
+    const pollPump = (async () => {
+      try {
+        for await (const event of pollSub) {
+          console.log("[spectrum-ts][imessage][poll] event", {
+            action: event.action,
+            pollMessageGuid: event.pollMessageGuid,
+            chatGuid: event.chatGuid,
+            isFromMe: event.message.isFromMe,
+            sender: event.message.sender?.address,
+          });
+          if (event.message.isFromMe) {
+            continue;
+          }
+          if (event.action !== "voted" && event.action !== "optionAdded") {
+            continue;
+          }
+          const senderAddress = event.message.sender?.address;
+          if (!senderAddress) {
+            console.log(
+              "[spectrum-ts][imessage][poll] missing sender address; skipping"
+            );
+            continue;
+          }
+          const voteMessage = await toPollVoteMessage(
+            client,
+            event.pollMessageGuid as string,
+            event.chatGuid as string,
+            senderAddress,
+            event.timestamp
+          );
+          if (voteMessage) {
+            await emit(voteMessage);
+          }
+        }
+      } catch (e) {
+        console.log("[spectrum-ts][imessage][poll] stream error", e);
+        end(e);
+      }
+    })();
     return async () => {
-      sub.close();
-      await pump;
+      messageSub.close();
+      updatedSub.close();
+      pollSub.close();
+      await Promise.all([messagePump, updatedPump, pollPump]);
     };
   });
 };
@@ -602,6 +740,14 @@ const sendSingle = async (
         })
       );
     }
+    case "poll":
+      return toSendResult(
+        await remote.polls.create(
+          chat,
+          content.title,
+          content.options.map((o) => o.title)
+        )
+      );
     default:
       throw unsupportedContent(content.type);
   }
@@ -713,6 +859,12 @@ export const replyToMessage = async (
         })
       );
     }
+    case "poll":
+      throw UnsupportedError.content(
+        "poll",
+        PLATFORM,
+        "polls cannot be sent as replies"
+      );
     default:
       throw unsupportedContent(content.type);
   }

--- a/packages/spectrum-ts/src/providers/imessage/remote.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote.ts
@@ -3,6 +3,8 @@ import {
   chatGuid,
   type MessageEvent,
   messageGuid,
+  type PollChangeDelta,
+  type PollEvent,
   Reaction,
 } from "@photon-ai/advanced-imessage";
 import { asAttachment } from "../../content/attachment";
@@ -470,26 +472,6 @@ const toMessages = async (
   }
 
   const text = event.message.text;
-  if (!text) {
-    const raw = (event.message as { _raw?: Record<string, unknown> })._raw;
-    console.log("[spectrum-ts][imessage][empty-text] _raw dump", {
-      guid: event.message.guid,
-      sender: event.message.sender?.address,
-      isFromMe: event.message.isFromMe,
-      balloonBundleId: raw?.balloonBundleId,
-      associatedMessageGuid: raw?.associatedMessageGuid,
-      associatedMessageType: raw?.associatedMessageType,
-      payloadDataLength:
-        raw?.payloadData instanceof Uint8Array
-          ? raw.payloadData.byteLength
-          : undefined,
-      messageSummaryInfoLength:
-        raw?.messageSummaryInfo instanceof Uint8Array
-          ? raw.messageSummaryInfo.byteLength
-          : undefined,
-      rawKeys: raw ? Object.keys(raw) : [],
-    });
-  }
   const msg: IMessageMessage = {
     ...base,
     id: messageGuidStr,
@@ -499,71 +481,49 @@ const toMessages = async (
   return [msg];
 };
 
-const toPollVoteMessage = async (
+type VotedPollEvent = PollEvent & {
+  delta: Extract<PollChangeDelta, { type: "voted" }>;
+};
+
+const toPollVoteMessages = async (
   client: AdvancedIMessage,
-  pollMessageGuid: string,
-  chatGuid: string,
-  senderAddress: string,
-  timestamp: Date
-): Promise<IMessageMessage | null> => {
-  const info = await client.polls.get(pollMessageGuid as never);
-  console.log("[spectrum-ts][imessage][poll] fetched poll info", {
-    pollMessageGuid,
-    title: info.title,
-    options: info.options.map((o) => ({
-      id: o.optionIdentifier,
-      text: o.text,
-    })),
-    votes: info.votes.map((v) => ({
-      participant: v.participantAddress,
-      option: v.optionIdentifier,
-    })),
-    senderAddress,
-  });
-  const vote = info.votes.find((v) => v.participantAddress === senderAddress);
-  if (!vote) {
-    console.log(
-      "[spectrum-ts][imessage][poll] no vote from sender",
-      senderAddress
-    );
-    return null;
+  event: VotedPollEvent
+): Promise<IMessageMessage[]> => {
+  const senderAddress = event.actor.address;
+  if (!senderAddress) {
+    return [];
   }
-  const chosen = info.options.find(
-    (o) => o.optionIdentifier === vote.optionIdentifier
-  );
-  if (!chosen) {
-    console.log(
-      "[spectrum-ts][imessage][poll] option not found",
-      vote.optionIdentifier
-    );
-    return null;
+  const info = await client.polls.get(event.pollMessageGuid);
+  const titleFor = (id: string): string | undefined =>
+    info.options.find((o) => o.optionIdentifier === id)?.text;
+  const chatGuidStr = event.chatGuid as string;
+  const messages: IMessageMessage[] = [];
+  for (const optionId of event.delta.optionIdentifiers) {
+    const title = titleFor(optionId);
+    if (!title) {
+      continue;
+    }
+    messages.push({
+      id: `${event.pollMessageGuid}:${senderAddress}:${optionId}`,
+      sender: { id: senderAddress },
+      space: {
+        id: chatGuidStr,
+        type: chatGuidStr.includes(";+;") ? "group" : "dm",
+      },
+      timestamp: event.at,
+      content: asPollOption({
+        title,
+        pollId: event.pollMessageGuid as string,
+      }),
+    });
   }
-  console.log(
-    "[spectrum-ts][imessage][poll] resolved vote",
-    senderAddress,
-    "->",
-    chosen.text
-  );
-  return {
-    id: `${pollMessageGuid}:${senderAddress}`,
-    sender: { id: senderAddress },
-    space: {
-      id: chatGuid,
-      type: chatGuid.includes(";+;") ? "group" : "dm",
-    },
-    timestamp,
-    content: asPollOption({
-      title: chosen.text,
-      pollId: pollMessageGuid,
-    }),
-  };
+  return messages;
 };
 
 const clientStream = (
   client: AdvancedIMessage
 ): ManagedStream<IMessageMessage> => {
   const messageSub = client.messages.subscribe("message.received");
-  const updatedSub = client.messages.subscribe("message.updated");
   const pollSub = client.polls.subscribe();
   const cache = getMessageCache(client);
   return stream<IMessageMessage>((emit, end) => {
@@ -581,65 +541,31 @@ const clientStream = (
         end(e);
       }
     })();
-    const updatedPump = (async () => {
-      try {
-        for await (const event of updatedSub) {
-          console.log("[spectrum-ts][imessage][message.updated]", {
-            updateType: event.updateType,
-            isFromMe: event.message.isFromMe,
-            guid: event.message.guid,
-            sender: event.message.sender?.address,
-            text: event.message.text,
-          });
-        }
-      } catch (e) {
-        console.log("[spectrum-ts][imessage][message.updated] error", e);
-      }
-    })();
     const pollPump = (async () => {
       try {
         for await (const event of pollSub) {
-          console.log("[spectrum-ts][imessage][poll] event", {
-            action: event.action,
-            pollMessageGuid: event.pollMessageGuid,
-            chatGuid: event.chatGuid,
-            isFromMe: event.message.isFromMe,
-            sender: event.message.sender?.address,
-          });
-          if (event.message.isFromMe) {
+          if (event.actor.isFromMe || event.delta.type !== "voted") {
             continue;
           }
-          if (event.action !== "voted" && event.action !== "optionAdded") {
-            continue;
-          }
-          const senderAddress = event.message.sender?.address;
-          if (!senderAddress) {
-            console.log(
-              "[spectrum-ts][imessage][poll] missing sender address; skipping"
-            );
-            continue;
-          }
-          const voteMessage = await toPollVoteMessage(
+          const votes = await toPollVoteMessages(
             client,
-            event.pollMessageGuid as string,
-            event.chatGuid as string,
-            senderAddress,
-            event.timestamp
+            event as VotedPollEvent
           );
-          if (voteMessage) {
-            await emit(voteMessage);
+          for (const vote of votes) {
+            await emit(vote);
           }
         }
       } catch (e) {
-        console.log("[spectrum-ts][imessage][poll] stream error", e);
-        end(e);
+        // Isolate the poll stream: a failure here (e.g. upstream SDK int64
+        // parse errors on SubscribePollEvents) must not kill the message
+        // stream. Log and move on — poll_option events simply won't arrive.
+        console.error("[spectrum-ts][imessage][poll] stream failed", e);
       }
     })();
     return async () => {
       messageSub.close();
-      updatedSub.close();
       pollSub.close();
-      await Promise.all([messagePump, updatedPump, pollPump]);
+      await Promise.all([messagePump, pollPump]);
     };
   });
 };

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -16,14 +16,14 @@ import {
   type ContactPhone as SpectrumContactPhone,
 } from "../../content/contact";
 import { asCustom } from "../../content/custom";
-import { asPollOption } from "../../content/poll";
+import { asPollOption, type Poll } from "../../content/poll";
 import { asReaction } from "../../content/reaction";
 import { asText } from "../../content/text";
 import type { Content } from "../../content/types";
 import type { SendResult } from "../../platform/types";
 import { UnsupportedError } from "../../utils/errors";
 import { type ManagedStream, mergeStreams, stream } from "../../utils/stream";
-import { pollToInteractive } from "./poll";
+import { pollOptionId, pollToInteractive } from "./poll";
 import type { WhatsAppClients, WhatsAppMessage } from "./types";
 
 // v1 routes outbound traffic to the first line. When multi-line send becomes a
@@ -42,6 +42,48 @@ type WaSendResult = Awaited<ReturnType<WhatsAppClient["messages"]["send"]>>;
 const toSendResult = (result: WaSendResult): SendResult => ({
   id: result.messageId,
 });
+
+const MAX_POLL_CACHE_SIZE = 1000;
+const OPTION_ID_PREFIX = "opt_";
+const pollCaches = new WeakMap<WhatsAppClient, Map<string, Poll>>();
+
+const getPollCache = (client: WhatsAppClient): Map<string, Poll> => {
+  let cache = pollCaches.get(client);
+  if (!cache) {
+    cache = new Map<string, Poll>();
+    pollCaches.set(client, cache);
+  }
+  return cache;
+};
+
+const cachePoll = (
+  client: WhatsAppClient,
+  messageId: string,
+  poll: Poll
+): void => {
+  const cache = getPollCache(client);
+  if (cache.has(messageId)) {
+    cache.delete(messageId);
+  }
+  cache.set(messageId, poll);
+  if (cache.size > MAX_POLL_CACHE_SIZE) {
+    const first = cache.keys().next().value;
+    if (first !== undefined) {
+      cache.delete(first);
+    }
+  }
+};
+
+const optionIndexFromId = (id: string): number | undefined => {
+  if (!id.startsWith(OPTION_ID_PREFIX)) {
+    return;
+  }
+  const index = Number(id.slice(OPTION_ID_PREFIX.length));
+  if (!Number.isInteger(index) || index < 0 || pollOptionId(index) !== id) {
+    return;
+  }
+  return index;
+};
 
 type WaContactName = ContactCard["name"];
 type WaContactPhone = ContactCard["phones"][number];
@@ -208,15 +250,13 @@ const toMessages = (
     {
       ...base,
       id: msg.id,
-      content: mapContent(client, msg.content),
+      content: mapContent(client, msg),
     },
   ];
 };
 
-const mapContent = (
-  client: WhatsAppClient,
-  content: InboundMessage["content"]
-): Content => {
+const mapContent = (client: WhatsAppClient, msg: InboundMessage): Content => {
+  const { content } = msg;
   switch (content.type) {
     case "text":
       return asText(content.body);
@@ -245,7 +285,16 @@ const mapContent = (
     case "interactive": {
       const inter = content.interactive;
       if (inter.type === "button_reply" || inter.type === "list_reply") {
-        return asPollOption({ title: inter.reply.title });
+        const poll =
+          msg.context?.id === undefined
+            ? undefined
+            : getPollCache(client).get(msg.context.id);
+        const optionIndex = optionIndexFromId(inter.reply.id);
+        const option =
+          optionIndex === undefined ? undefined : poll?.options[optionIndex];
+        if (poll && option) {
+          return asPollOption({ poll, option, selected: true });
+        }
       }
       return asCustom({ whatsapp_type: "interactive", ...inter });
     }
@@ -484,13 +533,14 @@ export const send = async (
         } as Parameters<typeof client.messages.send>[0])
       );
     }
-    case "poll":
-      return toSendResult(
-        await client.messages.send({
-          to: spaceId,
-          interactive: pollToInteractive(content),
-        })
-      );
+    case "poll": {
+      const result = await client.messages.send({
+        to: spaceId,
+        interactive: pollToInteractive(content),
+      });
+      cachePoll(client, result.messageId, content);
+      return toSendResult(result);
+    }
     default:
       throw UnsupportedError.content(content.type);
   }
@@ -565,14 +615,15 @@ export const replyToMessage = async (
         } as Parameters<typeof client.messages.send>[0])
       );
     }
-    case "poll":
-      return toSendResult(
-        await client.messages.send({
-          to: spaceId,
-          replyTo: messageId,
-          interactive: pollToInteractive(content),
-        })
-      );
+    case "poll": {
+      const result = await client.messages.send({
+        to: spaceId,
+        replyTo: messageId,
+        interactive: pollToInteractive(content),
+      });
+      cachePoll(client, result.messageId, content);
+      return toSendResult(result);
+    }
     default:
       throw UnsupportedError.content(content.type);
   }

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -16,12 +16,14 @@ import {
   type ContactPhone as SpectrumContactPhone,
 } from "../../content/contact";
 import { asCustom } from "../../content/custom";
+import { asPollOption } from "../../content/poll";
 import { asReaction } from "../../content/reaction";
 import { asText } from "../../content/text";
 import type { Content } from "../../content/types";
 import type { SendResult } from "../../platform/types";
 import { UnsupportedError } from "../../utils/errors";
 import { type ManagedStream, mergeStreams, stream } from "../../utils/stream";
+import { pollToInteractive } from "./poll";
 import type { WhatsAppClients, WhatsAppMessage } from "./types";
 
 // v1 routes outbound traffic to the first line. When multi-line send becomes a
@@ -240,8 +242,13 @@ const mapContent = (
         target: stubTarget as Parameters<typeof asReaction>[0]["target"],
       });
     }
-    case "interactive":
-      return asCustom({ whatsapp_type: "interactive", ...content.interactive });
+    case "interactive": {
+      const inter = content.interactive;
+      if (inter.type === "button_reply" || inter.type === "list_reply") {
+        return asPollOption({ title: inter.reply.title });
+      }
+      return asCustom({ whatsapp_type: "interactive", ...inter });
+    }
     case "button":
       return asCustom({ whatsapp_type: "button", ...content.button });
     case "order":
@@ -477,6 +484,13 @@ export const send = async (
         } as Parameters<typeof client.messages.send>[0])
       );
     }
+    case "poll":
+      return toSendResult(
+        await client.messages.send({
+          to: spaceId,
+          interactive: pollToInteractive(content),
+        })
+      );
     default:
       throw UnsupportedError.content(content.type);
   }
@@ -551,6 +565,14 @@ export const replyToMessage = async (
         } as Parameters<typeof client.messages.send>[0])
       );
     }
+    case "poll":
+      return toSendResult(
+        await client.messages.send({
+          to: spaceId,
+          replyTo: messageId,
+          interactive: pollToInteractive(content),
+        })
+      );
     default:
       throw UnsupportedError.content(content.type);
   }

--- a/packages/spectrum-ts/src/providers/whatsapp-business/poll.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/poll.ts
@@ -10,15 +10,17 @@ const MAX_BUTTON_OPTIONS = 3;
 const LIST_BUTTON_TEXT = "View options";
 const LIST_SECTION_TITLE = "Options";
 
+export const pollOptionId = (index: number): string => `opt_${index}`;
+
 export const pollToInteractive = (content: Poll): InteractiveInput => {
   if (content.options.length <= MAX_BUTTON_OPTIONS) {
     return buttons(
       content.title,
-      ...content.options.map((o, i) => button(`opt_${i}`, o.title))
+      ...content.options.map((o, i) => button(pollOptionId(i), o.title))
     );
   }
   return list(content.title, LIST_BUTTON_TEXT).section(
     LIST_SECTION_TITLE,
-    content.options.map((o, i) => ({ id: `opt_${i}`, title: o.title }))
+    content.options.map((o, i) => ({ id: pollOptionId(i), title: o.title }))
   );
 };

--- a/packages/spectrum-ts/src/providers/whatsapp-business/poll.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/poll.ts
@@ -1,0 +1,24 @@
+import {
+  button,
+  buttons,
+  type InteractiveInput,
+  list,
+} from "@photon-ai/whatsapp-business";
+import type { Poll } from "../../content/poll";
+
+const MAX_BUTTON_OPTIONS = 3;
+const LIST_BUTTON_TEXT = "View options";
+const LIST_SECTION_TITLE = "Options";
+
+export const pollToInteractive = (content: Poll): InteractiveInput => {
+  if (content.options.length <= MAX_BUTTON_OPTIONS) {
+    return buttons(
+      content.title,
+      ...content.options.map((o, i) => button(`opt_${i}`, o.title))
+    );
+  }
+  return list(content.title, LIST_BUTTON_TEXT).section(
+    LIST_SECTION_TITLE,
+    content.options.map((o, i) => ({ id: `opt_${i}`, title: o.title }))
+  );
+};


### PR DESCRIPTION
## Summary

- Adds a first-class `poll` content type with `pollSchema` / `pollOptionSchema`, plus the `poll(title, ...options)` and `option(title)` builders. Polls carry 2–10 string-titled options; vote events arrive as `poll_option` content (`{ option, poll, selected }`) so agents can reuse the same `messages` iterator they use for everything else.
- Teaches the iMessage remote provider to send polls (via `client.polls.create`) and to surface inbound poll vote/unvote deltas as `poll_option` messages. A new `PollCache` keyed off the poll message guid resolves provider-side option identifiers to public `PollChoice` objects, and tracks per-actor selection state so re-votes emit the correct `selected` / deselected pair.
- Teaches the WhatsApp Business provider to send polls as interactive `buttons` (≤3 options) or `list` (4–10 options); inbound `button_reply` / `list_reply` events that reference a cached poll round-trip back to `poll_option` content. A bounded per-client cache keeps the original `Poll` available so vote replies can be re-decorated.
- Bumps `@photon-ai/advanced-imessage` to `^0.5.1` to pick up `polls.create` / `polls.subscribe` / `PollEvent` types.
- Local iMessage explicitly throws `UnsupportedError` for poll sends; reply-with-poll throws on iMessage with the message "polls cannot be sent as replies".

## Usage

```typescript
import { Spectrum, poll, option } from "spectrum-ts";
import { imessage } from "spectrum-ts/providers/imessage";

const app = await Spectrum({ providers: [imessage.config()] });

// Send a poll
await space.send(poll("Lunch?", option("Pizza"), option("Salad"), option("Tacos")));
// or with an array
await space.send(poll("Lunch?", ["Pizza", "Salad", "Tacos"]));

// Receive votes
for await (const [, message] of app.messages) {
  if (message.content.type === "poll_option") {
    const { poll, option, selected } = message.content;
    console.log(`${message.sender.id} ${selected ? "picked" : "unpicked"} "${option.title}" on "${poll.title}"`);
  }
}
```

## Changes

| File | Change |
|---|---|
| `packages/spectrum-ts/src/content/poll.ts` | New — `pollSchema`, `pollOptionSchema`, `asPoll`, `asPollOption`, `option(title)`, and `poll(title, ...options)` builder (accepts both varargs and a single array). `pollOptionSchema` cross-checks that the chosen option exists in the parent poll. |
| `packages/spectrum-ts/src/content/types.ts`, `src/index.ts` | Add `pollSchema` + `pollOptionSchema` to the content discriminated union; export `poll` / `option` and the related types. |
| `packages/spectrum-ts/src/providers/imessage/cache.ts` | Add `PollCache` (bounded FIFO, default 1000) tracking cached polls + per-actor selections + per-actor last-event timestamps for stale-event suppression. Refactor `getMessageCache` / `getPollCache` to share the `WeakMap<owner, …>` pattern. |
| `packages/spectrum-ts/src/providers/imessage/remote.ts` | Subscribe to `client.polls.subscribe()` alongside the existing message stream; cache `created` / `optionAdded` deltas; on `voted` / `unvoted`, diff against the cached actor selection and emit one `poll_option` message per changed option. Outbound `send` routes `poll` content through `client.polls.create`; reply-with-poll throws an `UnsupportedError`. Poll stream failures are isolated so they can't kill the message stream. |
| `packages/spectrum-ts/src/providers/imessage/local.ts` | `send` throws `UnsupportedError.content("poll", "iMessage (local mode)")`. |
| `packages/spectrum-ts/src/providers/whatsapp-business/poll.ts` | New — `pollOptionId(index)` and `pollToInteractive(content)` helper that picks `buttons` for ≤3 options or a `list` section for 4–10. |
| `packages/spectrum-ts/src/providers/whatsapp-business/messages.ts` | Add bounded `WeakMap`-backed poll cache; outbound `send` / `replyToMessage` route `poll` content through `pollToInteractive` and stash the original `Poll` keyed by the resulting message id; inbound `button_reply` / `list_reply` events that reference a cached poll inflate to `poll_option` content via `asPollOption`. |
| `packages/spectrum-ts/package.json`, `bun.lock` | Bump `@photon-ai/advanced-imessage` to `^0.5.1`. |

## Test plan

- [ ] `bun x ultracite check` passes
- [ ] `bun x tsc --noEmit` clean across the workspace
- [ ] `bun run build` succeeds
- [ ] iMessage remote: `space.send(poll("Lunch?", "A", "B", "C"))` creates a real poll; recipients see all three options
- [ ] iMessage remote: another participant votes for one option → stream emits a single `poll_option` with `selected: true` and the correct `option.title`
- [ ] iMessage remote: same participant changes their vote → stream emits two `poll_option`s (the deselected old option + the selected new option) in a single delta
- [ ] iMessage remote: same participant clears their vote (`unvoted`) → stream emits `selected: false` for every previously-selected option
- [ ] iMessage remote: a stale `voted` event (timestamp older than the last committed event) is dropped without emitting
- [ ] iMessage remote: an upstream `polls.subscribe` failure logs once and does not terminate the message stream
- [ ] iMessage local: `space.send(poll(...))` throws an `UnsupportedError` (caught and warned by the runtime per #24)
- [ ] iMessage: `message.reply(poll(...))` throws with "polls cannot be sent as replies"
- [ ] WhatsApp Business: `space.send(poll("Q", "A", "B"))` (≤3 options) renders as interactive `buttons`; `poll("Q", "A", "B", "C", "D")` (4+) renders as a `list` with one section
- [ ] WhatsApp Business: a recipient tapping a button → stream emits `poll_option` with the matching `option` and `selected: true`; tapping a different option later still emits `poll_option` (note: WA doesn't surface deselect, only the new selection)
- [ ] Schema: `pollOptionSchema` rejects a `poll_option` whose `option.title` isn't in `poll.options`; `pollSchema` rejects 0/1/11+ options and titles >300 chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Polls can now be created, sent, and received via iMessage (remote mode) and WhatsApp Business
  * Poll vote tracking and response management now available

* **Refactor**
  * Code formatting improvements in example files

* **Chores**
  * Updated package dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->