### PR TITLE
feat(imessage): per-phone routing for multi-number accounts

### DIFF
--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -7,6 +7,7 @@ import type {
 } from "../types/message";
 import type { Space } from "../types/space";
 import { UnsupportedError } from "../utils/errors";
+import type { Store } from "../utils/store";
 import type { AnyPlatformDef, ProviderMessageRecord } from "./types";
 
 export type { ProviderMessageRecord } from "./types";
@@ -107,6 +108,7 @@ interface BaseBuildParams {
   id: string;
   space: Space;
   spaceRef: SpaceRef;
+  store: Store;
   timestamp: Date;
 }
 
@@ -128,7 +130,13 @@ export interface BuildSpaceParams {
   definition: AnyPlatformDef;
   extras: Record<string, unknown>;
   spaceRef: SpaceRef;
-  typingCtx: { space: SpaceRef; client: unknown; config: unknown };
+  store: Store;
+  typingCtx: {
+    space: SpaceRef;
+    client: unknown;
+    config: unknown;
+    store: Store;
+  };
 }
 
 // Raw provider message fields — everything else on a provider-emitted record
@@ -147,6 +155,7 @@ export interface WrapContext {
   definition: AnyPlatformDef;
   space: Space;
   spaceRef: SpaceRef;
+  store: Store;
 }
 
 const extractExtras = (
@@ -197,6 +206,7 @@ export function wrapProviderMessage(
     definition: ctx.definition,
     client: ctx.client,
     config: ctx.config,
+    store: ctx.store,
   };
   if (direction === "inbound") {
     if (!raw.sender) {
@@ -262,7 +272,8 @@ const isRawProviderRecord = (v: unknown): v is ProviderMessageRecord => {
 };
 
 export function buildSpace(params: BuildSpaceParams): Space {
-  const { spaceRef, extras, typingCtx, definition, client, config } = params;
+  const { spaceRef, extras, typingCtx, definition, client, config, store } =
+    params;
   // Declared first so inner arrows can reference it after assignment.
   let space: Space;
 
@@ -279,6 +290,7 @@ export function buildSpace(params: BuildSpaceParams): Space {
         reaction: item.emoji,
         client,
         config,
+        store,
       });
     } catch (err) {
       if (err instanceof UnsupportedError) {
@@ -319,7 +331,7 @@ export function buildSpace(params: BuildSpaceParams): Space {
     }
     return wrapProviderMessage(
       raw,
-      { client, config, definition, space, spaceRef },
+      { client, config, definition, space, spaceRef, store },
       "outbound"
     );
   }
@@ -360,6 +372,7 @@ export function buildSpace(params: BuildSpaceParams): Space {
         messageId: id,
         client,
         config,
+        store,
       })) as ProviderMessageRecord | undefined;
     } catch (err) {
       if (err instanceof UnsupportedError) {
@@ -373,7 +386,7 @@ export function buildSpace(params: BuildSpaceParams): Space {
     }
     return wrapProviderMessage(
       raw,
-      { client, config, definition, space, spaceRef },
+      { client, config, definition, space, spaceRef, store },
       "inbound"
     );
   }
@@ -410,7 +423,7 @@ export function buildSpace(params: BuildSpaceParams): Space {
 export function buildMessage(params: BuildInboundParams): InboundMessage;
 export function buildMessage(params: BuildOutboundParams): OutboundMessage;
 export function buildMessage(params: BuildMessageParams): Message {
-  const { definition, client, config, spaceRef, space } = params;
+  const { definition, client, config, spaceRef, space, store } = params;
 
   // Late-bound self reference so `react()` can pass the built Message as the
   // reaction target.
@@ -436,6 +449,7 @@ export function buildMessage(params: BuildMessageParams): Message {
         reaction,
         client,
         config,
+        store,
       });
     } catch (err) {
       if (err instanceof UnsupportedError) {
@@ -476,6 +490,7 @@ export function buildMessage(params: BuildMessageParams): Message {
         content: item,
         client,
         config,
+        store,
       })) as ProviderMessageRecord | undefined;
     } catch (err) {
       if (err instanceof UnsupportedError) {
@@ -491,7 +506,7 @@ export function buildMessage(params: BuildMessageParams): Message {
     }
     return wrapProviderMessage(
       raw,
-      { client, config, definition, space, spaceRef },
+      { client, config, definition, space, spaceRef, store },
       "outbound"
     );
   };
@@ -569,6 +584,7 @@ export function buildMessage(params: BuildMessageParams): Message {
             content: resolved,
             client,
             config,
+            store,
           });
         } catch (err) {
           if (err instanceof UnsupportedError) {

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -1,6 +1,7 @@
 import type z from "zod";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
+import type { Store } from "../utils/store";
 import { buildSpace } from "./build";
 import type {
   AnyPlatformDef,
@@ -36,6 +37,7 @@ function createPlatformInstance<
       input: { userID },
       client: runtime.client as _Client,
       config: runtime.config as z.infer<_ConfigSchema>,
+      store: runtime.store,
     });
     return {
       ...resolved,
@@ -98,6 +100,7 @@ function createPlatformInstance<
         input: { userID },
         client: runtime.client as _Client,
         config: runtime.config as z.infer<_ConfigSchema>,
+        store: runtime.store,
       });
       return {
         ...resolved,
@@ -116,6 +119,7 @@ function createPlatformInstance<
         input: { users, params: parsedParams },
         client: runtime.client as _Client,
         config: runtime.config as z.infer<_ConfigSchema>,
+        store: runtime.store,
       });
       const parsedSpace = def.space.schema
         ? def.space.schema.parse(resolved)
@@ -128,6 +132,7 @@ function createPlatformInstance<
         space: spaceRef,
         client: runtime.client as _Client,
         config: runtime.config as z.infer<_ConfigSchema>,
+        store: runtime.store,
       };
       return buildSpace({
         spaceRef,
@@ -136,6 +141,7 @@ function createPlatformInstance<
         definition: def as unknown as AnyPlatformDef,
         client: runtime.client,
         config: runtime.config,
+        store: runtime.store,
       }) as PlatformSpace<Def>;
     },
   };
@@ -147,12 +153,17 @@ function createPlatformInstance<
       continue;
     }
     const producer = def.events[eventName] as
-      | ((ctx: { client: unknown; config: unknown }) => AsyncIterable<unknown>)
+      | ((ctx: {
+          client: unknown;
+          config: unknown;
+          store: Store;
+        }) => AsyncIterable<unknown>)
       | undefined;
     if (producer) {
       eventProperties[eventName] = producer({
         client: runtime.client,
         config: runtime.config,
+        store: runtime.store,
       });
     }
   }

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -5,6 +5,8 @@ import type { Store } from "../utils/store";
 import { buildSpace } from "./build";
 import type {
   AnyPlatformDef,
+  CreateClientContext,
+  EventProducer,
   InboundPlatformMessage,
   Platform,
   PlatformDef,
@@ -17,6 +19,8 @@ import type {
   ProviderMessage,
   SpectrumLike,
 } from "./types";
+
+type NoInferValue<T> = [T][T extends unknown ? 0 : never];
 
 function createPlatformInstance<
   Def extends AnyPlatformDef,
@@ -210,20 +214,24 @@ export function definePlatform<
       : Record<never, never>
   >,
   _Events extends {
-    messages: (ctx: {
-      client: _Client;
-      config: z.infer<_ConfigSchema>;
-    }) => AsyncIterable<_MessageType>;
+    messages: EventProducer<_MessageType, _Client, z.infer<_ConfigSchema>>;
   } = {
-    messages: (ctx: {
-      client: _Client;
-      config: z.infer<_ConfigSchema>;
-    }) => AsyncIterable<_MessageType>;
+    messages: EventProducer<_MessageType, _Client, z.infer<_ConfigSchema>>;
   },
   _Static extends Record<string, unknown> = Record<never, never>,
 >(
   name: _Name,
-  def: Omit<
+  def: {
+    lifecycle: {
+      createClient: (
+        ctx: CreateClientContext<_ConfigSchema>
+      ) => Promise<_Client>;
+      destroyClient?: (ctx: {
+        client: NoInferValue<_Client>;
+        store: Store;
+      }) => Promise<void>;
+    };
+  } & Omit<
     PlatformDef<
       _Name,
       _ConfigSchema,
@@ -237,7 +245,7 @@ export function definePlatform<
       _MessageType,
       _Events
     >,
-    "name"
+    "lifecycle" | "name"
   > & { static?: _Static }
 ): Platform<
   PlatformDef<

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -129,6 +129,7 @@ function createPlatformInstance<
         ? def.space.schema.parse(resolved)
         : resolved;
       const spaceRef = {
+        ...(parsedSpace as Record<string, unknown>),
         id: parsedSpace.id,
         __platform: def.name,
       };

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -10,9 +10,10 @@ import type { ManagedStream } from "../utils/stream";
 type ResolvedSpace = Pick<Space, "id">;
 type SpaceRef = Pick<Space, "id" | "__platform">;
 type ResolvedUser = Pick<User, "id">;
-type AwaitedReturn<T> = T extends (...args: never[]) => Promise<infer R>
-  ? R
+type AwaitedReturn<T> = T extends (...args: never[]) => infer R
+  ? Awaited<R>
   : never;
+type NoInferClient<T> = [T][T extends unknown ? 0 : never];
 type SchemaInfer<T> = T extends { schema?: infer S extends z.ZodType<object> }
   ? z.infer<S>
   : Record<never, never>;
@@ -33,7 +34,7 @@ export type EventProducer<
   TClient = unknown,
   TConfig = unknown,
 > = (ctx: {
-  client: TClient;
+  client: NoInferClient<TClient>;
   config: TConfig;
   store: Store;
 }) => AsyncIterable<TPayload>;
@@ -100,6 +101,13 @@ type ReservedNames = "stop" | "send" | "__internal" | "__providers";
 // PlatformDef — the full definition of a platform adapter
 // ---------------------------------------------------------------------------
 
+export interface CreateClientContext<_ConfigSchema extends z.ZodType<object>> {
+  config: z.infer<_ConfigSchema>;
+  projectId: string | undefined;
+  projectSecret: string | undefined;
+  store: Store;
+}
+
 export interface PlatformDef<
   _Name extends string = string,
   _ConfigSchema extends z.ZodType<object> = z.ZodType<object>,
@@ -129,19 +137,19 @@ export interface PlatformDef<
     send: (_: {
       space: _ResolvedSpace & SpaceRef;
       content: Content;
-      client: _Client;
+      client: NoInferClient<_Client>;
       config: z.infer<_ConfigSchema>;
       store: Store;
     }) => Promise<ProviderMessageRecord>;
     startTyping?: (_: {
       space: _ResolvedSpace & SpaceRef;
-      client: _Client;
+      client: NoInferClient<_Client>;
       config: z.infer<_ConfigSchema>;
       store: Store;
     }) => Promise<void>;
     stopTyping?: (_: {
       space: _ResolvedSpace & SpaceRef;
-      client: _Client;
+      client: NoInferClient<_Client>;
       config: z.infer<_ConfigSchema>;
       store: Store;
     }) => Promise<void>;
@@ -149,7 +157,7 @@ export interface PlatformDef<
       space: _ResolvedSpace & SpaceRef;
       target: _MessageType;
       reaction: string;
-      client: _Client;
+      client: NoInferClient<_Client>;
       config: z.infer<_ConfigSchema>;
       store: Store;
     }) => Promise<void>;
