### PR TITLE
feat(imessage): first-class `effect` content type for iMessage message effects

### DIFF
--- a/packages/spectrum-ts/src/content/effect.ts
+++ b/packages/spectrum-ts/src/content/effect.ts
@@ -1,0 +1,17 @@
+import z from "zod";
+import { attachmentSchema } from "./attachment";
+import { textSchema } from "./text";
+
+const effectInnerSchema = z.discriminatedUnion("type", [
+  textSchema,
+  attachmentSchema,
+]);
+
+export const messageEffectSchema = z.object({
+  type: z.literal("effect"),
+  content: effectInnerSchema,
+  effect: z.string().nonempty(),
+});
+
+export type MessageEffect = z.infer<typeof messageEffectSchema>;
+export type MessageEffectInner = z.infer<typeof effectInnerSchema>;

--- a/packages/spectrum-ts/src/content/types.ts
+++ b/packages/spectrum-ts/src/content/types.ts
@@ -2,6 +2,7 @@ import z from "zod";
 import { attachmentSchema } from "./attachment";
 import { contactSchema } from "./contact";
 import { customSchema } from "./custom";
+import { messageEffectSchema } from "./effect";
 import { groupSchema } from "./group";
 import { pollOptionSchema, pollSchema } from "./poll";
 import { reactionSchema } from "./reaction";
@@ -20,6 +21,7 @@ export const contentSchema = z.discriminatedUnion("type", [
   groupSchema,
   pollSchema,
   pollOptionSchema,
+  messageEffectSchema,
 ]);
 
 export type Content = z.infer<typeof contentSchema>;

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -45,6 +45,54 @@ const warnUnsupported = (err: UnsupportedError, fallbackPlatform: string) => {
   );
 };
 
