### PR TITLE
feat(imessage): support shared-token cloud mode

### DIFF
--- a/packages/spectrum-ts/src/providers/imessage/auth.ts
+++ b/packages/spectrum-ts/src/providers/imessage/auth.ts
@@ -1,7 +1,10 @@
 import { createClient } from "@photon-ai/advanced-imessage";
-import { cloud, type DedicatedTokenData } from "../../utils/cloud";
-import { UnsupportedError } from "../../utils/errors";
-import type { RemoteClient } from "./types";
+import {
+  cloud,
+  type DedicatedTokenData,
+  type SharedTokenData,
+} from "../../utils/cloud";
+import { type RemoteClient, SHARED_PHONE } from "./types";
 
 const RENEWAL_RATIO = 0.8;
 const EXPIRY_BUFFER_MS = 30_000;
@@ -30,18 +33,9 @@ export async function createCloudClients(
   let disposed = false;
   let renewalTimer: ReturnType<typeof setTimeout> | undefined;
 
-  if (tokenData.type === "shared") {
-    throw UnsupportedError.action(
-      "multi-phone",
-      "iMessage shared mode",
-      "use dedicated-token cloud mode"
-    );
-  }
-
-  // Captured outside `buildClients` so renewal can mutate `entry.phone` in
-  // place, keeping live client refs and merged streams alive across renewals.
-  // The instanceId stays in this closure (paired with the entry) so it does
-  // not leak onto the public RemoteClient shape.
+  // The instanceId stays paired with each entry in this closure so renewal
+  // can rewrite `entry.phone` in place without leaking instanceId onto the
+  // public RemoteClient shape. Empty in shared mode.
   const records: { entry: RemoteClient; instanceId: string }[] = [];
 
   const syncPhones = (data: DedicatedTokenData) => {
@@ -60,15 +54,10 @@ export async function createCloudClients(
     renewalTimer = setTimeout(async () => {
       try {
         tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
-        if (tokenData.type === "shared") {
-          throw UnsupportedError.action(
-            "multi-phone",
-            "iMessage shared mode",
-            "use dedicated-token cloud mode"
-          );
-        }
         tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
-        syncPhones(tokenData);
+        if (tokenData.type === "dedicated") {
+          syncPhones(tokenData);
+        }
         scheduleRenewal();
       } catch {
         renewalTimer = setTimeout(() => scheduleRenewal(), RETRY_DELAY_MS);
@@ -85,17 +74,43 @@ export async function createCloudClients(
       return;
     }
     tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
-    if (tokenData.type === "shared") {
-      throw UnsupportedError.action(
-        "multi-phone",
-        "iMessage shared mode",
-        "use dedicated-token cloud mode"
-      );
-    }
     tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
-    syncPhones(tokenData);
+    if (tokenData.type === "dedicated") {
+      syncPhones(tokenData);
+    }
     scheduleRenewal();
   };
+
+  if (tokenData.type === "shared") {
+    const address =
+      process.env.SPECTRUM_IMESSAGE_ADDRESS ??
+      "imessage.spectrum.photon.codes:443";
+    const entries: RemoteClient[] = [
+      {
+        phone: SHARED_PHONE,
+        client: createClient({
+          address,
+          tls: true,
+          token: async () => {
+            await refreshIfNeeded();
+            return (tokenData as SharedTokenData).token;
+          },
+        }),
+      },
+    ];
+
+    cloudAuthState.set(entries, {
+      dispose: () => {
+        disposed = true;
+        if (renewalTimer !== undefined) {
+          clearTimeout(renewalTimer);
+          renewalTimer = undefined;
+        }
+      },
+    });
+
+    return entries;
+  }
 
   const dedicated = tokenData;
   for (const [instanceId, token] of Object.entries(dedicated.auth)) {

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -26,13 +26,14 @@ import {
   startTyping as remoteStartTyping,
   stopTyping as remoteStopTyping,
 } from "./remote/api";
-import { clientForPhone, randomPhone } from "./remote/client";
+import { clientForPhone, isSharedMode, randomPhone } from "./remote/client";
 import {
   configSchema,
   type IMessageClient,
   type IMessageMessage,
   isLocal,
   messageSchema,
+  SHARED_PHONE,
   spaceParamsSchema,
   spaceSchema,
 } from "./types";
@@ -117,7 +118,11 @@ export const imessage = definePlatform("iMessage", {
       if (client.length === 0) {
         throw new Error("No iMessage clients configured");
       }
-      const phone = input.params?.phone ?? randomPhone(client);
+      // Shared mode: ignore any user-supplied phone — there is only one
+      // identity, tagged at the SHARED_PHONE sentinel.
+      const phone = isSharedMode(client)
+        ? SHARED_PHONE
+        : (input.params?.phone ?? randomPhone(client));
       const remote = clientForPhone(client, phone);
       const addresses = input.users.map((u) => u.id);
 

--- a/packages/spectrum-ts/src/providers/imessage/remote/client.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/client.ts
@@ -1,5 +1,8 @@
 import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
-import type { RemoteClient } from "../types";
+import { type RemoteClient, SHARED_PHONE } from "../types";
+
+export const isSharedMode = (clients: RemoteClient[]): boolean =>
+  clients.length === 1 && clients[0]?.phone === SHARED_PHONE;
 
 export const availablePhones = (clients: RemoteClient[]): string[] =>
   clients.map((c) => c.phone);
@@ -8,6 +11,15 @@ export const clientForPhone = (
   clients: RemoteClient[],
   phone: string
 ): AdvancedIMessage => {
+  // Shared mode: a single client serves every conversation regardless of
+  // the phone arg, since the SDK exposes no per-number routing in this mode.
+  if (isSharedMode(clients)) {
+    const entry = clients[0];
+    if (!entry) {
+      throw new Error("No iMessage clients configured");
+    }
+    return entry.client;
+  }
   const entry = clients.find((c) => c.phone === phone);
   if (!entry) {
     const list = availablePhones(clients).join(", ") || "<none>";
@@ -21,6 +33,9 @@ export const clientForPhone = (
 export const randomPhone = (clients: RemoteClient[]): string => {
   if (clients.length === 0) {
     throw new Error("No iMessage phones configured for this account");
+  }
+  if (isSharedMode(clients)) {
+    return SHARED_PHONE;
   }
   const entry = clients[Math.floor(Math.random() * clients.length)];
   if (!entry) {

--- a/packages/spectrum-ts/src/providers/imessage/types.ts
+++ b/packages/spectrum-ts/src/providers/imessage/types.ts
@@ -10,6 +10,13 @@ export interface RemoteClient {
 
 export type IMessageClient = IMessageSDK | RemoteClient[];
 
+/**
+ * Sentinel phone for shared-token mode. The single shared client serves an
+ * unknown set of numbers (the SDK exposes no recipient field on inbound and
+ * no `from` parameter on send), so all routing through it tags this sentinel.
+ */
+export const SHARED_PHONE = "shared";
+
 export const isLocal = (client: IMessageClient): client is IMessageSDK =>
   client instanceof IMessageSDK;
 


### PR DESCRIPTION
## Summary

- Re-enables shared-token cloud mode for iMessage, which was rejected with `UnsupportedError` after the multi-phone refactor in #44.
- Shared mode exposes a single `RemoteClient` tagged with a sentinel phone (`SHARED_PHONE = "shared"`). The SDK has no per-recipient routing in this mode, so all sends/inbounds funnel through this one client; routing helpers short-circuit on the sentinel.
- Token renewal works for both shared and dedicated tokens — `syncPhones` is only called on `dedicated`, so a shared-token renewal no longer throws.

## Usage

No surface-level change for callers. A project provisioned with a shared cloud token now connects instead of throwing:

```typescript
import { Spectrum } from "spectrum-ts";
import { imessage } from "spectrum-ts/providers/imessage";

const app = await Spectrum({
  projectId: process.env.PROJECT_ID,
  projectSecret: process.env.PROJECT_SECRET,
  providers: [imessage.config()],
});

// Inbound spaces in shared mode carry `space.phone === "shared"`.
for await (const [space, message] of app.imessage.messages) {
  await space.responding(async () => {
    await message.reply("Hello from Spectrum.");
  });
}

// Outbound: `params.phone` is ignored in shared mode (the SDK can't honor it).
const space = await app.imessage.space({ users: [{ id: "+15551234567" }] });
await space.send("hi");
```

The shared address can be overridden via `SPECTRUM_IMESSAGE_ADDRESS`; defaults to `imessage.spectrum.photon.codes:443`.

## How it works

**Sentinel.** `providers/imessage/types.ts` exports `SHARED_PHONE = "shared"`. Shared-mode `RemoteClient[]` is exactly one entry tagged with this phone. The choice of sentinel matters because every existing routing helper keys off `phone`, so a real (but unused) string lets the multi-phone code paths run unchanged.

**Routing short-circuits.** `providers/imessage/remote/client.ts` adds `isSharedMode(clients)` (true iff `clients.length === 1 && clients[0].phone === SHARED_PHONE`):

- `clientForPhone(clients, phone)` returns the lone client without checking `phone` when in shared mode — so `clientForPhone(client, "+1…")` and `clientForPhone(client, SHARED_PHONE)` both resolve to the same SDK instance.
- `randomPhone(clients)` returns `SHARED_PHONE` directly in shared mode (no `Math.random()` over a single-element array).

**Outbound space resolve.** `providers/imessage/index.ts` checks `isSharedMode(client)` before reading `input.params?.phone`. In shared mode the user-supplied `phone` is dropped (the SDK can't honor it) and `space.phone` is stamped as `SHARED_PHONE`. In dedicated mode the existing behavior is unchanged.

**Auth.** `providers/imessage/auth.ts` no longer throws for `tokenData.type === "shared"`. Instead it builds a single `RemoteClient` with `phone: SHARED_PHONE` and a `createClient` whose `token` callback calls `refreshIfNeeded()` and returns `(tokenData as SharedTokenData).token`. The renewal path now guards `syncPhones(tokenData)` behind `tokenData.type === "dedicated"` — shared renewal just refreshes the token in-place; the closure'd `tokenData` ref is what the `token` callback reads, so no client recreation is needed. `records` stays empty in shared mode, so the dedicated renewal loop is a no-op.

## Changes

| File | Change |
|---|---|
| `packages/spectrum-ts/src/providers/imessage/types.ts` | Export `SHARED_PHONE = "shared"` sentinel with a doc comment explaining why it exists. |
| `packages/spectrum-ts/src/providers/imessage/remote/client.ts` | Add `isSharedMode()`. Make `clientForPhone()` and `randomPhone()` short-circuit when the array is the shared-mode singleton. |
| `packages/spectrum-ts/src/providers/imessage/index.ts` | In `space.resolve`, check `isSharedMode` before honoring `input.params?.phone`; stamp `SHARED_PHONE` instead. |
| `packages/spectrum-ts/src/providers/imessage/auth.ts` | Drop the `UnsupportedError.action(...)` throws on shared mode. Build a one-entry `RemoteClient[]` with `phone: SHARED_PHONE` and a token callback that refreshes via the existing renewal scheduler. Guard `syncPhones` so it only runs for `dedicated` tokens. |

## Test plan

- [ ] `bun x ultracite check` passes
- [ ] `bun x tsc --noEmit` clean across the workspace
- [ ] `bun run build` succeeds
- [ ] Cloud shared mode: a project provisioned with a shared token connects (no `UnsupportedError`); inbound messages surface with `space.phone === "shared"`; `space.send` / replies / reactions all route through the single client without throwing
- [ ] Cloud shared mode: `SPECTRUM_IMESSAGE_ADDRESS` overrides the default address; absence falls back to `imessage.spectrum.photon.codes:443`
- [ ] Cloud shared mode: token renewal across the 80% renewal window does not throw `UnsupportedError`; the `token` callback returns the refreshed token on the next call
- [ ] Cloud shared mode: `imessage.space({ users, params: { phone: "+1…" } })` ignores the user-supplied phone and stamps `space.phone === "shared"` (no `clientForPhone` "no client serves phone" throw)
- [ ] Cloud dedicated mode: behavior is unchanged — `randomPhone` still picks among configured numbers, `clientForPhone(client, unknown)` still throws `No iMessage client serves phone <unknown>. Available: …`, and `params.phone` is honored
- [ ] `isSharedMode([])` returns `false` (no array out-of-bounds), and `clientForPhone([], anything)` still throws "No iMessage clients configured" via the existing fallthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for iMessage shared token mode, enabling authentication using a single shared credential instead of per-phone dedicated tokens.

* **Improvements**
  * Optimized token renewal behavior to adjust operations based on token type, reducing unnecessary overhead in shared mode while maintaining renewal scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->