### PR TITLE
feat(imessage): typing event + unified `subscribeEvent` routing

### DIFF
--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -4,7 +4,6 @@ import type { Space } from "../types/space";
 import { buildSpace } from "./build";
 import type {
   AnyPlatformDef,
-  InboundPlatformMessage,
   Platform,
   PlatformDef,
   PlatformInstance,
@@ -140,39 +139,30 @@ function createPlatformInstance<
     },
   };
 
-  // Add flat event properties for custom events (non-messages)
-  const eventProperties: Record<string, AsyncIterable<unknown>> = {};
+  // Lazily resolve every event (including `messages`) through the runtime's
+  // single `subscribeEvent` entry point. Cached per-name so a second
+  // `for await (...of im.<event>)` reuses the broadcaster's existing
+  // subscription instead of opening a new upstream stream.
+  const eventCache = new Map<string, AsyncIterable<[Space, unknown]>>();
   for (const eventName of Object.keys(def.events)) {
-    if (eventName === "messages") {
-      continue;
-    }
-    const producer = def.events[eventName] as
-      | ((ctx: { client: unknown; config: unknown }) => AsyncIterable<unknown>)
-      | undefined;
-    if (producer) {
-      eventProperties[eventName] = producer({
-        client: runtime.client,
-        config: runtime.config,
-      });
-    }
+    Object.defineProperty(base, eventName, {
+      enumerable: true,
+      get() {
+        let cached = eventCache.get(eventName);
+        if (!cached) {
+          const subscription = runtime.subscribeEvent(eventName);
+          if (!subscription) {
+            return;
+          }
+          cached = subscription;
+          eventCache.set(eventName, cached);
+        }
+        return cached;
+      },
+    });
   }
 
-  // Lazily subscribe to the platform's message broadcast on first read.
-  // Cached so `for await (const x of im.messages)` twice doesn't double-subscribe.
-  let messagesIterable:
-    | AsyncIterable<[PlatformSpace<Def>, InboundPlatformMessage<Def>]>
-    | undefined;
-  Object.defineProperty(base, "messages", {
-    enumerable: true,
-    get() {
-      messagesIterable ??= runtime.subscribeMessages() as AsyncIterable<
-        [PlatformSpace<Def>, InboundPlatformMessage<Def>]
-      >;
-      return messagesIterable;
-    },
-  });
-
-  return Object.assign(base, eventProperties) as PlatformInstance<Def>;
+  return base as PlatformInstance<Def>;
 }
 
 export function definePlatform<

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -317,29 +317,6 @@ interface ExtractDefByName<Name extends string> extends Fn {
 }
 
 // ---------------------------------------------------------------------------
-// HotScript Fn's for custom event operations
-// ---------------------------------------------------------------------------
-
-interface ExtractCustomEventNames extends Fn {
-  return: this["arg0"] extends AnyPlatformDef
-    ? Exclude<keyof this["arg0"]["events"], "messages" | symbol | number>
-    : never;
-}
-
-interface ToCustomEventVariant<EventName extends string> extends Fn {
-  return: this["arg0"] extends PlatformProviderConfig<infer Def>
-    ? EventName extends keyof Def["events"]
-      ? [
-          Space,
-          EventPayload<InferEventPayload<Def["events"][EventName]>> & {
-            platform: Def["name"];
-          },
-        ]
-      : never
-    : never;
-}
-
-// ---------------------------------------------------------------------------
 // HasProvider — check if a platform name exists in providers tuple
 // ---------------------------------------------------------------------------
 
@@ -359,44 +336,6 @@ export type ExtractProviderDef<
   Providers,
   [Tuples.Map<ExtractDef>, Tuples.Find<ExtractDefByName<Name>>]
 >;
-
-// ---------------------------------------------------------------------------
-// AllCustomEventNames — union of all non-messages event names across providers
-// ---------------------------------------------------------------------------
-
-type AllCustomEventNames<Providers extends PlatformProviderConfig[]> = Exclude<
-  Pipe<
-    Providers,
-    [
-      Tuples.Map<ExtractDef>,
-      Tuples.Map<ExtractCustomEventNames>,
-      Tuples.ToUnion,
-    ]
-  >,
-  ReservedNames
->;
-
-// ---------------------------------------------------------------------------
-// UnifiedCustomEvent — for a given event name, union of payloads across providers
-// ---------------------------------------------------------------------------
-
-type UnifiedCustomEvent<
-  Providers extends PlatformProviderConfig[],
-  EventName extends string,
-> = Pipe<
-  Providers,
-  [Tuples.Map<ToCustomEventVariant<EventName>>, Tuples.ToUnion]
->;
-
-// ---------------------------------------------------------------------------
-// CustomEventStreams — mapped type producing async iterables for each custom event
-// ---------------------------------------------------------------------------
-
-export type CustomEventStreams<Providers extends PlatformProviderConfig[]> = {
-  [K in AllCustomEventNames<Providers> & string]: AsyncIterable<
-    UnifiedCustomEvent<Providers, K>
-  >;
-};
 
 // ---------------------------------------------------------------------------
 // Platform-specific Space, Message, and User types

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -27,11 +27,29 @@ type InputSchema<TSchema> =
 // Event system types
 // ---------------------------------------------------------------------------
 