@@ -158,7 +166,7 @@ export interface PlatformDef<
       messageId: string;
       target: _MessageType;
       content: Content;
-      client: _Client;
+      client: NoInferClient<_Client>;
       config: z.infer<_ConfigSchema>;
       store: Store;
     }) => Promise<ProviderMessageRecord>;
@@ -166,14 +174,14 @@ export interface PlatformDef<
       space: _ResolvedSpace & SpaceRef;
       messageId: string;
       content: Content;
-      client: _Client;
+      client: NoInferClient<_Client>;
       config: z.infer<_ConfigSchema>;
       store: Store;
     }) => Promise<void>;
     getMessage?: (_: {
       space: _ResolvedSpace & SpaceRef;
       messageId: string;
-      client: _Client;
+      client: NoInferClient<_Client>;
       config: z.infer<_ConfigSchema>;
       store: Store;
     }) => Promise<_MessageType | undefined>;
@@ -184,13 +192,11 @@ export interface PlatformDef<
   events: _Events;
 
   lifecycle: {
-    createClient: (ctx: {
-      config: z.infer<_ConfigSchema>;
-      projectId: string | undefined;
-      projectSecret: string | undefined;
+    createClient: (ctx: CreateClientContext<_ConfigSchema>) => Promise<_Client>;
+    destroyClient?: (ctx: {
+      client: NoInferClient<_Client>;
       store: Store;
-    }) => Promise<_Client>;
-    destroyClient: (ctx: { client: _Client; store: Store }) => Promise<void>;
+    }) => Promise<void>;
   };
 
   message?: {
@@ -208,7 +214,7 @@ export interface PlatformDef<
           ? z.infer<_SpaceParamsSchema>
           : undefined;
       };
-      client: _Client;
+      client: NoInferClient<_Client>;
       config: z.infer<_ConfigSchema>;
       store: Store;
     }) => Promise<_ResolvedSpace>;
@@ -218,7 +224,7 @@ export interface PlatformDef<
     schema?: _UserSchema;
     resolve: (_: {
       input: { userID: string };
-      client: _Client;
+      client: NoInferClient<_Client>;
       config: z.infer<_ConfigSchema>;
       store: Store;
     }) => Promise<_ResolvedUser>;
@@ -257,7 +263,7 @@ export interface AnyPlatformDef {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard lifecycle
     createClient: (ctx: any) => Promise<any>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard lifecycle
-    destroyClient: (ctx: any) => Promise<void>;
+    destroyClient?: (ctx: any) => Promise<void>;
   };
   message?: { schema?: z.ZodType<object> };
   name: string;

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -4,6 +4,7 @@ import type { Content } from "../content/types";
 import type { InboundMessage, Message } from "../types/message";
 import type { Space } from "../types/space";
 import type { User } from "../types/user";
+import type { Store } from "../utils/store";
 import type { ManagedStream } from "../utils/stream";
 
 type ResolvedSpace = Pick<Space, "id">;
@@ -31,7 +32,11 @@ export type EventProducer<
   TPayload = unknown,
   TClient = unknown,
   TConfig = unknown,
-> = (ctx: { client: TClient; config: TConfig }) => AsyncIterable<TPayload>;
+> = (ctx: {
+  client: TClient;
+  config: TConfig;
+  store: Store;
+}) => AsyncIterable<TPayload>;
 
 export type ProviderMessage<
   TSender extends ResolvedUser = ResolvedUser,
@@ -126,16 +131,19 @@ export interface PlatformDef<
       content: Content;
       client: _Client;
       config: z.infer<_ConfigSchema>;
+      store: Store;
     }) => Promise<ProviderMessageRecord>;
     startTyping?: (_: {
       space: _ResolvedSpace & SpaceRef;
       client: _Client;
       config: z.infer<_ConfigSchema>;
+      store: Store;
     }) => Promise<void>;
     stopTyping?: (_: {
       space: _ResolvedSpace & SpaceRef;
       client: _Client;
       config: z.infer<_ConfigSchema>;
+      store: Store;
     }) => Promise<void>;
     reactToMessage?: (_: {
       space: _ResolvedSpace & SpaceRef;
@@ -143,6 +151,7 @@ export interface PlatformDef<
       reaction: string;
       client: _Client;
       config: z.infer<_ConfigSchema>;
+      store: Store;
     }) => Promise<void>;
     replyToMessage?: (_: {
       space: _ResolvedSpace & SpaceRef;
@@ -151,6 +160,7 @@ export interface PlatformDef<
       content: Content;
       client: _Client;
       config: z.infer<_ConfigSchema>;
+      store: Store;
     }) => Promise<ProviderMessageRecord>;
     editMessage?: (_: {
       space: _ResolvedSpace & SpaceRef;
@@ -158,12 +168,14 @@ export interface PlatformDef<
       content: Content;
       client: _Client;
       config: z.infer<_ConfigSchema>;
+      store: Store;
     }) => Promise<void>;
     getMessage?: (_: {
       space: _ResolvedSpace & SpaceRef;
       messageId: string;
       client: _Client;
       config: z.infer<_ConfigSchema>;
+      store: Store;
     }) => Promise<_MessageType | undefined>;
   };
 
@@ -176,8 +188,9 @@ export interface PlatformDef<
       config: z.infer<_ConfigSchema>;
       projectId: string | undefined;
       projectSecret: string | undefined;
+      store: Store;
     }) => Promise<_Client>;
-    destroyClient: (ctx: { client: _Client }) => Promise<void>;
+    destroyClient: (ctx: { client: _Client; store: Store }) => Promise<void>;
   };
 
   message?: {
@@ -197,6 +210,7 @@ export interface PlatformDef<
       };
       client: _Client;
       config: z.infer<_ConfigSchema>;
+      store: Store;
     }) => Promise<_ResolvedSpace>;
   };
 
@@ -206,6 +220,7 @@ export interface PlatformDef<
       input: { userID: string };
       client: _Client;
       config: z.infer<_ConfigSchema>;
+      store: Store;
     }) => Promise<_ResolvedUser>;
   };
 }
@@ -459,6 +474,7 @@ export interface PlatformRuntime {
   client: unknown;
   config: unknown;
   definition: AnyPlatformDef;
+  store: Store;
   subscribeMessages: () => ManagedStream<[Space, InboundMessage]>;
 }
 

--- a/packages/spectrum-ts/src/providers/imessage/auth.ts
+++ b/packages/spectrum-ts/src/providers/imessage/auth.ts
@@ -1,67 +1,54 @@
-import {
-  type AdvancedIMessage,
-  createClient,
-} from "@photon-ai/advanced-imessage";
-import {
-  cloud,
-  type DedicatedTokenData,
-  type SharedTokenData,
-} from "../../utils/cloud";
-import type { Store } from "../../utils/store";
+import { createClient } from "@photon-ai/advanced-imessage";
+import { cloud, type DedicatedTokenData } from "../../utils/cloud";
+import { UnsupportedError } from "../../utils/errors";
+import type { RemoteClient } from "./types";
 
 const RENEWAL_RATIO = 0.8;
 const EXPIRY_BUFFER_MS = 30_000;
 const RETRY_DELAY_MS = 30_000;
 
-export const NUMBERS_KEY = "numbers";
-
-/**
- * Read the bidirectional phone↔instance mapping written by the iMessage cloud
- * auth path. Returns `{}` for local mode, BYO clients, or before the first
- * token issuance completes.
- */
-export const getNumbers = (store: Store): Record<string, string> =>
-  store.object<Record<string, string>>(NUMBERS_KEY) ?? {};
-
 interface CloudAuth {
   dispose: () => void;
 }
 
-const cloudAuthState = new WeakMap<AdvancedIMessage[], CloudAuth>();
+const cloudAuthState = new WeakMap<RemoteClient[], CloudAuth>();
 
