### PR TITLE
feat(provider/terminal): add richlink content type support

### DIFF
--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -15,10 +15,12 @@ import { asAttachment } from "../../content/attachment";
 import { asContact } from "../../content/contact";
 import { asCustom } from "../../content/custom";
 import { reactionSchema } from "../../content/reaction";
+import { type RichlinkCover, richlinkSchema } from "../../content/richlink";
 import { asVoice } from "../../content/voice";
 import type { ProviderMessageRecord } from "../../platform/build";
 import { definePlatform } from "../../platform/define";
 import { UnsupportedError } from "../../utils/errors";
+import { bufferToStream } from "../../utils/io";
 import { fromVCard, toVCard } from "../../utils/vcard";
 import {
   type ProtocolContent,
@@ -448,8 +450,35 @@ async function spectrumToProtocol(
       vcard: await toVCard(content),
     };
   }
+  if (content.type === "richlink") {
+    // Resolve the lazy accessors eagerly so the protocol carries plain
+    // values. Cover bytes are inlined as base64; an empty buffer (e.g. the
+    // image fetch failed) is dropped so we don't waste wire space.
+    const [title, summary, cover] = await Promise.all([
+      content.title(),
+      content.summary(),
+      content.cover(),
+    ]);
+    let coverPayload: { mimeType?: string; bytes: string } | undefined;
+    if (cover) {
+      const buf = await cover.read();
+      if (buf.length > 0) {
+        coverPayload = {
+          mimeType: cover.mimeType,
+          bytes: buf.toString("base64"),
+        };
+      }
+    }
+    return {
+      type: "richlink",
+      url: content.url,
+      title,
+      summary,
+      cover: coverPayload,
+    };
+  }
   // Surface the failure as an UnsupportedError — the platform builder
-  // catches those and warns+skips, so an agent sending e.g. `richlink` on
+  // catches those and warns+skips, so an agent sending e.g. `effect` on
   // this provider gets a warning rather than an uncaught throw that
   // crashes the whole process.
   throw UnsupportedError.content(
@@ -530,6 +559,59 @@ function protocolToSpectrum(p: ProtocolContent): SpectrumContent {
       }
     }
     return asContact({ name: p.name }) as SpectrumContent;
+  }
+  if (p.type === "richlink") {
+    // Wrap the static wire values back into the lazy-accessor shape that
+    // `richlinkSchema` requires. The protocol already eagerly resolved
+    // these on the sender side, so the accessors here are trivial — they
+    // just hand back what came in. No network call is made on the
+    // receiver, mirroring how `attachment` decode keeps `read()` lazy.
+    //
+    // Normalize empty strings to `undefined` at this wire boundary: the
+    // protocol type permits `""` (JSON has no min-length), but
+    // `richlinkSchema` enforces `z.string().min(1).optional()` on title /
+    // summary / mimeType and validates the accessor return value at call
+    // time. Without this normalization, a peer that sends an empty string
+    // would defer a `ZodError` into the agent's `await decoded.title()`.
+    const url = p.url;
+    const title = p.title || undefined;
+    const summary = p.summary || undefined;
+    const coverWire = p.cover;
+    const titleAccessor = (): Promise<string | undefined> =>
+      Promise.resolve(title);
+    const summaryAccessor = (): Promise<string | undefined> =>
+      Promise.resolve(summary);
+    let coverAccessor: () => Promise<RichlinkCover | undefined>;
+    // Guard against a peer that sends `cover: { mimeType: "..." }` without
+    // bytes — `bytes` is optional in the protocol type, so undefined here
+    // would otherwise crash `Buffer.from(undefined, "base64")` at call
+    // time. Treat a cover with no bytes as no cover at all.
+    if (coverWire?.bytes) {
+      const bytesB64 = coverWire.bytes;
+      const mimeType = coverWire.mimeType || undefined;
+      let cached: Promise<Buffer> | undefined;
+      const readCover = (): Promise<Buffer> => {
+        cached ??= Promise.resolve(Buffer.from(bytesB64, "base64") as Buffer);
+        return cached;
+      };
+      const streamCover = async (): Promise<ReadableStream<Uint8Array>> =>
+        bufferToStream(await readCover());
+      const cover: RichlinkCover = {
+        mimeType,
+        read: readCover,
+        stream: streamCover,
+      };
+      coverAccessor = () => Promise.resolve(cover);
+    } else {
+      coverAccessor = () => Promise.resolve(undefined);
+    }
+    return richlinkSchema.parse({
+      type: "richlink",
+      url,
+      title: titleAccessor,
+      summary: summaryAccessor,
+      cover: coverAccessor,
+    }) as SpectrumContent;
   }
   // Fallback so unknown future shapes don't crash the agent.
   return { type: "custom", raw: p } as SpectrumContent;

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -605,13 +605,20 @@ function protocolToSpectrum(p: ProtocolContent): SpectrumContent {
     } else {
       coverAccessor = () => Promise.resolve(undefined);
     }
