### PR TITLE
feat(spectrum-ts): add HTTP webhook ingress (WhatsApp Business first)

### DIFF
--- a/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
@@ -2,31 +2,52 @@ import { createClient } from "@photon-ai/whatsapp-business";
 import { definePlatform } from "../../platform/define";
 import { UnsupportedError } from "../../utils/errors";
 import { createCloudClients, disposeCloudAuth } from "./auth";
-import { messages, reactToMessage, replyToMessage, send } from "./messages";
+import {
+  messages,
+  reactToMessage,
+  replyToMessage,
+  send,
+  webhookMessages,
+} from "./messages";
 import {
   configSchema,
   isCloudConfig,
+  isWebhookIngress,
   spaceSchema,
   type WhatsAppClients,
 } from "./types";
+import { getWebhookInbound, initWebhookState, webhook } from "./webhook";
 
 export const whatsappBusiness = definePlatform("WhatsApp Business", {
   config: configSchema,
+
+  static: {
+    webhook,
+  },
 
   lifecycle: {
     createClient: async ({
       config,
       projectId,
       projectSecret,
+      store,
     }): Promise<WhatsAppClients> => {
       if (!isCloudConfig(config)) {
-        return [
-          createClient({
-            accessToken: config.accessToken,
-            appSecret: config.appSecret ?? "",
-            phoneNumberId: config.phoneNumberId,
-          }),
-        ];
+        if (isWebhookIngress(config) && !config.appSecret) {
+          throw new Error(
+            "WhatsApp Business webhook ingress requires `appSecret` for HMAC verification. " +
+              "Set it on whatsappBusiness.config({ accessToken, appSecret, phoneNumberId, ingress: { mode: 'webhook', verifyToken } })."
+          );
+        }
+        const client = createClient({
+          accessToken: config.accessToken,
+          appSecret: config.appSecret ?? "",
+          phoneNumberId: config.phoneNumberId,
+        });
+        if (isWebhookIngress(config)) {
+          initWebhookState(store, config.ingress, config.appSecret ?? "");
+        }
+        return [client];
       }
 
       if (!(projectId && projectSecret)) {
@@ -72,7 +93,12 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
   },
 
   events: {
-    messages: ({ client }) => messages(client),
+    messages: ({ client, config, store }) => {
+      if (isWebhookIngress(config)) {
+        return webhookMessages(client, getWebhookInbound(store));
+      }
+      return messages(client);
+    },
   },
 
   actions: {

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -491,6 +491,41 @@ export const messages = (
   clients: WhatsAppClients
 ): ManagedStream<WhatsAppMessage> => mergeStreams(clients.map(clientStream));
 
+/**
+ * Webhook-mode counterpart to {@link messages}. Drains the inbound queue
+ * fed by `whatsappBusiness.webhook(app)` and runs each `InboundMessage`
+ * through the same `toMessages` pipeline used by the subscription path,
+ * so downstream code can't tell the difference.
+ *
+ * Single-client by design: the queue is a per-platform-instance singleton
+ * (one `appSecret`/`verifyToken` per provider config), so multi-line fanout
+ * doesn't apply here.
+ */
+export const webhookMessages = (
+  clients: WhatsAppClients,
+  inbound: AsyncIterable<InboundMessage> & { close: () => void }
+): ManagedStream<WhatsAppMessage> => {
+  const client = primary(clients);
+  return stream<WhatsAppMessage>((emit, end) => {
+    const pump = (async () => {
+      try {
+        for await (const inboundMsg of inbound) {
+          for (const m of toMessages(client, inboundMsg)) {
+            await emit(m);
+          }
+        }
+        end();
+      } catch (e) {
+        end(e);
+      }
+    })();
+    return async () => {
+      inbound.close();
+      await pump;
+    };
+  });
+};
+
 export const send = async (
   clients: WhatsAppClients,
   spaceId: string,

--- a/packages/spectrum-ts/src/providers/whatsapp-business/types.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/types.ts
@@ -2,10 +2,18 @@ import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
 import z from "zod";
 import type { SchemaMessage } from "../../platform/types";
 
+const webhookIngressSchema = z.object({
+  mode: z.literal("webhook"),
+  verifyToken: z.string().min(1),
+});
+
+export type WebhookIngressConfig = z.infer<typeof webhookIngressSchema>;
+
 const directConfig = z.object({
   accessToken: z.string().min(1),
   appSecret: z.string().optional(),
   phoneNumberId: z.string().min(1),
+  ingress: webhookIngressSchema.optional(),
 });
 
 const cloudConfig = z.object({}).strict();
@@ -18,6 +26,12 @@ export type WhatsAppClients = WhatsAppClient[];
 export const isCloudConfig = (
   config: WhatsAppConfig
 ): config is z.infer<typeof cloudConfig> => !("accessToken" in config);
+
+export const isWebhookIngress = (
+  config: WhatsAppConfig
+): config is z.infer<typeof directConfig> & {
+  ingress: WebhookIngressConfig;
+} => "ingress" in config && config.ingress?.mode === "webhook";
 
 export const userSchema = z.object({});
 

--- a/packages/spectrum-ts/src/providers/whatsapp-business/webhook.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/webhook.ts
@@ -1,0 +1,623 @@
+import type {
+  ContactCard,
+  InboundInteractive,
+  InboundMedia,
+  InboundMessage,
+  InboundSticker,
+  Location,
+} from "@photon-ai/whatsapp-business";
+import type { SpectrumLike } from "../../platform/types";
+import type { Store } from "../../utils/store";
+import {
+  createWebhookStateSlot,
+  handleMetaChallenge,
+  type InboundQueue,
+  META_HUB_SIGNATURE_HEADER,
+  makeInboundQueue,
+  verifyMetaSignature,
+} from "../../utils/webhook";
+import type { WebhookIngressConfig } from "./types";
+
+const PLATFORM_NAME = "WhatsApp Business";
+const META_OBJECT = "whatsapp_business_account";
+
+/**
+ * Per-platform-instance webhook state. Stored on the platform's `Store`
+ * via the slot helper so both `events.messages` (called inside Spectrum)
+ * and `whatsappBusiness.webhook(app)` (called by user code) can reach the
+ * same queue. Initialized eagerly in `lifecycle.createClient` so a webhook
+ * that arrives before the agent's `for-await` loop starts is buffered,
+ * not lost.
+ */
+interface WebhookState {
+  appSecret: string;
+  inbound: InboundQueue<InboundMessage>;
+  verifyToken: string;
+}
+
+const slot = createWebhookStateSlot<WebhookState>({
+  platformName: PLATFORM_NAME,
+  storeKey: "spectrum-ts:whatsapp-business:webhook",
+  notConfiguredMessage:
+    `Platform "${PLATFORM_NAME}" is not configured for webhook ingress. ` +
+    "Set `ingress: { mode: 'webhook', verifyToken }` on whatsappBusiness.config().",
+  isState: (value): value is WebhookState =>
+    typeof value === "object" &&
+    value !== null &&
+    "appSecret" in value &&
+    "verifyToken" in value &&
+    "inbound" in value,
+});
+
+export const initWebhookState = (
+  store: Store,
+  config: WebhookIngressConfig,
+  appSecret: string
+): void => {
+  slot.init(store, {
+    appSecret,
+    verifyToken: config.verifyToken,
+    inbound: makeInboundQueue<InboundMessage>(),
+  });
+};
+
+export const getWebhookInbound = (
+  store: Store
+): AsyncIterable<InboundMessage> & { close: () => void } => {
+  const state = slot.read(store);
+  return Object.assign(state.inbound.iterable, {
+    close: () => state.inbound.close(),
+  });
+};
+
+export interface WebhookHandle {
+  handle(request: Request): Promise<Response>;
+}
+
+/**
+ * Returns a Web-Fetch-shaped handler the customer mounts in any HTTP
+ * framework (Hono, Bun.serve, Cloudflare Workers, Next.js Route Handlers,
+ * etc).
+ *
+ * - `GET` requests answer Meta's verification challenge.
+ * - `POST` requests verify the HMAC against the raw body, parse the Meta
+ *   webhook envelope, and enqueue each inbound message for the agent loop.
+ */
+export const webhook = (spectrum: SpectrumLike): WebhookHandle => {
+  const state = slot.readFromSpectrum(spectrum);
+  return {
+    async handle(request: Request): Promise<Response> {
+      if (request.method === "GET") {
+        return handleMetaChallenge(request, state.verifyToken);
+      }
+      if (request.method !== "POST") {
+        return new Response("Method Not Allowed", { status: 405 });
+      }
+      const rawBody = Buffer.from(await request.arrayBuffer());
+      const signature = request.headers.get(META_HUB_SIGNATURE_HEADER);
+      if (!verifyMetaSignature(rawBody, signature, state.appSecret)) {
+        return new Response("Forbidden", { status: 403 });
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(rawBody.toString("utf8"));
+      } catch {
+        return new Response("Bad Request", { status: 400 });
+      }
+      for (const message of parseMetaPayload(parsed)) {
+        state.inbound.push(message);
+      }
+      return new Response("", { status: 200 });
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Meta webhook payload parser
+//
+// Reference shape:
+//   https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks/payload-examples
+//
+// Maps Meta's JSON envelope into the same `InboundMessage` shape that
+// `@photon-ai/whatsapp-business`'s `events.subscribe()` produces, so the
+// downstream pipeline (toMessages / mapContent in messages.ts) is reused
+// unchanged.
+// ---------------------------------------------------------------------------
+
+interface MetaEnvelope {
+  entry?: MetaEntry[];
+  object?: string;
+}
+
+interface MetaEntry {
+  changes?: MetaChange[];
+}
+
+interface MetaChange {
+  field?: string;
+  value?: MetaChangeValue;
+}
+
+interface MetaChangeValue {
+  messages?: MetaMessage[];
+}
+
+interface MetaMessage {
+  audio?: MetaMedia & { voice?: boolean };
+  button?: { payload?: string; text?: string };
+  contacts?: MetaContactCard[];
+  context?: MetaContext;
+  document?: MetaMedia;
+  errors?: MetaApiError[];
+  from: string;
+  id: string;
+  image?: MetaMedia;
+  interactive?: MetaInteractive;
+  location?: MetaLocation;
+  order?: MetaOrder;
+  reaction?: { emoji?: string; message_id?: string };
+  referral?: MetaReferral;
+  sticker?: MetaSticker;
+  system?: MetaSystem;
+  text?: { body?: string };
+  timestamp: string;
+  type: string;
+  video?: MetaMedia;
+}
+
+interface MetaMedia {
+  caption?: string;
+  filename?: string;
+  id?: string;
+  mime_type?: string;
+  sha256?: string;
+}
+
+interface MetaSticker {
+  animated?: boolean;
+  id?: string;
+  mime_type?: string;
+  sha256?: string;
+}
+
+interface MetaLocation {
+  address?: string;
+  latitude?: number;
+  longitude?: number;
+  name?: string;
+}
+
+interface MetaContactCard {
+  addresses?: MetaContactAddress[];
+  birthday?: string;
+  emails?: MetaContactEmail[];
+  name?: MetaContactName;
+  org?: MetaContactOrg;
+  phones?: MetaContactPhone[];
+  urls?: MetaContactUrl[];
+}
+
+interface MetaContactName {
+  first_name?: string;
+  formatted_name?: string;
+  last_name?: string;
+  middle_name?: string;
+  prefix?: string;
+  suffix?: string;
+}
+
+interface MetaContactPhone {
+  phone?: string;
+  type?: string;
+  wa_id?: string;
+}
+
+interface MetaContactEmail {
+  email?: string;
+  type?: string;
+}
+
+interface MetaContactAddress {
+  city?: string;
+  country?: string;
+  country_code?: string;
+  state?: string;
+  street?: string;
+  type?: string;
+  zip?: string;
+}
+
+interface MetaContactOrg {
+  company?: string;
+  department?: string;
+  title?: string;
+}
+
+interface MetaContactUrl {
+  type?: string;
+  url?: string;
+}
+
+interface MetaContext {
+  forwarded?: boolean;
+  frequently_forwarded?: boolean;
+  from?: string;
+  id?: string;
+}
+
+interface MetaInteractive {
+  button_reply?: { id?: string; title?: string };
+  list_reply?: { description?: string; id?: string; title?: string };
+  nfm_reply?: { body?: string; name?: string; response_json?: string };
+  type?: string;
+}
+
+interface MetaOrder {
+  catalog_id?: string;
+  product_items?: Array<{
+    currency?: string;
+    item_price?: number;
+    product_retailer_id?: string;
+    quantity?: number;
+  }>;
+  text?: string;
+}
+
+interface MetaSystem {
+  body?: string;
+  new_wa_id?: string;
+  type?: string;
+  wa_id?: string;
+}
+
+interface MetaReferral {
+  body?: string;
+  headline?: string;
+  source_id?: string;
+  source_type?: string;
+  source_url?: string;
+}
+
+interface MetaApiError {
+  code?: number;
+  details?: string;
+  href?: string;
+  message?: string;
+  title?: string;
+}
+
+const isMetaEnvelope = (value: unknown): value is MetaEnvelope =>
+  typeof value === "object" &&
+  value !== null &&
+  (value as { object?: unknown }).object === META_OBJECT;
+
+const parseTimestamp = (raw: string | undefined): Date => {
+  if (!raw) {
+    return new Date();
+  }
+  const seconds = Number(raw);
+  if (!Number.isFinite(seconds)) {
+    return new Date();
+  }
+  return new Date(seconds * 1000);
+};
+
+const parseErrors = (
+  errors: MetaApiError[] | undefined
+): InboundMessage["errors"] => {
+  if (!errors) {
+    return [];
+  }
+  return errors.map((e) => ({
+    code: e.code ?? 0,
+    title: e.title ?? "",
+    details: e.details,
+    href: e.href,
+    message: e.message,
+  }));
+};
+
+const parseMedia = (m: MetaMedia | undefined): InboundMedia | undefined => {
+  if (!(m?.id && m.mime_type)) {
+    return;
+  }
+  return {
+    id: m.id,
+    mimeType: m.mime_type,
+    caption: m.caption,
+    filename: m.filename,
+    sha256: m.sha256,
+  };
+};
+
+const parseAudio = (
+  m: (MetaMedia & { voice?: boolean }) | undefined
+): InboundMedia | undefined => {
+  if (!(m?.id && m.mime_type)) {
+    return;
+  }
+  return {
+    id: m.id,
+    mimeType: m.mime_type,
+    caption: m.caption,
+    filename: m.filename,
+    sha256: m.sha256,
+    voice: m.voice,
+  };
+};
+
+const parseSticker = (
+  s: MetaSticker | undefined
+): InboundSticker | undefined => {
+  if (!(s?.id && s.mime_type)) {
+    return;
+  }
+  return {
+    id: s.id,
+    mimeType: s.mime_type,
+    animated: s.animated,
+    sha256: s.sha256,
+  };
+};
+
+const parseLocation = (l: MetaLocation | undefined): Location | undefined => {
+  if (l?.latitude === undefined || l?.longitude === undefined) {
+    return;
+  }
+  return {
+    latitude: l.latitude,
+    longitude: l.longitude,
+    address: l.address,
+    name: l.name,
+  };
+};
+
+const parseContacts = (
+  raw: MetaContactCard[] | undefined
+): readonly ContactCard[] => {
+  if (!raw || raw.length === 0) {
+    return [];
+  }
+  return raw.map((card) => ({
+    addresses: (card.addresses ?? []).map((a) => ({
+      city: a.city,
+      country: a.country,
+      countryCode: a.country_code,
+      state: a.state,
+      street: a.street,
+      type: a.type,
+      zip: a.zip,
+    })),
+    birthday: card.birthday,
+    emails: (card.emails ?? []).map((e) => ({
+      email: e.email ?? "",
+      type: e.type,
+    })),
+    name: {
+      formattedName: card.name?.formatted_name ?? "",
+      firstName: card.name?.first_name,
+      lastName: card.name?.last_name,
+      middleName: card.name?.middle_name,
+      prefix: card.name?.prefix,
+      suffix: card.name?.suffix,
+    },
+    org: card.org && {
+      company: card.org.company,
+      department: card.org.department,
+      title: card.org.title,
+    },
+    phones: (card.phones ?? []).map((p) => ({
+      phone: p.phone ?? "",
+      type: p.type,
+      waId: p.wa_id,
+    })),
+    urls: (card.urls ?? []).map((u) => ({
+      type: u.type,
+      url: u.url ?? "",
+    })),
+  }));
+};
+
+const parseInteractive = (
+  i: MetaInteractive | undefined
+): InboundInteractive | undefined => {
+  if (!i) {
+    return;
+  }
+  if (i.button_reply) {
+    return {
+      type: "button_reply",
+      reply: {
+        id: i.button_reply.id ?? "",
+        title: i.button_reply.title ?? "",
+      },
+    };
+  }
+  if (i.list_reply) {
+    return {
+      type: "list_reply",
+      reply: {
+        id: i.list_reply.id ?? "",
+        title: i.list_reply.title ?? "",
+        description: i.list_reply.description,
+      },
+    };
+  }
+  if (i.nfm_reply) {
+    return {
+      type: "nfm_reply",
+      reply: {
+        body: i.nfm_reply.body,
+        name: i.nfm_reply.name,
+        responseJson: i.nfm_reply.response_json ?? "",
+      },
+    };
+  }
+  return;
+};
+
+// ---------------------------------------------------------------------------
+// Per-content-type parsers — split into a dispatch table so `parseContent`
+// stays trivial. Adding a new content type is one new function plus one
+// new entry below.
+// ---------------------------------------------------------------------------
+
+type ContentParser = (msg: MetaMessage) => InboundMessage["content"];
+
+const parseTextContent: ContentParser = (msg) => ({
+  type: "text",
+  body: msg.text?.body ?? "",
+});
+
+const parseImageContent: ContentParser = (msg) => {
+  const media = parseMedia(msg.image);
+  return media ? { type: "image", media } : { type: "unknown" };
+};
+
+const parseVideoContent: ContentParser = (msg) => {
+  const media = parseMedia(msg.video);
+  return media ? { type: "video", media } : { type: "unknown" };
+};
+
+const parseAudioContent: ContentParser = (msg) => {
+  const media = parseAudio(msg.audio);
+  return media ? { type: "audio", media } : { type: "unknown" };
+};
+
+const parseDocumentContent: ContentParser = (msg) => {
+  const media = parseMedia(msg.document);
+  return media ? { type: "document", media } : { type: "unknown" };
+};
+
+const parseStickerContent: ContentParser = (msg) => {
+  const sticker = parseSticker(msg.sticker);
+  return sticker ? { type: "sticker", sticker } : { type: "unknown" };
+};
+
+const parseLocationContent: ContentParser = (msg) => {
+  const location = parseLocation(msg.location);
+  return location ? { type: "location", location } : { type: "unknown" };
+};
+
+const parseContactsContent: ContentParser = (msg) => {
+  const contacts = parseContacts(msg.contacts);
+  return contacts.length > 0
+    ? { type: "contacts", contacts }
+    : { type: "unknown" };
+};
+
+const parseReactionContent: ContentParser = (msg) => {
+  if (!(msg.reaction?.message_id && msg.reaction.emoji)) {
+    return { type: "unknown" };
+  }
+  return {
+    type: "reaction",
+    reaction: {
+      emoji: msg.reaction.emoji,
+      messageId: msg.reaction.message_id,
+    },
+  };
+};
+
+const parseInteractiveContent: ContentParser = (msg) => {
+  const interactive = parseInteractive(msg.interactive);
+  return interactive
+    ? { type: "interactive", interactive }
+    : { type: "unknown" };
+};
+
+const parseButtonContent: ContentParser = (msg) => ({
+  type: "button",
+  button: {
+    payload: msg.button?.payload ?? "",
+    text: msg.button?.text ?? "",
+  },
+});
+
+const parseOrderContent: ContentParser = (msg) => ({
+  type: "order",
+  order: {
+    catalogId: msg.order?.catalog_id ?? "",
+    productItems: (msg.order?.product_items ?? []).map((item) => ({
+      currency: item.currency ?? "",
+      itemPrice: item.item_price ?? 0,
+      productRetailerId: item.product_retailer_id ?? "",
+      quantity: item.quantity ?? 0,
+    })),
+    text: msg.order?.text,
+  },
+});
+
+const parseSystemContent: ContentParser = (msg) => ({
+  type: "system",
+  system: {
+    body: msg.system?.body ?? "",
+    type: msg.system?.type ?? "",
+    newWaId: msg.system?.new_wa_id,
+    waId: msg.system?.wa_id,
+  },
+});
+
+const CONTENT_PARSERS: Record<string, ContentParser> = {
+  text: parseTextContent,
+  image: parseImageContent,
+  video: parseVideoContent,
+  audio: parseAudioContent,
+  document: parseDocumentContent,
+  sticker: parseStickerContent,
+  location: parseLocationContent,
+  contacts: parseContactsContent,
+  reaction: parseReactionContent,
+  interactive: parseInteractiveContent,
+  button: parseButtonContent,
+  order: parseOrderContent,
+  system: parseSystemContent,
+};
+
+const parseContent = (msg: MetaMessage): InboundMessage["content"] => {
+  const parser = CONTENT_PARSERS[msg.type];
+  return parser ? parser(msg) : { type: "unknown" };
+};
+
+const buildInboundMessage = (msg: MetaMessage): InboundMessage => ({
+  id: msg.id,
+  from: msg.from,
+  timestamp: parseTimestamp(msg.timestamp),
+  messageType: msg.type,
+  content: parseContent(msg),
+  context: msg.context && {
+    forwarded: msg.context.forwarded,
+    frequentlyForwarded: msg.context.frequently_forwarded,
+    from: msg.context.from,
+    id: msg.context.id,
+  },
+  errors: parseErrors(msg.errors),
+  referral: msg.referral && {
+    sourceType: msg.referral.source_type ?? "",
+    sourceUrl: msg.referral.source_url ?? "",
+    sourceId: msg.referral.source_id,
+    headline: msg.referral.headline,
+    body: msg.referral.body,
+  },
+});
+
+export const parseMetaPayload = (payload: unknown): InboundMessage[] => {
+  if (!isMetaEnvelope(payload)) {
+    return [];
+  }
+  const result: InboundMessage[] = [];
+  for (const entry of payload.entry ?? []) {
+    for (const change of entry.changes ?? []) {
+      if (change.field !== "messages") {
+        continue;
+      }
+      for (const message of change.value?.messages ?? []) {
+        if (!(message.id && message.from)) {
+          continue;
+        }
+        result.push(buildInboundMessage(message));
+      }
+    }
+  }
+  return result;
+};

--- a/packages/spectrum-ts/src/utils/webhook.ts
+++ b/packages/spectrum-ts/src/utils/webhook.ts
@@ -1,0 +1,232 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { SpectrumLike } from "../platform/types";
+import type { Store } from "./store";
+
+/**
+ * Webhook utilities shared across providers.
+ *
+ * Two layers live here:
+ *
+ * 1. **Provider-agnostic primitives** — `InboundQueue<T>` /
+ *    `makeInboundQueue<T>()` and `createWebhookStateSlot()`. Every
+ *    webhook-capable provider uses these to bridge an HTTP handler into
+ *    the platform's `events.messages` async iterable, without each
+ *    provider re-implementing the queue or the `Store` lookup.
+ *
+ * 2. **Meta-family helpers** — `verifyMetaSignature` and
+ *    `handleMetaChallenge`. Reused by providers whose platforms speak
+ *    Meta's webhook format (WhatsApp Business today; Instagram and
+ *    Facebook Messenger when they ship). Slack/Telegram/Stripe families
+ *    add their own sibling helpers when those providers are added.
+ *
+ * The handlers are deliberately request/response-oriented (Web Fetch
+ * `Request`/`Response`) so providers can return handlers that mount in
+ * any HTTP framework (Hono, Express, Bun.serve, Cloudflare Workers, etc).
+ */
+
+// ---------------------------------------------------------------------------
+// Generic primitive: buffered async queue
+// ---------------------------------------------------------------------------
+
+export interface InboundQueue<T> {
+  close(): void;
+  iterable: AsyncIterable<T>;
+  push(message: T): void;
+}
+
+/**
+ * Buffered async queue. Producer never blocks; consumer's `for-await`
+ * resolves as items arrive. Used by webhook-mode providers to bridge
+ * HTTP requests into `events.messages` without losing messages that
+ * arrive before the agent's loop starts iterating.
+ */
+export const makeInboundQueue = <T>(): InboundQueue<T> => {
+  const buffered: T[] = [];
+  const waiters: Array<(result: IteratorResult<T>) => void> = [];
+  let closed = false;
+
+  const drain = () => {
+    while (waiters.length > 0) {
+      waiters.shift()?.({ value: undefined as never, done: true });
+    }
+  };
+
+  const iterable: AsyncIterable<T> = {
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<T>> {
+          if (closed && buffered.length === 0) {
+            return Promise.resolve({ value: undefined as never, done: true });
+          }
+          const next = buffered.shift();
+          if (next !== undefined) {
+            return Promise.resolve({ value: next, done: false });
+          }
+          return new Promise((resolve) => waiters.push(resolve));
+        },
+        return(): Promise<IteratorResult<T>> {
+          closed = true;
+          drain();
+          return Promise.resolve({ value: undefined as never, done: true });
+        },
+      };
+    },
+  };
+
+  return {
+    iterable,
+    push(message) {
+      if (closed) {
+        return;
+      }
+      const waiter = waiters.shift();
+      if (waiter) {
+        waiter({ value: message, done: false });
+        return;
+      }
+      buffered.push(message);
+    },
+    close() {
+      closed = true;
+      drain();
+    },
+  };
+};
+
+// ---------------------------------------------------------------------------
+// Generic primitive: per-platform webhook state slot on `Store`
+// ---------------------------------------------------------------------------
+
+/**
+ * Common shape for webhook state. Each provider extends this with whatever
+ * verification material it needs (HMAC secret, verify token, signing
+ * secret, timestamp window, etc).
+ */
+export interface WebhookStateBase<TMessage> {
+  inbound: InboundQueue<TMessage>;
+}
+
+export interface WebhookStateSlot<TState extends WebhookStateBase<unknown>> {
+  /** Idempotent — preserves the existing state if the slot is already set. */
+  init(store: Store, state: TState): void;
+  /** Read directly from a `Store` (used inside provider lifecycle/events). */
+  read(store: Store): TState;
+  /** Read via the Spectrum runtime (used by user-facing `webhook(spectrum)`). */
+  readFromSpectrum(spectrum: SpectrumLike): TState;
+}
+
+export interface CreateWebhookSlotOptions<TState> {
+  isState: (value: unknown) => value is TState;
+  /** User-facing message thrown when reads happen before init. */
+  notConfiguredMessage?: string;
+  platformName: string;
+  storeKey: string;
+}
+
+/**
+ * Encapsulates the per-platform `Store` slot machinery: the storage key,
+ * the runtime lookup, and the type-guarded read. Each provider creates
+ * one of these once at module scope and reuses it from `lifecycle`,
+ * `events.messages`, and the user-facing webhook accessor.
+ */
+export const createWebhookStateSlot = <
+  TState extends WebhookStateBase<unknown>,
+>(
+  opts: CreateWebhookSlotOptions<TState>
+): WebhookStateSlot<TState> => {
+  const notConfigured =
+    opts.notConfiguredMessage ??
+    `Platform "${opts.platformName}" is not configured for webhook ingress.`;
+
+  const init = (store: Store, state: TState): void => {
+    if (store.has(opts.storeKey)) {
+      return;
+    }
+    store.set(opts.storeKey, state);
+  };
+
+  const read = (store: Store): TState => {
+    const value = store.get(opts.storeKey);
+    if (!opts.isState(value)) {
+      throw new Error(notConfigured);
+    }
+    return value;
+  };
+
+  const readFromSpectrum = (spectrum: SpectrumLike): TState => {
+    const runtime = spectrum.__internal.platforms.get(opts.platformName);
+    if (!runtime) {
+      throw new Error(`Platform "${opts.platformName}" is not registered`);
+    }
+    return read(runtime.store);
+  };
+
+  return { init, read, readFromSpectrum };
+};
+
+// ---------------------------------------------------------------------------
+// Meta-family helpers (WhatsApp Business, Instagram, Facebook Messenger)
+// ---------------------------------------------------------------------------
+
+const META_SIGNATURE_PREFIX = "sha256=";
+
+/**
+ * Constant-time HMAC-SHA256 verification of a Meta-shaped webhook signature.
+ * Returns false on missing header, malformed prefix, length mismatch, or
+ * digest mismatch. Never throws.
+ *
+ * The HMAC is computed over the raw request body — any middleware that
+ * re-serializes the JSON before this runs will silently invalidate the
+ * signature, so callers must pass the original bytes.
+ */
+export const verifyMetaSignature = (
+  rawBody: Buffer,
+  signatureHeader: string | null,
+  appSecret: string
+): boolean => {
+  if (!signatureHeader?.startsWith(META_SIGNATURE_PREFIX)) {
+    return false;
+  }
+  const providedHex = signatureHeader.slice(META_SIGNATURE_PREFIX.length);
+  let provided: Buffer;
+  try {
+    provided = Buffer.from(providedHex, "hex");
+  } catch {
+    return false;
+  }
+  const expected = createHmac("sha256", appSecret).update(rawBody).digest();
+  if (provided.length !== expected.length) {
+    return false;
+  }
+  return timingSafeEqual(provided, expected);
+};
+
+/**
+ * Handle Meta's one-time GET verification handshake. Echoes `hub.challenge`
+ * with 200 when `hub.mode=subscribe` and `hub.verify_token` matches.
+ * Returns 400 on a missing/malformed challenge, 403 on token mismatch.
+ *
+ * https://developers.facebook.com/docs/graph-api/webhooks/getting-started
+ */
+export const handleMetaChallenge = (
+  req: Request,
+  verifyToken: string
+): Response => {
+  const url = new URL(req.url);
+  const mode = url.searchParams.get("hub.mode");
+  const token = url.searchParams.get("hub.verify_token");
+  const challenge = url.searchParams.get("hub.challenge");
+
+  if (mode !== "subscribe" || token === null || challenge === null) {
+    return new Response("Bad Request", { status: 400 });
+  }
+  if (token !== verifyToken) {
+    return new Response("Forbidden", { status: 403 });
+  }
+  return new Response(challenge, {
+    status: 200,
+    headers: { "Content-Type": "text/plain" },
+  });
+};
+
+export const META_HUB_SIGNATURE_HEADER = "x-hub-signature-256";


### PR DESCRIPTION
Add a webhook ingress primitive at the spectrum-ts level so any webhook-capable provider can opt into HTTP-delivered events. WhatsApp Business is the first implementor; Instagram, FB Messenger, Slack, and Telegram drop in by reusing the same primitives.

Customer-facing API:

  - Opt in via `ingress: { mode: "webhook", verifyToken }` on the provider config (WhatsApp today).
  - Receive events via `provider.webhook(app)`, which returns a framework-agnostic `(Request) => Response` handler the customer mounts in any HTTP framework (Hono, Bun.serve, Cloudflare Workers, Next.js, Lambda, etc).
  - The agent's `for await (const [space, message] of app.messages)` loop is unchanged.

Unlocks deployment on serverless platforms where long-lived connections aren't possible, and lets customers receive events directly without going through Spectrum Cloud's relay.

SDK-level primitives (`utils/webhook.ts`) so future providers don't re-implement plumbing:

  - `makeInboundQueue<T>()` / `InboundQueue<T>` — buffered async queue bridging HTTP into `events.messages`.
  - `createWebhookStateSlot()` — encapsulates the per-platform `Store` slot machinery (key, runtime lookup, type guard).
  - Meta-family wire-format helpers (`verifyMetaSignature`, `handleMetaChallenge`), reusable by Instagram and FB Messenger when those providers ship. Slack/Telegram add sibling helpers.

WhatsApp Business is the first user of these primitives; its provider exposes `whatsappBusiness.webhook(app)` via the new `static: { webhook }` field on `definePlatform`. Existing customers who omit `ingress` keep the existing long-lived subscription path with no behavior change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->