### PR TITLE
Per-platform `messages` stream + broadcast fanout

### DIFF
--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -31,11 +31,13 @@ export { definePlatform } from "./platform/define";
 export type {
   AnyPlatformDef,
   EventProducer,
+  InboundPlatformMessage,
   Platform,
   PlatformDef,
   PlatformInstance,
   PlatformMessage,
   PlatformProviderConfig,
+  PlatformRuntime,
   PlatformSpace,
   PlatformUser,
   SchemaMessage,
@@ -57,5 +59,11 @@ export type {
 } from "./utils/cloud";
 export { cloud, SpectrumCloudError } from "./utils/cloud";
 export { UnsupportedError, type UnsupportedKind } from "./utils/errors";
-export { type ManagedStream, mergeStreams, stream } from "./utils/stream";
+export {
+  type Broadcaster,
+  broadcast,
+  type ManagedStream,
+  mergeStreams,
+  stream,
+} from "./utils/stream";
 export { fromVCard, toVCard } from "./utils/vcard";

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -4,11 +4,13 @@ import type { Space } from "../types/space";
 import { buildSpace } from "./build";
 import type {
   AnyPlatformDef,
+  InboundPlatformMessage,
   Platform,
   PlatformDef,
   PlatformInstance,
   PlatformMessage,
   PlatformProviderConfig,
+  PlatformRuntime,
   PlatformSpace,
   PlatformUser,
   ProviderMessage,
@@ -19,10 +21,7 @@ function createPlatformInstance<
   Def extends AnyPlatformDef,
   _Client,
   _ConfigSchema extends z.ZodType<object>,
->(
-  def: Def,
-  runtime: { client: unknown; config: unknown }
-): PlatformInstance<Def> {
+>(def: Def, runtime: PlatformRuntime): PlatformInstance<Def> {
   const isPlatformUser = (value: unknown): value is PlatformUser<Def> => {
     return (
       typeof value === "object" &&
@@ -157,6 +156,21 @@ function createPlatformInstance<
       });
     }
   }
+
+  // Lazily subscribe to the platform's message broadcast on first read.
+  // Cached so `for await (const x of im.messages)` twice doesn't double-subscribe.
+  let messagesIterable:
+    | AsyncIterable<[PlatformSpace<Def>, InboundPlatformMessage<Def>]>
+    | undefined;
+  Object.defineProperty(base, "messages", {
+    enumerable: true,
+    get() {
+      messagesIterable ??= runtime.subscribeMessages() as AsyncIterable<
+        [PlatformSpace<Def>, InboundPlatformMessage<Def>]
+      >;
+      return messagesIterable;
+    },
+  });
 
   return Object.assign(base, eventProperties) as PlatformInstance<Def>;
 }

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -1,9 +1,10 @@
 import type { Fn, Pipe, Tuples } from "hotscript";
 import type z from "zod";
 import type { Content } from "../content/types";
-import type { Message } from "../types/message";
+import type { InboundMessage, Message } from "../types/message";
 import type { Space } from "../types/space";
 import type { User } from "../types/user";
+import type { ManagedStream } from "../utils/stream";
 
 type ResolvedSpace = Pick<Space, "id">;
 type SpaceRef = Pick<Space, "id" | "__platform">;
@@ -414,6 +415,12 @@ export type PlatformMessage<Def extends AnyPlatformDef> = Omit<
 > &
   Message<Def["name"], PlatformUser<Def>, PlatformSpace<Def>>;
 
+export type InboundPlatformMessage<Def extends AnyPlatformDef> = Omit<
+  SchemaInfer<Def["message"]>,
+  keyof InboundMessage
+> &
+  InboundMessage<Def["name"], PlatformUser<Def>, PlatformSpace<Def>>;
+
 export type PlatformUser<Def extends AnyPlatformDef> = Omit<
   ResolvedUserOf<Def>,
   keyof User
@@ -425,6 +432,9 @@ export type PlatformUser<Def extends AnyPlatformDef> = Omit<
 // ---------------------------------------------------------------------------
 
 export type PlatformInstance<Def extends AnyPlatformDef> = {
+  readonly messages: AsyncIterable<
+    [PlatformSpace<Def>, InboundPlatformMessage<Def>]
+  >;
   space(...args: SpaceArgs<Def>): Promise<PlatformSpace<Def>>;
   user(userID: string): Promise<PlatformUser<Def>>;
 } & {
@@ -440,14 +450,18 @@ export type PlatformInstance<Def extends AnyPlatformDef> = {
 // SpectrumLike — minimal interface for platform narrowing
 // ---------------------------------------------------------------------------
 
+export interface PlatformRuntime {
+  client: unknown;
+  config: unknown;
+  definition: AnyPlatformDef;
+  subscribeMessages: () => ManagedStream<[Space, Message]>;
+}
+
 export interface SpectrumLike<
   Providers extends PlatformProviderConfig[] = PlatformProviderConfig[],
 > {
   readonly __internal: {
-    platforms: Map<
-      string,
-      { client: unknown; config: unknown; definition: AnyPlatformDef }
-    >;
+    platforms: Map<string, PlatformRuntime>;
   };
   readonly __providers: Providers;
 }

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -454,7 +454,7 @@ export interface PlatformRuntime {
   client: unknown;
   config: unknown;
   definition: AnyPlatformDef;
-  subscribeMessages: () => ManagedStream<[Space, Message]>;
+  subscribeMessages: () => ManagedStream<[Space, InboundMessage]>;
 }
 
 export interface SpectrumLike<

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -9,11 +9,18 @@ import type {
   AnyPlatformDef,
   CustomEventStreams,
   PlatformProviderConfig,
+  PlatformRuntime,
   SpectrumLike,
 } from "./platform/types";
 import type { InboundMessage, Message, OutboundMessage } from "./types/message";
 import type { Space } from "./types/space";
-import { type ManagedStream, mergeStreams, stream } from "./utils/stream";
+import {
+  type Broadcaster,
+  broadcast,
+  type ManagedStream,
+  mergeStreams,
+  stream,
+} from "./utils/stream";
 
 // ---------------------------------------------------------------------------
 // SpectrumInstance — the typed return of Spectrum()
@@ -114,34 +121,15 @@ export async function Spectrum<
   } = options;
   const flattenGroups = runtimeOptions?.flattenGroups ?? false;
 
-  const platformStates = new Map<
-    string,
-    { client: unknown; config: unknown; definition: AnyPlatformDef }
-  >();
+  const platformStates = new Map<string, PlatformRuntime>();
+
+  // Per-platform message broadcasters (lazy: created on first subscribe).
+  const messageBroadcasters = new Map<string, Broadcaster<[Space, Message]>>();
 
   // Custom event streams keyed by event name
   const customEventStreams = new Map<string, ManagedStream<unknown>>();
 
   let stopped = false;
-
-  // Initialize all provider clients eagerly
-  for (const provider of providers) {
-    const providerConfig = provider as PlatformProviderConfig;
-    const def = providerConfig.__definition;
-    const userConfig = def.config.parse(providerConfig.config);
-
-    const client = await def.lifecycle.createClient({
-      config: userConfig,
-      projectId,
-      projectSecret,
-    });
-
-    platformStates.set(def.name, {
-      client,
-      config: userConfig,
-      definition: def,
-    });
-  }
 
   const adaptIterable = <T>(iterable: AsyncIterable<T>): ManagedStream<T> => {
     return stream<T>((emit, end) => {
@@ -213,10 +201,52 @@ export async function Spectrum<
     return adaptIterable(bindSend());
   };
 
+  const getOrCreateMessageBroadcast = (state: {
+    client: unknown;
+    config: unknown;
+    definition: AnyPlatformDef;
+  }): Broadcaster<[Space, Message]> => {
+    const name = state.definition.name;
+    let broadcaster = messageBroadcasters.get(name);
+    if (!broadcaster) {
+      broadcaster = broadcast(createProviderMessagesStream(state));
+      messageBroadcasters.set(name, broadcaster);
+    }
+    return broadcaster;
+  };
+
+  // Initialize all provider clients eagerly. Each runtime exposes
+  // `subscribeMessages()` that returns a fresh fanout consumer of the
+  // platform's single upstream message stream.
+  for (const provider of providers) {
+    const providerConfig = provider as PlatformProviderConfig;
+    const def = providerConfig.__definition;
+    const userConfig = def.config.parse(providerConfig.config);
+
+    const client = await def.lifecycle.createClient({
+      config: userConfig,
+      projectId,
+      projectSecret,
+    });
+
+    const state = {
+      client,
+      config: userConfig,
+      definition: def,
+    };
+
+    platformStates.set(def.name, {
+      ...state,
+      subscribeMessages: () => getOrCreateMessageBroadcast(state).subscribe(),
+    });
+  }
+
   const createMessagesStream = (): ManagedStream<[Space, Message]> => {
     return stream<[Space, Message]>((emit, end) => {
       const merged = mergeStreams(
-        Array.from(platformStates.values(), createProviderMessagesStream)
+        Array.from(platformStates.values(), (runtime) =>
+          runtime.subscribeMessages()
+        )
       );
 
       const pump = (async () => {
@@ -298,6 +328,9 @@ export async function Spectrum<
       ...Array.from(customEventStreams.values(), (eventStream) =>
         eventStream.close()
       ),
+      ...Array.from(messageBroadcasters.values(), (broadcaster) =>
+        broadcaster.close()
+      ),
     ];
 
     process.off("SIGINT", handleSignal);
@@ -311,6 +344,7 @@ export async function Spectrum<
     );
     await Promise.allSettled(clientShutdowns);
     customEventStreams.clear();
+    messageBroadcasters.clear();
     platformStates.clear();
   };
 

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -12,7 +12,7 @@ import type {
   PlatformRuntime,
   SpectrumLike,
 } from "./platform/types";
-import type { InboundMessage, Message, OutboundMessage } from "./types/message";
+import type { InboundMessage, OutboundMessage } from "./types/message";
 import type { Space } from "./types/space";
 import {
   type Broadcaster,
@@ -124,7 +124,10 @@ export async function Spectrum<
   const platformStates = new Map<string, PlatformRuntime>();
 
   // Per-platform message broadcasters (lazy: created on first subscribe).
-  const messageBroadcasters = new Map<string, Broadcaster<[Space, Message]>>();
+  const messageBroadcasters = new Map<
+    string,
+    Broadcaster<[Space, InboundMessage]>
+  >();
 
   // Custom event streams keyed by event name
   const customEventStreams = new Map<string, ManagedStream<unknown>>();
@@ -159,14 +162,16 @@ export async function Spectrum<
     client: unknown;
     config: unknown;
     definition: AnyPlatformDef;
-  }): ManagedStream<[Space, Message]> => {
+  }): ManagedStream<[Space, InboundMessage]> => {
     const { client, config, definition } = state;
     const raw = definition.events.messages({
       client,
       config,
     }) as AsyncIterable<ProviderMessageRecord>;
 
-    const bindSend = async function* (): AsyncIterable<[Space, Message]> {
+    const bindSend = async function* (): AsyncIterable<
+      [Space, InboundMessage]
+    > {
       for await (const msg of raw) {
         const spaceRef = {
           ...msg.space,
@@ -190,7 +195,10 @@ export async function Spectrum<
         });
         if (flattenGroups && normalizedMessage.content.type === "group") {
           for (const item of normalizedMessage.content.items) {
-            yield [space, item];
+            // Group items in the inbound flow are wrapped via wrapProviderMessage,
+            // which always produces InboundMessages — Group.items is just the
+            // wider Message type at the schema level.
+            yield [space, item as InboundMessage];
           }
           continue;
         }
@@ -205,7 +213,12 @@ export async function Spectrum<
     client: unknown;
     config: unknown;
     definition: AnyPlatformDef;
-  }): Broadcaster<[Space, Message]> => {
+  }): Broadcaster<[Space, InboundMessage]> => {
+    if (stopped) {
+      throw new Error(
+        `Spectrum instance has been stopped; cannot subscribe to "${state.definition.name}" messages`
+      );
+    }
     const name = state.definition.name;
     let broadcaster = messageBroadcasters.get(name);
     if (!broadcaster) {
@@ -241,8 +254,8 @@ export async function Spectrum<
     });
   }
 
-  const createMessagesStream = (): ManagedStream<[Space, Message]> => {
-    return stream<[Space, Message]>((emit, end) => {
+  const createMessagesStream = (): ManagedStream<[Space, InboundMessage]> => {
+    return stream<[Space, InboundMessage]>((emit, end) => {
       const merged = mergeStreams(
         Array.from(platformStates.values(), (runtime) =>
           runtime.subscribeMessages()
@@ -357,7 +370,7 @@ export async function Spectrum<
   process.on("SIGINT", handleSignal);
   process.on("SIGTERM", handleSignal);
 
-  const messages = messagesStream as AsyncIterable<[Space, InboundMessage]>;
+  const messages: AsyncIterable<[Space, InboundMessage]> = messagesStream;
 
   // Proxy for flat custom event access (app.typing, app.readReceipt, etc.)
   const customEventProxy = new Proxy(

--- a/packages/spectrum-ts/src/utils/stream.ts
+++ b/packages/spectrum-ts/src/utils/stream.ts
@@ -71,3 +71,91 @@ export function mergeStreams<T>(
     };
   });
 }
+
+export interface Broadcaster<T> {
+  close(): Promise<void>;
+  subscribe(): ManagedStream<T>;
+}
+
+interface BroadcastConsumer<T> {
+  emit: (value: T) => Promise<void>;
+  end: (error?: unknown) => void;
+}
+
+export function broadcast<T>(source: ManagedStream<T>): Broadcaster<T> {
+  const consumers = new Set<BroadcastConsumer<T>>();
+  let pumping = false;
+  let terminated = false;
+  let terminalError: unknown;
+  let pumpPromise: Promise<void> | undefined;
+  let closed = false;
+
+  const startPump = () => {
+    if (pumping || terminated) {
+      return;
+    }
+    pumping = true;
+    pumpPromise = (async () => {
+      try {
+        for await (const value of source) {
+          if (consumers.size === 0) {
+            continue;
+          }
+          await Promise.all(
+            Array.from(consumers, (consumer) =>
+              consumer.emit(value).catch(() => {
+                // consumer closed mid-emit; it will be removed via its cleanup
+              })
+            )
+          );
+        }
+        terminated = true;
+        for (const consumer of consumers) {
+          consumer.end();
+        }
+        consumers.clear();
+      } catch (error) {
+        terminated = true;
+        terminalError = error;
+        for (const consumer of consumers) {
+          consumer.end(error);
+        }
+        consumers.clear();
+      }
+    })();
+  };
+
+  return {
+    subscribe(): ManagedStream<T> {
+      return stream<T>((emit, end) => {
+        if (terminated) {
+          end(terminalError);
+          return;
+        }
+        const consumer: BroadcastConsumer<T> = { emit, end };
+        consumers.add(consumer);
+        startPump();
+        return () => {
+          consumers.delete(consumer);
+        };
+      });
+    },
+    async close(): Promise<void> {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      await source.close();
+      if (pumpPromise) {
+        await pumpPromise;
+      }
+      if (!terminated) {
+        terminated = true;
+        for (const consumer of consumers) {
+          consumer.end();
+        }
+        consumers.clear();
+      }
+    },
+  };
+}

--- a/packages/spectrum-ts/src/utils/stream.ts
+++ b/packages/spectrum-ts/src/utils/stream.ts
@@ -78,6 +78,9 @@ export interface Broadcaster<T> {
 }
 
 interface BroadcastConsumer<T> {
+  // Chain each delivery off the previous one so a slow consumer's pending
+  // emit doesn't block the broadcast pump or other consumers.
+  deliveries: Promise<void>;
   emit: (value: T) => Promise<void>;
   end: (error?: unknown) => void;
 }
@@ -98,18 +101,20 @@ export function broadcast<T>(source: ManagedStream<T>): Broadcaster<T> {
     pumpPromise = (async () => {
       try {
         for await (const value of source) {
-          if (consumers.size === 0) {
-            continue;
-          }
-          await Promise.all(
-            Array.from(consumers, (consumer) =>
+          for (const consumer of consumers) {
+            consumer.deliveries = consumer.deliveries.then(() =>
               consumer.emit(value).catch(() => {
-                // consumer closed mid-emit; it will be removed via its cleanup
+                // consumer closed mid-emit; cleanup removes it from the set
               })
-            )
-          );
+            );
+          }
         }
         terminated = true;
+        // Wait for in-flight deliveries to drain before ending each consumer
+        // so values queued just before EOF still reach them.
+        await Promise.allSettled(
+          Array.from(consumers, (consumer) => consumer.deliveries)
+        );
         for (const consumer of consumers) {
           consumer.end();
         }
@@ -132,7 +137,11 @@ export function broadcast<T>(source: ManagedStream<T>): Broadcaster<T> {
           end(terminalError);
           return;
         }
-        const consumer: BroadcastConsumer<T> = { emit, end };
+        const consumer: BroadcastConsumer<T> = {
+          emit,
+          end,
+          deliveries: Promise.resolve(),
+        };
         consumers.add(consumer);
         startPump();
         return () => {
@@ -145,16 +154,19 @@ export function broadcast<T>(source: ManagedStream<T>): Broadcaster<T> {
         return;
       }
       closed = true;
-      await source.close();
-      if (pumpPromise) {
-        await pumpPromise;
-      }
-      if (!terminated) {
-        terminated = true;
-        for (const consumer of consumers) {
-          consumer.end();
+      try {
+        await source.close();
+        if (pumpPromise) {
+          await pumpPromise;
         }
-        consumers.clear();
+      } finally {
+        if (!terminated) {
+          terminated = true;
+          for (const consumer of consumers) {
+            consumer.end();
+          }
+          consumers.clear();
+        }
       }
     },
   };


### PR DESCRIPTION
## Summary

- Adds a per-platform `messages` async iterable on each `PlatformInstance`, so consumers can subscribe to messages from one specific provider (e.g. iMessage only) with the platform's narrowed message and space types — instead of having to filter the merged `app.messages` stream by `__platform`.
- Introduces a `broadcast(source)` fanout utility in `utils/stream.ts` so a single upstream `ManagedStream` (the provider's actual message subscription) can be multiplexed to many independent consumers without double-subscribing on the wire. The top-level `app.messages` and any per-platform `im.messages` reads now share one underlying provider stream.
- Promotes the inline `{ client, config, definition }` shape to a named `PlatformRuntime` interface that also carries `subscribeMessages()`. The core `Spectrum()` runtime owns the per-platform `Broadcaster`s and threads `subscribeMessages` into each runtime entry; cleanup closes the broadcasters alongside custom event streams and provider clients.

## Usage

```typescript
import { Spectrum } from "spectrum-ts";
import { imessage } from "spectrum-ts/providers/imessage";
import { whatsapp } from "spectrum-ts/providers/whatsapp";

const app = await Spectrum({
  providers: [imessage.config(), whatsapp.config()],
});

// Old: filter the merged stream
for await (const [space, message] of app.messages) {
  if (message.__platform !== "imessage") continue;
  // …
}

// New: subscribe directly to one platform — fully typed to that provider
for await (const [space, message] of app.imessage.messages) {
  await space.responding(async () => {
    await message.reply("hi from iMessage only");
  });
}
```

Both consumers above can run concurrently — `broadcast` ensures the underlying provider subscription is opened once and fanned out.

## How it works

`broadcast(source)` in `utils/stream.ts`:

1. Lazy pump — the upstream iteration only starts after the first `subscribe()`.
2. Each `subscribe()` returns a fresh `ManagedStream<T>`; on emit, the pump awaits all consumer emits in parallel so a slow consumer doesn't reorder values for others. A consumer that errors mid-emit is swallowed (it'll be removed via its own teardown).
3. When the source completes or errors, every consumer is ended (with the error if any) and the consumer set is cleared.
4. `close()` closes the source and waits for the pump to drain; safe to call repeatedly. If the pump hadn't terminated (no items ever pulled), consumers are ended cleanly.

`createPlatformInstance` (in `platform/define.ts`) lazily wires the new `messages` getter via `Object.defineProperty`, caching the iterable so reading `im.messages` twice doesn't double-subscribe to the broadcaster:

```typescript
let messagesIterable;
Object.defineProperty(base, "messages", {
  enumerable: true,
  get() {
    messagesIterable ??= runtime.subscribeMessages();
    return messagesIterable;
  },
});
```

In `spectrum.ts`, each provider state gets a `Broadcaster<[Space, Message]>` on first subscribe; the top-level `createMessagesStream()` now merges `runtime.subscribeMessages()` per platform instead of opening fresh provider streams.

## Changes

| File | Change |
|---|---|
| `packages/spectrum-ts/src/utils/stream.ts` | New `Broadcaster<T>` interface + `broadcast(source)` factory: lazy single-pump fanout with per-consumer `ManagedStream`, parallel emit, terminal-state replay for late subscribers, and idempotent `close()`. |
| `packages/spectrum-ts/src/platform/types.ts` | Add `InboundPlatformMessage<Def>` (mirrors `PlatformMessage<Def>` but over `InboundMessage`). Add `readonly messages: AsyncIterable<[PlatformSpace<Def>, InboundPlatformMessage<Def>]>` to `PlatformInstance<Def>`. Promote `{ client, config, definition }` to `PlatformRuntime` with `subscribeMessages: () => ManagedStream<[Space, Message]>`; `SpectrumLike.__internal.platforms` now stores `PlatformRuntime`. |
| `packages/spectrum-ts/src/platform/define.ts` | Accept `runtime: PlatformRuntime` (instead of the inline shape). Define `messages` as a lazy cached getter on the platform instance so repeat reads share one fanout subscription. |
| `packages/spectrum-ts/src/spectrum.ts` | Maintain per-platform `Broadcaster<[Space, Message]>`s; each `platformStates` entry now exposes `subscribeMessages()` returning a fresh fanout consumer. `createMessagesStream()` merges those subscriber streams. Shutdown closes every broadcaster (and clears the map) alongside custom event streams. |
| `packages/spectrum-ts/src/index.ts` | Re-export `InboundPlatformMessage`, `PlatformRuntime`, `Broadcaster`, and `broadcast`. |

## Test plan

- [ ] `bun x ultracite check` passes
- [ ] `bun x tsc --noEmit` clean across the workspace
- [ ] `bun run build` succeeds
- [ ] `for await (const [space, message] of app.imessage.messages)` yields only iMessage messages, with `message` typed as the iMessage `InboundPlatformMessage` (not the union)
- [ ] Subscribing to `app.messages` and `app.imessage.messages` concurrently both observe every iMessage event exactly once each — the upstream provider subscription is opened only once
- [ ] Reading `app.imessage.messages` twice in the same process re-uses the same iterable (no double subscribe to the broadcaster)
- [ ] Tearing down `app.stop()` closes all broadcasters; no dangling pump tasks; per-provider lifecycle `destroyClient` still runs
- [ ] An upstream provider error propagates to every active consumer of that platform's broadcast, then the broadcast is terminated; subsequent `subscribe()` calls end immediately with the same error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a broadcaster utility for multi-subscriber message streams
  * Exported new platform message and runtime types for integration

* **Improvements**
  * Message streams use lazy loading with caching to avoid duplicate subscriptions
  * Platform runtime and top-level message fanout reworked for more robust multi-platform streaming and clean shutdown handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->