-    return richlinkSchema.parse({
-      type: "richlink",
-      url,
-      title: titleAccessor,
-      summary: summaryAccessor,
-      cover: coverAccessor,
-    }) as SpectrumContent;
+    try {
+      return richlinkSchema.parse({
+        type: "richlink",
+        url,
+        title: titleAccessor,
+        summary: summaryAccessor,
+        cover: coverAccessor,
+      }) as SpectrumContent;
+    } catch {
+      // If the schema rejects the constructed object — most likely a
+      // malformed `url` from a non-conforming peer — fall through to a
+      // `custom` payload so a single bad wire shape doesn't halt the
+      // event stream. Mirrors the contact-decode try/catch above.
+    }
   }
   // Fallback so unknown future shapes don't crash the agent.
   return { type: "custom", raw: p } as SpectrumContent;

--- a/packages/spectrum-ts/src/providers/terminal/protocol.ts
+++ b/packages/spectrum-ts/src/providers/terminal/protocol.ts
@@ -35,6 +35,13 @@ export type ProtocolContent =
       };
       vcard?: string;
     }
+  | {
+      type: "richlink";
+      url: string;
+      title?: string;
+      summary?: string;
+      cover?: { mimeType?: string; bytes?: string };
+    }
   | { type: "custom"; raw: unknown };
 
 export interface ProtocolMessageNotification {


### PR DESCRIPTION
## Summary

Adds `richlink` content type support to the `terminal` provider — encode in `spectrumToProtocol`, decode in `protocolToSpectrum`. Closes the `UnsupportedError` gap that surfaced after #29 introduced `richlink` as a first-class content type.

## Background

#29 added `richlink` to spectrum-ts as a content type with lazy async accessors for `title` / `summary` / `cover`. None of the existing providers (iMessage, WhatsApp Business, terminal) handle it yet — they all throw `UnsupportedError`. This PR closes the gap for `terminal`.

## Usage

```typescript
import { Spectrum, richlink } from "spectrum-ts";
import { terminal } from "spectrum-ts/providers/terminal";

const app = await Spectrum({ providers: [terminal.config()] });
for await (const [space] of app.messages) {
  await space.send(richlink("https://example.com/article"));
}
```

## Changes

| File | Change |
|------|--------|
| `packages/spectrum-ts/src/providers/terminal/protocol.ts` | Adds `richlink` variant to `ProtocolContent` (`{ type: "richlink"; url; title?; summary?; cover?: { mimeType?; bytes? } }`). `cover.bytes?` mirrors the `attachment` / `voice` `bytes?` precedent. |
| `packages/spectrum-ts/src/providers/terminal/index.ts` | Adds encode + decode branches mirroring the existing `attachment` / `voice` / `contact` lazy-accessor wrapping pattern. Imports `richlinkSchema` + `RichlinkCover` + `bufferToStream`. Updates the `UnsupportedError` doc-comment example to `effect` (since `richlink` is now supported here). |

## Design notes

**Encode (`spectrumToProtocol`)** — Resolves the lazy accessors eagerly (`Promise.all([title(), summary(), cover()])`), inlines cover bytes as base64. An empty cover buffer (e.g. `buildCover`'s catch-all returns `Buffer.alloc(0)` after a failed image fetch) is dropped to save wire space.

**Decode (`protocolToSpectrum`)** — Wraps the static wire values back into the lazy-accessor shape `richlinkSchema` requires. The accessors are trivial closures — no network call on the receiver, mirroring how `attachment` decode keeps `read()` lazy.

**Wire-boundary normalization** — three runtime safety guards at the decode boundary:

1. `title` / `summary`: normalize `""` → `undefined`. The protocol type permits `""` (JSON has no min-length) but `richlinkSchema` enforces `z.string().min(1).optional()` and Zod v4 validates the accessor *return value* at call time. Without normalization, a peer sending an empty string would defer a `ZodError` into the agent's `await decoded.title()`.
2. `cover.mimeType`: same `""` → `undefined` (same Zod constraint on `richlinkCoverSchema`).
3. `cover.bytes`: optional in the protocol type. Decoder guards `coverWire?.bytes` truthy before constructing the cover; otherwise treats as no-cover (avoids `Buffer.from(undefined, "base64")` crashing on a malformed `cover: { mimeType: "..." }` payload).

## Verification

Local environment: macOS arm64, Bun 1.3.11.

| Tier | Result |
|------|--------|
| `bun run check` (Ultracite / Biome) | ✓ 75 files, 0 issues |
| `bun run build` (tsup ESM + DTS) | ✓ ~3s |
| Contract test (8 scenarios / 19 assertions: full round-trip + empty metadata + empty cover bytes elision + 256-byte binary identity + 4 wire-boundary regression scenarios) | ✓ All pass |
| TCP-level E2E against pinned `tuichat v0.1.4` (real spawn + real LSP-framed JSON-RPC + real `send` with richlink content) | ✓ `SendResult{id, timestamp}`, no `-32099`, exit code 0 |

The wire-boundary normalization fixes were caught by a multi-engine review pass before push (Codex + Claude reviewers + cross-scorer): three independent reviewers flagged the empty-string Zod deferral pattern; one additionally flagged the missing `cover.bytes` guard with a `Buffer.from(undefined)` reproduction. All three fixes were verified by adding regression scenarios to the contract test.

Verification scripts kept locally as artifacts; not part of this PR since the project doesn't have test infrastructure yet — happy to add a `bun:test` setup as a follow-up if welcome.

## Limitations / follow-ups

- **tuichat visual rendering** — `tuichat v0.1.4` (the pinned default binary) accepts the wire shape (verified empirically — no `-32099`) but doesn't yet render `richlink` content visually. `internal/protocol/types.go` `Content` struct has no `Url` / `Title` / `Summary` / `Cover` fields, so unknown wire fields are silently dropped on Go's `Unmarshal`. Filed as photon-hq/tuichat#1 for tracking. The wire-level integration in this PR is forward-compatible — no spectrum-ts-side change needed when tuichat ships rendering.
- **`as SpectrumContent` cast** — My new decode branch ends with `richlinkSchema.parse(...) as SpectrumContent`, consistent with the five existing branches in `protocolToSpectrum`. The project's `.claude/CLAUDE.md` recommends "leverage TypeScript's type narrowing instead of type assertions" — happy to follow up with a separate refactor PR converting all five branches to schema-inferred types, if that direction is welcome.

## Test plan

- [x] `bun run check`
- [x] `bun run build`
- [x] Contract test (round-trip + edge cases + 4 wire-boundary regression)
- [x] TCP-level E2E against real `tuichat v0.1.4`
- [ ] Maintainer review

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Richlink content support added to the terminal provider: send and receive rich links with optional title, summary, and cover images. Cover image data is serialized for reliable transmission.

* **Bug Fixes / Resilience**
  * Decoding is more robust: empty or missing fields are normalized and invalid richlink payloads gracefully fall back to the generic payload handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->