### PR TITLE
style: replace `return undefined` with bare return, simplify arrow functions, await pump cleanup

### DIFF
--- a/packages/spectrum-ts/src/content/voice.ts
+++ b/packages/spectrum-ts/src/content/voice.ts
@@ -36,7 +36,7 @@ const resolveVoiceName = (
   if (typeof input === "string") {
     return basename(input);
   }
-  return undefined;
+  return;
 };
 
 const resolveVoiceMimeType = (

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -27,14 +27,11 @@ function createPlatformInstance<
   _Client,
   _ConfigSchema extends z.ZodType<object>,
 >(def: Def, runtime: PlatformRuntime): PlatformInstance<Def> {
-  const isPlatformUser = (value: unknown): value is PlatformUser<Def> => {
-    return (
-      typeof value === "object" &&
-      value !== null &&
-      "__platform" in value &&
-      (value as { __platform?: unknown }).__platform === def.name
-    );
-  };
+  const isPlatformUser = (value: unknown): value is PlatformUser<Def> =>
+    typeof value === "object" &&
+    value !== null &&
+    "__platform" in value &&
+    (value as { __platform?: unknown }).__platform === def.name;
 
   const resolveUserID = async (userID: string): Promise<PlatformUser<Def>> => {
     const resolved = await def.user.resolve({

--- a/packages/spectrum-ts/src/providers/imessage/local/inbound.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local/inbound.ts
@@ -29,7 +29,7 @@ const refetchUntilAttachmentsSettle = async (
 
   for (let attempt = 0; attempt < ATTACHMENT_JOIN_RETRY_LIMIT; attempt += 1) {
     await sleep(ATTACHMENT_JOIN_RETRY_DELAY_MS);
-    let rows: LocalIMessage[];
+    let rows: readonly LocalIMessage[];
     try {
       rows = await client.getMessages({
         chatId: message.chatId,

--- a/packages/spectrum-ts/src/providers/imessage/remote/stream.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/stream.ts
@@ -153,7 +153,7 @@ async function* catchUpEvents<T extends MessageEvent | PollEvent>(
 
 const toResumeAfter = (cursor: string | undefined): number | undefined => {
   if (!cursor) {
-    return undefined;
+    return;
   }
   const sequence = Number(cursor);
   return Number.isSafeInteger(sequence) && sequence >= 0 ? sequence : undefined;

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -551,9 +551,8 @@ export const terminal = definePlatform("terminal", {
   },
 
   lifecycle: {
-    createClient: async ({ config }) => {
-      return await spawnClient({ commands: config.commands });
-    },
+    createClient: async ({ config }) =>
+      await spawnClient({ commands: config.commands }),
 
     destroyClient: async ({ client }) => {
       // Restore console FIRST so any further logs in this teardown go to the

--- a/packages/spectrum-ts/src/providers/whatsapp-business/auth.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/auth.ts
@@ -165,8 +165,9 @@ const buildClientProxy = (
 ): WhatsAppClient => {
   const forwarder = <T extends object>(pick: (c: WhatsAppClient) => T): T =>
     new Proxy({} as T, {
-      get: (_, prop: string | symbol) => {
-        return async (...args: unknown[]) => {
+      get:
+        (_, prop: string | symbol) =>
+        async (...args: unknown[]) => {
           await refresh();
           const target = pick(state.current) as Record<
             string | symbol,
@@ -174,8 +175,7 @@ const buildClientProxy = (
           >;
           const fn = target[prop] as (...a: unknown[]) => unknown;
           return Reflect.apply(fn, pick(state.current), args);
-        };
-      },
+        },
     });
 
   const events = {

--- a/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
@@ -76,16 +76,14 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
   },
 
   actions: {
-    send: async ({ space, content, client }) => {
-      return await send(client, space.id, content);
-    },
+    send: async ({ space, content, client }) =>
+      await send(client, space.id, content),
 
     reactToMessage: async ({ space, target, reaction, client }) => {
       await reactToMessage(client, space.id, target.id, reaction);
     },
 
-    replyToMessage: async ({ space, messageId, content, client }) => {
-      return await replyToMessage(client, space.id, messageId, content);
-    },
+    replyToMessage: async ({ space, messageId, content, client }) =>
+      await replyToMessage(client, space.id, messageId, content),
   },
 });

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -103,7 +103,7 @@ const mapWaPhoneType = (
   type: string | undefined
 ): SpectrumContactPhone["type"] => {
   if (!type) {
-    return undefined;
+    return;
   }
   const upper = type.toUpperCase();
   if (upper === "CELL" || upper === "MOBILE" || upper === "IPHONE") {
@@ -122,7 +122,7 @@ const mapWaSimpleType = (
   type: string | undefined
 ): "home" | "work" | "other" | undefined => {
   if (!type) {
-    return undefined;
+    return;
   }
   const upper = type.toUpperCase();
   if (upper === "HOME") {
@@ -380,7 +380,7 @@ const spectrumPhoneTypeToWa = (
   if (type === "home" || type === "work" || type === "other") {
     return type.toUpperCase();
   }
-  return undefined;
+  return;
 };
 
 const spectrumSimpleTypeToWa = (

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -137,8 +137,8 @@ export async function Spectrum<
 
   let stopped = false;
 
-  const adaptIterable = <T>(iterable: AsyncIterable<T>): ManagedStream<T> => {
-    return stream<T>((emit, end) => {
+  const adaptIterable = <T>(iterable: AsyncIterable<T>): ManagedStream<T> =>
+    stream<T>((emit, end) => {
       const iterator = iterable[Symbol.asyncIterator]();
 
       const pump = (async () => {
@@ -156,10 +156,9 @@ export async function Spectrum<
 
       return async () => {
         await iterator.return?.();
-        void pump.catch(ignoreCleanupError);
+        await pump.catch(ignoreCleanupError);
       };
     });
-  };
 
   const createProviderMessagesStream = (state: {
     client: unknown;
@@ -269,8 +268,8 @@ export async function Spectrum<
     });
   }
 
-  const createMessagesStream = (): ManagedStream<[Space, InboundMessage]> => {
-    return stream<[Space, InboundMessage]>((emit, end) => {
+  const createMessagesStream = (): ManagedStream<[Space, InboundMessage]> =>
+    stream<[Space, InboundMessage]>((emit, end) => {
       const merged = mergeStreams(
         Array.from(platformStates.values(), (runtime) =>
           runtime.subscribeMessages()
@@ -290,16 +289,14 @@ export async function Spectrum<
 
       return async () => {
         await merged.close();
-        void pump.catch(ignoreCleanupError);
+        await pump.catch(ignoreCleanupError);
       };
     });
-  };
 
-  const createCustomEventStream = (
-    eventName: string
-  ): ManagedStream<unknown> => {
-    return stream<unknown>((emit, end) => {
-      const providerStreams = Array.from(platformStates.values(), (state) => {
+  const createCustomEventStream = (eventName: string): ManagedStream<unknown> =>
+    stream<unknown>((emit, end) => {
+      const providerStreams: ManagedStream<unknown>[] = [];
+      for (const state of platformStates.values()) {
         const { client, config, definition, store } = state;
         const producer = definition.events[eventName] as
           | ((ctx: {
@@ -309,7 +306,7 @@ export async function Spectrum<
             }) => AsyncIterable<unknown>)
           | undefined;
         if (!producer) {
-          return undefined;
+          continue;
         }
 
         const providerEvents = producer({ client, config, store });
@@ -319,10 +316,8 @@ export async function Spectrum<
           }
         };
 
-        return adaptIterable(annotatePlatform());
-      }).filter(
-        (value): value is ManagedStream<unknown> => value !== undefined
-      );
+        providerStreams.push(adaptIterable(annotatePlatform()));
+      }
 
       const merged = mergeStreams(providerStreams);
 
@@ -339,10 +334,9 @@ export async function Spectrum<
 
       return async () => {
         await merged.close();
-        void pump.catch(ignoreCleanupError);
+        await pump.catch(ignoreCleanupError);
       };
     });
-  };
 
   const messagesStream = createMessagesStream();
 
@@ -412,22 +406,17 @@ export async function Spectrum<
     send: (async (
       space: Space,
       ...content: [ContentInput, ...ContentInput[]]
-    ): Promise<OutboundMessage | OutboundMessage[] | undefined> => {
-      return content.length === 1
+    ): Promise<OutboundMessage | OutboundMessage[] | undefined> =>
+      content.length === 1
         ? await space.send(content[0])
         : await space.send(
             ...(content as [ContentInput, ContentInput, ...ContentInput[]])
-          );
-    }) as SpectrumInstance["send"],
+          )) as SpectrumInstance["send"],
     edit: async (message: OutboundMessage, newContent: ContentInput) => {
       await message.edit(newContent);
     },
-    responding: async <T>(
-      space: Space,
-      fn: () => T | Promise<T>
-    ): Promise<T> => {
-      return space.responding(fn);
-    },
+    responding: async <T>(space: Space, fn: () => T | Promise<T>): Promise<T> =>
+      space.responding(fn),
   };
 
   // Merge base instance with custom event proxy
@@ -439,7 +428,7 @@ export async function Spectrum<
       if (typeof prop === "string") {
         return customEventProxy[prop];
       }
-      return undefined;
+      return;
     },
   }) as SpectrumInstance<Providers>;
 }

--- a/packages/spectrum-ts/src/utils/audio.ts
+++ b/packages/spectrum-ts/src/utils/audio.ts
@@ -45,7 +45,7 @@ const tryStaticBinary = async (): Promise<string | undefined> => {
     const mod = await import("ffmpeg-static");
     return mod.default ?? undefined;
   } catch {
-    return undefined;
+    return;
   }
 };
 
@@ -99,7 +99,7 @@ const DURATION_PATTERN = /Duration:\s*(\d+):(\d{2}):(\d{2})(?:\.(\d{1,3}))?/;
 const parseDuration = (stderr: string): number | undefined => {
   const match = stderr.match(DURATION_PATTERN);
   if (!match) {
-    return undefined;
+    return;
   }
   const [, hh, mm, ss, frac] = match;
   const seconds =

--- a/packages/spectrum-ts/src/utils/resumable-stream.ts
+++ b/packages/spectrum-ts/src/utils/resumable-stream.ts
@@ -296,7 +296,7 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
           activeLive = undefined;
         }
         await closeIterable(live);
-        void livePump.pump.catch(ignoreCleanupError);
+        await livePump.pump.catch(ignoreCleanupError);
       }
     };
 
@@ -334,6 +334,6 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
       closed = true;
       cancelSleep();
       await closeIterable(activeLive);
-      void pump.catch(ignoreCleanupError);
+      await pump.catch(ignoreCleanupError);
     };
   });

--- a/packages/spectrum-ts/src/utils/stream.ts
+++ b/packages/spectrum-ts/src/utils/stream.ts
@@ -37,7 +37,7 @@ export function stream<T>(
 
   return Object.assign(repeater, {
     close: async () => {
-      void repeater.return(undefined).catch(ignoreCleanupError);
+      await repeater.return(undefined).catch(ignoreCleanupError);
     },
   });
 }
@@ -69,7 +69,7 @@ export function mergeStreams<T>(
 
     return async () => {
       await Promise.allSettled(streams.map((source) => source.close()));
-      void Promise.allSettled(workers).catch(ignoreCleanupError);
+      await Promise.allSettled(workers).catch(ignoreCleanupError);
     };
   });
 }
@@ -159,7 +159,7 @@ export function broadcast<T>(source: ManagedStream<T>): Broadcaster<T> {
       try {
         await source.close();
         if (pumpPromise) {
-          void pumpPromise.catch(ignoreCleanupError);
+          await pumpPromise.catch(ignoreCleanupError);
         }
       } finally {
         if (!terminated) {

--- a/packages/spectrum-ts/src/utils/vcard.ts
+++ b/packages/spectrum-ts/src/utils/vcard.ts
@@ -54,7 +54,7 @@ const mapPhoneType = (prop: VCardProperty): ContactPhone["type"] => {
   if (types.length > 0) {
     return "other";
   }
-  return undefined;
+  return;
 };
 
 const mapSimpleType = (
@@ -70,7 +70,7 @@ const mapSimpleType = (
   if (types.length > 0) {
     return "other";
   }
-  return undefined;
+  return;
 };
 
 const splitStructured = (value: string): string[] =>
@@ -80,7 +80,7 @@ const extractName = (card: vCard): ContactName | undefined => {
   const fn = propString(card.data.fn);
   const n = propString(card.data.n);
   if (!(fn || n)) {
-    return undefined;
+    return;
   }
 
   const result: ContactName = {};
@@ -111,7 +111,7 @@ const extractName = (card: vCard): ContactName | undefined => {
 const extractPhones = (card: vCard): ContactPhone[] | undefined => {
   const props = asPropertyArray(card.data.tel);
   if (props.length === 0) {
-    return undefined;
+    return;
   }
   return props.map((p) => {
     const entry: ContactPhone = { value: p.valueOf().trim() };
@@ -126,7 +126,7 @@ const extractPhones = (card: vCard): ContactPhone[] | undefined => {
 const extractEmails = (card: vCard): ContactEmail[] | undefined => {
   const props = asPropertyArray(card.data.email);
   if (props.length === 0) {
-    return undefined;
+    return;
   }
   return props.map((p) => {
     const entry: ContactEmail = { value: p.valueOf().trim() };
@@ -141,7 +141,7 @@ const extractEmails = (card: vCard): ContactEmail[] | undefined => {
 const extractAddresses = (card: vCard): ContactAddress[] | undefined => {
   const props = asPropertyArray(card.data.adr);
   if (props.length === 0) {
-    return undefined;
+    return;
   }
   return props.map((p) => {
     // ADR fields: PO Box; extended; street; locality; region; postal code; country
@@ -176,7 +176,7 @@ const extractOrg = (card: vCard): ContactOrg | undefined => {
   const orgStr = propString(card.data.org);
   const title = propString(card.data.title);
   if (!(orgStr || title)) {
-    return undefined;
+    return;
   }
   const result: ContactOrg = {};
   if (orgStr) {
@@ -197,7 +197,7 @@ const extractOrg = (card: vCard): ContactOrg | undefined => {
 const extractUrls = (card: vCard): string[] | undefined => {
   const props = asPropertyArray(card.data.url);
   if (props.length === 0) {
-    return undefined;
+    return;
   }
   return props.map((p) => p.valueOf().trim());
 };
@@ -218,7 +218,7 @@ const DATA_URI_PATTERN = /^data:([^;,]+);base64,(.*)$/i;
 const extractPhoto = (card: vCard): Contact["photo"] | undefined => {
   const [prop] = asPropertyArray(card.data.photo);
   if (!prop) {
-    return undefined;
+    return;
   }
   const value = prop.valueOf();
   // vCard 4.0 can carry a data URI; 3.0 typically uses ENCODING=b with raw base64.
@@ -311,7 +311,7 @@ const phoneTypeParam = (type: ContactPhone["type"]): string | undefined => {
   if (type === "home" || type === "work" || type === "other") {
     return type.toUpperCase();
   }
-  return undefined;
+  return;
 };
 
 const simpleTypeParam = (


### PR DESCRIPTION
## Summary
- Replace `return undefined` with bare `return` in helpers that return `T | undefined`.
- Collapse arrow functions whose body is a single `return` expression to expression bodies.
- Switch stream cleanup hooks from `void pump.catch(ignoreCleanupError)` to `await pump.catch(ignoreCleanupError)` so `close()` actually waits for inflight pumps to settle before resolving.
- Tighten `getMessages` row binding in iMessage local inbound to `readonly LocalIMessage[]`.
- Refactor `createCustomEventStream` to build the provider stream list with a `for…of` loop and `continue` instead of `Array.from(...).filter(...)`, removing the intermediate `undefined` slot.
- Replace `Spectrum`'s custom-event proxy fallthrough `return undefined` with a bare `return` so the `Reflect`-style accessor stays consistent with the rest of the file.

No public API changes — TypeScript inference and behavior are preserved except where cleanup is now properly awaited.

## Changes
| File | Change |
|---|---|
| `packages/spectrum-ts/src/content/voice.ts` | bare `return` in `resolveVoiceName` |
| `packages/spectrum-ts/src/platform/define.ts` | collapse `isPlatformUser` to expression body |
| `packages/spectrum-ts/src/providers/imessage/local/inbound.ts` | `readonly LocalIMessage[]` for refetched rows |
| `packages/spectrum-ts/src/providers/imessage/remote/stream.ts` | bare `return` in `toResumeAfter` |
| `packages/spectrum-ts/src/providers/terminal/index.ts` | collapse `createClient` to expression body |
| `packages/spectrum-ts/src/providers/whatsapp-business/auth.ts` | hoist async getter into proxy `get` shorthand |
| `packages/spectrum-ts/src/providers/whatsapp-business/index.ts` | collapse `send` / `replyToMessage` to expression bodies |
| `packages/spectrum-ts/src/providers/whatsapp-business/messages.ts` | bare `return` in `mapWaPhoneType`, `mapWaSimpleType`, `spectrumPhoneTypeToWa` |
| `packages/spectrum-ts/src/spectrum.ts` | expression bodies for `adaptIterable`, `createMessagesStream`, `createCustomEventStream`; for-of refactor; `await` pump cleanups; bare `return` in custom-event proxy |
| `packages/spectrum-ts/src/utils/audio.ts` | bare `return` in `tryStaticBinary`, `parseDuration` |
| `packages/spectrum-ts/src/utils/resumable-stream.ts` | `await` pump cleanups in live + outer close |
| `packages/spectrum-ts/src/utils/stream.ts` | `await` cleanups in `stream`, `mergeStreams`, `broadcast` |
| `packages/spectrum-ts/src/utils/vcard.ts` | bare `return` across `mapPhoneType`, `mapSimpleType`, `extractName`, `extractPhones`, `extractEmails`, `extractAddresses`, `extractOrg`, `extractUrls`, `extractPhoto`, `phoneTypeParam` |

## Verification
- [ ] `bun x ultracite check`
- [ ] `bun x tsc -p packages/spectrum-ts/tsconfig.json --noEmit`
- [ ] `bun run build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified and standardized internal code patterns across multiple modules for improved maintainability.
  * Enhanced promise handling by properly awaiting cleanup operations instead of ignoring them.
  * Updated function implementations to use more concise expression-bodied patterns where applicable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/54)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->