+const contentPlatform = (content: Content): string | undefined => {
+  const platform = (content as { __platform?: unknown }).__platform;
+  return typeof platform === "string" ? platform : undefined;
+};
+
+const findUnsupportedPlatformContent = (
+  content: Content,
+  platform: string
+): string | undefined => {
+  const scopedPlatform = contentPlatform(content);
+  if (scopedPlatform && scopedPlatform !== platform) {
+    return scopedPlatform;
+  }
+
+  if (content.type !== "group") {
+    return;
+  }
+
+  for (const item of content.items) {
+    const nested = (item as { content?: unknown }).content;
+    if (typeof nested !== "object" || nested === null || !("type" in nested)) {
+      continue;
+    }
+    const unsupported = findUnsupportedPlatformContent(
+      nested as Content,
+      platform
+    );
+    if (unsupported) {
+      return unsupported;
+    }
+  }
+};
+
+const unsupportedPlatformContentError = (
+  content: Content,
+  platform: string
+): UnsupportedError | undefined => {
+  const requiredPlatform = findUnsupportedPlatformContent(content, platform);
+  if (!requiredPlatform) {
+    return;
+  }
+  return UnsupportedError.content(
+    content.type,
+    platform,
+    `requires ${requiredPlatform}`
+  );
+};
+
 export type SpaceRef = {
   id: string;
   __platform: string;
@@ -246,6 +294,13 @@ export function buildSpace(params: BuildSpaceParams): Space {
   ): Promise<OutboundMessage | undefined> {
     let raw: ProviderMessageRecord | undefined;
     try {
+      const platformError = unsupportedPlatformContentError(
+        item,
+        definition.name
+      );
+      if (platformError) {
+        throw platformError;
+      }
       raw = (await definition.actions.send({
         ...typingCtx,
         content: item,
@@ -407,6 +462,13 @@ export function buildMessage(params: BuildMessageParams): Message {
   ): Promise<OutboundMessage | undefined> => {
     let raw: ProviderMessageRecord | undefined;
     try {
+      const platformError = unsupportedPlatformContentError(
+        item,
+        definition.name
+      );
+      if (platformError) {
+        throw platformError;
+      }
       raw = (await replyToMessage({
         space: spaceRef,
         messageId: params.id,
@@ -490,6 +552,14 @@ export function buildMessage(params: BuildMessageParams): Message {
         }
         const [resolved] = await resolveContents([newContent]);
         if (!resolved) {
+          return;
+        }
+        const platformError = unsupportedPlatformContentError(
+          resolved,
+          definition.name
+        );
+        if (platformError) {
+          warnUnsupported(platformError, definition.name);
           return;
         }
         try {

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -323,6 +323,19 @@ export function definePlatform<
     } satisfies PlatformProviderConfig<Def> as PlatformProviderConfig<Def>;
   };
 
+  narrower.is = ((input: unknown) => {
+    if (typeof input !== "object" || input === null) {
+      return false;
+    }
+    if ("__platform" in input) {
+      return (input as { __platform?: unknown }).__platform === name;
+    }
+    if ("platform" in input) {
+      return (input as { platform?: unknown }).platform === name;
+    }
+    return false;
+  }) as Platform<Def>["is"];
+
   if (def.static) {
     Object.assign(narrower, def.static);
   }

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -481,6 +481,9 @@ export interface Platform<Def extends AnyPlatformDef> {
       ? [config?: z.input<Def["config"]>]
       : [config: z.input<Def["config"]>]
   ): PlatformProviderConfig<Def>;
+  is(input: Message): input is PlatformMessage<Def>;
+  is(input: Space): input is PlatformSpace<Def>;
+  is(input: unknown): input is PlatformMessage<Def> | PlatformSpace<Def>;
   <Providers extends PlatformProviderConfig[]>(
     spectrum: SpectrumLike<Providers>
   ): HasProvider<Providers, Def["name"]> extends true

--- a/packages/spectrum-ts/src/providers/imessage/content/effect.ts
+++ b/packages/spectrum-ts/src/providers/imessage/content/effect.ts
@@ -2,102 +2,20 @@ import {
   type MessageEffect as AdvancedIMessageMessageEffect,
   MessageEffect,
 } from "@photon-ai/advanced-imessage";
+import { messageEffectSchema } from "../../../content/effect";
 import { text } from "../../../content/text";
 import type {
   Content,
   ContentBuilder,
   ContentInput,
 } from "../../../content/types";
-import { IMESSAGE_PLATFORM } from "../shared/errors";
-
-const MESSAGE_EFFECT_VALUES = new Set<string>(Object.values(MessageEffect));
 
 export type IMessageMessageEffect = AdvancedIMessageMessageEffect;
 
-type EffectContent = Extract<Content, { type: "attachment" | "text" }>;
-
-type IMessageMessageEffectContent = EffectContent & {
-  readonly __platform: typeof IMESSAGE_PLATFORM;
-  readonly effect: IMessageMessageEffect;
-};
-
-const isEffectContent = (content: Content): content is EffectContent =>
-  content.type === "text" || content.type === "attachment";
-
-const rawEffect = (content: Content): string | undefined => {
-  if (!isEffectContent(content)) {
-    return;
-  }
-  const platform = (content as { __platform?: unknown }).__platform;
-  const effect = (content as { effect?: unknown }).effect;
-  if (platform !== IMESSAGE_PLATFORM || typeof effect !== "string") {
-    return;
-  }
-  return effect;
-};
-
-const isIMessageMessageEffectContent = (
-  content: Content
-): content is IMessageMessageEffectContent => {
-  const effect = rawEffect(content);
-  return effect !== undefined && MESSAGE_EFFECT_VALUES.has(effect);
-};
-
-const assertMessageEffect = (
-  messageEffect: IMessageMessageEffect
-): IMessageMessageEffect => {
-  if (!MESSAGE_EFFECT_VALUES.has(messageEffect)) {
-    throw new Error(`Unsupported iMessage message effect "${messageEffect}"`);
-  }
-  return messageEffect;
-};
+const SUPPORTED_EFFECTS = new Set<string>(Object.values(MessageEffect));
 
 const resolveContent = (input: ContentInput): Promise<Content> =>
   typeof input === "string" ? text(input).build() : input.build();
-
-export const getIMessageMessageEffect = (
-  content: Content
-): IMessageMessageEffect | undefined => {
-  if (!isIMessageMessageEffectContent(content)) {
-    return;
-  }
-  return content.effect;
-};
-
-export const hasIMessageMessageEffect = (content: Content): boolean => {
-  if (rawEffect(content) !== undefined) {
-    return true;
-  }
-
-  if (content.type !== "group") {
-    return false;
-  }
-
-  for (const item of content.items) {
-    const nested = (item as { content?: unknown }).content;
-    if (typeof nested !== "object" || nested === null || !("type" in nested)) {
-      continue;
-    }
-    if (hasIMessageMessageEffect(nested as Content)) {
-      return true;
-    }
-  }
-  return false;
-};
-
-export const stripIMessageMessageEffect = <T extends Content>(
-  content: T
-): T => {
-  if (rawEffect(content) === undefined) {
-    return content;
-  }
-  const {
-    __platform: _platform,
-    effect: _effect,
-    ...rest
-  } = content as IMessageMessageEffectContent;
-  return rest as T;
-};
 
 export function effect(
   input: ContentInput,
@@ -105,22 +23,22 @@ export function effect(
 ): ContentBuilder {
   return {
     build: async () => {
-      const content = await resolveContent(input);
-      if (!isEffectContent(content)) {
+      if (!SUPPORTED_EFFECTS.has(messageEffect)) {
         throw new Error(
-          `imessage effect() only supports text and attachment content, got "${content.type}"`
+          `Unsupported iMessage message effect "${messageEffect}"`
         );
       }
-      if (getIMessageMessageEffect(content)) {
+      const inner = await resolveContent(input);
+      if (inner.type !== "text" && inner.type !== "attachment") {
         throw new Error(
-          "imessage effect() cannot wrap content that already has an effect"
+          `imessage effect() only supports text and attachment content, got "${inner.type}"`
         );
       }
-      return {
-        ...content,
-        __platform: IMESSAGE_PLATFORM,
-        effect: assertMessageEffect(messageEffect),
-      };
+      return messageEffectSchema.parse({
+        type: "effect",
+        content: inner,
+        effect: messageEffect,
+      });
     },
   };
 }

--- a/packages/spectrum-ts/src/providers/imessage/content/effect.ts
+++ b/packages/spectrum-ts/src/providers/imessage/content/effect.ts
@@ -1,0 +1,126 @@
+import {
+  type MessageEffect as AdvancedIMessageMessageEffect,
+  MessageEffect,
+} from "@photon-ai/advanced-imessage";
+import { text } from "../../../content/text";
+import type {
+  Content,
+  ContentBuilder,
+  ContentInput,
+} from "../../../content/types";
+import { IMESSAGE_PLATFORM } from "../shared/errors";
+
+const MESSAGE_EFFECT_VALUES = new Set<string>(Object.values(MessageEffect));
+
+export type IMessageMessageEffect = AdvancedIMessageMessageEffect;
+
+type EffectContent = Extract<Content, { type: "attachment" | "text" }>;
+
+type IMessageMessageEffectContent = EffectContent & {
+  readonly __platform: typeof IMESSAGE_PLATFORM;
+  readonly effect: IMessageMessageEffect;
+};
+
+const isEffectContent = (content: Content): content is EffectContent =>
+  content.type === "text" || content.type === "attachment";
+
+const rawEffect = (content: Content): string | undefined => {
+  if (!isEffectContent(content)) {
+    return;
+  }
+  const platform = (content as { __platform?: unknown }).__platform;
+  const effect = (content as { effect?: unknown }).effect;
+  if (platform !== IMESSAGE_PLATFORM || typeof effect !== "string") {
+    return;
+  }
+  return effect;
+};
+
+const isIMessageMessageEffectContent = (
+  content: Content
+): content is IMessageMessageEffectContent => {
+  const effect = rawEffect(content);
+  return effect !== undefined && MESSAGE_EFFECT_VALUES.has(effect);
+};
+
+const assertMessageEffect = (
+  messageEffect: IMessageMessageEffect
+): IMessageMessageEffect => {
+  if (!MESSAGE_EFFECT_VALUES.has(messageEffect)) {
+    throw new Error(`Unsupported iMessage message effect "${messageEffect}"`);
+  }
+  return messageEffect;
+};
+
+const resolveContent = (input: ContentInput): Promise<Content> =>
+  typeof input === "string" ? text(input).build() : input.build();
+
+export const getIMessageMessageEffect = (
+  content: Content
+): IMessageMessageEffect | undefined => {
+  if (!isIMessageMessageEffectContent(content)) {
+    return;
+  }
+  return content.effect;
+};
+
+export const hasIMessageMessageEffect = (content: Content): boolean => {
+  if (rawEffect(content) !== undefined) {
+    return true;
+  }
+
+  if (content.type !== "group") {
+    return false;
+  }
+
+  for (const item of content.items) {
+    const nested = (item as { content?: unknown }).content;
+    if (typeof nested !== "object" || nested === null || !("type" in nested)) {
+      continue;
+    }
+    if (hasIMessageMessageEffect(nested as Content)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+export const stripIMessageMessageEffect = <T extends Content>(
+  content: T
+): T => {
+  if (rawEffect(content) === undefined) {
+    return content;
+  }
+  const {
+    __platform: _platform,
+    effect: _effect,
+    ...rest
+  } = content as IMessageMessageEffectContent;
+  return rest as T;
+};
+
+export function effect(
+  input: ContentInput,
+  messageEffect: IMessageMessageEffect
+): ContentBuilder {
+  return {
+    build: async () => {
+      const content = await resolveContent(input);
+      if (!isEffectContent(content)) {
+        throw new Error(
+          `imessage effect() only supports text and attachment content, got "${content.type}"`
+        );
+      }
+      if (getIMessageMessageEffect(content)) {
+        throw new Error(
+          "imessage effect() cannot wrap content that already has an effect"
+        );
+      }
+      return {
+        ...content,
+        __platform: IMESSAGE_PLATFORM,
+        effect: assertMessageEffect(messageEffect),
+      };
+    },
+  };
+}

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -1,7 +1,15 @@
-import { createClient, directChat } from "@photon-ai/advanced-imessage";
+import {
+  createClient,
+  directChat,
+  MessageEffect,
+} from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
 import { definePlatform } from "../../platform/define";
 import { UnsupportedError } from "../../utils/errors";
+
+// biome-ignore lint/performance/noBarrelFile: provider entrypoint exports its public helper
+export { effect, type IMessageMessageEffect } from "./content/effect";
+
 import { createCloudClients, disposeCloudAuth } from "./auth";
 import {
   getMessage as localGetMessage,
@@ -32,6 +40,12 @@ const isPollContent = (content: { type: string }): boolean =>
 
 export const imessage = definePlatform("iMessage", {
   config: configSchema,
+
+  static: {
+    effect: {
+      message: MessageEffect,
+    },
+  },
 
   user: {
     resolve: async ({ input }) => ({ id: input.userID }),

--- a/packages/spectrum-ts/src/providers/imessage/local/send.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local/send.ts
@@ -5,6 +5,7 @@ import type { IMessageSDK } from "@photon-ai/imessage-kit";
 import type { Content } from "../../../content/types";
 import type { ProviderMessageRecord } from "../../../platform/types";
 import { toVCard } from "../../../utils/vcard";
+import { hasIMessageMessageEffect } from "../content/effect";
 import { unsupportedLocalContent } from "../shared/errors";
 import { vcardFileName } from "../shared/vcard";
 import type { IMessageMessage } from "../types";
@@ -46,6 +47,13 @@ export const send = async (
   spaceId: string,
   content: Content
 ): Promise<ProviderMessageRecord> => {
+  if (hasIMessageMessageEffect(content)) {
+    throw unsupportedLocalContent(
+      content.type,
+      "message effects require remote iMessage"
+    );
+  }
+
   switch (content.type) {
     case "text":
       await client.send({ to: spaceId, text: content.text });

--- a/packages/spectrum-ts/src/providers/imessage/local/send.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local/send.ts
@@ -5,7 +5,6 @@ import type { IMessageSDK } from "@photon-ai/imessage-kit";
 import type { Content } from "../../../content/types";
 import type { ProviderMessageRecord } from "../../../platform/types";
 import { toVCard } from "../../../utils/vcard";
-import { hasIMessageMessageEffect } from "../content/effect";
 import { unsupportedLocalContent } from "../shared/errors";
 import { vcardFileName } from "../shared/vcard";
 import type { IMessageMessage } from "../types";
@@ -47,13 +46,6 @@ export const send = async (
   spaceId: string,
   content: Content
 ): Promise<ProviderMessageRecord> => {
-  if (hasIMessageMessageEffect(content)) {
-    throw unsupportedLocalContent(
-      content.type,
-      "message effects require remote iMessage"
-    );
-  }
-
   switch (content.type) {
     case "text":
       await client.send({ to: spaceId, text: content.text });
@@ -71,6 +63,11 @@ export const send = async (
       );
       return synthRecord(spaceId, content);
     }
+    case "effect":
+      throw unsupportedLocalContent(
+        "effect",
+        "message effects require remote iMessage"
+      );
     case "poll":
       throw unsupportedLocalContent("poll");
     default:

--- a/packages/spectrum-ts/src/providers/imessage/remote/send.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/send.ts
@@ -2,6 +2,7 @@ import {
   type AdvancedIMessage,
   type AttachmentGuid,
   chatGuid,
+  type MessageEffect,
   type MessagePart,
   messageGuid,
   type SendOptions,
@@ -12,11 +13,6 @@ import type { ProviderMessageRecord } from "../../../platform/types";
 import type { Message } from "../../../types/message";
 import { ensureM4a } from "../../../utils/audio";
 import { toVCard } from "../../../utils/vcard";
-import {
-  getIMessageMessageEffect,
-  hasIMessageMessageEffect,
-  stripIMessageMessageEffect,
-} from "../content/effect";
 import { unsupportedRemoteContent } from "../shared/errors";
 import { vcardFileName } from "../shared/vcard";
 import type { IMessageMessage } from "../types";
@@ -86,16 +82,9 @@ const replyOptions = (
   replyTo: ReplyGuid | undefined
 ): SendOptions | undefined => (replyTo ? { replyTo } : undefined);
 
-const effectOptions = (content: Content): Pick<SendOptions, "effect"> => {
-  const effect = getIMessageMessageEffect(content);
-  return effect ? { effect } : {};
-};
-
-const rejectMessageEffect = (content: Content, detail: string): void => {
-  if (hasIMessageMessageEffect(content)) {
-    throw unsupportedRemoteContent(content.type, detail);
-  }
-};
+const effectOption = (
+  effect: MessageEffect | undefined
+): Pick<SendOptions, "effect"> => (effect ? { effect } : {});
 
 const sendVCardAttachment = (
   remote: AdvancedIMessage,
@@ -149,28 +138,33 @@ const sendContent = async (
   spaceId: string,
   chat: ChatGuid,
   content: Content,
-  replyTo?: ReplyGuid
+  replyTo?: ReplyGuid,
+  effect?: MessageEffect
 ): Promise<ProviderMessageRecord> => {
   switch (content.type) {
+    case "effect":
+      return sendContent(
+        remote,
+        spaceId,
+        chat,
+        content.content,
+        replyTo,
+        content.effect as MessageEffect
+      );
     case "text": {
-      const sentContent = stripIMessageMessageEffect(content);
       const receipt = await remote.messages.send(
         chat,
-        sentContent.text,
-        withReply(effectOptions(content), replyTo)
+        content.text,
+        withReply(effectOption(effect), replyTo)
       );
       return outboundRecord(
         spaceId,
         receiptGuid(receipt),
-        sentContent,
+        content,
         receiptTimestamp(receipt)
       );
     }
     case "richlink": {
-      rejectMessageEffect(
-        content,
-        "message effects are only supported for text and attachment content"
-      );
       const receipt = await remote.messages.send(
         chat,
         content.url,
@@ -184,25 +178,20 @@ const sendContent = async (
       );
     }
     case "attachment": {
-      const sentContent = stripIMessageMessageEffect(content);
-      const { guid } = await uploadAttachment(remote, sentContent);
+      const { guid } = await uploadAttachment(remote, content);
       const receipt = await remote.messages.send(chat, "", {
         attachment: guid,
-        ...effectOptions(content),
+        ...effectOption(effect),
         ...replyOptions(replyTo),
       });
       return outboundRecord(
         spaceId,
         receiptGuid(receipt),
-        sentContent,
+        content,
         receiptTimestamp(receipt)
       );
     }
     case "contact": {
-      rejectMessageEffect(
-        content,
-        "message effects are only supported for text and attachment content"
-      );
       const { guid } = await sendContactAttachment(remote, content);
       const receipt = await remote.messages.send(chat, "", {
         attachment: guid,
@@ -216,10 +205,6 @@ const sendContent = async (
       );
     }
     case "voice": {
-      rejectMessageEffect(
-        content,
-        "message effects are only supported for text and attachment content"
-      );
       const { guid } = await uploadVoice(remote, content);
       const receipt = await remote.messages.send(chat, "", {
         attachment: guid,
@@ -234,10 +219,6 @@ const sendContent = async (
       );
     }
     case "poll":
-      rejectMessageEffect(
-        content,
-        "message effects are only supported for text and attachment content"
-      );
       if (replyTo) {
         throw unsupportedRemoteContent(
           "poll",
@@ -264,15 +245,10 @@ const sendContent = async (
 export const validateGroupContent = (
   content: Extract<Content, { type: "group" }>
 ): void => {
-  if (hasIMessageMessageEffect(content)) {
-    throw unsupportedRemoteContent(
-      "group",
-      "message effects are not supported inside groups"
-    );
-  }
-
   // Strict validation: fail before any upload when a group contains items
-  // iMessage cannot carry inside a multi-part message.
+  // iMessage cannot carry inside a multi-part message. `effect` is rejected
+  // here too — it isn't in `GROUP_ITEM_ALLOWED` because iMessage does not
+  // apply message effects to multi-part sends.
   let textCount = 0;
   for (const sub of content.items) {
     const itemType = sub.content.type;
@@ -383,11 +359,6 @@ export const editMessage = async (
   msgId: string,
   content: Content
 ): Promise<void> => {
-  rejectMessageEffect(
-    content,
-    "message effects are only supported when sending messages"
-  );
-
   if (content.type !== "text") {
     throw unsupportedRemoteContent(
       content.type,

--- a/packages/spectrum-ts/src/providers/imessage/remote/send.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/send.ts
@@ -12,6 +12,11 @@ import type { ProviderMessageRecord } from "../../../platform/types";
 import type { Message } from "../../../types/message";
 import { ensureM4a } from "../../../utils/audio";
 import { toVCard } from "../../../utils/vcard";
+import {
+  getIMessageMessageEffect,
+  hasIMessageMessageEffect,
+  stripIMessageMessageEffect,
+} from "../content/effect";
 import { unsupportedRemoteContent } from "../shared/errors";
 import { vcardFileName } from "../shared/vcard";
 import type { IMessageMessage } from "../types";
@@ -81,6 +86,17 @@ const replyOptions = (
   replyTo: ReplyGuid | undefined
 ): SendOptions | undefined => (replyTo ? { replyTo } : undefined);
 
+const effectOptions = (content: Content): Pick<SendOptions, "effect"> => {
+  const effect = getIMessageMessageEffect(content);
+  return effect ? { effect } : {};
+};
+
+const rejectMessageEffect = (content: Content, detail: string): void => {
+  if (hasIMessageMessageEffect(content)) {
+    throw unsupportedRemoteContent(content.type, detail);
+  }
+};
+
 const sendVCardAttachment = (
   remote: AdvancedIMessage,
   name: string,
@@ -137,19 +153,24 @@ const sendContent = async (
 ): Promise<ProviderMessageRecord> => {
   switch (content.type) {
     case "text": {
+      const sentContent = stripIMessageMessageEffect(content);
       const receipt = await remote.messages.send(
         chat,
-        content.text,
-        withReply({}, replyTo)
+        sentContent.text,
+        withReply(effectOptions(content), replyTo)
       );
       return outboundRecord(
         spaceId,
         receiptGuid(receipt),
-        content,
+        sentContent,
         receiptTimestamp(receipt)
       );
     }
     case "richlink": {
+      rejectMessageEffect(
+        content,
+        "message effects are only supported for text and attachment content"
+      );
       const receipt = await remote.messages.send(
         chat,
         content.url,
@@ -163,19 +184,25 @@ const sendContent = async (
       );
     }
     case "attachment": {
-      const { guid } = await uploadAttachment(remote, content);
+      const sentContent = stripIMessageMessageEffect(content);
+      const { guid } = await uploadAttachment(remote, sentContent);
       const receipt = await remote.messages.send(chat, "", {
         attachment: guid,
+        ...effectOptions(content),
         ...replyOptions(replyTo),
       });
       return outboundRecord(
         spaceId,
         receiptGuid(receipt),
-        content,
+        sentContent,
         receiptTimestamp(receipt)
       );
     }
     case "contact": {
+      rejectMessageEffect(
+        content,
+        "message effects are only supported for text and attachment content"
+      );
       const { guid } = await sendContactAttachment(remote, content);
       const receipt = await remote.messages.send(chat, "", {
         attachment: guid,
@@ -189,6 +216,10 @@ const sendContent = async (
       );
     }
     case "voice": {
+      rejectMessageEffect(
+        content,
+        "message effects are only supported for text and attachment content"
+      );
       const { guid } = await uploadVoice(remote, content);
       const receipt = await remote.messages.send(chat, "", {
         attachment: guid,
@@ -203,6 +234,10 @@ const sendContent = async (
       );
     }
     case "poll":
+      rejectMessageEffect(
+        content,
+        "message effects are only supported for text and attachment content"
+      );
       if (replyTo) {
         throw unsupportedRemoteContent(
           "poll",
@@ -229,6 +264,13 @@ const sendContent = async (
 export const validateGroupContent = (
   content: Extract<Content, { type: "group" }>
 ): void => {
+  if (hasIMessageMessageEffect(content)) {
+    throw unsupportedRemoteContent(
+      "group",
+      "message effects are not supported inside groups"
+    );
+  }
+
   // Strict validation: fail before any upload when a group contains items
   // iMessage cannot carry inside a multi-part message.
   let textCount = 0;
@@ -341,6 +383,11 @@ export const editMessage = async (
   msgId: string,
   content: Content
 ): Promise<void> => {
+  rejectMessageEffect(
+    content,
+    "message effects are only supported when sending messages"
+  );
+
   if (content.type !== "text") {
     throw unsupportedRemoteContent(
       content.type,

--- a/packages/spectrum-ts/src/providers/imessage/shared/errors.ts
+++ b/packages/spectrum-ts/src/providers/imessage/shared/errors.ts
@@ -9,5 +9,8 @@ export const unsupportedRemoteContent = (
 ): UnsupportedError =>
   UnsupportedError.content(type, IMESSAGE_PLATFORM, detail);
 
-export const unsupportedLocalContent = (type: string): UnsupportedError =>
-  UnsupportedError.content(type, LOCAL_IMESSAGE_PLATFORM);
+export const unsupportedLocalContent = (
+  type: string,
+  detail?: string
+): UnsupportedError =>
+  UnsupportedError.content(type, LOCAL_IMESSAGE_PLATFORM, detail);


### PR DESCRIPTION
## Summary

- Adds a first-class `effect` content type — `{ type: "effect", content, effect }` where `content` is a `text` or `attachment` and `effect` is a non-empty string. Registered in `contentSchema` so it flows through the same validation, send, and wrap pipelines as every other content type.
- Teaches the iMessage remote provider to honor message effects: `effect` content is unwrapped, the inner part is sent via the existing text/attachment paths, and the effect name is passed as the `effect` `SendOption` on the underlying `client.messages.send` call. Works for both standalone sends and replies.
- Exposes an `effect(input, messageEffect)` builder and the `MessageEffect` enum from the iMessage provider entrypoint, so agents write `space.send(imessage.effect(text("Boom"), imessage.effect.message.SLAM))` without importing from `@photon-ai/advanced-imessage` directly.
- Local-mode iMessage explicitly rejects `effect` with `unsupportedLocalContent("effect", "message effects require remote iMessage")`. Multipart group sends still reject `effect` (it isn't in `GROUP_ITEM_ALLOWED`) — iMessage doesn't apply effects to multi-part bubbles.
- Adds a generic `Platform.is(input)` type guard and a `unsupportedPlatformContentError` walker on the build path. The walker recurses into group items and short-circuits a send when nested content is platform-tagged for a provider other than the current one — defensive infrastructure so future platform-scoped content types can't be silently dispatched to the wrong provider.

## Usage

```typescript
import { Spectrum, text } from "spectrum-ts";
import { imessage, effect } from "spectrum-ts/providers/imessage";

const app = await Spectrum({ providers: [imessage.config()] });

for await (const [space, message] of app.imessage.messages) {
  await space.responding(async () => {
    // Slam a text reply
    await message.reply(
      effect(text("Got it!"), imessage.effect.message.SLAM)
    );

    // Effects also work on attachments
    await space.send(
      effect(attachment(buf, "party.png", "image/png"), imessage.effect.message.CONFETTI)
    );
  });
}
```

The second argument is `IMessageMessageEffect` (re-exported from `@photon-ai/advanced-imessage`). Available effects come from `imessage.effect.message` (the `MessageEffect` enum: `SLAM`, `LOUD`, `GENTLE`, `INVISIBLE_INK`, `CONFETTI`, `FIREWORKS`, etc.).

## Changes

| File | Change |
|---|---|
| `packages/spectrum-ts/src/content/effect.ts` | New — `messageEffectSchema` (`{ type: "effect", content: text \| attachment, effect: non-empty string }`) plus `MessageEffect` / `MessageEffectInner` types. |
| `packages/spectrum-ts/src/content/types.ts` | Register `messageEffectSchema` in the `contentSchema` discriminated union. |
| `packages/spectrum-ts/src/providers/imessage/content/effect.ts` | New — `effect(input, messageEffect)` builder. Accepts a `string \| ContentBuilder` for `input`, resolves it, validates the inner type is `text` or `attachment`, validates `messageEffect` is in `MessageEffect`, returns parsed `effect` content. Re-exports `IMessageMessageEffect` type. |
| `packages/spectrum-ts/src/providers/imessage/index.ts` | Re-export `effect` and `IMessageMessageEffect`. Add `static.effect.message = MessageEffect` so the enum is reachable as `imessage.effect.message`. |
| `packages/spectrum-ts/src/providers/imessage/remote/send.ts` | Add `effect` case to `sendContent` switch — unwraps and recurses with the effect threaded through. Text and attachment branches accept an optional `effect` and merge it into `SendOptions` via a new `effectOption` helper. Group validator comment updated to note `effect` is rejected in multi-part sends because iMessage doesn't apply effects there. |
| `packages/spectrum-ts/src/providers/imessage/local/send.ts` | Add `effect` case → throws `unsupportedLocalContent("effect", "message effects require remote iMessage")`. |
| `packages/spectrum-ts/src/providers/imessage/shared/errors.ts` | `unsupportedLocalContent` now accepts an optional `detail` string (parity with `unsupportedRemoteContent`). |
| `packages/spectrum-ts/src/platform/build.ts` | New `unsupportedPlatformContentError` helper: walks `Content` (recursing into group items) for any subtree whose `__platform` doesn't match the sending provider, and synthesizes an `UnsupportedError`. Wired into `dispatchSend`, `runReply`, and `editMessage` — sends throw, edits warn-and-skip. |
| `packages/spectrum-ts/src/platform/define.ts` | Add `narrower.is(input)` runtime check matching the `__platform` (or fallback `platform`) field. |
| `packages/spectrum-ts/src/platform/types.ts` | Declare `Platform.is` overloads for `Message`, `Space`, and `unknown`. |

## Test plan

- [ ] `bun x ultracite check` passes
- [ ] `bun x tsc --noEmit` clean across the workspace
- [ ] iMessage remote: `space.send(effect(text("hi"), imessage.effect.message.SLAM))` arrives with the slam animation; receipt id and timestamp are populated
- [ ] iMessage remote: `effect(attachment(...), imessage.effect.message.CONFETTI)` uploads the attachment, sends with the effect, and round-trips through `wrapProviderMessage`
- [ ] iMessage remote: `message.reply(effect(text("ack"), imessage.effect.message.GENTLE))` carries `replyTo` *and* the effect on the underlying `SendOptions`
- [ ] iMessage remote: an unknown effect string (e.g. `effect(text("x"), "BOGUS" as any)`) throws `Unsupported iMessage message effect "BOGUS"` at build time, before any network call
- [ ] iMessage remote: `effect(poll(...), ...)` throws `imessage effect() only supports text and attachment content, got "poll"`
- [ ] iMessage remote: a `group(...)` containing an `effect` item is rejected by `validateGroupContent` before any upload
- [ ] iMessage local: `space.send(effect(text("hi"), ...))` throws `UnsupportedError` with detail `"message effects require remote iMessage"` (caught and warned by the runtime per the existing unsupported-content path)
- [ ] `imessage.is(message)` returns `true` for an iMessage message and `false` for a WhatsApp message; same for spaces
- [ ] Cross-platform safety: a content payload tagged with `__platform: "iMessage"` sent through a non-iMessage provider throws `UnsupportedError` from `unsupportedPlatformContentError` before reaching `definition.actions.send`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/photon-hq/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added message effects functionality for iMessage communications, allowing effects to be included in messages.
  * Implemented platform validation to ensure effects are only used in supported environments and configurations.
  * Enhanced error handling with improved messaging when effects are unavailable or unsupported in specific modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->