### PR TITLE
Unify send/receive provider contract under `ProviderMessageRecord` and use atomic iMessage group sends

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,9 +19,9 @@
     },
     "packages/spectrum-ts": {
       "name": "spectrum-ts",
-      "version": "1.0.1",
+      "version": "1.1.1",
       "dependencies": {
-        "@photon-ai/advanced-imessage": "^0.5.1",
+        "@photon-ai/advanced-imessage": "^0.6.0",
         "@photon-ai/imessage-kit": "^3.0.0",
         "@photon-ai/whatsapp-business": "^0.1.1",
         "@repeaterjs/repeater": "^3.0.6",
@@ -145,7 +145,7 @@
 
     "@parseaple/typedstream": ["@parseaple/typedstream@2.0.2", "", { "dependencies": { "@parseaple/bplist": "1.0.1" } }, "sha512-bzKNZjiBtZN2T2U7Nqq/hhv+EezkPnaWoB5WvPuBwNpQvOr3EI0XrDTkFnAzsA9DKdu57es/gcb1d2ctd1u8xw=="],
 
-    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.5.1", "", { "dependencies": { "@grpc/grpc-js": "^1.12.6", "long": "^5.2.4", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2", "protobufjs": "^7.4.0" } }, "sha512-LBohv663myuJ9WIGgUP/Ksw57PreD5BbpOO9aJTAiCBWFpgrkaaOjgFRW1kIBrN2/x0ghItc6Nn1DGPaYnxxew=="],
+    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.6.0", "", { "dependencies": { "@grpc/grpc-js": "^1.12.6", "long": "^5.2.4", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2", "protobufjs": "^7.4.0" } }, "sha512-6pkkS9Pb2T4G1pO7dtUfrV7koklFMq16vSG+RNrXGrKtidTM/2j1HdyGc8BhNZgg5OabDWoq2vA6owp2jFy1Iw=="],
 
     "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-GGDETlRbrPXP5eaRvswaead7MCBGQkm8f7d3aVbx8+rXhB4GEyPiw7Q1/yz5ix53rmxqKRevWywOfG7n+kZDBw=="],
 

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -39,7 +39,7 @@
     "generate:emoji": "bun scripts/generate-emoji.ts"
   },
   "dependencies": {
-    "@photon-ai/advanced-imessage": "^0.5.1",
+    "@photon-ai/advanced-imessage": "^0.6.0",
     "@photon-ai/imessage-kit": "^3.0.0",
     "@photon-ai/whatsapp-business": "^0.1.1",
     "@repeaterjs/repeater": "^3.0.6",

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -169,6 +169,12 @@ const wrapNestedContent = (
   if (content.type === "reaction") {
     const target = content.target as unknown;
     if (isRawProviderRecord(target)) {
+      // Reaction targets are always wrapped as "inbound": the target refers to
+      // the original received message, not the reaction event itself. So even
+      // when the wrapping reaction is outbound (e.g. our own reaction sent via
+      // `reactToMessage`), the *target* it points at is a message we received.
+      // This differs from `group.items`, which propagate the wrapping
+      // direction because each item is itself one piece of the same send.
       return {
         ...content,
         target: wrapProviderMessage(target, ctx, "inbound"),

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -7,7 +7,9 @@ import type {
 } from "../types/message";
 import type { Space } from "../types/space";
 import { UnsupportedError } from "../utils/errors";
-import type { AnyPlatformDef, SendResult } from "./types";
+import type { AnyPlatformDef, ProviderMessageRecord } from "./types";
+
+export type { ProviderMessageRecord } from "./types";
 
 type ReplyToMessageAction = NonNullable<
   AnyPlatformDef["actions"]["replyToMessage"]
@@ -91,14 +93,6 @@ export const providerMessageCoreKeys: ReadonlySet<string> = new Set([
   "timestamp",
 ]);
 
-export type ProviderMessageRecord = {
-  id: string;
-  content: Content;
-  sender: { id: string } & Record<string, unknown>;
-  space: { id: string } & Record<string, unknown>;
-  timestamp?: Date;
-} & Record<string, unknown>;
-
 export interface WrapContext {
   client: unknown;
   config: unknown;
@@ -122,18 +116,32 @@ const extractExtras = (
 
 /**
  * Wrap a raw provider message record (and any nested raw targets/items inside
- * its content) into a fully-built inbound `Message`. The recursion handles
- * reaction targets and group items, which arrive from providers as raw shapes.
+ * its content) into a fully-built `Message`. The same path serves inbound
+ * (`events.messages`, `getMessage`) and outbound (`send`, `replyToMessage`)
+ * flows — the only difference is `direction`, which decides whether the
+ * resulting Message exposes inbound (`react`/`reply`) or outbound (`edit`)
+ * affordances. Recursion through `wrapNestedContent` handles reaction targets
+ * and group items, which providers return as nested raw records.
  */
 export function wrapProviderMessage(
   raw: ProviderMessageRecord,
-  ctx: WrapContext
-): InboundMessage {
-  const wrappedContent = wrapNestedContent(raw.content, ctx);
-  return buildMessage({
+  ctx: WrapContext,
+  direction: "inbound"
+): InboundMessage;
+export function wrapProviderMessage(
+  raw: ProviderMessageRecord,
+  ctx: WrapContext,
+  direction: "outbound"
+): OutboundMessage;
+export function wrapProviderMessage(
+  raw: ProviderMessageRecord,
+  ctx: WrapContext,
+  direction: "inbound" | "outbound"
+): Message {
+  const wrappedContent = wrapNestedContent(raw.content, ctx, direction);
+  const base = {
     id: raw.id,
     content: wrappedContent,
-    sender: raw.sender,
     timestamp: raw.timestamp ?? new Date(),
     extras: extractExtras(raw, ctx.definition),
     spaceRef: ctx.spaceRef,
@@ -141,17 +149,29 @@ export function wrapProviderMessage(
     definition: ctx.definition,
     client: ctx.client,
     config: ctx.config,
-    direction: "inbound",
-  });
+  };
+  if (direction === "inbound") {
+    if (!raw.sender) {
+      throw new Error(
+        `Inbound provider message missing sender (platform "${ctx.definition.name}", id "${raw.id}")`
+      );
+    }
+    return buildMessage({ ...base, sender: raw.sender, direction: "inbound" });
+  }
+  return buildMessage({ ...base, sender: raw.sender, direction: "outbound" });
 }
 
-const wrapNestedContent = (content: Content, ctx: WrapContext): Content => {
+const wrapNestedContent = (
+  content: Content,
+  ctx: WrapContext,
+  direction: "inbound" | "outbound"
+): Content => {
   if (content.type === "reaction") {
     const target = content.target as unknown;
     if (isRawProviderRecord(target)) {
       return {
         ...content,
-        target: wrapProviderMessage(target, ctx),
+        target: wrapProviderMessage(target, ctx, "inbound"),
       };
     }
     return content;
@@ -159,7 +179,12 @@ const wrapNestedContent = (content: Content, ctx: WrapContext): Content => {
   if (content.type === "group") {
     const items = content.items.map((item) => {
       const raw = item as unknown;
-      return isRawProviderRecord(raw) ? wrapProviderMessage(raw, ctx) : item;
+      if (!isRawProviderRecord(raw)) {
+        return item;
+      }
+      return direction === "inbound"
+        ? wrapProviderMessage(raw, ctx, "inbound")
+        : wrapProviderMessage(raw, ctx, "outbound");
     });
     return { ...content, items };
   }
@@ -213,12 +238,12 @@ export function buildSpace(params: BuildSpaceParams): Space {
   async function dispatchSend(
     item: Exclude<Content, { type: "reaction" }>
   ): Promise<OutboundMessage | undefined> {
-    let sendResult: SendResult | undefined;
+    let raw: ProviderMessageRecord | undefined;
     try {
-      sendResult = (await definition.actions.send({
+      raw = (await definition.actions.send({
         ...typingCtx,
         content: item,
-      })) as SendResult | undefined;
+      })) as ProviderMessageRecord | undefined;
     } catch (err) {
       if (err instanceof UnsupportedError) {
         warnUnsupported(err, definition.name);
@@ -226,56 +251,16 @@ export function buildSpace(params: BuildSpaceParams): Space {
       }
       throw err;
     }
-    if (!sendResult?.id) {
+    if (!raw?.id) {
       throw new Error(
         `Platform "${definition.name}" send did not return a message id`
       );
     }
-
-    // If the provider reported per-item send receipts for a group, replace
-    // the placeholder items (produced by the `group()` builder, which cannot
-    // know ids before the send) with real outbound Messages carrying each
-    // native receipt. This is what lets consumers call
-    // `outMsg.content.items[i].react(...)` after a group send.
-    const outboundContent =
-      item.type === "group" && sendResult.groupMembers
-        ? {
-            ...item,
-            items: item.items.map((stub, idx) => {
-              const member = sendResult?.groupMembers?.[idx];
-              if (!member?.id) {
-                return stub;
-              }
-              return buildMessage({
-                id: member.id,
-                content: stub.content,
-                sender: member.sender,
-                timestamp: member.timestamp ?? new Date(),
-                extras: {},
-                spaceRef,
-                space,
-                definition,
-                client,
-                config,
-                direction: "outbound",
-              });
-            }),
-          }
-        : item;
-
-    return buildMessage({
-      id: sendResult.id,
-      content: outboundContent,
-      sender: sendResult.sender,
-      timestamp: sendResult.timestamp ?? new Date(),
-      extras: {},
-      spaceRef,
-      space,
-      definition,
-      client,
-      config,
-      direction: "outbound",
-    });
+    return wrapProviderMessage(
+      raw,
+      { client, config, definition, space, spaceRef },
+      "outbound"
+    );
   }
 
   async function sendImpl(
@@ -325,13 +310,11 @@ export function buildSpace(params: BuildSpaceParams): Space {
     if (!raw) {
       return;
     }
-    return wrapProviderMessage(raw, {
-      client,
-      config,
-      definition,
-      space,
-      spaceRef,
-    });
+    return wrapProviderMessage(
+      raw,
+      { client, config, definition, space, spaceRef },
+      "inbound"
+    );
   }
 
   space = {
@@ -416,16 +399,16 @@ export function buildMessage(params: BuildMessageParams): Message {
     target: Message,
     replyToMessage: ReplyToMessageAction
   ): Promise<OutboundMessage | undefined> => {
-    let sendResult: SendResult | undefined;
+    let raw: ProviderMessageRecord | undefined;
     try {
-      sendResult = (await replyToMessage({
+      raw = (await replyToMessage({
         space: spaceRef,
         messageId: params.id,
         target,
         content: item,
         client,
         config,
-      })) as SendResult | undefined;
+      })) as ProviderMessageRecord | undefined;
     } catch (err) {
       if (err instanceof UnsupportedError) {
         warnUnsupported(err, definition.name);
@@ -433,24 +416,16 @@ export function buildMessage(params: BuildMessageParams): Message {
       }
       throw err;
     }
-    if (!sendResult?.id) {
+    if (!raw?.id) {
       throw new Error(
         `Platform "${definition.name}" reply did not return a message id`
       );
     }
-    return buildMessage({
-      id: sendResult.id,
-      content: item,
-      sender: sendResult.sender,
-      timestamp: sendResult.timestamp ?? new Date(),
-      extras: {},
-      spaceRef,
-      space,
-      definition,
-      client,
-      config,
-      direction: "outbound",
-    });
+    return wrapProviderMessage(
+      raw,
+      { client, config, definition, space, spaceRef },
+      "outbound"
+    );
   };
 
   async function reply(

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -45,19 +45,24 @@ export type ProviderMessage<
   timestamp?: Date;
 } & TExtra;
 
-export interface SendResult<TSender extends ResolvedUser = ResolvedUser> {
-  /**
-   * Per-item send receipts returned when the dispatched content was a
-   * `group`. Providers that iterate native sends to emulate a group
-   * (e.g. iMessage) populate this so the platform build layer can
-   * replace the outbound group's placeholder items with real Messages
-   * that carry each item's own id.
-   */
-  groupMembers?: SendResult<TSender>[];
+/**
+ * A message a provider produced — used for both inbound (`events.messages`,
+ * `getMessage`) and outbound (`send`, `replyToMessage`) flows. Providers
+ * return their native record shape (including platform extras like
+ * `partIndex`/`parentId` for iMessage) and the platform `wrapProviderMessage`
+ * pipeline turns it into a fully-built Message.
+ *
+ * `sender` is optional because outbound sends often can't synthesize one
+ * (the SDK doesn't surface the bot's own handle); inbound providers are
+ * expected to populate it.
+ */
+export type ProviderMessageRecord = {
   id: string;
-  sender?: TSender;
+  content: Content;
+  sender?: { id: string } & Record<string, unknown>;
+  space: { id: string } & Record<string, unknown>;
   timestamp?: Date;
-}
+} & Record<string, unknown>;
 
 type MergeSchema<
   TSchema extends z.ZodType | undefined,
@@ -121,7 +126,7 @@ export interface PlatformDef<
       content: Content;
       client: _Client;
       config: z.infer<_ConfigSchema>;
-    }) => Promise<SendResult<_ResolvedUser>>;
+    }) => Promise<ProviderMessageRecord>;
     startTyping?: (_: {
       space: _ResolvedSpace & SpaceRef;
       client: _Client;
@@ -146,7 +151,7 @@ export interface PlatformDef<
       content: Content;
       client: _Client;
       config: z.infer<_ConfigSchema>;
-    }) => Promise<SendResult<_ResolvedUser>>;
+    }) => Promise<ProviderMessageRecord>;
     editMessage?: (_: {
       space: _ResolvedSpace & SpaceRef;
       messageId: string;
@@ -212,7 +217,7 @@ export interface PlatformDef<
 export interface AnyPlatformDef {
   actions: {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
-    send: (_: any) => Promise<SendResult>;
+    send: (_: any) => Promise<ProviderMessageRecord>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     startTyping?: (_: any) => Promise<void>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
@@ -220,7 +225,7 @@ export interface AnyPlatformDef {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     reactToMessage?: (_: any) => Promise<void>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
-    replyToMessage?: (_: any) => Promise<SendResult>;
+    replyToMessage?: (_: any) => Promise<ProviderMessageRecord>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     editMessage?: (_: any) => Promise<void>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action

--- a/packages/spectrum-ts/src/providers/imessage/local/api.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local/api.ts
@@ -1,6 +1,6 @@
 import type { IMessageSDK } from "@photon-ai/imessage-kit";
 import type { Content } from "../../../content/types";
-import type { SendResult } from "../../../platform/types";
+import type { ProviderMessageRecord } from "../../../platform/types";
 import type { ManagedStream } from "../../../utils/stream";
 import type { IMessageMessage } from "../types";
 import { messages as localMessages } from "./inbound";
@@ -16,7 +16,7 @@ export const send = async (
   client: IMessageSDK,
   spaceId: string,
   content: Content
-): Promise<SendResult> => sendLocalMessage(client, spaceId, content);
+): Promise<ProviderMessageRecord> => sendLocalMessage(client, spaceId, content);
 
 export const getMessage = async (
   client: IMessageSDK,

--- a/packages/spectrum-ts/src/providers/imessage/local/send.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local/send.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
 import type { IMessageSDK } from "@photon-ai/imessage-kit";
 import type { Content } from "../../../content/types";
-import type { SendResult } from "../../../platform/types";
+import type { ProviderMessageRecord } from "../../../platform/types";
 import { toVCard } from "../../../utils/vcard";
 import { unsupportedLocalContent } from "../shared/errors";
 import { vcardFileName } from "../shared/vcard";
@@ -11,11 +11,16 @@ import type { IMessageMessage } from "../types";
 import { DEFAULT_ATTACHMENT_NAME } from "./attachments";
 
 // v3 `IMessageSDK.send` resolves to `void`: the chat.db row id only
-// surfaces later via the watcher's `onFromMeMessage`. A synthetic id
-// satisfies spectrum's SendResult contract; iMessage local does not
-// implement `editMessage`, so the id is never resolved back to a real row.
-const synthSendResult = (): SendResult => ({
+// surfaces later via the watcher's `onFromMeMessage`. A synthetic id keeps
+// the platform contract intact; iMessage local does not implement
+// `editMessage`, so the id is never resolved back to a real row.
+const synthRecord = (
+  spaceId: string,
+  content: Content
+): ProviderMessageRecord => ({
   id: crypto.randomUUID(),
+  content,
+  space: { id: spaceId },
   timestamp: new Date(),
 });
 
@@ -40,14 +45,14 @@ export const send = async (
   client: IMessageSDK,
   spaceId: string,
   content: Content
-): Promise<SendResult> => {
+): Promise<ProviderMessageRecord> => {
   switch (content.type) {
     case "text":
       await client.send({ to: spaceId, text: content.text });
-      return synthSendResult();
+      return synthRecord(spaceId, content);
     case "attachment":
       await sendTempFile(client, spaceId, content.name, await content.read());
-      return synthSendResult();
+      return synthRecord(spaceId, content);
     case "contact": {
       const vcf = await toVCard(content);
       await sendTempFile(
@@ -56,7 +61,7 @@ export const send = async (
         vcardFileName(content),
         Buffer.from(vcf, "utf8")
       );
-      return synthSendResult();
+      return synthRecord(spaceId, content);
     }
     case "poll":
       throw unsupportedLocalContent("poll");

--- a/packages/spectrum-ts/src/providers/imessage/remote/api.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/api.ts
@@ -1,6 +1,6 @@
 import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
 import type { Content } from "../../../content/types";
-import type { SendResult } from "../../../platform/types";
+import type { ProviderMessageRecord } from "../../../platform/types";
 import type { ManagedStream } from "../../../utils/stream";
 import type { IMessageMessage } from "../types";
 import { firstRemoteClient, primaryRemoteClient } from "./client";
@@ -50,7 +50,7 @@ export const send = async (
   clients: AdvancedIMessage[],
   spaceId: string,
   content: Content
-): Promise<SendResult> =>
+): Promise<ProviderMessageRecord> =>
   sendRemoteMessage(primaryRemoteClient(clients), spaceId, content);
 
 /** Throws when primaryRemoteClient(clients) is unavailable. */
@@ -59,7 +59,7 @@ export const replyToMessage = async (
   spaceId: string,
   msgId: string,
   content: Content
-): Promise<SendResult> =>
+): Promise<ProviderMessageRecord> =>
   replyToRemoteMessage(primaryRemoteClient(clients), spaceId, msgId, content);
 
 /** Throws when primaryRemoteClient(clients) is unavailable. */

--- a/packages/spectrum-ts/src/providers/imessage/remote/send.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/send.ts
@@ -249,42 +249,27 @@ export const validateGroupContent = (
   }
 };
 
-interface ResolvedPart {
-  /** The displayed file name for attachments; undefined for text parts. */
-  attachmentName?: string;
-  part: MessagePart;
-}
-
 const resolvePart = async (
   remote: AdvancedIMessage,
   content: Content
-): Promise<ResolvedPart> => {
+): Promise<MessagePart> => {
   switch (content.type) {
     case "text":
-      return { part: { text: content.text } };
+      return { text: content.text };
     case "attachment": {
       const { guid, name } = await uploadAttachment(remote, content);
-      return {
-        part: { attachmentGuid: guid, attachmentName: name },
-        attachmentName: name,
-      };
+      return { attachmentGuid: guid, attachmentName: name };
     }
     case "contact": {
       const { guid, name } = await sendContactAttachment(remote, content);
-      return {
-        part: { attachmentGuid: guid, attachmentName: name },
-        attachmentName: name,
-      };
+      return { attachmentGuid: guid, attachmentName: name };
     }
     case "voice": {
       // As a sendMultipart part, voice loses the audio-bubble UI and renders
       // as a regular audio attachment. Send a single voice message (not in a
       // group) for the proper UI.
       const { guid, name } = await uploadVoice(remote, content);
-      return {
-        part: { attachmentGuid: guid, attachmentName: name },
-        attachmentName: name,
-      };
+      return { attachmentGuid: guid, attachmentName: name };
     }
     default:
       throw unsupportedRemoteContent(content.type);
@@ -311,7 +296,7 @@ export const send = async (
     );
     const receipt = await remote.messages.sendMultipart(
       chat,
-      resolved.map((r, idx) => ({ ...r.part, partIndex: idx }))
+      resolved.map((part, idx) => ({ ...part, partIndex: idx }))
     );
     const parentGuid = receiptGuid(receipt);
     const timestamp = receiptTimestamp(receipt);

--- a/packages/spectrum-ts/src/providers/imessage/remote/send.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/send.ts
@@ -2,21 +2,28 @@ import {
   type AdvancedIMessage,
   type AttachmentGuid,
   chatGuid,
+  type MessagePart,
   messageGuid,
   type SendOptions,
 } from "@photon-ai/advanced-imessage";
+import { asGroup } from "../../../content/group";
 import type { Content } from "../../../content/types";
-import type { SendResult } from "../../../platform/types";
+import type { ProviderMessageRecord } from "../../../platform/types";
+import type { Message } from "../../../types/message";
 import { ensureM4a } from "../../../utils/audio";
 import { toVCard } from "../../../utils/vcard";
 import { unsupportedRemoteContent } from "../shared/errors";
 import { vcardFileName } from "../shared/vcard";
+import type { IMessageMessage } from "../types";
+import { formatChildId } from "./ids";
 
 const GROUP_ITEM_ALLOWED: ReadonlySet<Content["type"]> = new Set([
+  "text",
   "attachment",
   "contact",
   "voice",
 ]);
+const MAX_GROUP_TEXT_ITEMS = 1;
 
 type ChatGuid = ReturnType<typeof chatGuid>;
 type ReplyGuid = ReturnType<typeof messageGuid>;
@@ -26,18 +33,6 @@ interface SendReceiptLike {
   dateCreated?: unknown;
   guid: unknown;
   timestamp?: unknown;
-}
-
-export class PartialGroupSendError extends Error {
-  override readonly cause: unknown;
-  readonly groupMembers: readonly SendResult[];
-
-  constructor(groupMembers: readonly SendResult[], cause: unknown) {
-    super("iMessage group send failed after one or more items were sent");
-    this.name = "PartialGroupSendError";
-    this.cause = cause;
-    this.groupMembers = groupMembers;
-  }
 }
 
 const toDate = (value: unknown): Date | undefined => {
@@ -56,15 +51,26 @@ const receiptTimestamp = (receipt: SendReceiptLike): Date =>
   toDate(receipt.dateCreated) ??
   new Date();
 
-const toSendResult = (receipt: SendReceiptLike): SendResult => {
+const receiptGuid = (receipt: SendReceiptLike): string => {
   if (typeof receipt.guid !== "string" || receipt.guid.length === 0) {
     throw new Error("iMessage send receipt is missing a message guid");
   }
-  return {
-    id: receipt.guid,
-    timestamp: receiptTimestamp(receipt),
-  };
+  return receipt.guid;
 };
+
+const outboundRecord = (
+  spaceId: string,
+  id: string,
+  content: Content,
+  timestamp: Date,
+  extras?: Pick<IMessageMessage, "partIndex" | "parentId">
+): ProviderMessageRecord => ({
+  id,
+  content,
+  space: { id: spaceId },
+  timestamp,
+  ...extras,
+});
 
 const withReply = (
   options: SendOptions,
@@ -89,78 +95,113 @@ const sendVCardAttachment = (
 const sendContactAttachment = async (
   remote: AdvancedIMessage,
   content: Extract<Content, { type: "contact" }>
-): Promise<AttachmentGuid> => {
+): Promise<{ guid: AttachmentGuid; name: string }> => {
   const vcf = await toVCard(content);
-  const upload = await sendVCardAttachment(remote, vcardFileName(content), vcf);
-  return upload.guid;
+  const name = vcardFileName(content);
+  const upload = await sendVCardAttachment(remote, name, vcf);
+  return { guid: upload.guid, name };
 };
 
 const uploadAttachment = async (
   remote: AdvancedIMessage,
   content: Extract<Content, { type: "attachment" }>
-): Promise<AttachmentGuid> => {
+): Promise<{ guid: AttachmentGuid; name: string }> => {
   const attachment = await remote.attachments.upload({
     data: await content.read(),
     fileName: content.name,
     mimeType: content.mimeType,
   });
-  return attachment.guid;
+  return { guid: attachment.guid, name: content.name };
 };
 
 const uploadVoice = async (
   remote: AdvancedIMessage,
   content: Extract<Content, { type: "voice" }>
-): Promise<AttachmentGuid> => {
+): Promise<{ guid: AttachmentGuid; name: string }> => {
   const { buffer } = await ensureM4a(await content.read(), content.mimeType);
+  const name = content.name ?? "voice.m4a";
   const attachment = await remote.attachments.upload({
     data: buffer,
-    fileName: content.name ?? "voice.m4a",
+    fileName: name,
     mimeType: "audio/x-m4a",
   });
-  return attachment.guid;
+  return { guid: attachment.guid, name };
 };
 
 const sendContent = async (
   remote: AdvancedIMessage,
+  spaceId: string,
   chat: ChatGuid,
   content: Content,
   replyTo?: ReplyGuid
-): Promise<SendResult> => {
+): Promise<ProviderMessageRecord> => {
   switch (content.type) {
-    case "text":
-      return toSendResult(
-        await remote.messages.send(chat, content.text, withReply({}, replyTo))
+    case "text": {
+      const receipt = await remote.messages.send(
+        chat,
+        content.text,
+        withReply({}, replyTo)
       );
-    case "richlink":
-      return toSendResult(
-        await remote.messages.send(
-          chat,
-          content.url,
-          withReply({ richLink: true }, replyTo)
-        )
+      return outboundRecord(
+        spaceId,
+        receiptGuid(receipt),
+        content,
+        receiptTimestamp(receipt)
       );
-    case "attachment":
-      return toSendResult(
-        await remote.messages.send(chat, "", {
-          attachment: await uploadAttachment(remote, content),
-          ...replyOptions(replyTo),
-        })
+    }
+    case "richlink": {
+      const receipt = await remote.messages.send(
+        chat,
+        content.url,
+        withReply({ richLink: true }, replyTo)
       );
-    case "contact":
-      return toSendResult(
-        await remote.messages.send(chat, "", {
-          attachment: await sendContactAttachment(remote, content),
-          ...replyOptions(replyTo),
-        })
+      return outboundRecord(
+        spaceId,
+        receiptGuid(receipt),
+        content,
+        receiptTimestamp(receipt)
       );
-    case "voice":
-      return toSendResult(
-        await remote.messages.send(chat, "", {
-          attachment: await uploadVoice(remote, content),
-          audioMessage: true,
-          ...replyOptions(replyTo),
-        })
+    }
+    case "attachment": {
+      const { guid } = await uploadAttachment(remote, content);
+      const receipt = await remote.messages.send(chat, "", {
+        attachment: guid,
+        ...replyOptions(replyTo),
+      });
+      return outboundRecord(
+        spaceId,
+        receiptGuid(receipt),
+        content,
+        receiptTimestamp(receipt)
       );
+    }
+    case "contact": {
+      const { guid } = await sendContactAttachment(remote, content);
+      const receipt = await remote.messages.send(chat, "", {
+        attachment: guid,
+        ...replyOptions(replyTo),
+      });
+      return outboundRecord(
+        spaceId,
+        receiptGuid(receipt),
+        content,
+        receiptTimestamp(receipt)
+      );
+    }
+    case "voice": {
+      const { guid } = await uploadVoice(remote, content);
+      const receipt = await remote.messages.send(chat, "", {
+        attachment: guid,
+        audioMessage: true,
+        ...replyOptions(replyTo),
+      });
+      return outboundRecord(
+        spaceId,
+        receiptGuid(receipt),
+        content,
+        receiptTimestamp(receipt)
+      );
+    }
     case "poll":
       if (replyTo) {
         throw unsupportedRemoteContent(
@@ -168,12 +209,17 @@ const sendContent = async (
           "polls cannot be sent as replies"
         );
       }
-      return toSendResult(
-        await remote.polls.create(
-          chat,
-          content.title,
-          content.options.map((option) => option.title)
-        )
+      return outboundRecord(
+        spaceId,
+        receiptGuid(
+          await remote.polls.create(
+            chat,
+            content.title,
+            content.options.map((option) => option.title)
+          )
+        ),
+        content,
+        new Date()
       );
     default:
       throw unsupportedRemoteContent(content.type);
@@ -183,8 +229,9 @@ const sendContent = async (
 export const validateGroupContent = (
   content: Extract<Content, { type: "group" }>
 ): void => {
-  // Strict validation: fail before any native send when a group contains items
-  // iMessage cannot carry natively.
+  // Strict validation: fail before any upload when a group contains items
+  // iMessage cannot carry inside a multi-part message.
+  let textCount = 0;
   for (const sub of content.items) {
     const itemType = sub.content.type;
     if (!GROUP_ITEM_ALLOWED.has(itemType)) {
@@ -193,46 +240,103 @@ export const validateGroupContent = (
         `"${itemType}" items are not supported inside a group`
       );
     }
+    if (itemType === "text" && ++textCount > MAX_GROUP_TEXT_ITEMS) {
+      throw unsupportedRemoteContent(
+        "group",
+        `groups can contain at most ${MAX_GROUP_TEXT_ITEMS} text item`
+      );
+    }
+  }
+};
+
+interface ResolvedPart {
+  /** The displayed file name for attachments; undefined for text parts. */
+  attachmentName?: string;
+  part: MessagePart;
+}
+
+const resolvePart = async (
+  remote: AdvancedIMessage,
+  content: Content
+): Promise<ResolvedPart> => {
+  switch (content.type) {
+    case "text":
+      return { part: { text: content.text } };
+    case "attachment": {
+      const { guid, name } = await uploadAttachment(remote, content);
+      return {
+        part: { attachmentGuid: guid, attachmentName: name },
+        attachmentName: name,
+      };
+    }
+    case "contact": {
+      const { guid, name } = await sendContactAttachment(remote, content);
+      return {
+        part: { attachmentGuid: guid, attachmentName: name },
+        attachmentName: name,
+      };
+    }
+    case "voice": {
+      // As a sendMultipart part, voice loses the audio-bubble UI and renders
+      // as a regular audio attachment. Send a single voice message (not in a
+      // group) for the proper UI.
+      const { guid, name } = await uploadVoice(remote, content);
+      return {
+        part: { attachmentGuid: guid, attachmentName: name },
+        attachmentName: name,
+      };
+    }
+    default:
+      throw unsupportedRemoteContent(content.type);
   }
 };
 
 /**
- * Sends iMessage content. Group sends are emulated with sequential native sends
- * and are non-atomic; `PartialGroupSendError.groupMembers` contains receipts
- * for children that were sent before a later child failed.
+ * Sends iMessage content. Group sends compose a single atomic multi-part
+ * message via `sendMultipart`: one parent guid covers all parts, and per-part
+ * operations (reactions, replies) key off `partIndex` against that parent.
  */
 export const send = async (
   remote: AdvancedIMessage,
   spaceId: string,
   content: Content
-): Promise<SendResult> => {
+): Promise<ProviderMessageRecord> => {
   const chat = chatGuid(spaceId);
 
   if (content.type === "group") {
     validateGroupContent(content);
 
-    // The SDK has no single multi-attachment send with uploaded bytes
-    // (MessagePart requires server-side paths; upload returns guids only),
-    // so we fall back to N sequential sends. Return per-child receipts on
-    // `groupMembers` so the platform layer can build real outbound Messages
-    // for each group item. The outer `id` tracks the first child purely for
-    // OutboundMessage compatibility: prefer items[i].id for per-item ops.
-    const groupMembers: SendResult[] = [];
-    try {
-      for (const sub of content.items) {
-        groupMembers.push(await sendContent(remote, chat, sub.content));
-      }
-    } catch (err) {
-      throw new PartialGroupSendError(groupMembers, err);
-    }
-    const first = groupMembers[0];
-    if (!first) {
-      throw new Error("Empty group");
-    }
-    return { ...first, groupMembers };
+    const resolved = await Promise.all(
+      content.items.map((sub) => resolvePart(remote, sub.content))
+    );
+    const receipt = await remote.messages.sendMultipart(
+      chat,
+      resolved.map((r, idx) => ({ ...r.part, partIndex: idx }))
+    );
+    const parentGuid = receiptGuid(receipt);
+    const timestamp = receiptTimestamp(receipt);
+
+    const items = content.items.map((sub, idx) =>
+      outboundRecord(
+        spaceId,
+        formatChildId(idx, parentGuid),
+        sub.content,
+        timestamp,
+        { partIndex: idx, parentId: parentGuid }
+      )
+    );
+    // Items are raw provider records — wrapProviderMessage("outbound") will
+    // turn each into a real OutboundMessage via wrapNestedContent. The Zod
+    // schema's `isMessage` guard is loose enough to accept the raw shape.
+    return outboundRecord(
+      spaceId,
+      parentGuid,
+      asGroup({ items: items as unknown as Message[] }),
+      timestamp
+    );
   }
 
-  return sendContent(remote, chat, content);
+  return sendContent(remote, spaceId, chat, content);
 };
 
 export const replyToMessage = async (
@@ -240,10 +344,10 @@ export const replyToMessage = async (
   spaceId: string,
   msgId: string,
   content: Content
-): Promise<SendResult> => {
+): Promise<ProviderMessageRecord> => {
   const chat = chatGuid(spaceId);
   const replyTo = messageGuid(msgId);
-  return sendContent(remote, chat, content, replyTo);
+  return sendContent(remote, spaceId, chat, content, replyTo);
 };
 
 export const editMessage = async (

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -366,6 +366,19 @@ function parseTimestamp(s: string): Date {
   return Number.isNaN(t) ? new Date() : new Date(t);
 }
 
+function buildOutboundRecord(
+  result: { id: string; timestamp: string },
+  content: SpectrumContent,
+  spaceId: string
+): ProviderMessageRecord {
+  return {
+    id: result.id,
+    content,
+    space: { id: spaceId },
+    timestamp: parseTimestamp(result.timestamp),
+  };
+}
+
 function reactionTargetFromProtocol(
   reaction: ProtocolReactionNotification
 ): ProviderMessageRecord {
@@ -622,12 +635,7 @@ export const terminal = definePlatform("terminal", {
         "send",
         { spaceId: space.id, content: proto }
       );
-      return {
-        id: result.id,
-        content,
-        space: { id: space.id },
-        timestamp: parseTimestamp(result.timestamp),
-      };
+      return buildOutboundRecord(result, content, space.id);
     },
 
     startTyping: async ({ client, space }) => {
@@ -656,12 +664,7 @@ export const terminal = definePlatform("terminal", {
         "replyToMessage",
         { spaceId: space.id, messageId, content: proto }
       );
-      return {
-        id: result.id,
-        content,
-        space: { id: space.id },
-        timestamp: parseTimestamp(result.timestamp),
-      };
+      return buildOutboundRecord(result, content, space.id);
     },
   },
 });

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -622,7 +622,12 @@ export const terminal = definePlatform("terminal", {
         "send",
         { spaceId: space.id, content: proto }
       );
-      return { id: result.id, timestamp: parseTimestamp(result.timestamp) };
+      return {
+        id: result.id,
+        content,
+        space: { id: space.id },
+        timestamp: parseTimestamp(result.timestamp),
+      };
     },
 
     startTyping: async ({ client, space }) => {
@@ -651,7 +656,12 @@ export const terminal = definePlatform("terminal", {
         "replyToMessage",
         { spaceId: space.id, messageId, content: proto }
       );
-      return { id: result.id, timestamp: parseTimestamp(result.timestamp) };
+      return {
+        id: result.id,
+        content,
+        space: { id: space.id },
+        timestamp: parseTimestamp(result.timestamp),
+      };
     },
   },
 });

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -20,7 +20,7 @@ import { asPollOption, type Poll } from "../../content/poll";
 import { asReaction } from "../../content/reaction";
 import { asText } from "../../content/text";
 import type { Content } from "../../content/types";
-import type { SendResult } from "../../platform/types";
+import type { ProviderMessageRecord } from "../../platform/types";
 import { UnsupportedError } from "../../utils/errors";
 import { type ManagedStream, mergeStreams, stream } from "../../utils/stream";
 import { pollOptionId, pollToInteractive } from "./poll";
@@ -39,8 +39,15 @@ const primary = (clients: WhatsAppClients): WhatsAppClient => {
 
 type WaSendResult = Awaited<ReturnType<WhatsAppClient["messages"]["send"]>>;
 
-const toSendResult = (result: WaSendResult): SendResult => ({
+const toRecord = (
+  result: WaSendResult,
+  spaceId: string,
+  content: Content
+): ProviderMessageRecord => ({
   id: result.messageId,
+  content,
+  space: { id: spaceId },
+  timestamp: new Date(),
 });
 
 const MAX_POLL_CACHE_SIZE = 1000;
@@ -488,12 +495,14 @@ export const send = async (
   clients: WhatsAppClients,
   spaceId: string,
   content: Content
-): Promise<SendResult> => {
+): Promise<ProviderMessageRecord> => {
   const client = primary(clients);
   switch (content.type) {
     case "text":
-      return toSendResult(
-        await client.messages.send({ to: spaceId, text: content.text })
+      return toRecord(
+        await client.messages.send({ to: spaceId, text: content.text }),
+        spaceId,
+        content
       );
     case "attachment": {
       const { mediaId } = await client.media.upload({
@@ -506,19 +515,23 @@ export const send = async (
         mediaType === "document"
           ? { id: mediaId, filename: content.name }
           : { id: mediaId };
-      return toSendResult(
+      return toRecord(
         await client.messages.send({
           to: spaceId,
           [mediaType]: mediaPayload,
-        } as Parameters<typeof client.messages.send>[0])
+        } as Parameters<typeof client.messages.send>[0]),
+        spaceId,
+        content
       );
     }
     case "contact":
-      return toSendResult(
+      return toRecord(
         await client.messages.send({
           to: spaceId,
           contacts: [contactToWa(content)],
-        })
+        }),
+        spaceId,
+        content
       );
     case "voice": {
       const { mediaId } = await client.media.upload({
@@ -526,11 +539,13 @@ export const send = async (
         mimeType: content.mimeType,
         filename: voiceFilename(content),
       });
-      return toSendResult(
+      return toRecord(
         await client.messages.send({
           to: spaceId,
           audio: { id: mediaId },
-        } as Parameters<typeof client.messages.send>[0])
+        } as Parameters<typeof client.messages.send>[0]),
+        spaceId,
+        content
       );
     }
     case "poll": {
@@ -539,7 +554,7 @@ export const send = async (
         interactive: pollToInteractive(content),
       });
       cachePoll(client, result.messageId, content);
-      return toSendResult(result);
+      return toRecord(result, spaceId, content);
     }
     default:
       throw UnsupportedError.content(content.type);
@@ -563,16 +578,18 @@ export const replyToMessage = async (
   spaceId: string,
   messageId: string,
   content: Content
-): Promise<SendResult> => {
+): Promise<ProviderMessageRecord> => {
   const client = primary(clients);
   switch (content.type) {
     case "text":
-      return toSendResult(
+      return toRecord(
         await client.messages.send({
           to: spaceId,
           replyTo: messageId,
           text: content.text,
-        })
+        }),
+        spaceId,
+        content
       );
     case "attachment": {
       const { mediaId } = await client.media.upload({
@@ -585,21 +602,25 @@ export const replyToMessage = async (
         mediaType === "document"
           ? { id: mediaId, filename: content.name }
           : { id: mediaId };
-      return toSendResult(
+      return toRecord(
         await client.messages.send({
           to: spaceId,
           replyTo: messageId,
           [mediaType]: mediaPayload,
-        } as Parameters<typeof client.messages.send>[0])
+        } as Parameters<typeof client.messages.send>[0]),
+        spaceId,
+        content
       );
     }
     case "contact":
-      return toSendResult(
+      return toRecord(
         await client.messages.send({
           to: spaceId,
           replyTo: messageId,
           contacts: [contactToWa(content)],
-        })
+        }),
+        spaceId,
+        content
       );
     case "voice": {
       const { mediaId } = await client.media.upload({
@@ -607,12 +628,14 @@ export const replyToMessage = async (
         mimeType: content.mimeType,
         filename: voiceFilename(content),
       });
-      return toSendResult(
+      return toRecord(
         await client.messages.send({
           to: spaceId,
           replyTo: messageId,
           audio: { id: mediaId },
-        } as Parameters<typeof client.messages.send>[0])
+        } as Parameters<typeof client.messages.send>[0]),
+        spaceId,
+        content
       );
     }
     case "poll": {
@@ -622,7 +645,7 @@ export const replyToMessage = async (
         interactive: pollToInteractive(content),
       });
       cachePoll(client, result.messageId, content);
-      return toSendResult(result);
+      return toRecord(result, spaceId, content);
     }
     default:
       throw UnsupportedError.content(content.type);

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -186,13 +186,17 @@ export async function Spectrum<
           client,
           config,
         });
-        const normalizedMessage = wrapProviderMessage(msg, {
-          client,
-          config,
-          definition,
-          space,
-          spaceRef,
-        });
+        const normalizedMessage = wrapProviderMessage(
+          msg,
+          {
+            client,
+            config,
+            definition,
+            space,
+            spaceRef,
+          },
+          "inbound"
+        );
         if (flattenGroups && normalizedMessage.content.type === "group") {
           for (const item of normalizedMessage.content.items) {
             // Group items in the inbound flow are wrapped via wrapProviderMessage,


### PR DESCRIPTION
## Summary

- Collapses the separate `SendResult` shape into a single `ProviderMessageRecord` type used for both inbound (`events.messages`, `getMessage`) and outbound (`send`, `replyToMessage`) flows. Outbound sends now return a full record (with `content` and `space`), so `wrapProviderMessage` builds outbound `Message`s through the same pipeline as inbound ones.
- Switches the iMessage remote group send from N sequential native sends (non-atomic, with a `PartialGroupSendError` recovery path) to a single atomic `sendMultipart` call. One parent guid covers all parts; per-part operations key off `partIndex`/`parentId`.
- Allows a single `text` part inside an iMessage group (in addition to attachment/contact/voice).
- Bumps `@photon-ai/advanced-imessage` to `^0.6.0` and `spectrum-ts` to `1.1.1`.

## Why

The old `SendResult` carried only enough fields to reconstruct an outbound `Message` at the call site, which meant `buildSpace.dispatchSend` and `buildMessage.runReply` each open-coded their own `buildMessage(...)` call (including a special branch that re-stitched group-member receipts back onto the placeholder items). Returning a full provider record from `send`/`replyToMessage` lets `wrapProviderMessage` handle outbound construction the same way it already handles inbound — including nested group items and reaction targets via `wrapNestedContent`.

The group send change is enabled by `advanced-imessage@0.6.0`'s `sendMultipart`. Atomic sends remove the partial-failure window and let the parent guid + `partIndex` model per-item ops cleanly, so the workaround that surfaced `groupMembers` on `SendResult` is no longer needed.

## Changes

### `platform/types.ts`, `platform/build.ts`
- Remove `SendResult` and `groupMembers`. Export `ProviderMessageRecord` (id, content, space, optional sender, optional timestamp, plus pass-through extras).
- `wrapProviderMessage` is now overloaded on `direction: "inbound" | "outbound"`. Inbound enforces a non-null `sender`; outbound allows it to be missing (since the SDK doesn't always surface the bot's own handle). `wrapNestedContent` threads the same direction into recursed group items / reaction targets.
- `dispatchSend` and `runReply` no longer build outbound Messages by hand — they call `wrapProviderMessage(raw, ctx, "outbound")`. The placeholder-replacement path for group members is gone (providers now return full records for each item directly).

### `providers/imessage/remote/send.ts`
- Group sends use `remote.messages.sendMultipart` with `{ partIndex }` parts. One `receipt.guid` is the parent; each child item gets `formatChildId(idx, parent)` plus `partIndex` / `parentId` extras so reactions/replies hit the right part.
- `validateGroupContent` now permits `text` (capped at `MAX_GROUP_TEXT_ITEMS = 1`) and rejects unsupported types early. `sendContent` and per-content helpers (`uploadAttachment`, `uploadVoice`, `sendContactAttachment`) return both the `guid` and the display `name` so multipart parts can carry `attachmentName`.
- `PartialGroupSendError` is removed.

### `providers/imessage/local/send.ts`, `providers/imessage/{local,remote}/api.ts`
- Local `send` returns a synthetic `ProviderMessageRecord` (id + content + space + timestamp) instead of a synthetic `SendResult`. Behavior is unchanged — chat.db row id still surfaces later via the watcher.
- API surface types updated to `ProviderMessageRecord`.

### `providers/whatsapp-business/messages.ts`, `providers/terminal/index.ts`
- `toSendResult` → `toRecord` (WhatsApp) and inline construction (terminal) now produce full `ProviderMessageRecord`s including `content` and `space`.

### `spectrum.ts`
- Pass `"inbound"` to `wrapProviderMessage` at the events-stream call site.

### Versions
- `@photon-ai/advanced-imessage` `^0.5.1` → `^0.6.0` (provides `sendMultipart` + `MessagePart`).
- `spectrum-ts` `1.0.1` → `1.1.1`.

## Test plan

- [ ] iMessage remote: single text, attachment, contact, voice, richlink, poll sends still return real ids + timestamps.
- [ ] iMessage remote group: multi-part send arrives as one bubble; per-item `react`/`reply` work and key off `partIndex`/`parentId`.
- [ ] Group with one text part is allowed; group with two text parts throws `unsupportedRemoteContent`.
- [ ] iMessage local: text/attachment/contact sends still succeed and return synthetic ids.
- [ ] WhatsApp: text/attachment/contact/voice/poll sends + replies still resolve to outbound `Message`s with correct ids.
- [ ] Terminal: send + replyToMessage round-trip through the gRPC client.
- [ ] Inbound flow: `events.messages` and `getMessage` still produce inbound Messages (sender enforcement path).
- [ ] Inbound group flow with `flattenGroups` still emits per-item messages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated messaging dependency to the latest version.

* **Refactor**
  * Send/reply actions now return unified provider message records (id, content, space, timestamp).
  * Message wrapping is direction-aware for inbound vs outbound flows.
  * Group sends are atomic with stricter validation and richer multipart metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->