+/**
+ * Every provider event yields records that carry a `space: { id }` field.
+ * Spectrum extracts `space`, builds a full `Space`, and yields `[Space, rest]`
+ * tuples downstream — so consumers see `for await (const [space, payload] of
+ * platform(app).<event>)`. `messages` is the canonical example.
+ */
+export interface ProviderEventRecord {
+  space: { id: string };
+}
+
 export type EventProducer<
-  TPayload = unknown,
+  TPayload extends ProviderEventRecord = ProviderEventRecord,
   TClient = unknown,
   TConfig = unknown,
 > = (ctx: { client: TClient; config: TConfig }) => AsyncIterable<TPayload>;
+
+/**
+ * The shape consumers see as the second tuple element — the producer's record
+ * with `space` stripped (it lives in the first tuple element instead).
+ */
+export type EventPayload<P> = P extends { space: unknown }
+  ? Omit<P, "space">
+  : P;
 
 export type ProviderMessage<
   TSender extends ResolvedUser = ResolvedUser,
@@ -116,6 +134,11 @@ export interface PlatformDef<
   >,
   _Events extends {
     messages: EventProducer<_MessageType, _Client, z.infer<_ConfigSchema>>;
+    [key: string]: EventProducer<
+      ProviderEventRecord,
+      _Client,
+      z.infer<_ConfigSchema>
+    >;
   } = {
     messages: EventProducer<_MessageType, _Client, z.infer<_ConfigSchema>>;
   },
@@ -306,7 +329,12 @@ interface ExtractCustomEventNames extends Fn {
 interface ToCustomEventVariant<EventName extends string> extends Fn {
   return: this["arg0"] extends PlatformProviderConfig<infer Def>
     ? EventName extends keyof Def["events"]
-      ? InferEventPayload<Def["events"][EventName]> & { platform: Def["name"] }
+      ? [
+          Space,
+          EventPayload<InferEventPayload<Def["events"][EventName]>> & {
+            platform: Def["name"];
+          },
+        ]
       : never
     : never;
 }
@@ -336,9 +364,16 @@ export type ExtractProviderDef<
 // AllCustomEventNames — union of all non-messages event names across providers
 // ---------------------------------------------------------------------------
 
-type AllCustomEventNames<Providers extends PlatformProviderConfig[]> = Pipe<
-  Providers,
-  [Tuples.Map<ExtractDef>, Tuples.Map<ExtractCustomEventNames>, Tuples.ToUnion]
+type AllCustomEventNames<Providers extends PlatformProviderConfig[]> = Exclude<
+  Pipe<
+    Providers,
+    [
+      Tuples.Map<ExtractDef>,
+      Tuples.Map<ExtractCustomEventNames>,
+      Tuples.ToUnion,
+    ]
+  >,
+  ReservedNames
 >;
 
 // ---------------------------------------------------------------------------
@@ -358,8 +393,9 @@ type UnifiedCustomEvent<
 // ---------------------------------------------------------------------------
 
 export type CustomEventStreams<Providers extends PlatformProviderConfig[]> = {
-  [K in Exclude<AllCustomEventNames<Providers>, ReservedNames> &
-    string]: AsyncIterable<UnifiedCustomEvent<Providers, K>>;
+  [K in AllCustomEventNames<Providers> & string]: AsyncIterable<
+    UnifiedCustomEvent<Providers, K>
+  >;
 };
 
 // ---------------------------------------------------------------------------
@@ -447,7 +483,7 @@ export type PlatformInstance<Def extends AnyPlatformDef> = {
     keyof Def["events"],
     "messages" | symbol | number
   > as K extends ReservedNames ? never : K]: AsyncIterable<
-    InferEventPayload<Def["events"][K]>
+    [PlatformSpace<Def>, EventPayload<InferEventPayload<Def["events"][K]>>]
   >;
 };
 
@@ -459,7 +495,17 @@ export interface PlatformRuntime {
   client: unknown;
   config: unknown;
   definition: AnyPlatformDef;
-  subscribeMessages: () => ManagedStream<[Space, InboundMessage]>;
+  /**
+   * Returns a fresh fanout consumer of the platform's `[Space, payload]` event
+   * stream for `eventName`, or `undefined` if the platform doesn't define
+   * that event. Both `messages` and any custom event flow through this single
+   * entry point — Spectrum lazily creates one broadcaster per
+   * `(platform, event)` pair so multiple consumers share a single upstream
+   * subscription.
+   */
+  subscribeEvent: (
+    eventName: string
+  ) => ManagedStream<[Space, unknown]> | undefined;
 }
 
 export interface SpectrumLike<

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -26,6 +26,7 @@ import {
   startTyping as remoteStartTyping,
   stopTyping as remoteStopTyping,
 } from "./remote/api";