-const buildNumbersMap = (data: DedicatedTokenData): Record<string, string> => {
-  const mapping: Record<string, string> = {};
-  for (const [instanceId, phone] of Object.entries(data.numbers ?? {})) {
-    if (phone) {
-      mapping[phone] = instanceId;
-      mapping[instanceId] = phone;
-    }
+const requirePhone = (data: DedicatedTokenData, instanceId: string): string => {
+  const phone = data.numbers?.[instanceId];
+  if (!phone) {
+    throw new Error(`iMessage instance ${instanceId} has no phone assigned`);
   }
-  return mapping;
-};
-
-const writeNumbers = (
-  store: Store,
-  data: DedicatedTokenData | SharedTokenData
-): void => {
-  if (data.type === "dedicated") {
-    store.set(NUMBERS_KEY, buildNumbersMap(data));
-    return;
-  }
-  store.delete(NUMBERS_KEY);
+  return phone;
 };
 
 export async function createCloudClients(
   projectId: string,
-  projectSecret: string,
-  store: Store
-): Promise<AdvancedIMessage[]> {
+  projectSecret: string
+): Promise<RemoteClient[]> {
   let tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
   let tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
   let disposed = false;
   let renewalTimer: ReturnType<typeof setTimeout> | undefined;
 
-  writeNumbers(store, tokenData);
+  if (tokenData.type === "shared") {
+    throw UnsupportedError.action(
+      "multi-phone",
+      "iMessage shared mode",
+      "use dedicated-token cloud mode"
+    );
+  }
+
+  // Captured outside `buildClients` so renewal can mutate `entry.phone` in
+  // place, keeping live client refs and merged streams alive across renewals.
+  // The instanceId stays in this closure (paired with the entry) so it does
+  // not leak onto the public RemoteClient shape.
+  const records: { entry: RemoteClient; instanceId: string }[] = [];
+
+  const syncPhones = (data: DedicatedTokenData) => {
+    for (const { entry, instanceId } of records) {
+      entry.phone = requirePhone(data, instanceId);
+    }
+  };
 
   const scheduleRenewal = () => {
     if (disposed) {
@@ -73,8 +60,15 @@ export async function createCloudClients(
     renewalTimer = setTimeout(async () => {
       try {
         tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
+        if (tokenData.type === "shared") {
+          throw UnsupportedError.action(
+            "multi-phone",
+            "iMessage shared mode",
+            "use dedicated-token cloud mode"
+          );
+        }
         tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
-        writeNumbers(store, tokenData);
+        syncPhones(tokenData);
         scheduleRenewal();
       } catch {
         renewalTimer = setTimeout(() => scheduleRenewal(), RETRY_DELAY_MS);
@@ -91,31 +85,23 @@ export async function createCloudClients(
       return;
     }
     tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
+    if (tokenData.type === "shared") {
+      throw UnsupportedError.action(
+        "multi-phone",
+        "iMessage shared mode",
+        "use dedicated-token cloud mode"
+      );
+    }
     tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
-    writeNumbers(store, tokenData);
+    syncPhones(tokenData);
     scheduleRenewal();
   };
 
-  const buildClients = (): AdvancedIMessage[] => {
-    if (tokenData.type === "shared") {
-      const address =
-        process.env.SPECTRUM_IMESSAGE_ADDRESS ??
-        "imessage.spectrum.photon.codes:443";
-
-      return [
-        createClient({
-          address,
-          tls: true,
-          token: async () => {
-            await refreshIfNeeded();
-            return (tokenData as SharedTokenData).token;
-          },
-        }),
-      ];
-    }
-
-    return Object.entries(tokenData.auth).map(([instanceId, token]) =>
-      createClient({
+  const dedicated = tokenData;
+  for (const [instanceId, token] of Object.entries(dedicated.auth)) {
+    const entry: RemoteClient = {
+      phone: requirePhone(dedicated, instanceId),
+      client: createClient({
         address: `${instanceId}.imsg.photon.codes:443`,
         tls: true,
         token: async () => {
@@ -123,13 +109,13 @@ export async function createCloudClients(
           const data = tokenData as DedicatedTokenData;
           return data.auth[instanceId] ?? token;
         },
-      })
-    );
-  };
+      }),
+    };
+    records.push({ entry, instanceId });
+  }
+  const entries = records.map((r) => r.entry);
 
-  const clients = buildClients();
-
-  cloudAuthState.set(clients, {
+  cloudAuthState.set(entries, {
     dispose: () => {
       disposed = true;
       if (renewalTimer !== undefined) {
@@ -139,12 +125,10 @@ export async function createCloudClients(
     },
   });
 
-  return clients;
+  return entries;
 }
 
-export async function disposeCloudAuth(
-  clients: AdvancedIMessage[]
-): Promise<void> {
+export async function disposeCloudAuth(clients: RemoteClient[]): Promise<void> {
   const auth = cloudAuthState.get(clients);
   if (auth) {
     auth.dispose();

--- a/packages/spectrum-ts/src/providers/imessage/auth.ts
+++ b/packages/spectrum-ts/src/providers/imessage/auth.ts
@@ -7,10 +7,21 @@ import {
   type DedicatedTokenData,
   type SharedTokenData,
 } from "../../utils/cloud";
+import type { Store } from "../../utils/store";
 
 const RENEWAL_RATIO = 0.8;
 const EXPIRY_BUFFER_MS = 30_000;
 const RETRY_DELAY_MS = 30_000;
+
+export const NUMBERS_KEY = "numbers";
+
+/**
+ * Read the bidirectional phone↔instance mapping written by the iMessage cloud
+ * auth path. Returns `{}` for local mode, BYO clients, or before the first
+ * token issuance completes.
+ */
+export const getNumbers = (store: Store): Record<string, string> =>
+  store.object<Record<string, string>>(NUMBERS_KEY) ?? {};
 
 interface CloudAuth {
   dispose: () => void;
@@ -18,14 +29,39 @@ interface CloudAuth {
 
 const cloudAuthState = new WeakMap<AdvancedIMessage[], CloudAuth>();
 
+const buildNumbersMap = (data: DedicatedTokenData): Record<string, string> => {
+  const mapping: Record<string, string> = {};
+  for (const [instanceId, phone] of Object.entries(data.numbers ?? {})) {
+    if (phone) {
+      mapping[phone] = instanceId;
+      mapping[instanceId] = phone;
+    }
+  }
+  return mapping;
+};
+
+const writeNumbers = (
+  store: Store,
+  data: DedicatedTokenData | SharedTokenData
+): void => {
+  if (data.type === "dedicated") {
+    store.set(NUMBERS_KEY, buildNumbersMap(data));
+    return;
+  }
+  store.delete(NUMBERS_KEY);
+};
+
 export async function createCloudClients(
   projectId: string,
-  projectSecret: string
+  projectSecret: string,
+  store: Store
 ): Promise<AdvancedIMessage[]> {
   let tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
   let tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
   let disposed = false;
   let renewalTimer: ReturnType<typeof setTimeout> | undefined;
+
+  writeNumbers(store, tokenData);
 
   const scheduleRenewal = () => {
     if (disposed) {
@@ -38,6 +74,7 @@ export async function createCloudClients(
       try {
         tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
         tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
+        writeNumbers(store, tokenData);
         scheduleRenewal();
       } catch {
         renewalTimer = setTimeout(() => scheduleRenewal(), RETRY_DELAY_MS);
@@ -55,6 +92,7 @@ export async function createCloudClients(
     }
     tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
     tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
+    writeNumbers(store, tokenData);
     scheduleRenewal();
   };
 

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -94,6 +94,7 @@ export const imessage = definePlatform("iMessage", {
       config,
       projectId,
       projectSecret,
+      store,
     }): Promise<IMessageClient> => {
       if (config.local) {
         return new IMessageSDK();
@@ -116,7 +117,7 @@ export const imessage = definePlatform("iMessage", {
         );
       }
 
-      return await createCloudClients(projectId, projectSecret);
+      return await createCloudClients(projectId, projectSecret, store);
     },
 
     destroyClient: async ({ client }: { client: IMessageClient }) => {

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -47,6 +47,47 @@ export const imessage = definePlatform("iMessage", {
     },
   },
 
+  lifecycle: {
+    createClient: async ({
+      config,
+      projectId,
+      projectSecret,
+      store,
+    }): Promise<IMessageClient> => {
+      if (config.local) {
+        return new IMessageSDK();
+      }
+
+      if (config.clients) {
+        const entries = Array.isArray(config.clients)
+          ? config.clients
+          : [config.clients];
+        return entries.map((e) =>
+          createClient({ address: e.address, tls: true, token: e.token })
+        );
+      }
+
+      if (!(projectId && projectSecret)) {
+        throw new Error(
+          "iMessage requires projectId and projectSecret. " +
+            "Either pass credentials to Spectrum(), use local mode: imessage.config({ local: true }), " +
+            "or provide explicit client config: imessage.config({ clients: [...] })"
+        );
+      }
+
+      return await createCloudClients(projectId, projectSecret, store);
+    },
+
+    destroyClient: async ({ client }) => {
+      if (isLocal(client)) {
+        await client.close();
+        return;
+      }
+      await disposeCloudAuth(client);
+      await Promise.all(client.map((c) => c.close()));
+    },
+  },
+
   user: {
     resolve: async ({ input }) => ({ id: input.userID }),
   },
@@ -87,47 +128,6 @@ export const imessage = definePlatform("iMessage", {
 
   message: {
     schema: messageSchema,
-  },
-
-  lifecycle: {
-    createClient: async ({
-      config,
-      projectId,
-      projectSecret,
-      store,
-    }): Promise<IMessageClient> => {
-      if (config.local) {
-        return new IMessageSDK();
-      }
-
-      if (config.clients) {
-        const entries = Array.isArray(config.clients)
-          ? config.clients
-          : [config.clients];
-        return entries.map((e) =>
-          createClient({ address: e.address, tls: true, token: e.token })
-        );
-      }
-
-      if (!(projectId && projectSecret)) {
-        throw new Error(
-          "iMessage requires projectId and projectSecret. " +
-            "Either pass credentials to Spectrum(), use local mode: imessage.config({ local: true }), " +
-            "or provide explicit client config: imessage.config({ clients: [...] })"
-        );
-      }
-
-      return await createCloudClients(projectId, projectSecret, store);
-    },
-
-    destroyClient: async ({ client }: { client: IMessageClient }) => {
-      if (isLocal(client)) {
-        await client.close();
-        return;
-      }
-      await disposeCloudAuth(client);
-      await Promise.all(client.map((c) => c.close()));
-    },
   },
 
   events: {

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -26,12 +26,14 @@ import {
   startTyping as remoteStartTyping,
   stopTyping as remoteStopTyping,
 } from "./remote/api";
+import { clientForPhone, randomPhone } from "./remote/client";
 import {
   configSchema,
   type IMessageClient,
   type IMessageMessage,
   isLocal,
   messageSchema,
+  spaceParamsSchema,
   spaceSchema,
 } from "./types";
 
@@ -52,7 +54,6 @@ export const imessage = definePlatform("iMessage", {
       config,
       projectId,
       projectSecret,
-      store,
     }): Promise<IMessageClient> => {
       if (config.local) {
         return new IMessageSDK();
@@ -62,9 +63,14 @@ export const imessage = definePlatform("iMessage", {
         const entries = Array.isArray(config.clients)
           ? config.clients
           : [config.clients];
-        return entries.map((e) =>
-          createClient({ address: e.address, tls: true, token: e.token })
-        );
+        return entries.map((e) => ({
+          phone: e.phone,
+          client: createClient({
+            address: e.address,
+            tls: true,
+            token: e.token,
+          }),
+        }));
       }
 
       if (!(projectId && projectSecret)) {
@@ -75,7 +81,7 @@ export const imessage = definePlatform("iMessage", {
         );
       }
 
-      return await createCloudClients(projectId, projectSecret, store);
+      return await createCloudClients(projectId, projectSecret);
     },
 
     destroyClient: async ({ client }) => {
@@ -84,7 +90,7 @@ export const imessage = definePlatform("iMessage", {
         return;
       }
       await disposeCloudAuth(client);
-      await Promise.all(client.map((c) => c.close()));
+      await Promise.all(client.map((entry) => entry.client.close()));
     },
   },
 
@@ -94,6 +100,7 @@ export const imessage = definePlatform("iMessage", {
 
   space: {
     schema: spaceSchema,
+    params: spaceParamsSchema,
     resolve: async ({ input, client }) => {
       if (isLocal(client)) {
         throw UnsupportedError.action(
@@ -107,22 +114,23 @@ export const imessage = definePlatform("iMessage", {
         throw new Error("iMessage space creation requires at least one user");
       }
 
+      if (client.length === 0) {
+        throw new Error("No iMessage clients configured");
+      }
+      const phone = input.params?.phone ?? randomPhone(client);
+      const remote = clientForPhone(client, phone);
       const addresses = input.users.map((u) => u.id);
 
       if (input.users.length === 1) {
         return {
           id: directChat(addresses[0] ?? "") as string,
           type: "dm" as const,
+          phone,
         };
       }
 
-      const remote = client[0];
-      if (!remote) {
-        throw new Error("No remote iMessage client available");
-      }
-
       const { chat } = await remote.chats.create(addresses);
-      return { id: chat.guid as string, type: "group" as const };
+      return { id: chat.guid as string, type: "group" as const, phone };
     },
   },
 
@@ -140,19 +148,22 @@ export const imessage = definePlatform("iMessage", {
       if (isLocal(client)) {
         return await localSend(client, space.id, content);
       }
-      return await remoteSend(client, space.id, content);
+      const remote = clientForPhone(client, space.phone);
+      return await remoteSend(remote, space.id, content);
     },
     startTyping: async ({ space, client }) => {
       if (isLocal(client)) {
         return;
       }
-      await remoteStartTyping(client, space.id);
+      const remote = clientForPhone(client, space.phone);
+      await remoteStartTyping(remote, space.id);
     },
     stopTyping: async ({ space, client }) => {
       if (isLocal(client)) {
         return;
       }
-      await remoteStopTyping(client, space.id);
+      const remote = clientForPhone(client, space.phone);
+      await remoteStopTyping(remote, space.id);
     },
     reactToMessage: async ({ space, target, reaction, client }) => {
       if (isLocal(client)) {
@@ -165,8 +176,9 @@ export const imessage = definePlatform("iMessage", {
           "iMessage polls do not support reactions"
         );
       }
+      const remote = clientForPhone(client, space.phone);
       await remoteReactToMessage(
-        client,
+        remote,
         space.id,
         target as IMessageMessage,
         reaction
@@ -183,19 +195,22 @@ export const imessage = definePlatform("iMessage", {
           "iMessage polls do not support replies"
         );
       }
-      return await remoteReplyToMessage(client, space.id, messageId, content);
+      const remote = clientForPhone(client, space.phone);
+      return await remoteReplyToMessage(remote, space.id, messageId, content);
     },
     editMessage: async ({ space, messageId, content, client }) => {
       if (isLocal(client)) {
         throw UnsupportedError.action("edit", "iMessage (local mode)");
       }
-      await remoteEditMessage(client, space.id, messageId, content);
+      const remote = clientForPhone(client, space.phone);
+      await remoteEditMessage(remote, space.id, messageId, content);
     },
     getMessage: async ({ space, messageId, client }) => {
       if (isLocal(client)) {
         return localGetMessage(client, messageId);
       }
-      return remoteGetMessage(client, space.id, messageId);
+      const remote = clientForPhone(client, space.phone);
+      return remoteGetMessage(remote, space.id, messageId, space.phone);
     },
   },
 });

--- a/packages/spectrum-ts/src/providers/imessage/local/inbound.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local/inbound.ts
@@ -27,7 +27,12 @@ export const toMessages = async (
 
   const base: Omit<IMessageMessage, "id" | "content"> = {
     sender: { id: message.participant ?? "" },
-    space: { id: chatId, type: chatKind === "group" ? "group" : "dm" },
+    // Local mode has no concept of "which-of-my-phones"; phone is empty.
+    space: {
+      id: chatId,
+      type: chatKind === "group" ? "group" : "dm",
+      phone: "",
+    },
     timestamp: message.createdAt,
   };
 

--- a/packages/spectrum-ts/src/providers/imessage/remote/api.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/api.ts
@@ -2,8 +2,7 @@ import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
 import type { Content } from "../../../content/types";
 import type { ProviderMessageRecord } from "../../../platform/types";
 import type { ManagedStream } from "../../../utils/stream";
-import type { IMessageMessage } from "../types";
-import { firstRemoteClient, primaryRemoteClient } from "./client";
+import type { IMessageMessage, RemoteClient } from "../types";
 import { getMessage as getRemoteMessage } from "./inbound";
 import { reactToMessage as reactToRemoteMessage } from "./reactions";
 import {
@@ -18,82 +17,58 @@ import {
 } from "./typing";
 
 export const messages = (
-  clients: AdvancedIMessage[]
+  clients: RemoteClient[]
 ): ManagedStream<IMessageMessage> => remoteMessages(clients);
 
-/** Best-effort no-op when firstRemoteClient(clients) is unavailable. */
 export const startTyping = async (
-  clients: AdvancedIMessage[],
+  remote: AdvancedIMessage,
   spaceId: string
 ): Promise<void> => {
-  const remote = firstRemoteClient(clients);
-  if (!remote) {
-    return;
-  }
   await startRemoteTyping(remote, spaceId);
 };
 
-/** Best-effort no-op when firstRemoteClient(clients) is unavailable. */
 export const stopTyping = async (
-  clients: AdvancedIMessage[],
+  remote: AdvancedIMessage,
   spaceId: string
 ): Promise<void> => {
-  const remote = firstRemoteClient(clients);
-  if (!remote) {
-    return;
-  }
   await stopRemoteTyping(remote, spaceId);
 };
 
-/** Throws when primaryRemoteClient(clients) is unavailable. */
 export const send = async (
-  clients: AdvancedIMessage[],
+  remote: AdvancedIMessage,
   spaceId: string,
   content: Content
 ): Promise<ProviderMessageRecord> =>
-  sendRemoteMessage(primaryRemoteClient(clients), spaceId, content);
+  sendRemoteMessage(remote, spaceId, content);
 
-/** Throws when primaryRemoteClient(clients) is unavailable. */
 export const replyToMessage = async (
-  clients: AdvancedIMessage[],
+  remote: AdvancedIMessage,
   spaceId: string,
   msgId: string,
   content: Content
 ): Promise<ProviderMessageRecord> =>
-  replyToRemoteMessage(primaryRemoteClient(clients), spaceId, msgId, content);
+  replyToRemoteMessage(remote, spaceId, msgId, content);
 
-/** Throws when primaryRemoteClient(clients) is unavailable. */
 export const editMessage = async (
-  clients: AdvancedIMessage[],
+  remote: AdvancedIMessage,
   spaceId: string,
   msgId: string,
   content: Content
-): Promise<void> =>
-  editRemoteMessage(primaryRemoteClient(clients), spaceId, msgId, content);
+): Promise<void> => editRemoteMessage(remote, spaceId, msgId, content);
 
-/** Best-effort no-op when firstRemoteClient(clients) is unavailable. */
 export const reactToMessage = async (
-  clients: AdvancedIMessage[],
+  remote: AdvancedIMessage,
   spaceId: string,
   target: IMessageMessage,
   reaction: string
 ): Promise<void> => {
-  const remote = firstRemoteClient(clients);
-  if (!remote) {
-    return;
-  }
   await reactToRemoteMessage(remote, spaceId, target, reaction);
 };
 
-/** Best-effort undefined when firstRemoteClient(clients) is unavailable. */
 export const getMessage = async (
-  clients: AdvancedIMessage[],
+  remote: AdvancedIMessage,
   spaceId: string,
-  msgId: string
-): Promise<IMessageMessage | undefined> => {
-  const remote = firstRemoteClient(clients);
-  if (!remote) {
-    return;
-  }
-  return getRemoteMessage(remote, spaceId, msgId);
-};
+  msgId: string,
+  phone: string
+): Promise<IMessageMessage | undefined> =>
+  getRemoteMessage(remote, spaceId, msgId, phone);

--- a/packages/spectrum-ts/src/providers/imessage/remote/client.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/client.ts
@@ -1,17 +1,30 @@
 import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { RemoteClient } from "../types";
 
-const REMOTE_CLIENT_MISSING = "No remote iMessage client available";
+export const availablePhones = (clients: RemoteClient[]): string[] =>
+  clients.map((c) => c.phone);
 
-export const firstRemoteClient = (
-  clients: AdvancedIMessage[]
-): AdvancedIMessage | undefined => clients[0];
-
-export const primaryRemoteClient = (
-  clients: AdvancedIMessage[]
+export const clientForPhone = (
+  clients: RemoteClient[],
+  phone: string
 ): AdvancedIMessage => {
-  const remote = firstRemoteClient(clients);
-  if (!remote) {
-    throw new Error(REMOTE_CLIENT_MISSING);
+  const entry = clients.find((c) => c.phone === phone);
+  if (!entry) {
+    const list = availablePhones(clients).join(", ") || "<none>";
+    throw new Error(
+      `No iMessage client serves phone ${phone}. Available: ${list}`
+    );
   }
-  return remote;
+  return entry.client;
+};
+
+export const randomPhone = (clients: RemoteClient[]): string => {
+  if (clients.length === 0) {
+    throw new Error("No iMessage phones configured for this account");
+  }
+  const entry = clients[Math.floor(Math.random() * clients.length)];
+  if (!entry) {
+    throw new Error("No iMessage phones configured for this account");
+  }
+  return entry.phone;
 };

--- a/packages/spectrum-ts/src/providers/imessage/remote/inbound.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/inbound.ts
@@ -72,7 +72,8 @@ const asProviderGroup = (items: readonly RawProviderMessage[]): Group =>
 export const buildMessageBase = (
   message: AppleMessage,
   chatGuidHint: string | undefined,
-  timestamp: Date
+  timestamp: Date,
+  phone: string
 ): RemoteMessageBase => {
   const chat = resolveChatGuid(message, chatGuidHint);
   return {
@@ -80,6 +81,7 @@ export const buildMessageBase = (
     space: {
       id: chat,
       type: chat.includes(";+;") ? "group" : "dm",
+      phone,
     },
     timestamp,
   };
@@ -175,11 +177,12 @@ const toRichlinkMessage = (
 export const rebuildFromAppleMessage = async (
   client: AdvancedIMessage,
   message: AppleMessage,
+  phone: string,
   chatGuidHint?: string
 ): Promise<IMessageMessage> => {
   const messageGuidStr = message.guid as string;
   const timestamp = message.dateCreated ?? new Date();
-  const base = buildMessageBase(message, chatGuidHint, timestamp);
+  const base = buildMessageBase(message, chatGuidHint, timestamp, phone);
 
   if (message.attachments.length === 1) {
     const info = message.attachments[0];
@@ -243,9 +246,15 @@ export const cacheMessage = (
 export const toInboundMessages = async (
   client: AdvancedIMessage,
   cache: MessageCache,
-  event: ReceivedEvent
+  event: ReceivedEvent,
+  phone: string
 ): Promise<IMessageMessage[]> => {
-  const base = buildMessageBase(event.message, event.chatGuid, event.timestamp);
+  const base = buildMessageBase(
+    event.message,
+    event.chatGuid,
+    event.timestamp,
+    phone
+  );
   const messageGuidStr = event.message.guid as string;
 
   if (getBalloonBundleId(event.message) === URL_BALLOON_BUNDLE_ID) {
@@ -310,8 +319,11 @@ export const toInboundMessages = async (
 export const getMessage = async (
   remote: AdvancedIMessage,
   spaceId: string,
-  msgId: string
+  msgId: string,
+  phone: string
 ): Promise<IMessageMessage | undefined> => {
+  // Per-AdvancedIMessage cache: keyed off the inner client object so each
+  // phone has its own message cache.
   const cache = getMessageCache(remote);
   const cached = cache.get(msgId);
   if (cached) {
@@ -327,7 +339,12 @@ export const getMessage = async (
       const fetched = await remote.messages.get(
         messageGuid(childRef.parentGuid)
       );
-      const parent = await rebuildFromAppleMessage(remote, fetched, spaceId);
+      const parent = await rebuildFromAppleMessage(
+        remote,
+        fetched,
+        phone,
+        spaceId
+      );
       cacheMessage(cache, parent);
       if (parent.content.type !== "group") {
         return;
@@ -344,7 +361,12 @@ export const getMessage = async (
 
   try {
     const fetched = await remote.messages.get(messageGuid(msgId));
-    const rebuilt = await rebuildFromAppleMessage(remote, fetched, spaceId);
+    const rebuilt = await rebuildFromAppleMessage(
+      remote,
+      fetched,
+      phone,
+      spaceId
+    );
     cacheMessage(cache, rebuilt);
     return rebuilt;
   } catch (err) {

--- a/packages/spectrum-ts/src/providers/imessage/remote/polls.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/polls.ts
@@ -27,6 +27,7 @@ interface PollOptionMessageInput {
   chatGuid: string;
   event: Pick<PollEvent, "at" | "pollMessageGuid">;
   optionId: string;
+  phone: string;
   selected: boolean;
   senderAddress: string;
 }
@@ -36,6 +37,7 @@ interface PollOptionMessagesInput {
   chatGuid: string;
   deltas: readonly PollSelectionDelta[];
   event: Pick<PollEvent, "at" | "pollMessageGuid">;
+  phone: string;
   senderAddress: string;
 }
 
@@ -137,6 +139,7 @@ const buildPollOptionMessage = (
     space: {
       id: input.chatGuid,
       type: input.chatGuid.includes(";+;") ? "group" : "dm",
+      phone: input.phone,
     },
     timestamp: input.event.at,
     content: asPollOption({
@@ -157,6 +160,7 @@ const buildPollOptionMessages = (
       chatGuid: input.chatGuid,
       event: input.event,
       optionId: delta.optionId,
+      phone: input.phone,
       selected: delta.selected,
       senderAddress: input.senderAddress,
     });
@@ -196,7 +200,8 @@ const refreshPollMetadata = async (
 const toPollVoteMessages = async (
   client: AdvancedIMessage,
   pollCache: PollCache,
-  event: VotedPollEvent
+  event: VotedPollEvent,
+  phone: string
 ): Promise<IMessageMessage[]> => {
   const senderAddress = event.actor.address;
   if (!senderAddress) {
@@ -245,6 +250,7 @@ const toPollVoteMessages = async (
     chatGuid: chatGuidStr,
     deltas,
     event,
+    phone,
     senderAddress,
   });
 
@@ -261,7 +267,8 @@ const toPollVoteMessages = async (
 const toPollUnvoteMessages = async (
   client: AdvancedIMessage,
   pollCache: PollCache,
-  event: UnvotedPollEvent
+  event: UnvotedPollEvent,
+  phone: string
 ): Promise<IMessageMessage[]> => {
   const senderAddress = event.actor.address;
   if (!senderAddress) {
@@ -282,6 +289,7 @@ const toPollUnvoteMessages = async (
     chatGuid: chatGuidStr,
     deltas,
     event,
+    phone,
     senderAddress,
   });
   pollCache.commitActorSelection(pollId, senderAddress, [], event.at);
@@ -291,13 +299,14 @@ const toPollUnvoteMessages = async (
 export const toPollDeltaMessages = async (
   client: AdvancedIMessage,
   pollCache: PollCache,
-  event: PollEvent
+  event: PollEvent,
+  phone: string
 ): Promise<IMessageMessage[]> => {
   if (isVotedPollEvent(event)) {
-    return toPollVoteMessages(client, pollCache, event);
+    return toPollVoteMessages(client, pollCache, event, phone);
   }
   if (isUnvotedPollEvent(event)) {
-    return toPollUnvoteMessages(client, pollCache, event);
+    return toPollUnvoteMessages(client, pollCache, event, phone);
   }
   return [];
 };

--- a/packages/spectrum-ts/src/providers/imessage/remote/reactions.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/reactions.ts
@@ -95,13 +95,14 @@ const resolveReactionTarget = async (
   client: AdvancedIMessage,
   cache: MessageCache,
   strippedGuid: string,
-  partIndex: number
+  partIndex: number,
+  phone: string
 ): Promise<IMessageMessage | undefined> => {
   let candidate = cache.get(strippedGuid);
   if (!candidate) {
     try {
       const fetched = await client.messages.get(messageGuid(strippedGuid));
-      candidate = await rebuildFromAppleMessage(client, fetched);
+      candidate = await rebuildFromAppleMessage(client, fetched, phone);
       cacheMessage(cache, candidate);
     } catch {
       return;
@@ -122,7 +123,8 @@ export const toReactionMessages = async (
   client: AdvancedIMessage,
   cache: MessageCache,
   event: ReceivedEvent,
-  target: string
+  target: string,
+  phone: string
 ): Promise<IMessageMessage[]> => {
   const type = getAssociatedMessageType(event.message);
   if (type && isTapbackRemoval(type)) {
@@ -140,7 +142,8 @@ export const toReactionMessages = async (
     client,
     cache,
     strippedGuid,
-    partIndex
+    partIndex,
+    phone
   );
   if (!resolved) {
     return [];
@@ -149,7 +152,12 @@ export const toReactionMessages = async (
   if (typeof messageId !== "string" || messageId.length === 0) {
     return [];
   }
-  const base = buildMessageBase(event.message, event.chatGuid, event.timestamp);
+  const base = buildMessageBase(
+    event.message,
+    event.chatGuid,
+    event.timestamp,
+    phone
+  );
   return [
     {
       ...base,

--- a/packages/spectrum-ts/src/providers/imessage/remote/stream.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/stream.ts
@@ -18,7 +18,7 @@ import {
   stream,
 } from "../../../utils/stream";
 import { getMessageCache, getPollCache, type PollCache } from "../cache";
-import type { IMessageMessage } from "../types";
+import type { IMessageMessage, RemoteClient } from "../types";
 import {
   type AppleMessage,
   type ReceivedEvent,
@@ -47,6 +47,7 @@ const isRetryableIMessageStreamError = (error: unknown): boolean => {
 const toMessageItem = async (
   client: AdvancedIMessage,
   event: ReceivedEvent,
+  phone: string,
   cursor?: string
 ): Promise<ResumableStreamItem<IMessageMessage>> => {
   const id = event.message.guid as string;
@@ -54,24 +55,27 @@ const toMessageItem = async (
     return { cursor, id, values: [] };
   }
 
+  // Per-AdvancedIMessage cache: keyed off the inner client object so each
+  // phone has its own message cache.
   const cache = getMessageCache(client);
   const target = event.message.associatedMessageGuid as string | undefined;
   const values = target
-    ? await toReactionMessages(client, cache, event, target)
-    : await toInboundMessages(client, cache, event);
+    ? await toReactionMessages(client, cache, event, target, phone)
+    : await toInboundMessages(client, cache, event, phone);
   return { cursor, id, values };
 };
 
 const messageStream = (
-  client: AdvancedIMessage
+  client: AdvancedIMessage,
+  phone: string
 ): ManagedStream<IMessageMessage> =>
   resumableOrderedStream<ReceivedEvent, AppleMessage, IMessageMessage>({
     fetchMissed: (cursor, { limit }) =>
       client.messages.fetchMissed(cursor, { limit }),
     isRetryableError: isRetryableIMessageStreamError,
-    processLive: (event) => toMessageItem(client, event, event.cursor),
+    processLive: (event) => toMessageItem(client, event, phone, event.cursor),
     processMissed: (message) =>
-      toMessageItem(client, receivedEventFromMessage(message)),
+      toMessageItem(client, receivedEventFromMessage(message), phone),
     subscribeLive: () => client.messages.subscribe("message.received"),
   });
 
@@ -86,13 +90,14 @@ const emitPollMessages = async (
   client: AdvancedIMessage,
   pollCache: PollCache,
   event: PollEvent,
+  phone: string,
   emit: (message: IMessageMessage) => Promise<void>
 ): Promise<void> => {
   cachePollEvent(pollCache, event);
   if (event.actor.isFromMe) {
     return;
   }
-  const messages = await toPollDeltaMessages(client, pollCache, event);
+  const messages = await toPollDeltaMessages(client, pollCache, event, phone);
   for (const vote of messages) {
     await emit(vote);
   }
@@ -102,18 +107,20 @@ const runPollSubscription = async (
   client: AdvancedIMessage,
   pollCache: PollCache,
   subscription: ReturnType<AdvancedIMessage["polls"]["subscribe"]>,
+  phone: string,
   emit: (message: IMessageMessage) => Promise<void>,
   onEvent: () => void
 ): Promise<void> => {
   for await (const event of subscription) {
     onEvent();
-    await emitPollMessages(client, pollCache, event, emit);
+    await emitPollMessages(client, pollCache, event, phone, emit);
   }
 };
 
 const pollStream = (
   client: AdvancedIMessage,
-  pollCache: PollCache
+  pollCache: PollCache,
+  phone: string
 ): ManagedStream<IMessageMessage> =>
   stream<IMessageMessage>((emit, end) => {
     let active = client.polls.subscribe();
@@ -146,9 +153,16 @@ const pollStream = (
     const pump = (async () => {
       while (!closed) {
         try {
-          await runPollSubscription(client, pollCache, active, emit, () => {
-            retryDelayMs = RECONNECT_INITIAL_DELAY_MS;
-          });
+          await runPollSubscription(
+            client,
+            pollCache,
+            active,
+            phone,
+            emit,
+            () => {
+              retryDelayMs = RECONNECT_INITIAL_DELAY_MS;
+            }
+          );
         } catch (e) {
           if (!closed) {
             logPollStreamError(e);
@@ -176,14 +190,23 @@ const pollStream = (
 
 const clientStream = (
   client: AdvancedIMessage,
-  pollCache: PollCache
+  pollCache: PollCache,
+  phone: string
 ): ManagedStream<IMessageMessage> => {
-  return mergeStreams([messageStream(client), pollStream(client, pollCache)]);
+  return mergeStreams([
+    messageStream(client, phone),
+    pollStream(client, pollCache, phone),
+  ]);
 };
 
 export const messages = (
-  clients: AdvancedIMessage[]
+  clients: RemoteClient[]
 ): ManagedStream<IMessageMessage> => {
+  // Outer-array poll cache: shared across all per-phone streams to dedupe
+  // poll events that fan out to every client. Keyed off the RemoteClient[]
+  // identity, so each iMessage provider instance has its own.
   const pollCache = getPollCache(clients);
-  return mergeStreams(clients.map((client) => clientStream(client, pollCache)));
+  return mergeStreams(
+    clients.map((entry) => clientStream(entry.client, pollCache, entry.phone))
+  );
 };

--- a/packages/spectrum-ts/src/providers/imessage/types.ts
+++ b/packages/spectrum-ts/src/providers/imessage/types.ts
@@ -3,12 +3,21 @@ import { IMessageSDK } from "@photon-ai/imessage-kit";
 import z from "zod";
 import type { SchemaMessage } from "../../platform/types";
 
-export type IMessageClient = IMessageSDK | AdvancedIMessage[];
+export interface RemoteClient {
+  client: AdvancedIMessage;
+  phone: string;
+}
+
+export type IMessageClient = IMessageSDK | RemoteClient[];
 
 export const isLocal = (client: IMessageClient): client is IMessageSDK =>
   client instanceof IMessageSDK;
 
-const clientEntry = z.object({ address: z.string(), token: z.string() });
+const clientEntry = z.object({
+  address: z.string(),
+  token: z.string(),
+  phone: z.string(),
+});
 
 export const configSchema = z.union([
   z.object({ local: z.literal(true) }),
@@ -23,6 +32,11 @@ export const userSchema = z.object({});
 export const spaceSchema = z.object({
   id: z.string(),
   type: z.enum(["dm", "group"]),
+  phone: z.string(),
+});
+
+export const spaceParamsSchema = z.object({
+  phone: z.string().optional(),
 });
 
 /**

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -550,6 +550,34 @@ export const terminal = definePlatform("terminal", {
     }),
   },
 
+  lifecycle: {
+    createClient: async ({ config }) => {
+      return await spawnClient({ commands: config.commands });
+    },
+
+    destroyClient: async ({ client }) => {
+      // Restore console FIRST so any further logs in this teardown go to the
+      // real stderr instead of a closing socket.
+      client.hijack.restore();
+      try {
+        // Bounded so an unresponsive subprocess can't hang destroyClient.
+        await client.session.request(
+          "shutdown",
+          undefined,
+          SHUTDOWN_TIMEOUT_MS
+        );
+      } catch {
+        // best-effort
+      }
+      client.session.close();
+      try {
+        client.proc.kill("SIGTERM");
+      } catch {
+        // best-effort
+      }
+    },
+  },
+
   user: {
     resolve: async ({ input }) => ({
       id: input.userID,
@@ -558,43 +586,16 @@ export const terminal = definePlatform("terminal", {
 
   space: {
     params: z.object({ id: z.string().optional() }),
-    resolve: async (ctx) => {
-      const client = ctx.client as TerminalClient;
-      const id = ctx.input.params?.id ?? generateChatId(client);
+    resolve: async ({ client, input }) => {
+      const id = input.params?.id ?? generateChatId(client);
       client.knownChats.add(id);
       await client.session.request("ensureSpace", { id });
       return { id };
     },
   },
 
-  lifecycle: {
-    createClient: async ({ config }) => {
-      return await spawnClient({ commands: config.commands });
-    },
-
-    destroyClient: async ({ client }) => {
-      const c = client as TerminalClient;
-      // Restore console FIRST so any further logs in this teardown go to the
-      // real stderr instead of a closing socket.
-      c.hijack.restore();
-      try {
-        // Bounded so an unresponsive subprocess can't hang destroyClient.
-        await c.session.request("shutdown", undefined, SHUTDOWN_TIMEOUT_MS);
-      } catch {
-        // best-effort
-      }
-      c.session.close();
-      try {
-        c.proc.kill("SIGTERM");
-      } catch {
-        // best-effort
-      }
-    },
-  },
-
   events: {
-    async *messages(ctx) {
-      const client = ctx.client as TerminalClient;
+    async *messages({ client }) {
       for await (const evt of client.events) {
         if (evt.kind === "message") {
           const msg = evt.value;
@@ -629,28 +630,24 @@ export const terminal = definePlatform("terminal", {
 
   actions: {
     send: async ({ client, content, space }) => {
-      const c = client as TerminalClient;
       const proto = await spectrumToProtocol(content);
-      const result = await c.session.request<{ id: string; timestamp: string }>(
-        "send",
-        { spaceId: space.id, content: proto }
-      );
+      const result = await client.session.request<{
+        id: string;
+        timestamp: string;
+      }>("send", { spaceId: space.id, content: proto });
       return buildOutboundRecord(result, content, space.id);
     },
 
     startTyping: async ({ client, space }) => {
-      const c = client as TerminalClient;
-      await c.session.request("startTyping", { spaceId: space.id });
+      await client.session.request("startTyping", { spaceId: space.id });
     },
 
     stopTyping: async ({ client, space }) => {
-      const c = client as TerminalClient;
-      await c.session.request("stopTyping", { spaceId: space.id });
+      await client.session.request("stopTyping", { spaceId: space.id });
     },
 
     reactToMessage: async ({ client, space, target, reaction }) => {
-      const c = client as TerminalClient;
-      await c.session.request("reactToMessage", {
+      await client.session.request("reactToMessage", {
         spaceId: space.id,
         messageId: target.id,
         reaction,
@@ -658,12 +655,11 @@ export const terminal = definePlatform("terminal", {
     },
 
     replyToMessage: async ({ client, space, messageId, content }) => {
-      const c = client as TerminalClient;
       const proto = await spectrumToProtocol(content);
-      const result = await c.session.request<{ id: string; timestamp: string }>(
-        "replyToMessage",
-        { spaceId: space.id, messageId, content: proto }
-      );
+      const result = await client.session.request<{
+        id: string;
+        timestamp: string;
+      }>("replyToMessage", { spaceId: space.id, messageId, content: proto });
       return buildOutboundRecord(result, content, space.id);
     },
   },

--- a/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
@@ -13,31 +13,6 @@ import {
 export const whatsappBusiness = definePlatform("WhatsApp Business", {
   config: configSchema,
 
-  user: {
-    resolve: async ({ input }) => ({ id: input.userID }),
-  },
-
-  space: {
-    schema: spaceSchema,
-    resolve: async ({ input }) => {
-      if (input.users.length === 0) {
-        throw new Error("WhatsApp space creation requires at least one user");
-      }
-      if (input.users.length > 1) {
-        throw UnsupportedError.action(
-          "createSpace",
-          "WhatsApp Business",
-          "only 1:1 conversations are supported"
-        );
-      }
-      const user = input.users[0];
-      if (!user) {
-        throw new Error("WhatsApp space creation requires a user");
-      }
-      return { id: user.id };
-    },
-  },
-
   lifecycle: {
     createClient: async ({
       config,
@@ -65,37 +40,52 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
       return await createCloudClients(projectId, projectSecret);
     },
 
-    destroyClient: async ({ client }: { client: WhatsAppClients }) => {
+    destroyClient: async ({ client }) => {
       await disposeCloudAuth(client);
       await Promise.all(client.map((c) => c.close()));
     },
   },
 
+  user: {
+    resolve: async ({ input }) => ({ id: input.userID }),
+  },
+
+  space: {
+    schema: spaceSchema,
+    resolve: async ({ input }) => {
+      if (input.users.length === 0) {
+        throw new Error("WhatsApp space creation requires at least one user");
+      }
+      if (input.users.length > 1) {
+        throw UnsupportedError.action(
+          "createSpace",
+          "WhatsApp Business",
+          "only 1:1 conversations are supported"
+        );
+      }
+      const user = input.users[0];
+      if (!user) {
+        throw new Error("WhatsApp space creation requires a user");
+      }
+      return { id: user.id };
+    },
+  },
+
   events: {
-    messages: ({ client }) => messages(client as WhatsAppClients),
+    messages: ({ client }) => messages(client),
   },
 
   actions: {
     send: async ({ space, content, client }) => {
-      return await send(client as WhatsAppClients, space.id, content);
+      return await send(client, space.id, content);
     },
 
     reactToMessage: async ({ space, target, reaction, client }) => {
-      await reactToMessage(
-        client as WhatsAppClients,
-        space.id,
-        target.id,
-        reaction
-      );
+      await reactToMessage(client, space.id, target.id, reaction);
     },
 
     replyToMessage: async ({ space, messageId, content, client }) => {
-      return await replyToMessage(
-        client as WhatsAppClients,
-        space.id,
-        messageId,
-        content
-      );
+      return await replyToMessage(client, space.id, messageId, content);
     },
   },
 });

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -14,6 +14,7 @@ import type {
 } from "./platform/types";
 import type { InboundMessage, OutboundMessage } from "./types/message";
 import type { Space } from "./types/space";
+import { createStore, type Store } from "./utils/store";
 import {
   type Broadcaster,
   broadcast,
@@ -162,11 +163,13 @@ export async function Spectrum<
     client: unknown;
     config: unknown;
     definition: AnyPlatformDef;
+    store: Store;
   }): ManagedStream<[Space, InboundMessage]> => {
-    const { client, config, definition } = state;
+    const { client, config, definition, store } = state;
     const raw = definition.events.messages({
       client,
       config,
+      store,
     }) as AsyncIterable<ProviderMessageRecord>;
 
     const bindSend = async function* (): AsyncIterable<
@@ -177,7 +180,7 @@ export async function Spectrum<
           ...msg.space,
           __platform: definition.name,
         };
-        const typingCtx = { space: spaceRef, client, config };
+        const typingCtx = { space: spaceRef, client, config, store };
         const space = buildSpace({
           spaceRef,
           extras: {},
@@ -185,6 +188,7 @@ export async function Spectrum<
           definition,
           client,
           config,
+          store,
         });
         const normalizedMessage = wrapProviderMessage(
           msg,
@@ -194,6 +198,7 @@ export async function Spectrum<
             definition,
             space,
             spaceRef,
+            store,
           },
           "inbound"
         );
@@ -217,6 +222,7 @@ export async function Spectrum<
     client: unknown;
     config: unknown;
     definition: AnyPlatformDef;
+    store: Store;
   }): Broadcaster<[Space, InboundMessage]> => {
     if (stopped) {
       throw new Error(
@@ -239,17 +245,20 @@ export async function Spectrum<
     const providerConfig = provider as PlatformProviderConfig;
     const def = providerConfig.__definition;
     const userConfig = def.config.parse(providerConfig.config);
+    const store = createStore();
 
     const client = await def.lifecycle.createClient({
       config: userConfig,
       projectId,
       projectSecret,
+      store,
     });
 
     const state = {
       client,
       config: userConfig,
       definition: def,
+      store,
     };
 
     platformStates.set(def.name, {
@@ -289,18 +298,19 @@ export async function Spectrum<
   ): ManagedStream<unknown> => {
     return stream<unknown>((emit, end) => {
       const providerStreams = Array.from(platformStates.values(), (state) => {
-        const { client, config, definition } = state;
+        const { client, config, definition, store } = state;
         const producer = definition.events[eventName] as
           | ((ctx: {
               client: unknown;
               config: unknown;
+              store: Store;
             }) => AsyncIterable<unknown>)
           | undefined;
         if (!producer) {
           return undefined;
         }
 
-        const providerEvents = producer({ client, config });
+        const providerEvents = producer({ client, config, store });
         const annotatePlatform = async function* (): AsyncIterable<unknown> {
           for await (const value of providerEvents) {
             yield { ...(value as object), platform: definition.name };
@@ -357,6 +367,7 @@ export async function Spectrum<
     const clientShutdowns = Array.from(platformStates.values(), (state) =>
       state.definition.lifecycle.destroyClient({
         client: state.client,
+        store: state.store,
       })
     );
     await Promise.allSettled(clientShutdowns);

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -365,11 +365,11 @@ export async function Spectrum<
 
     await Promise.allSettled(streamShutdowns);
     const clientShutdowns = Array.from(platformStates.values(), (state) =>
-      state.definition.lifecycle.destroyClient({
+      state.definition.lifecycle.destroyClient?.({
         client: state.client,
         store: state.store,
       })
-    );
+    ).filter((shutdown): shutdown is Promise<void> => shutdown !== undefined);
     await Promise.allSettled(clientShutdowns);
     customEventStreams.clear();
     messageBroadcasters.clear();

--- a/packages/spectrum-ts/src/utils/cloud.ts
+++ b/packages/spectrum-ts/src/utils/cloud.ts
@@ -20,6 +20,7 @@ export interface SharedTokenData {
 export interface DedicatedTokenData {
   auth: Record<string, string>;
   expiresIn: number;
+  numbers: Record<string, string | null>;
   type: "dedicated";
 }
 

--- a/packages/spectrum-ts/src/utils/store.ts
+++ b/packages/spectrum-ts/src/utils/store.ts
@@ -22,6 +22,14 @@ export interface Store {
   string(key: string): string | undefined;
 }
 
+const isRecordObject = (value: unknown): value is Record<string, unknown> => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+};
+
 export function createStore(): Store {
   const data = new Map<string, unknown>();
 
@@ -58,7 +66,7 @@ export function createStore(): Store {
     },
     object<T = Record<string, unknown>>(key: string): T | undefined {
       const v = data.get(key);
-      if (typeof v !== "object" || v === null || Array.isArray(v)) {
+      if (!isRecordObject(v)) {
         return;
       }
       return v as T;

--- a/packages/spectrum-ts/src/utils/store.ts
+++ b/packages/spectrum-ts/src/utils/store.ts
@@ -1,0 +1,71 @@
+/**
+ * A small per-platform key-value bag, modeled after Swift's `UserDefaults`.
+ * Untyped writes; typed reads return `undefined` on missing key OR type
+ * mismatch (no throws). In-memory only.
+ *
+ * SDK-internal: reachable from inside `definePlatform` callbacks via the
+ * `store` field on lifecycle/action/event ctx. Not exposed on the public
+ * SpectrumInstance or platform narrower.
+ */
+export interface Store {
+  array<T = unknown>(key: string): T[] | undefined;
+  bool(key: string): boolean | undefined;
+  clear(): void;
+  delete(key: string): boolean;
+  get(key: string): unknown;
+  has(key: string): boolean;
+  keys(): string[];
+  number(key: string): number | undefined;
+  object<T = Record<string, unknown>>(key: string): T | undefined;
+  set(key: string, value: unknown): void;
+
+  string(key: string): string | undefined;
+}
+
+export function createStore(): Store {
+  const data = new Map<string, unknown>();
+
+  return {
+    set(key, value) {
+      data.set(key, value);
+    },
+    get(key) {
+      return data.get(key);
+    },
+    has(key) {
+      return data.has(key);
+    },
+    delete(key) {
+      return data.delete(key);
+    },
+    clear() {
+      data.clear();
+    },
+    keys() {
+      return Array.from(data.keys());
+    },
+    string(key) {
+      const v = data.get(key);
+      return typeof v === "string" ? v : undefined;
+    },
+    number(key) {
+      const v = data.get(key);
+      return typeof v === "number" ? v : undefined;
+    },
+    bool(key) {
+      const v = data.get(key);
+      return typeof v === "boolean" ? v : undefined;
+    },
+    object<T = Record<string, unknown>>(key: string): T | undefined {
+      const v = data.get(key);
+      if (typeof v !== "object" || v === null || Array.isArray(v)) {
+        return;
+      }
+      return v as T;
+    },
+    array<T = unknown>(key: string): T[] | undefined {
+      const v = data.get(key);
+      return Array.isArray(v) ? (v as T[]) : undefined;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Adds first-class support for iMessage accounts that have multiple phone numbers attached. The remote client surface is now `RemoteClient[]` (`{ client, phone }`) instead of bare `AdvancedIMessage[]`, every iMessage `Space` carries the `phone` it belongs to, and per-message actions (`send`, `reply`, `react`, `edit`, `getMessage`, typing) route to the correct underlying client by `phone` instead of always picking `clients[0]`.
- Introduces a `phone?: string` space param so callers can pin a new conversation to a specific number — `imessage.space({ users, params: { phone: "+1…" } })`. When omitted, `randomPhone(client)` picks one of the available numbers; resolving a 1:1 chat doesn't need network at all (it just builds the direct chat guid). Group creation routes through whichever number was selected.
- Adds a generic per-platform `Store` (modeled on Swift's `UserDefaults`) on every lifecycle / action / event context. It is SDK-internal — reachable inside `definePlatform` callbacks via `ctx.store`, but not exposed on the public `SpectrumInstance` or platform narrower.
- Makes `lifecycle.destroyClient` optional and tightens client-type inference across `definePlatform` so providers can drop `const c = client as TerminalClient` casts and write `({ client }) => client.session.request(...)` directly.
- Spreads parsed space props into `spaceRef` so action callbacks see the full resolved space (e.g. `space.phone`, `space.type`), not just `{ id, __platform }`.

## Usage

```typescript
import { Spectrum } from "spectrum-ts";
import { imessage } from "spectrum-ts/providers/imessage";

const app = await Spectrum({
  projectId: process.env.PROJECT_ID,
  projectSecret: process.env.PROJECT_SECRET,
  providers: [imessage.config()],
});

// Inbound: every iMessage space carries the phone it arrived on.
for await (const [space, message] of app.imessage.messages) {
  console.log(`message arrived on ${space.phone}: ${message.id}`);
  await space.responding(async () => {
    // Replies/sends/reactions automatically route to the same phone.
    await message.reply("Hello from Spectrum.");
  });
}

// Outbound: pin a new conversation to a specific phone.
const space = await app.imessage.space({
  users: [{ id: "+15551234567" }],
  params: { phone: "+15557654321" },
});
await space.send("hi");

// Or omit `phone` and let Spectrum pick one of the configured numbers.
const space2 = await app.imessage.space({ users: [{ id: "+15551234567" }] });
```

For self-hosted setups, the `clients` config now requires a `phone` per entry:

```typescript
imessage.config({
  clients: [
    { phone: "+15551111111", address: "instance-a.example:443", token: "..." },
    { phone: "+15552222222", address: "instance-b.example:443", token: "..." },
  ],
});
```

Cloud mode picks up the per-instance phone map from `DedicatedTokenData.numbers`. Shared-token cloud mode is now rejected with `UnsupportedError` because it has no per-phone identity to route by.

## How it works

**Routing.** `providers/imessage/remote/client.ts` exposes:

- `availablePhones(clients)` — for diagnostics and error messages.
- `clientForPhone(clients, phone)` — strict lookup; throws `No iMessage client serves phone <phone>. Available: <list>` so misrouted sends fail loud instead of silently hitting the wrong number.
- `randomPhone(clients)` — picks one of the configured phones for new outbound conversations.

`firstRemoteClient` / `primaryRemoteClient` are gone — every send-side helper in `remote/api.ts` now takes a single `AdvancedIMessage` (resolved upstream from `space.phone`) instead of the array. Inbound paths (`buildMessageBase`, `toInboundMessages`, `rebuildFromAppleMessage`, `toReactionMessages`, `toPollDeltaMessages`, `getRemoteMessage`) thread `phone` through so emitted messages carry it on their `space`.

**Streams.** `remote/stream.ts` now spins up one `messageStream` + one `pollStream` per `RemoteClient` and merges them. The `MessageCache` is keyed off the inner `AdvancedIMessage` (so each phone has its own message cache), and the `PollCache` is keyed off the outer `RemoteClient[]` array identity (shared across phones to dedupe poll fan-out within one provider instance).

**Auth.** `providers/imessage/auth.ts` now consumes `DedicatedTokenData.numbers` (a new `Record<string, string | null>` on the token shape) to attach a `phone` to each `RemoteClient`. `requirePhone(data, instanceId)` throws if the cloud hasn't assigned a number for an instance. The renewal path captures `records: { entry, instanceId }[]` in a closure and mutates `entry.phone` in place across renewals so live client refs and merged streams stay alive.

**Store.** `utils/store.ts` is a thin in-memory key-value bag with typed accessors (`string`, `number`, `bool`, `object<T>`, `array<T>`) that return `undefined` on missing keys *or* type mismatches — never throws. Each `Spectrum()` call creates one store per provider in `__internal.platforms` and threads it through `lifecycle.{create,destroy}Client`, `events.<name>`, every action (`send`, `startTyping`, `reactToMessage`, …), and the resolvers in `space` / `user`.

**Optional `destroyClient`.** `PlatformDef.lifecycle.destroyClient` is now optional. The `Spectrum()` shutdown loop filters out undefined results before `Promise.allSettled`, so a platform that has nothing to clean up can simply omit the field.

**Type inference.** `platform/types.ts` introduces `NoInferClient<T>` so the `_Client` type parameter is *only* inferred from `lifecycle.createClient`'s return type, never from action callback parameters. That removes the need for `client as MyClient` casts inside `definePlatform` callbacks — see `providers/terminal/index.ts` and `providers/whatsapp-business/index.ts` for the cleanup. `definePlatform`'s signature also splits `lifecycle` into a non-`Omit`'d branch so `createClient`'s context type is reachable to consumers via the new exported `CreateClientContext<_ConfigSchema>`.

**`spaceRef` spread.** `platform/define.ts` now spreads `parsedSpace` into `spaceRef` (`{ ...parsedSpace, id, __platform }`) so every action callback's `space` argument carries the full resolved schema — including `phone` for iMessage and `type` for groups vs. DMs — not just `{ id, __platform }`.

## Changes

| File | Change |
|---|---|
| `packages/spectrum-ts/src/utils/store.ts` | **New.** `Store` interface (`get/set/has/delete/clear/keys` + typed `string/number/bool/object/array` accessors) and `createStore()` factory. In-memory only, never throws on type mismatch. |
| `packages/spectrum-ts/src/utils/cloud.ts` | `DedicatedTokenData` gains `numbers: Record<string, string \| null>` for per-instance phone routing. |
| `packages/spectrum-ts/src/platform/types.ts` | Add `Store` to every action / event / lifecycle / resolver context. Wrap `_Client` references in `NoInferClient<T>` so client type is inferred only from `createClient`. Export new `CreateClientContext<_ConfigSchema>`. Make `lifecycle.destroyClient` optional. Add `store: Store` to `PlatformRuntime`. Fix `AwaitedReturn<T>` to use `Awaited<R>` so non-`Promise` returns work. |
| `packages/spectrum-ts/src/platform/define.ts` | Thread `runtime.store` into every callback (`user.resolve`, `space.resolve`, `events.<name>`, `actions.*`, `lifecycle.{create,destroy}Client`). Spread `parsedSpace` into `spaceRef`. Split `definePlatform`'s param into `{ lifecycle: { createClient, destroyClient? } } & Omit<…, "lifecycle" \| "name">` so destroyClient can be omitted. Use `NoInferValue<_Client>` for `destroyClient`. |
| `packages/spectrum-ts/src/platform/build.ts` | Add `store: Store` to `BaseBuildParams`, `BuildSpaceParams`, `WrapContext`, and the `typingCtx` shape. Thread it through `wrapProviderMessage`, `buildSpace`, `buildMessage`, `dispatchSend`, `runReply`, `editMessage`, `getMessage`, `reactToMessage`. |
| `packages/spectrum-ts/src/spectrum.ts` | Create one `Store` per provider in `Spectrum()`. Pass it into `lifecycle.createClient`, custom event producers, and per-platform message subscriptions. Filter undefined returns from optional `destroyClient` during shutdown. |
| `packages/spectrum-ts/src/providers/imessage/types.ts` | Add `RemoteClient` (`{ client, phone }`). `IMessageClient` is now `IMessageSDK \| RemoteClient[]`. `clientEntry` config schema gains `phone: z.string()`. `spaceSchema` gains `phone: z.string()`. New `spaceParamsSchema = { phone?: string }`. |
| `packages/spectrum-ts/src/providers/imessage/index.ts` | `space.params: spaceParamsSchema`. `resolve` validates clients array, picks `phone` from params or `randomPhone(client)`, builds 1:1 chats locally, routes group creation through `clientForPhone`. Every action (`send`, `startTyping`, `stopTyping`, `reactToMessage`, `replyToMessage`, `editMessage`, `getMessage`) resolves the `AdvancedIMessage` via `clientForPhone(client, space.phone)` before delegating. `destroyClient` updated to iterate `entry.client.close()`. Lifecycle moved above space/user for readability. |
| `packages/spectrum-ts/src/providers/imessage/auth.ts` | `createCloudClients` returns `RemoteClient[]`. New `requirePhone(data, instanceId)` helper. Shared-mode tokens now throw `UnsupportedError.action("multi-phone", "iMessage shared mode", "use dedicated-token cloud mode")`. Token renewal mutates `entry.phone` in place via captured `records` array. `disposeCloudAuth` and `cloudAuthState` re-keyed to `RemoteClient[]`. |
| `packages/spectrum-ts/src/providers/imessage/remote/client.ts` | Replace `firstRemoteClient` / `primaryRemoteClient` with `availablePhones`, `clientForPhone`, `randomPhone`. |
| `packages/spectrum-ts/src/providers/imessage/remote/api.ts` | Every send-side helper takes a single resolved `AdvancedIMessage` instead of the array. `getMessage` takes an extra `phone` argument so the rebuilt message carries it. |
| `packages/spectrum-ts/src/providers/imessage/remote/stream.ts` | One `messageStream` + `pollStream` per `RemoteClient`, merged. `phone` threaded through `toMessageItem`, `messageStream`, `pollStream`, `runPollSubscription`, `emitPollMessages`, `clientStream`. Outer poll cache shared across phones. |
| `packages/spectrum-ts/src/providers/imessage/remote/inbound.ts` | `buildMessageBase`, `toInboundMessages`, `rebuildFromAppleMessage`, `getMessage` accept `phone` and stamp it onto every emitted `space`. |
| `packages/spectrum-ts/src/providers/imessage/remote/reactions.ts` | `resolveReactionTarget` and `toReactionMessages` accept `phone` and forward it to `rebuildFromAppleMessage` + `buildMessageBase`. |
| `packages/spectrum-ts/src/providers/imessage/remote/polls.ts` | Poll vote/unvote message builders accept `phone` and stamp it onto the synthesized poll-option `space`. |
| `packages/spectrum-ts/src/providers/imessage/local/inbound.ts` | Local mode has no per-phone identity, so emitted spaces use `phone: ""`. |
| `packages/spectrum-ts/src/providers/terminal/index.ts` | Drop redundant `client as TerminalClient` casts now that `_Client` infers correctly. `space.resolve` and every action use destructured `({ client })` directly. |
| `packages/spectrum-ts/src/providers/whatsapp-business/index.ts` | Same cleanup — drop the `client as WhatsAppClients` casts. `destroyClient` no longer needs an inline parameter type. |

## Test plan

- [ ] `bun x ultracite check` passes
- [ ] `bun x tsc --noEmit` clean across the workspace
- [ ] `bun run build` succeeds
- [ ] Cloud mode: a project with two phones connects, both `RemoteClient` entries are created with the right `phone`, and inbound messages on each line surface with `space.phone` set correctly
- [ ] Cloud mode: a project where `numbers[instanceId]` is absent throws `iMessage instance <id> has no phone assigned` rather than silently routing to whatever the SDK returns
- [ ] Cloud mode: shared-token cloud mode now throws `Unsupported … iMessage shared mode … use dedicated-token cloud mode`
- [ ] Cloud mode: token renewal across the 80% renewal window keeps existing `RemoteClient[]` references and live merged streams alive (no reconnect storm)
- [ ] Self-hosted: `imessage.config({ clients: [{ phone, address, token }, …] })` round-trips through `clientEntry` schema; an entry without `phone` fails Zod validation
- [ ] Outbound: `imessage.space({ users, params: { phone: "+15557654321" } })` builds a space with `space.phone === "+15557654321"`; subsequent `space.send`, `space.startTyping`, replies, edits, reactions all route to the matching `AdvancedIMessage`
- [ ] Outbound: `imessage.space({ users })` (no params) picks one of the configured phones via `randomPhone` and the resulting `space.phone` matches an entry in `availablePhones(client)`
- [ ] Outbound: `imessage.space({ users, params: { phone: "<unknown>" } })` throws `No iMessage client serves phone <unknown>. Available: …` from `clientForPhone`, before any network call
- [ ] Outbound 1:1: `directChat(addresses[0])` is used and no network request is made to the iMessage backend until `space.send` is called
- [ ] Outbound group: group creation routes through the picked phone and the returned `chat.guid` is stamped onto `space.id`, with `space.phone` retained
- [ ] Inbound poll events fan out to every phone but are deduped by the shared `PollCache` so a single delta produces one emitted message per provider instance, not one per phone
- [ ] Inbound reactions: `toReactionMessages` resolves the target via the same phone the reaction arrived on; `space.phone` on the synthesized reaction matches the carrier
- [ ] Local mode: inbound messages still emit with `space.phone === ""`; remote-only space resolution still throws `UnsupportedError`
- [ ] `Store`: a value `set` inside `lifecycle.createClient` is readable via `ctx.store` from a later `actions.send` call on the same provider; cross-provider stores are isolated
- [ ] `Store`: `store.string("missing")` returns `undefined`, `store.string("not-a-string")` (where the value is a `number`) returns `undefined` (no throw), and `store.delete("k")` returns `false` if the key was absent
- [ ] Optional `destroyClient`: a platform that omits `lifecycle.destroyClient` shuts down cleanly (no `TypeError: not a function`); a platform that defines it still has it called
- [ ] Type inference: in a fresh provider, `definePlatform("x", { lifecycle: { createClient: async () => new Foo() }, actions: { send: async ({ client }) => …` types `client` as `Foo` without an explicit `as`
- [ ] `spaceRef` spread: inside `actions.send`, `space.phone` (iMessage) and `space.type` (whatsapp groups) are accessible — not just `space.id` / `space.__platform`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-phone iMessage support: select and route actions by phone, per-phone message streams, and phone-aware spaces
  * Per-platform Store: typed in-memory key-value store for platform state

* **Refactor**
  * Provider lifecycle and client handling unified for phone-specific clients and cleaner teardown
  * Improved typing and context wiring across platform event/actions to include per-platform state
<!-- end of auto-generated comment: release notes by coderabbit.ai -->