### PR TITLE
fix: include README in package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ dist
 # local scratch work (ad-hoc scripts, debugging, real-account experiments)
 tmp
 
+# copied from repo root by `build` so they ship with the npm package
+# (clean-publish strips all scripts from the staged package.json, so prepack/prepublish hooks never run)
+packages/spectrum-ts/README.md
+packages/spectrum-ts/LICENSE
+
 # code coverage
 coverage
 *.lcov

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -33,9 +33,8 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && cp ../../README.md ../../LICENSE .",
     "dev": "tsup --watch",
-    "prepack": "cp ../../README.md ../../LICENSE .",
     "generate:emoji": "bun scripts/generate-emoji.ts"
   },
   "dependencies": {


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build process now copies the repository documentation and license into the packaged output so they ship with the published package.
  * Packaging step moved into the build command (previous separate pre-pack step removed).
  * Package ignore rules updated to exclude the copied documentation and license files from source commits within the package directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->