+import { subscribeTyping as remoteTyping } from "./remote/typing-events";
 import {
   configSchema,
   type IMessageClient,
@@ -132,6 +133,8 @@ export const imessage = definePlatform("iMessage", {
   events: {
     messages: ({ client }) =>
       isLocal(client) ? localMessages(client) : remoteMessages(client),
+    typing: ({ client }: { client: IMessageClient }) =>
+      isLocal(client) ? (async function* () {})() : remoteTyping(client),
   },
 
   actions: {

--- a/packages/spectrum-ts/src/providers/imessage/remote/typing-events.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/typing-events.ts
@@ -1,0 +1,123 @@
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import {
+  RECONNECT_INITIAL_DELAY_MS,
+  RECONNECT_MAX_DELAY_MS,
+} from "../../../utils/resumable-stream";
+import {
+  type ManagedStream,
+  mergeStreams,
+  stream,
+} from "../../../utils/stream";
+
+/**
+ * Inbound `typing` event record. Matches the generic `[Space, payload]`
+ * protocol — `space.id` carries the chat guid; the rest is the indicator
+ * status. `displayName` is the typing participant's name (undefined when
+ * the SDK can't resolve it). The bot's own typing is not filtered: the
+ * SDK doesn't surface an `isFromMe` flag here, so consumers who need to
+ * distinguish should check `displayName`.
+ *
+ * Two cloud clients in the same chat will each emit their own copy of a
+ * single typing event — same caveat as the poll stream.
+ */
+export interface IMessageTypingRecord {
+  displayName?: string;
+  isTyping: boolean;
+  space: { id: string };
+  timestamp: Date;
+}
+
+const typingRetryJitter = (delayMs: number): number => Math.random() * delayMs;
+
+const logTypingStreamError = (error: unknown) => {
+  // Typing events have no cursor — failures are logged and the stream
+  // reconnects with backoff. Don't propagate: a transient typing-stream
+  // error must not kill peer message/poll streams.
+  console.error("[spectrum-ts][imessage][typing] stream failed", error);
+};
+
+const runTypingSubscription = async (
+  subscription: ReturnType<AdvancedIMessage["chats"]["subscribe"]>,
+  emit: (record: IMessageTypingRecord) => Promise<void>,
+  onEvent: () => void
+): Promise<void> => {
+  for await (const event of subscription) {
+    if (event.type !== "chat.typingIndicator") {
+      continue;
+    }
+    onEvent();
+    await emit({
+      space: { id: event.chatGuid as string },
+      isTyping: event.isTyping,
+      displayName: event.displayName,
+      timestamp: event.timestamp,
+    });
+  }
+};
+
+const clientTypingStream = (
+  client: AdvancedIMessage
+): ManagedStream<IMessageTypingRecord> =>
+  stream<IMessageTypingRecord>((emit, end) => {
+    let active = client.chats.subscribe();
+    let closed = false;
+    let retryDelayMs = RECONNECT_INITIAL_DELAY_MS;
+    let sleepTimer: ReturnType<typeof setTimeout> | undefined;
+    let wakeSleep: (() => void) | undefined;
+
+    const sleep = async (delayMs: number): Promise<void> => {
+      if (closed) {
+        return;
+      }
+      await new Promise<void>((resolve) => {
+        wakeSleep = resolve;
+        sleepTimer = setTimeout(resolve, typingRetryJitter(delayMs));
+      });
+      sleepTimer = undefined;
+      wakeSleep = undefined;
+    };
+
+    const cancelSleep = () => {
+      if (sleepTimer) {
+        clearTimeout(sleepTimer);
+        sleepTimer = undefined;
+      }
+      wakeSleep?.();
+      wakeSleep = undefined;
+    };
+
+    const pump = (async () => {
+      while (!closed) {
+        try {
+          await runTypingSubscription(active, emit, () => {
+            retryDelayMs = RECONNECT_INITIAL_DELAY_MS;
+          });
+        } catch (e) {
+          if (!closed) {
+            logTypingStreamError(e);
+          }
+        } finally {
+          await active.close();
+        }
+
+        if (!closed) {
+          await sleep(retryDelayMs);
+          retryDelayMs = Math.min(retryDelayMs * 2, RECONNECT_MAX_DELAY_MS);
+          active = client.chats.subscribe();
+        }
+      }
+      end();
+    })();
+
+    return async () => {
+      closed = true;
+      cancelSleep();
+      await active.close();
+      await pump;
+    };
+  });
+
+export const subscribeTyping = (
+  clients: AdvancedIMessage[]
+): ManagedStream<IMessageTypingRecord> =>
+  mergeStreams(clients.map(clientTypingStream));

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -7,7 +7,6 @@ import {
 } from "./platform/build";
 import type {
   AnyPlatformDef,
-  CustomEventStreams,
   PlatformProviderConfig,
   PlatformRuntime,
   ProviderEventRecord,
@@ -29,21 +28,20 @@ import {
 
 export type SpectrumInstance<
   Providers extends PlatformProviderConfig[] = PlatformProviderConfig[],
-> = SpectrumLike<Providers> &
-  CustomEventStreams<Providers> & {
-    readonly messages: AsyncIterable<[Space, InboundMessage]>;
-    stop(): Promise<void>;
-    send(
-      space: Space,
-      content: ContentInput
-    ): Promise<OutboundMessage | undefined>;
-    send(
-      space: Space,
-      ...content: [ContentInput, ContentInput, ...ContentInput[]]
-    ): Promise<OutboundMessage[]>;
-    edit(message: OutboundMessage, newContent: ContentInput): Promise<void>;
-    responding<T>(space: Space, fn: () => T | Promise<T>): Promise<T>;
-  };
+> = SpectrumLike<Providers> & {
+  readonly messages: AsyncIterable<[Space, InboundMessage]>;
+  stop(): Promise<void>;
+  send(
+    space: Space,
+    content: ContentInput
+  ): Promise<OutboundMessage | undefined>;
+  send(
+    space: Space,
+    ...content: [ContentInput, ContentInput, ...ContentInput[]]
+  ): Promise<OutboundMessage[]>;
+  edit(message: OutboundMessage, newContent: ContentInput): Promise<void>;
+  responding<T>(space: Space, fn: () => T | Promise<T>): Promise<T>;
+};
 
 // ---------------------------------------------------------------------------
 // Runtime options
@@ -136,11 +134,6 @@ export async function Spectrum<
   // consumes the stream.
   const eventBroadcasters = new Map<string, Broadcaster<[Space, unknown]>>();
 
-  // Spectrum-level merged streams (one per event name) that fan in across
-  // every platform. Cached so multiple `for await (...of app.typing)`
-  // consumers share one merge.
-  const mergedEventStreams = new Map<string, ManagedStream<unknown>>();
-
   let stopped = false;
 
   const adaptIterable = <T>(iterable: AsyncIterable<T>): ManagedStream<T> => {
@@ -174,8 +167,9 @@ export async function Spectrum<
    * groups when `flattenGroups` is set; every other event yields the raw
    * record minus its `space` field.
    *
-   * Returns `undefined` when the platform doesn't define `eventName`, so the
-   * spectrum-level merge can simply skip it.
+   * Returns `undefined` when the platform doesn't define `eventName`, so
+   * downstream consumers (the messages merge and platform-level event
+   * accessors) can simply skip it.
    */
   const createProviderEventStream = (
     state: {
@@ -293,79 +287,38 @@ export async function Spectrum<
   }
 
   /**
-   * Merge every platform's `subscribeEvent(eventName)` into one stream.
-   * For the canonical `messages` event no per-tuple annotation is added —
-   * `InboundMessage` already carries `.platform`. For any other event the
-   * payload (second tuple element) is annotated with `{ platform: name }`
-   * so spectrum-level consumers can branch.
+   * Merge every platform's `messages` stream into one. No per-tuple
+   * annotation is added — `InboundMessage` already carries `.platform`.
+   * Non-`messages` events are only consumable through the platform-specific
+   * accessor (e.g. `imessage(app).typing`); they never fan in here.
    */
-  const createMergedEventStream = (
-    eventName: string
-  ): ManagedStream<unknown> => {
-    return stream<unknown>((emit, end) => {
-      const isMessages = eventName === MESSAGES_EVENT;
-
-      const wrap = (
-        runtime: PlatformRuntime
-      ): ManagedStream<[Space, unknown]> | undefined => {
-        const source = runtime.subscribeEvent(eventName);
-        if (!source) {
-          return undefined;
-        }
-        if (isMessages) {
-          return source;
-        }
-        const platformName = runtime.definition.name;
-        const annotate = async function* (): AsyncIterable<[Space, unknown]> {
-          for await (const [space, payload] of source) {
-            yield [
-              space,
-              {
-                ...(payload as Record<string, unknown>),
-                platform: platformName,
-              },
-            ];
-          }
-        };
-        return adaptIterable(annotate());
-      };
-
-      const perPlatform = Array.from(platformStates.values(), wrap).filter(
-        (value): value is ManagedStream<[Space, unknown]> => value !== undefined
-      );
-
-      const merged = mergeStreams(perPlatform);
-
-      const pump = (async () => {
-        try {
-          for await (const value of merged) {
-            await emit(value);
-          }
-          end();
-        } catch (error) {
-          end(error);
-        }
-      })();
-
-      return async () => {
-        await merged.close();
-        await pump;
-      };
-    });
-  };
-
-  const getMergedEventStream = (eventName: string): ManagedStream<unknown> => {
-    let merged = mergedEventStreams.get(eventName);
-    if (!merged) {
-      merged = createMergedEventStream(eventName);
-      mergedEventStreams.set(eventName, merged);
-    }
-    return merged;
-  };
-
-  const messagesStream = getMergedEventStream(MESSAGES_EVENT) as ManagedStream<
+  const messagesStream: ManagedStream<[Space, InboundMessage]> = stream<
     [Space, InboundMessage]
-  >;
+  >((emit, end) => {
+    const perPlatform = Array.from(platformStates.values(), (runtime) =>
+      runtime.subscribeEvent(MESSAGES_EVENT)
+    ).filter(
+      (value): value is ManagedStream<[Space, unknown]> => value !== undefined
+    ) as ManagedStream<[Space, InboundMessage]>[];
+
+    const merged = mergeStreams(perPlatform);
+
+    const pump = (async () => {
+      try {
+        for await (const value of merged) {
+          await emit(value);
+        }
+        end();
+      } catch (error) {
+        end(error);
+      }
+    })();
+
+    return async () => {
+      await merged.close();
+      await pump;
+    };
+  });
 
   const stopOnce = async () => {
     if (stopped) {
@@ -374,9 +327,7 @@ export async function Spectrum<
     stopped = true;
 
     const streamShutdowns = [
-      ...Array.from(mergedEventStreams.values(), (eventStream) =>
-        eventStream.close()
-      ),
+      messagesStream.close(),
       ...Array.from(eventBroadcasters.values(), (broadcaster) =>
         broadcaster.close()
       ),
@@ -392,7 +343,6 @@ export async function Spectrum<
       })
     );
     await Promise.allSettled(clientShutdowns);
-    mergedEventStreams.clear();
     eventBroadcasters.clear();
     platformStates.clear();
   };
@@ -408,23 +358,7 @@ export async function Spectrum<
 
   const messages: AsyncIterable<[Space, InboundMessage]> = messagesStream;
 
-  // Lazy proxy for flat custom event access (`app.typing`, etc.). Each event
-  // name resolves to a cached merged stream that fans in across platforms.
-  const customEventProxy = new Proxy(
-    {} as Record<string, AsyncIterable<unknown>>,
-    {
-      get(_target, prop) {
-        // Avoid spawning streams for thenable / introspection probes that the
-        // SpectrumInstance Proxy may forward here.
-        if (typeof prop !== "string" || prop === "then") {
-          return;
-        }
-        return getMergedEventStream(prop);
-      },
-    }
-  );
-
-  const base = {
+  return {
     __providers: providers,
     __internal: { platforms: platformStates },
     messages,
@@ -448,18 +382,5 @@ export async function Spectrum<
     ): Promise<T> => {
       return space.responding(fn);
     },
-  };
-
-  // Merge base instance with custom event proxy
-  return new Proxy(base, {
-    get(target, prop, receiver) {
-      if (prop in target) {
-        return Reflect.get(target, prop, receiver);
-      }
-      if (typeof prop === "string") {
-        return customEventProxy[prop];
-      }
-      return;
-    },
-  }) as SpectrumInstance<Providers>;
+  } as SpectrumInstance<Providers>;
 }

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -10,6 +10,7 @@ import type {
   CustomEventStreams,
   PlatformProviderConfig,
   PlatformRuntime,
+  ProviderEventRecord,
   SpectrumLike,
 } from "./platform/types";
 import type { InboundMessage, OutboundMessage } from "./types/message";
@@ -90,6 +91,13 @@ const spectrumConfigSchema = z.union([
   }),
 ]);
 
+const MESSAGES_EVENT = "messages";
+
+const stripSpace = (record: ProviderEventRecord): Record<string, unknown> => {
+  const { space: _space, ...rest } = record;
+  return rest;
+};
+
 // ---------------------------------------------------------------------------
 // Spectrum() factory
 // ---------------------------------------------------------------------------
@@ -123,14 +131,15 @@ export async function Spectrum<
 
   const platformStates = new Map<string, PlatformRuntime>();
 
-  // Per-platform message broadcasters (lazy: created on first subscribe).
-  const messageBroadcasters = new Map<
-    string,
-    Broadcaster<[Space, InboundMessage]>
-  >();
+  // One broadcaster per (platform, eventName). Lazy: created on first
+  // subscribe so the upstream SDK subscription only runs when something
+  // consumes the stream.
+  const eventBroadcasters = new Map<string, Broadcaster<[Space, unknown]>>();
 
-  // Custom event streams keyed by event name
-  const customEventStreams = new Map<string, ManagedStream<unknown>>();
+  // Spectrum-level merged streams (one per event name) that fan in across
+  // every platform. Cached so multiple `for await (...of app.typing)`
+  // consumers share one merge.
+  const mergedEventStreams = new Map<string, ManagedStream<unknown>>();
 
   let stopped = false;
 
@@ -158,23 +167,42 @@ export async function Spectrum<
     });
   };
 
-  const createProviderMessagesStream = (state: {
-    client: unknown;
-    config: unknown;
-    definition: AnyPlatformDef;
-  }): ManagedStream<[Space, InboundMessage]> => {
+  /**
+   * Wrap a single provider's `events[eventName]` stream into a
+   * `[Space, payload]` tuple stream. The `messages` event additionally runs
+   * `wrapProviderMessage` to attach `.reply()` / `.react()` and to flatten
+   * groups when `flattenGroups` is set; every other event yields the raw
+   * record minus its `space` field.
+   *
+   * Returns `undefined` when the platform doesn't define `eventName`, so the
+   * spectrum-level merge can simply skip it.
+   */
+  const createProviderEventStream = (
+    state: {
+      client: unknown;
+      config: unknown;
+      definition: AnyPlatformDef;
+    },
+    eventName: string
+  ): ManagedStream<[Space, unknown]> | undefined => {
     const { client, config, definition } = state;
-    const raw = definition.events.messages({
-      client,
-      config,
-    }) as AsyncIterable<ProviderMessageRecord>;
+    const producer = definition.events[eventName] as
+      | ((ctx: {
+          client: unknown;
+          config: unknown;
+        }) => AsyncIterable<ProviderEventRecord>)
+      | undefined;
+    if (!producer) {
+      return;
+    }
 
-    const bindSend = async function* (): AsyncIterable<
-      [Space, InboundMessage]
-    > {
-      for await (const msg of raw) {
+    const raw = producer({ client, config });
+    const isMessages = eventName === MESSAGES_EVENT;
+
+    const project = async function* (): AsyncIterable<[Space, unknown]> {
+      for await (const record of raw) {
         const spaceRef = {
-          ...msg.space,
+          ...record.space,
           __platform: definition.name,
         };
         const typingCtx = { space: spaceRef, client, config };
@@ -186,55 +214,60 @@ export async function Spectrum<
           client,
           config,
         });
-        const normalizedMessage = wrapProviderMessage(
-          msg,
-          {
-            client,
-            config,
-            definition,
-            space,
-            spaceRef,
-          },
-          "inbound"
-        );
-        if (flattenGroups && normalizedMessage.content.type === "group") {
-          for (const item of normalizedMessage.content.items) {
-            // Group items in the inbound flow are wrapped via wrapProviderMessage,
-            // which always produces InboundMessages — Group.items is just the
-            // wider Message type at the schema level.
-            yield [space, item as InboundMessage];
+
+        if (isMessages) {
+          const wrapped = wrapProviderMessage(
+            record as ProviderMessageRecord,
+            { client, config, definition, space, spaceRef },
+            "inbound"
+          );
+          if (flattenGroups && wrapped.content.type === "group") {
+            for (const item of wrapped.content.items) {
+              yield [space, item as InboundMessage];
+            }
+            continue;
           }
+          yield [space, wrapped];
           continue;
         }
-        yield [space, normalizedMessage];
+
+        yield [space, stripSpace(record)];
       }
     };
 
-    return adaptIterable(bindSend());
+    return adaptIterable(project());
   };
 
-  const getOrCreateMessageBroadcast = (state: {
-    client: unknown;
-    config: unknown;
-    definition: AnyPlatformDef;
-  }): Broadcaster<[Space, InboundMessage]> => {
+  const getOrCreateEventBroadcast = (
+    state: {
+      client: unknown;
+      config: unknown;
+      definition: AnyPlatformDef;
+    },
+    eventName: string
+  ): Broadcaster<[Space, unknown]> | undefined => {
     if (stopped) {
       throw new Error(
-        `Spectrum instance has been stopped; cannot subscribe to "${state.definition.name}" messages`
+        `Spectrum instance has been stopped; cannot subscribe to "${state.definition.name}" event "${eventName}"`
       );
     }
-    const name = state.definition.name;
-    let broadcaster = messageBroadcasters.get(name);
-    if (!broadcaster) {
-      broadcaster = broadcast(createProviderMessagesStream(state));
-      messageBroadcasters.set(name, broadcaster);
+    const key = `${state.definition.name}:${eventName}`;
+    let broadcaster = eventBroadcasters.get(key);
+    if (broadcaster) {
+      return broadcaster;
     }
+    const source = createProviderEventStream(state, eventName);
+    if (!source) {
+      return;
+    }
+    broadcaster = broadcast(source);
+    eventBroadcasters.set(key, broadcaster);
     return broadcaster;
   };
 
   // Initialize all provider clients eagerly. Each runtime exposes
-  // `subscribeMessages()` that returns a fresh fanout consumer of the
-  // platform's single upstream message stream.
+  // `subscribeEvent(name)` so per-platform and spectrum-level consumers
+  // share one broadcaster per (platform, event).
   for (const provider of providers) {
     const providerConfig = provider as PlatformProviderConfig;
     const def = providerConfig.__definition;
@@ -254,65 +287,54 @@ export async function Spectrum<
 
     platformStates.set(def.name, {
       ...state,
-      subscribeMessages: () => getOrCreateMessageBroadcast(state).subscribe(),
+      subscribeEvent: (eventName) =>
+        getOrCreateEventBroadcast(state, eventName)?.subscribe(),
     });
   }
 
-  const createMessagesStream = (): ManagedStream<[Space, InboundMessage]> => {
-    return stream<[Space, InboundMessage]>((emit, end) => {
-      const merged = mergeStreams(
-        Array.from(platformStates.values(), (runtime) =>
-          runtime.subscribeMessages()
-        )
-      );
-
-      const pump = (async () => {
-        try {
-          for await (const value of merged) {
-            await emit(value);
-          }
-          end();
-        } catch (error) {
-          end(error);
-        }
-      })();
-
-      return async () => {
-        await merged.close();
-        await pump;
-      };
-    });
-  };
-
-  const createCustomEventStream = (
+  /**
+   * Merge every platform's `subscribeEvent(eventName)` into one stream.
+   * For the canonical `messages` event no per-tuple annotation is added —
+   * `InboundMessage` already carries `.platform`. For any other event the
+   * payload (second tuple element) is annotated with `{ platform: name }`
+   * so spectrum-level consumers can branch.
+   */
+  const createMergedEventStream = (
     eventName: string
   ): ManagedStream<unknown> => {
     return stream<unknown>((emit, end) => {
-      const providerStreams = Array.from(platformStates.values(), (state) => {
-        const { client, config, definition } = state;
-        const producer = definition.events[eventName] as
-          | ((ctx: {
-              client: unknown;
-              config: unknown;
-            }) => AsyncIterable<unknown>)
-          | undefined;
-        if (!producer) {
+      const isMessages = eventName === MESSAGES_EVENT;
+
+      const wrap = (
+        runtime: PlatformRuntime
+      ): ManagedStream<[Space, unknown]> | undefined => {
+        const source = runtime.subscribeEvent(eventName);
+        if (!source) {
           return undefined;
         }
-
-        const providerEvents = producer({ client, config });
-        const annotatePlatform = async function* (): AsyncIterable<unknown> {
-          for await (const value of providerEvents) {
-            yield { ...(value as object), platform: definition.name };
+        if (isMessages) {
+          return source;
+        }
+        const platformName = runtime.definition.name;
+        const annotate = async function* (): AsyncIterable<[Space, unknown]> {
+          for await (const [space, payload] of source) {
+            yield [
+              space,
+              {
+                ...(payload as Record<string, unknown>),
+                platform: platformName,
+              },
+            ];
           }
         };
+        return adaptIterable(annotate());
+      };
 
-        return adaptIterable(annotatePlatform());
-      }).filter(
-        (value): value is ManagedStream<unknown> => value !== undefined
+      const perPlatform = Array.from(platformStates.values(), wrap).filter(
+        (value): value is ManagedStream<[Space, unknown]> => value !== undefined
       );
 
-      const merged = mergeStreams(providerStreams);
+      const merged = mergeStreams(perPlatform);
 
       const pump = (async () => {
         try {
@@ -332,7 +354,18 @@ export async function Spectrum<
     });
   };
 
-  const messagesStream = createMessagesStream();
+  const getMergedEventStream = (eventName: string): ManagedStream<unknown> => {
+    let merged = mergedEventStreams.get(eventName);
+    if (!merged) {
+      merged = createMergedEventStream(eventName);
+      mergedEventStreams.set(eventName, merged);
+    }
+    return merged;
+  };
+
+  const messagesStream = getMergedEventStream(MESSAGES_EVENT) as ManagedStream<
+    [Space, InboundMessage]
+  >;
 
   const stopOnce = async () => {
     if (stopped) {
@@ -341,11 +374,10 @@ export async function Spectrum<
     stopped = true;
 
     const streamShutdowns = [
-      messagesStream.close(),
-      ...Array.from(customEventStreams.values(), (eventStream) =>
+      ...Array.from(mergedEventStreams.values(), (eventStream) =>
         eventStream.close()
       ),
-      ...Array.from(messageBroadcasters.values(), (broadcaster) =>
+      ...Array.from(eventBroadcasters.values(), (broadcaster) =>
         broadcaster.close()
       ),
     ];
@@ -360,8 +392,8 @@ export async function Spectrum<
       })
     );
     await Promise.allSettled(clientShutdowns);
-    customEventStreams.clear();
-    messageBroadcasters.clear();
+    mergedEventStreams.clear();
+    eventBroadcasters.clear();
     platformStates.clear();
   };
 
@@ -376,17 +408,18 @@ export async function Spectrum<
 
   const messages: AsyncIterable<[Space, InboundMessage]> = messagesStream;
 
-  // Proxy for flat custom event access (app.typing, app.readReceipt, etc.)
+  // Lazy proxy for flat custom event access (`app.typing`, etc.). Each event
+  // name resolves to a cached merged stream that fans in across platforms.
   const customEventProxy = new Proxy(
     {} as Record<string, AsyncIterable<unknown>>,
     {
-      get(_target, prop: string) {
-        let eventStream = customEventStreams.get(prop);
-        if (!eventStream) {
-          eventStream = createCustomEventStream(prop);
-          customEventStreams.set(prop, eventStream);
+      get(_target, prop) {
+        // Avoid spawning streams for thenable / introspection probes that the
+        // SpectrumInstance Proxy may forward here.
+        if (typeof prop !== "string" || prop === "then") {
+          return;
         }
-        return eventStream;
+        return getMergedEventStream(prop);
       },
     }
   );
@@ -426,7 +459,7 @@ export async function Spectrum<
       if (typeof prop === "string") {
         return customEventProxy[prop];
       }
-      return undefined;
+      return;
     },
   }) as SpectrumInstance<Providers>;
 }


### PR DESCRIPTION
## Summary

- Collapses the split `subscribeMessages` / custom-event-streams paths into a single `subscribeEvent(name)` entry point on `PlatformRuntime`. All events — including `messages` — flow through one broadcaster-per-`(platform, event)` map, share one upstream subscription across consumers, and yield uniform `[Space, payload]` tuples (the producer's `space` field is stripped from the payload half).
- Removes the spectrum-level custom event fan-in (`CustomEventStreams`, the lazy `Proxy` on `SpectrumInstance`, `createCustomEventStream`, `mergedEventStreams`). Non-`messages` events are now consumed only through the platform-specific accessor (e.g. `imessage(app).typing`); the `app.<event>` shape is gone.
- Adds an iMessage `typing` event backed by a new resilient `subscribeTyping` stream — wraps `client.chats.subscribe()`, filters for `chat.typingIndicator`, and reconnects on failure with exponential backoff + jitter (shared `RECONNECT_INITIAL_DELAY_MS` / `RECONNECT_MAX_DELAY_MS` from `resumable-stream`). Local clients yield an empty stream.
- Tightens `EventProducer` so every event payload must extend `ProviderEventRecord` (`{ space: { id } }`), and updates `PlatformInstance` to surface `[PlatformSpace<Def>, EventPayload<...>]` for non-`messages` events.

## Usage

```typescript
import { Spectrum } from "spectrum-ts";
import { imessage } from "spectrum-ts/providers/imessage";

const app = await Spectrum({
  projectId: process.env.PROJECT_ID,
  projectSecret: process.env.PROJECT_SECRET,
  providers: [imessage.config()],
});

// Per-platform event accessor (only path for non-`messages` events)
for await (const [space, typing] of imessage(app).typing) {
  if (typing.isTyping) {
    console.log(`${typing.displayName ?? "someone"} is typing in ${space.id}`);
  }
}
```

Note: a previous `app.typing` shape (the spectrum-level proxy) is removed in this PR — consumers must go through `imessage(app).typing`.

## Changes

| File | Change |
|------|--------|
| `packages/spectrum-ts/src/spectrum.ts` | Replaces `messageBroadcasters` + `customEventStreams` with one `eventBroadcasters` map keyed by `platform:eventName`. New `createProviderEventStream` / `getOrCreateEventBroadcast` handle every event uniformly; `messages` still runs through `wrapProviderMessage` and `flattenGroups` while other events yield the raw record minus `space`. The `customEventProxy` and outer `Proxy` wrapper around the returned instance are removed. |
| `packages/spectrum-ts/src/platform/types.ts` | Adds `ProviderEventRecord` and `EventPayload<P>`; tightens `EventProducer` and `PlatformDef.events` index signature to require records that carry `space`. Replaces `subscribeMessages` on `PlatformRuntime` with `subscribeEvent(name)`. Updates `PlatformInstance` mapped type to yield `[PlatformSpace<Def>, EventPayload<...>]` per event. Drops the unused `ExtractCustomEventNames` / `ToCustomEventVariant` / `AllCustomEventNames` / `UnifiedCustomEvent` / `CustomEventStreams` machinery. |
| `packages/spectrum-ts/src/platform/define.ts` | Per-platform `PlatformInstance` accessors are now generated for **every** event (including `messages`) by lazily calling `runtime.subscribeEvent(name)` and caching the resulting iterable per-name, so a second `for await` reuses the broadcaster's subscription. The old eager `eventProperties` / dedicated `messages` `Object.defineProperty` are removed. |
| `packages/spectrum-ts/src/providers/imessage/remote/typing-events.ts` | New file. `subscribeTyping(clients)` returns a merged `ManagedStream<IMessageTypingRecord>`. Per-client stream filters `chat.typingIndicator`, emits `{ space: { id: chatGuid }, isTyping, displayName, timestamp }`, and reconnects with backoff (resets the delay after any successful event). Errors are logged, never propagated. |
| `packages/spectrum-ts/src/providers/imessage/index.ts` | Wires the `typing` event into the iMessage platform definition (remote only — local yields an empty async iterable). |

## Behavior notes

- Bot's own typing is **not** filtered: the SDK doesn't expose an `isFromMe` flag on the typing indicator. Consumers that need to ignore self-typing should branch on `displayName`.
- Two cloud clients in the same chat will each emit their own copy of a single typing event — same caveat as the existing poll stream.
- `subscribeEvent(name)` returns `undefined` when the platform doesn't define that event, so the merged messages stream and platform-level accessors silently skip unsupported events instead of throwing.

## Test plan

- [ ] `bun x ultracite check` passes
- [ ] `bun run typecheck` passes
- [ ] Manual: connect to a remote iMessage client, iterate `imessage(app).typing`, confirm `isTyping` toggles when a peer starts/stops typing
- [ ] Manual: kill the upstream `chats.subscribe()` connection mid-iteration, confirm the typing stream reconnects with backoff and resumes emitting
- [ ] Manual: confirm `for await (const [space, msg] of app.messages)` still works across iMessage + WhatsApp providers
- [ ] Manual: confirm a second `for await (...of imessage(app).messages)` reuses the broadcaster (no duplicate upstream subscription)
- [ ] Manual: confirm `app.stop()` shuts down the typing stream cleanly

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added remote typing indicator support for iMessage, providing real-time visibility when contacts are actively typing in conversations.

* **Improvements**
  * Unified event handling architecture across all platform events for consistent access patterns.
  * Event payloads restructured to include space context information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->