### PR TITLE
refactor(platform): collapse provider surface to `messages` + `send`

### DIFF
--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -1,4 +1,4 @@
-import { reply, Spectrum, text } from "spectrum-ts";
+import { reaction, reply, Spectrum, text } from "spectrum-ts";
 import { terminal } from "spectrum-ts/providers/terminal";
 
 const app = await Spectrum({ providers: [terminal.config()] });
@@ -32,8 +32,10 @@ for await (const [space, message] of app.messages) {
     continue;
   }
 
-  // Always react with 👀 first so we can verify the agent → user reaction path.
+  // Sugar form: message.react delegates to space.send(reaction(emoji, self)).
   await message.react("👀");
+  // Canonical form: reaction as first-class content via space.send.
+  await space.send(reaction("✨", message));
 
   const replyTo = (message as { replyTo?: { messageId: string } }).replyTo;
   if (replyTo) {

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -1,4 +1,4 @@
-import { Spectrum, text } from "spectrum-ts";
+import { reply, Spectrum, text } from "spectrum-ts";
 import { terminal } from "spectrum-ts/providers/terminal";
 
 const app = await Spectrum({ providers: [terminal.config()] });
@@ -40,7 +40,10 @@ for await (const [space, message] of app.messages) {
     console.log(
       `REPLY to ${replyTo.messageId.slice(0, 8)}…: "${message.content.text}"`
     );
-    await message.reply(text("acknowledged your reply"));
+    // Direct: reply as first-class content.
+    await space.send(reply(text("ack via space.send(reply(...))"), message));
+    // Sugar: same end result, message.reply delegates to space.send(reply(...)).
+    await message.reply(text("ack via message.reply(...)"));
   } else {
     console.log(`message: "${message.content.text}"`);
     await space.send(text(`echo: ${message.content.text}`));

--- a/packages/spectrum-ts/src/content/edit.ts
+++ b/packages/spectrum-ts/src/content/edit.ts
@@ -1,0 +1,78 @@
+import z from "zod";
+import type { Message, OutboundMessage } from "../types/message";
+import { resolveContents } from "./resolve";
+import type { BaseContent, ContentBuilder, ContentInput } from "./types";
+
+const isMessage = (v: unknown): v is Message =>
+  typeof v === "object" && v !== null && "id" in v && "content" in v;
+
+// Same circularity dodge as reply.ts: predicate returns boolean rather than
+// `v is Content` so the schema field is typed as BaseContent without
+// referencing the outer Content union. Edit rejects nested
+// edit/reply/reaction/group/typing in its builder so the looser static
+// type is still correct at runtime.
+const isContent = (v: unknown): boolean =>
+  typeof v === "object" &&
+  v !== null &&
+  "type" in v &&
+  typeof (v as { type: unknown }).type === "string";
+
+/**
+ * An `edit` rewrites the content of a previously-sent outbound message.
+ *
+ * `space.send(edit(newContent, message))` is the canonical outbound API;
+ * `message.edit(newContent)` and `space.edit(message, newContent)` are
+ * sugar that delegate here. Edits are fire-and-forget — providers handle
+ * them inside their `send` action and the resolved value is `undefined`
+ * (no new message id is produced; the existing message mutates in place).
+ *
+ * Edit cannot wrap `edit`, `reply`, `reaction`, `group`, or `typing`.
+ */
+export const editSchema = z.object({
+  type: z.literal("edit"),
+  content: z.custom<BaseContent>(isContent, {
+    message: "edit content must be a Content value",
+  }),
+  target: z.custom<Message>(isMessage, {
+    message: "edit target must be a Message",
+  }),
+});
+
+export type Edit = z.infer<typeof editSchema>;
+
+export const asEdit = (input: {
+  content: BaseContent;
+  target: Message;
+}): Edit => editSchema.parse({ type: "edit", ...input });
+
+/**
+ * Construct an `edit` content value rewriting `target`'s content.
+ *
+ * `target` is typed as `OutboundMessage` because only messages you sent can
+ * be edited; the schema field stays loose at `Message` (matching
+ * reply/reaction) so providers receive the same shape regardless of
+ * direction.
+ */
+export function edit(
+  content: ContentInput,
+  target: OutboundMessage
+): ContentBuilder {
+  return {
+    build: async () => {
+      const [resolved] = await resolveContents([content]);
+      if (!resolved) {
+        throw new Error("edit() requires content");
+      }
+      if (
+        resolved.type === "edit" ||
+        resolved.type === "reply" ||
+        resolved.type === "reaction" ||
+        resolved.type === "group" ||
+        resolved.type === "typing"
+      ) {
+        throw new Error(`edit() cannot wrap "${resolved.type}" content`);
+      }
+      return asEdit({ content: resolved, target });
+    },
+  };
+}

--- a/packages/spectrum-ts/src/content/reaction.ts
+++ b/packages/spectrum-ts/src/content/reaction.ts
@@ -31,5 +31,15 @@ export const asReaction = (input: {
  * `space.getMessage(id)`.
  */
 export function reaction(emoji: string, target: Message): ContentBuilder {
-  return { build: async () => asReaction({ emoji, target }) };
+  return {
+    build: async () => {
+      // Reacting to a reaction is universally nonsensical — guard against it
+      // mirroring `reply()`'s reject-list. Replies and group items are valid
+      // reaction targets (real chat clients allow both), so only reject this.
+      if (target.content.type === "reaction") {
+        throw new Error('reaction() cannot target "reaction" content');
+      }
+      return asReaction({ emoji, target });
+    },
+  };
 }

--- a/packages/spectrum-ts/src/content/reply.ts
+++ b/packages/spectrum-ts/src/content/reply.ts
@@ -54,7 +54,8 @@ export function reply(content: ContentInput, target: Message): ContentBuilder {
       if (
         resolved.type === "reply" ||
         resolved.type === "reaction" ||
-        resolved.type === "group"
+        resolved.type === "group" ||
+        resolved.type === "typing"
       ) {
         throw new Error(`reply() cannot wrap "${resolved.type}" content`);
       }

--- a/packages/spectrum-ts/src/content/reply.ts
+++ b/packages/spectrum-ts/src/content/reply.ts
@@ -53,6 +53,7 @@ export function reply(content: ContentInput, target: Message): ContentBuilder {
       }
       if (
         resolved.type === "reply" ||
+        resolved.type === "edit" ||
         resolved.type === "reaction" ||
         resolved.type === "group" ||
         resolved.type === "typing"

--- a/packages/spectrum-ts/src/content/reply.ts
+++ b/packages/spectrum-ts/src/content/reply.ts
@@ -1,0 +1,64 @@
+import z from "zod";
+import type { Message } from "../types/message";
+import { resolveContents } from "./resolve";
+import type { BaseContent, ContentBuilder, ContentInput } from "./types";
+
+const isMessage = (v: unknown): v is Message =>
+  typeof v === "object" && v !== null && "id" in v && "content" in v;
+
+// Predicate returns `boolean` rather than `v is Content` so its signature
+// does not reference `Content` directly. The schema below types its inner
+// `content` field as `BaseContent` (the union of every content type *except*
+// reply) so `Reply ↔ Content` is not a circular type alias. Reply rejects
+// nested `reply`/`reaction`/`group` content in its builder anyway, so this
+// looser static type is still correct at runtime.
+const isContent = (v: unknown): boolean =>
+  typeof v === "object" &&
+  v !== null &&
+  "type" in v &&
+  typeof (v as { type: unknown }).type === "string";
+
+/**
+ * A `reply` wraps inner content with the message it replies to.
+ *
+ * `space.send(reply(content, message))` is the canonical outbound API;
+ * `message.reply(content)` is sugar that delegates here. Providers see
+ * `reply` like any other content type and route to a threaded send.
+ *
+ * Reply cannot wrap `reply`, `reaction`, or `group` content.
+ */
+export const replySchema = z.object({
+  type: z.literal("reply"),
+  content: z.custom<BaseContent>(isContent, {
+    message: "reply content must be a Content value",
+  }),
+  target: z.custom<Message>(isMessage, {
+    message: "reply target must be a Message",
+  }),
+});
+
+export type Reply = z.infer<typeof replySchema>;
+
+export const asReply = (input: {
+  content: BaseContent;
+  target: Message;
+}): Reply => replySchema.parse({ type: "reply", ...input });
+
+export function reply(content: ContentInput, target: Message): ContentBuilder {
+  return {
+    build: async () => {
+      const [resolved] = await resolveContents([content]);
+      if (!resolved) {
+        throw new Error("reply() requires content");
+      }
+      if (
+        resolved.type === "reply" ||
+        resolved.type === "reaction" ||
+        resolved.type === "group"
+      ) {
+        throw new Error(`reply() cannot wrap "${resolved.type}" content`);
+      }
+      return asReply({ content: resolved, target });
+    },
+  };
+}

--- a/packages/spectrum-ts/src/content/types.ts
+++ b/packages/spectrum-ts/src/content/types.ts
@@ -2,6 +2,7 @@ import z from "zod";
 import { attachmentSchema } from "./attachment";
 import { contactSchema } from "./contact";
 import { customSchema } from "./custom";
+import { editSchema } from "./edit";
 import { messageEffectSchema } from "./effect";
 import { groupSchema } from "./group";
 import { pollOptionSchema, pollSchema } from "./poll";
@@ -12,10 +13,11 @@ import { textSchema } from "./text";
 import { typingSchema } from "./typing";
 import { voiceSchema } from "./voice";
 
-// `baseContentSchema` is everything except `reply`. It exists so the inner
-// content of a `Reply` can be typed against this non-circular union without
-// `Content` referencing itself via `Reply.content`. Reply rejects nested
-// `reply` in its builder anyway, so the looser typing here is also correct.
+// `baseContentSchema` is everything except `reply` and `edit`. It exists so
+// the inner content of a `Reply` (and `Edit`) can be typed against this
+// non-circular union without `Content` referencing itself via
+// `Reply.content` / `Edit.content`. Both builders reject nested wrapping
+// in their reject-lists, so the looser typing here is also correct.
 const baseContentSchemas = [
   textSchema,
   customSchema,
@@ -41,6 +43,7 @@ export type BaseContent = z.infer<typeof baseContentSchema>;
 export const contentSchema = z.discriminatedUnion("type", [
   ...baseContentSchemas,
   replySchema,
+  editSchema,
 ]);
 
 export type Content = z.infer<typeof contentSchema>;

--- a/packages/spectrum-ts/src/content/types.ts
+++ b/packages/spectrum-ts/src/content/types.ts
@@ -9,6 +9,7 @@ import { reactionSchema } from "./reaction";
 import { replySchema } from "./reply";
 import { richlinkSchema } from "./richlink";
 import { textSchema } from "./text";
+import { typingSchema } from "./typing";
 import { voiceSchema } from "./voice";
 
 // `baseContentSchema` is everything except `reply`. It exists so the inner
@@ -27,6 +28,7 @@ const baseContentSchemas = [
   pollSchema,
   pollOptionSchema,
   messageEffectSchema,
+  typingSchema,
 ] as const;
 
 export const baseContentSchema = z.discriminatedUnion(

--- a/packages/spectrum-ts/src/content/types.ts
+++ b/packages/spectrum-ts/src/content/types.ts
@@ -6,11 +6,16 @@ import { messageEffectSchema } from "./effect";
 import { groupSchema } from "./group";
 import { pollOptionSchema, pollSchema } from "./poll";
 import { reactionSchema } from "./reaction";
+import { replySchema } from "./reply";
 import { richlinkSchema } from "./richlink";
 import { textSchema } from "./text";
 import { voiceSchema } from "./voice";
 
-export const contentSchema = z.discriminatedUnion("type", [
+// `baseContentSchema` is everything except `reply`. It exists so the inner
+// content of a `Reply` can be typed against this non-circular union without
+// `Content` referencing itself via `Reply.content`. Reply rejects nested
+// `reply` in its builder anyway, so the looser typing here is also correct.
+const baseContentSchemas = [
   textSchema,
   customSchema,
   attachmentSchema,
@@ -22,6 +27,18 @@ export const contentSchema = z.discriminatedUnion("type", [
   pollSchema,
   pollOptionSchema,
   messageEffectSchema,
+] as const;
+
+export const baseContentSchema = z.discriminatedUnion(
+  "type",
+  baseContentSchemas
+);
+
+export type BaseContent = z.infer<typeof baseContentSchema>;
+
+export const contentSchema = z.discriminatedUnion("type", [
+  ...baseContentSchemas,
+  replySchema,
 ]);
 
 export type Content = z.infer<typeof contentSchema>;

--- a/packages/spectrum-ts/src/content/typing.ts
+++ b/packages/spectrum-ts/src/content/typing.ts
@@ -1,0 +1,35 @@
+import z from "zod";
+import type { ContentBuilder } from "./types";
+
+/**
+ * A `typing` content value carries a typing-indicator signal — either
+ * `"start"` or `"stop"`. Like `reaction`, it's fire-and-forget: providers
+ * dispatch on `content.type === "typing"` inside their `send()` action and
+ * `space.send(typing(...))` resolves to `undefined`.
+ *
+ * `space.startTyping()` / `space.stopTyping()` / `space.responding()` are
+ * sugar over `space.send(typing("start" | "stop"))`. Platforms that have no
+ * typing-indicator API (e.g. WhatsApp Business) silently no-op so the
+ * signal is best-effort everywhere.
+ */
+export const typingSchema = z.object({
+  type: z.literal("typing"),
+  state: z.enum(["start", "stop"]),
+});
+
+export type Typing = z.infer<typeof typingSchema>;
+
+export const isTyping = (value: unknown): value is Typing =>
+  typingSchema.safeParse(value).success;
+
+/**
+ * Construct a `typing` content value. Defaults to `"start"`.
+ *
+ * `space.send(typing())` is equivalent to `space.startTyping()`;
+ * `space.send(typing("stop"))` is equivalent to `space.stopTyping()`.
+ */
+export function typing(state: "start" | "stop" = "start"): ContentBuilder {
+  return {
+    build: async () => typingSchema.parse({ type: "typing", state }),
+  };
+}

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -21,6 +21,7 @@ export {
   poll,
 } from "./content/poll";
 export { type Reaction, reaction } from "./content/reaction";
+export { type Reply, reply } from "./content/reply";
 export { resolveContents } from "./content/resolve";
 export { type Richlink, richlink } from "./content/richlink";
 export { text } from "./content/text";

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -11,6 +11,7 @@ export {
   contact,
 } from "./content/contact";
 export { custom } from "./content/custom";
+export { type Edit, edit } from "./content/edit";
 export { type Group, group } from "./content/group";
 export {
   option,

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -26,6 +26,7 @@ export { resolveContents } from "./content/resolve";
 export { type Richlink, richlink } from "./content/richlink";
 export { text } from "./content/text";
 export type { Content, ContentBuilder, ContentInput } from "./content/types";
+export { type Typing, typing } from "./content/typing";
 export { type Voice, voice } from "./content/voice";
 export { Emoji, type EmojiKey } from "./emoji";
 export { definePlatform } from "./platform/define";

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -1,3 +1,4 @@
+import { reaction as reactionContent } from "../content/reaction";
 import { reply as replyContent } from "../content/reply";
 import { resolveContents } from "../content/resolve";
 import type { Content, ContentInput } from "../content/types";
@@ -231,9 +232,10 @@ const wrapNestedContent = (
       // Reaction targets are always wrapped as "inbound": the target refers to
       // the original received message, not the reaction event itself. So even
       // when the wrapping reaction is outbound (e.g. our own reaction sent via
-      // `reactToMessage`), the *target* it points at is a message we received.
-      // This differs from `group.items`, which propagate the wrapping
-      // direction because each item is itself one piece of the same send.
+      // `space.send(reaction(...))`), the *target* it points at is a message
+      // we received. This differs from `group.items`, which propagate the
+      // wrapping direction because each item is itself one piece of the same
+      // send.
       return {
         ...content,
         target: wrapProviderMessage(target, ctx, "inbound"),
@@ -278,32 +280,8 @@ export function buildSpace(params: BuildSpaceParams): Space {
   // Declared first so inner arrows can reference it after assignment.
   let space: Space;
 
-  async function dispatchReaction(
-    item: Extract<Content, { type: "reaction" }>
-  ): Promise<void> {
-    try {
-      if (!definition.actions.reactToMessage) {
-        throw UnsupportedError.action("react", definition.name);
-      }
-      await definition.actions.reactToMessage({
-        space: spaceRef,
-        target: item.target,
-        reaction: item.emoji,
-        client,
-        config,
-        store,
-      });
-    } catch (err) {
-      if (err instanceof UnsupportedError) {
-        warnUnsupported(err, definition.name);
-        return;
-      }
-      throw err;
-    }
-  }
-
   async function dispatchSend(
-    item: Exclude<Content, { type: "reaction" }>
+    item: Content
   ): Promise<OutboundMessage | undefined> {
     let raw: ProviderMessageRecord | undefined;
     try {
@@ -326,6 +304,11 @@ export function buildSpace(params: BuildSpaceParams): Space {
       throw err;
     }
     if (!raw?.id) {
+      // Reactions are fire-and-forget on most platforms — providers may return
+      // `void` from `send`. Every other content type must produce a message id.
+      if (item.type === "reaction") {
+        return;
+      }
       throw new Error(
         `Platform "${definition.name}" send did not return a message id`
       );
@@ -343,10 +326,6 @@ export function buildSpace(params: BuildSpaceParams): Space {
     const resolved = await resolveContents(content);
     const results: OutboundMessage[] = [];
     for (const item of resolved) {
-      if (item.type === "reaction") {
-        await dispatchReaction(item);
-        continue;
-      }
       const sent = await dispatchSend(item);
       if (sent) {
         results.push(sent);
@@ -430,35 +409,13 @@ export function buildMessage(params: BuildMessageParams): Message {
   // reaction target.
   let self: Message | undefined;
 
-  const react = async (reaction: string): Promise<void> => {
-    if (!definition.actions.reactToMessage) {
-      warnUnsupported(
-        UnsupportedError.action("react", definition.name),
-        definition.name
-      );
-      return;
-    }
-    if (!self) {
-      throw new Error(
-        "react() called before message construction completed (internal bug)"
-      );
-    }
-    try {
-      await definition.actions.reactToMessage({
-        space: spaceRef,
-        target: self,
-        reaction,
-        client,
-        config,
-        store,
-      });
-    } catch (err) {
-      if (err instanceof UnsupportedError) {
-        warnUnsupported(err, definition.name);
-        return;
-      }
-      throw err;
-    }
+  const react = async (emoji: string): Promise<void> => {
+    const target = requireBuiltMessage("react");
+    // Sugar for `space.send(reaction(emoji, target))`. The canonical form
+    // returns `OutboundMessage | undefined`; this surface discards it because
+    // reactions are fire-and-forget on most platforms (callers reach for the
+    // canonical form when they need the result).
+    await space.send(reactionContent(emoji, target));
   };
 
   const requireBuiltMessage = (action: "react" | "reply"): Message => {

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -2,6 +2,7 @@ import { reaction as reactionContent } from "../content/reaction";
 import { reply as replyContent } from "../content/reply";
 import { resolveContents } from "../content/resolve";
 import type { Content, ContentInput } from "../content/types";
+import { typing as typingContent } from "../content/typing";
 import type {
   InboundMessage,
   Message,
@@ -127,18 +128,20 @@ type BuildOutboundParams = BaseBuildParams & {
 export type BuildMessageParams = BuildInboundParams | BuildOutboundParams;
 
 export interface BuildSpaceParams {
+  // Pre-built context object passed to `definition.actions.send`. Sites that
+  // dispatch actions spread this and add per-call fields (e.g. `content`).
+  actionCtx: {
+    space: SpaceRef;
+    client: unknown;
+    config: unknown;
+    store: Store;
+  };
   client: unknown;
   config: unknown;
   definition: AnyPlatformDef;
   extras: Record<string, unknown>;
   spaceRef: SpaceRef;
   store: Store;
-  typingCtx: {
-    space: SpaceRef;
-    client: unknown;
-    config: unknown;
-    store: Store;
-  };
 }
 
 // Raw provider message fields — everything else on a provider-emitted record
@@ -275,7 +278,7 @@ const isRawProviderRecord = (v: unknown): v is ProviderMessageRecord => {
 };
 
 export function buildSpace(params: BuildSpaceParams): Space {
-  const { spaceRef, extras, typingCtx, definition, client, config, store } =
+  const { spaceRef, extras, actionCtx, definition, client, config, store } =
     params;
   // Declared first so inner arrows can reference it after assignment.
   let space: Space;
@@ -293,7 +296,7 @@ export function buildSpace(params: BuildSpaceParams): Space {
         throw platformError;
       }
       raw = (await definition.actions.send({
-        ...typingCtx,
+        ...actionCtx,
         content: item,
       })) as ProviderMessageRecord | undefined;
     } catch (err) {
@@ -304,9 +307,10 @@ export function buildSpace(params: BuildSpaceParams): Space {
       throw err;
     }
     if (!raw?.id) {
-      // Reactions are fire-and-forget on most platforms — providers may return
-      // `void` from `send`. Every other content type must produce a message id.
-      if (item.type === "reaction") {
+      // Reactions and typing indicators are fire-and-forget control signals —
+      // providers may return `void` from `send` for them. Every other content
+      // type must produce a message id.
+      if (item.type === "reaction" || item.type === "typing") {
         return;
       }
       throw new Error(
@@ -383,17 +387,20 @@ export function buildSpace(params: BuildSpaceParams): Space {
     },
     getMessage: getMessageImpl,
     startTyping: async () => {
-      await definition.actions.startTyping?.(typingCtx);
+      // Sugar for `space.send(typing("start"))`. Typing is fire-and-forget;
+      // providers handle it inside their `send` action and any platforms
+      // without a typing API silently no-op.
+      await space.send(typingContent("start"));
     },
     stopTyping: async () => {
-      await definition.actions.stopTyping?.(typingCtx);
+      await space.send(typingContent("stop"));
     },
     responding: async <T>(fn: () => T | Promise<T>): Promise<T> => {
-      await definition.actions.startTyping?.(typingCtx);
+      await space.send(typingContent("start"));
       try {
         return await fn();
       } finally {
-        await definition.actions.stopTyping?.(typingCtx).catch(() => {});
+        await space.send(typingContent("stop")).catch(() => {});
       }
     },
   };

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -1,3 +1,4 @@
+import { reply as replyContent } from "../content/reply";
 import { resolveContents } from "../content/resolve";
 import type { Content, ContentInput } from "../content/types";
 import type {
@@ -11,10 +12,6 @@ import type { Store } from "../utils/store";
 import type { AnyPlatformDef, ProviderMessageRecord } from "./types";
 
 export type { ProviderMessageRecord } from "./types";
-
-type ReplyToMessageAction = NonNullable<
-  AnyPlatformDef["actions"]["replyToMessage"]
->;
 
 const ANSI_YELLOW = "\x1b[33m";
 const ANSI_RESET = "\x1b[0m";
@@ -58,6 +55,10 @@ const findUnsupportedPlatformContent = (
   const scopedPlatform = contentPlatform(content);
   if (scopedPlatform && scopedPlatform !== platform) {
     return scopedPlatform;
+  }
+
+  if (content.type === "reply") {
+    return findUnsupportedPlatformContent(content.content, platform);
   }
 
   if (content.type !== "group") {
@@ -174,11 +175,11 @@ const extractExtras = (
 /**
  * Wrap a raw provider message record (and any nested raw targets/items inside
  * its content) into a fully-built `Message`. The same path serves inbound
- * (`events.messages`, `getMessage`) and outbound (`send`, `replyToMessage`)
- * flows — the only difference is `direction`, which decides whether the
- * resulting Message exposes inbound (`react`/`reply`) or outbound (`edit`)
- * affordances. Recursion through `wrapNestedContent` handles reaction targets
- * and group items, which providers return as nested raw records.
+ * (`events.messages`, `getMessage`) and outbound (`send`) flows — the only
+ * difference is `direction`, which decides whether the resulting Message
+ * exposes inbound (`react`/`reply`) or outbound (`edit`) affordances.
+ * Recursion through `wrapNestedContent` handles reaction targets and group
+ * items, which providers return as nested raw records.
  */
 export function wrapProviderMessage(
   raw: ProviderMessageRecord,
@@ -469,48 +470,6 @@ export function buildMessage(params: BuildMessageParams): Message {
     return self;
   };
 
-  const dispatchReplyItem = async (
-    item: Content,
-    target: Message,
-    replyToMessage: ReplyToMessageAction
-  ): Promise<OutboundMessage | undefined> => {
-    let raw: ProviderMessageRecord | undefined;
-    try {
-      const platformError = unsupportedPlatformContentError(
-        item,
-        definition.name
-      );
-      if (platformError) {
-        throw platformError;
-      }
-      raw = (await replyToMessage({
-        space: spaceRef,
-        messageId: params.id,
-        target,
-        content: item,
-        client,
-        config,
-        store,
-      })) as ProviderMessageRecord | undefined;
-    } catch (err) {
-      if (err instanceof UnsupportedError) {
-        warnUnsupported(err, definition.name);
-        return;
-      }
-      throw err;
-    }
-    if (!raw?.id) {
-      throw new Error(
-        `Platform "${definition.name}" reply did not return a message id`
-      );
-    }
-    return wrapProviderMessage(
-      raw,
-      { client, config, definition, space, spaceRef, store },
-      "outbound"
-    );
-  };
-
   async function reply(
     content: ContentInput
   ): Promise<OutboundMessage | undefined>;
@@ -520,27 +479,19 @@ export function buildMessage(params: BuildMessageParams): Message {
   async function reply(
     ...content: [ContentInput, ...ContentInput[]]
   ): Promise<OutboundMessage | OutboundMessage[] | undefined> {
-    const replyToMessage = definition.actions.replyToMessage;
-    if (!replyToMessage) {
-      warnUnsupported(
-        UnsupportedError.action("reply", definition.name),
-        definition.name
-      );
-      return content.length === 1 ? undefined : [];
-    }
-    const resolved = await resolveContents(content);
     const target = requireBuiltMessage("reply");
-    const results: OutboundMessage[] = [];
-    for (const item of resolved) {
-      const sent = await dispatchReplyItem(item, target, replyToMessage);
-      if (sent) {
-        results.push(sent);
-      }
-    }
-    if (content.length === 1) {
-      return results[0];
-    }
-    return results;
+    const wrapped = content.map((c) => replyContent(c, target)) as [
+      ContentInput,
+      ...ContentInput[],
+    ];
+    // The cast mirrors the existing `sendImpl as Space["send"]` below —
+    // overload resolution can't pick the right shape from a generic
+    // spread, but the runtime delegates 1:1.
+    return (
+      space.send as (
+        ...c: [ContentInput, ...ContentInput[]]
+      ) => Promise<OutboundMessage | OutboundMessage[] | undefined>
+    )(...wrapped);
   }
 
   const senderWithPlatform =

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -129,8 +129,9 @@ type BuildOutboundParams = BaseBuildParams & {
 export type BuildMessageParams = BuildInboundParams | BuildOutboundParams;
 
 export interface BuildSpaceParams {
-  // Pre-built context object passed to `definition.actions.send`. Sites that
-  // dispatch actions spread this and add per-call fields (e.g. `content`).
+  // Pre-built context object passed to `definition.send`. Sites that dispatch
+  // through the send pipeline spread this and add per-call fields (e.g.
+  // `content`).
   actionCtx: {
     space: SpaceRef;
     client: unknown;
@@ -180,7 +181,7 @@ const extractExtras = (
 /**
  * Wrap a raw provider message record (and any nested raw targets/items inside
  * its content) into a fully-built `Message`. The same path serves inbound
- * (`events.messages`, `getMessage`) and outbound (`send`) flows — the only
+ * (`messages`, `actions.getMessage`) and outbound (`send`) flows — the only
  * difference is `direction`, which decides whether the resulting Message
  * exposes inbound (`react`/`reply`) or outbound (`edit`) affordances.
  * Recursion through `wrapNestedContent` handles reaction targets and group
@@ -311,7 +312,7 @@ export function buildSpace(params: BuildSpaceParams): Space {
       if (platformError) {
         throw platformError;
       }
-      raw = (await definition.actions.send({
+      raw = (await definition.send({
         ...actionCtx,
         content: item,
       })) as ProviderMessageRecord | undefined;
@@ -362,7 +363,8 @@ export function buildSpace(params: BuildSpaceParams): Space {
   }
 
   async function getMessageImpl(id: string): Promise<Message | undefined> {
-    if (!definition.actions.getMessage) {
+    const getMessage = definition.actions?.getMessage;
+    if (!getMessage) {
       warnUnsupported(
         UnsupportedError.action("getMessage", definition.name),
         definition.name
@@ -371,7 +373,7 @@ export function buildSpace(params: BuildSpaceParams): Space {
     }
     let raw: ProviderMessageRecord | undefined;
     try {
-      raw = (await definition.actions.getMessage({
+      raw = (await getMessage({
         space: spaceRef,
         messageId: id,
         client,

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -1,3 +1,4 @@
+import { edit as editContent } from "../content/edit";
 import { reaction as reactionContent } from "../content/reaction";
 import { reply as replyContent } from "../content/reply";
 import { resolveContents } from "../content/resolve";
@@ -59,7 +60,7 @@ const findUnsupportedPlatformContent = (
     return scopedPlatform;
   }
 
-  if (content.type === "reply") {
+  if (content.type === "reply" || content.type === "edit") {
     return findUnsupportedPlatformContent(content.content, platform);
   }
 
@@ -246,6 +247,21 @@ const wrapNestedContent = (
     }
     return content;
   }
+  if (content.type === "edit") {
+    const target = content.target as unknown;
+    if (isRawProviderRecord(target)) {
+      // The target of an edit is always one of *our* outbound messages —
+      // the message being rewritten. Wrap as outbound so its `.edit`
+      // affordance is available downstream. Defensive parity with the
+      // reaction branch above; in practice providers return `undefined`
+      // from `send` for edits, so this rarely fires.
+      return {
+        ...content,
+        target: wrapProviderMessage(target, ctx, "outbound"),
+      };
+    }
+    return content;
+  }
   if (content.type === "group") {
     const items = content.items.map((item) => {
       const raw = item as unknown;
@@ -307,10 +323,14 @@ export function buildSpace(params: BuildSpaceParams): Space {
       throw err;
     }
     if (!raw?.id) {
-      // Reactions and typing indicators are fire-and-forget control signals —
-      // providers may return `void` from `send` for them. Every other content
-      // type must produce a message id.
-      if (item.type === "reaction" || item.type === "typing") {
+      // Reactions, typing indicators, and edits are fire-and-forget control
+      // signals — providers may return `void` from `send` for them. Every
+      // other content type must produce a message id.
+      if (
+        item.type === "reaction" ||
+        item.type === "typing" ||
+        item.type === "edit"
+      ) {
         return;
       }
       throw new Error(
@@ -383,7 +403,9 @@ export function buildSpace(params: BuildSpaceParams): Space {
       message: OutboundMessage,
       newContent: ContentInput
     ): Promise<void> => {
-      await message.edit(newContent);
+      // Sugar for `space.send(edit(newContent, message))`. Edits are
+      // fire-and-forget; the (always-undefined) result is discarded.
+      await space.send(editContent(newContent, message));
     },
     getMessage: getMessageImpl,
     startTyping: async () => {
@@ -410,7 +432,7 @@ export function buildSpace(params: BuildSpaceParams): Space {
 export function buildMessage(params: BuildInboundParams): InboundMessage;
 export function buildMessage(params: BuildOutboundParams): OutboundMessage;
 export function buildMessage(params: BuildMessageParams): Message {
-  const { definition, client, config, spaceRef, space, store } = params;
+  const { definition, space } = params;
 
   // Late-bound self reference so `react()` can pass the built Message as the
   // reaction target.
@@ -425,7 +447,7 @@ export function buildMessage(params: BuildMessageParams): Message {
     await space.send(reactionContent(emoji, target));
   };
 
-  const requireBuiltMessage = (action: "react" | "reply"): Message => {
+  const requireBuiltMessage = (action: "react" | "reply" | "edit"): Message => {
     if (!self) {
       throw new Error(
         `${action}() called before message construction completed (internal bug)`
@@ -473,41 +495,11 @@ export function buildMessage(params: BuildMessageParams): Message {
       react,
       reply,
       edit: async (newContent: ContentInput): Promise<void> => {
-        if (!definition.actions.editMessage) {
-          warnUnsupported(
-            UnsupportedError.action("edit", definition.name),
-            definition.name
-          );
-          return;
-        }
-        const [resolved] = await resolveContents([newContent]);
-        if (!resolved) {
-          return;
-        }
-        const platformError = unsupportedPlatformContentError(
-          resolved,
-          definition.name
-        );
-        if (platformError) {
-          warnUnsupported(platformError, definition.name);
-          return;
-        }
-        try {
-          await definition.actions.editMessage({
-            space: spaceRef,
-            messageId: params.id,
-            content: resolved,
-            client,
-            config,
-            store,
-          });
-        } catch (err) {
-          if (err instanceof UnsupportedError) {
-            warnUnsupported(err, definition.name);
-            return;
-          }
-          throw err;
-        }
+        // Sugar for `space.send(edit(newContent, self))`. Unsupported-content
+        // checks, fire-and-forget dispatch, and provider delegation all flow
+        // through the canonical send pipeline.
+        const target = requireBuiltMessage("edit") as OutboundMessage;
+        await space.send(editContent(newContent, target));
       },
       sender: senderWithPlatform,
       space,

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -148,13 +148,14 @@ function createPlatformInstance<
     },
   };
 
-  // Add flat event properties for custom events (non-messages)
+  // Add flat event properties for custom events. The core `messages` stream
+  // lives at the top level of the def — only the optional `events?` slot
+  // (custom platform events like presence, read receipts, etc.) is projected
+  // onto the instance here.
   const eventProperties: Record<string, AsyncIterable<unknown>> = {};
-  for (const eventName of Object.keys(def.events)) {
-    if (eventName === "messages") {
-      continue;
-    }
-    const producer = def.events[eventName] as
+  const customEvents = def.events ?? {};
+  for (const eventName of Object.keys(customEvents)) {
+    const producer = customEvents[eventName] as
       | ((ctx: {
           client: unknown;
           config: unknown;
@@ -211,11 +212,12 @@ export function definePlatform<
       ? z.infer<_MessageSchema>
       : Record<never, never>
   >,
-  _Events extends {
-    messages: EventProducer<_MessageType, _Client, z.infer<_ConfigSchema>>;
-  } = {
-    messages: EventProducer<_MessageType, _Client, z.infer<_ConfigSchema>>;
-  },
+  _Events extends
+    | (Record<
+        string,
+        EventProducer<unknown, _Client, z.infer<_ConfigSchema>>
+      > & { messages?: never })
+    | undefined = undefined,
   _Static extends Record<string, unknown> = Record<never, never>,
 >(
   name: _Name,

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -130,7 +130,7 @@ function createPlatformInstance<
         id: parsedSpace.id,
         __platform: def.name,
       };
-      const typingCtx = {
+      const actionCtx = {
         space: spaceRef,
         client: runtime.client as _Client,
         config: runtime.config as z.infer<_ConfigSchema>,
@@ -139,7 +139,7 @@ function createPlatformInstance<
       return buildSpace({
         spaceRef,
         extras: parsedSpace as Record<string, unknown>,
-        typingCtx,
+        actionCtx,
         definition: def as unknown as AnyPlatformDef,
         client: runtime.client,
         config: runtime.config,

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -140,7 +140,7 @@ export interface PlatformDef<
       client: NoInferClient<_Client>;
       config: z.infer<_ConfigSchema>;
       store: Store;
-    }) => Promise<ProviderMessageRecord>;
+    }) => Promise<ProviderMessageRecord | undefined>;
     startTyping?: (_: {
       space: _ResolvedSpace & SpaceRef;
       client: NoInferClient<_Client>;
@@ -149,14 +149,6 @@ export interface PlatformDef<
     }) => Promise<void>;
     stopTyping?: (_: {
       space: _ResolvedSpace & SpaceRef;
-      client: NoInferClient<_Client>;
-      config: z.infer<_ConfigSchema>;
-      store: Store;
-    }) => Promise<void>;
-    reactToMessage?: (_: {
-      space: _ResolvedSpace & SpaceRef;
-      target: _MessageType;
-      reaction: string;
       client: NoInferClient<_Client>;
       config: z.infer<_ConfigSchema>;
       store: Store;
@@ -229,13 +221,11 @@ export interface PlatformDef<
 export interface AnyPlatformDef {
   actions: {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
-    send: (_: any) => Promise<ProviderMessageRecord>;
+    send: (_: any) => Promise<ProviderMessageRecord | undefined>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     startTyping?: (_: any) => Promise<void>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     stopTyping?: (_: any) => Promise<void>;
-    // biome-ignore lint/suspicious/noExplicitAny: wildcard action
-    reactToMessage?: (_: any) => Promise<void>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     editMessage?: (_: any) => Promise<void>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -141,14 +141,6 @@ export interface PlatformDef<
       config: z.infer<_ConfigSchema>;
       store: Store;
     }) => Promise<ProviderMessageRecord | undefined>;
-    editMessage?: (_: {
-      space: _ResolvedSpace & SpaceRef;
-      messageId: string;
-      content: Content;
-      client: NoInferClient<_Client>;
-      config: z.infer<_ConfigSchema>;
-      store: Store;
-    }) => Promise<void>;
     getMessage?: (_: {
       space: _ResolvedSpace & SpaceRef;
       messageId: string;
@@ -210,8 +202,6 @@ export interface AnyPlatformDef {
   actions: {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     send: (_: any) => Promise<ProviderMessageRecord | undefined>;
-    // biome-ignore lint/suspicious/noExplicitAny: wildcard action
-    editMessage?: (_: any) => Promise<void>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     getMessage?: (_: any) => Promise<any>;
   };

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -141,18 +141,6 @@ export interface PlatformDef<
       config: z.infer<_ConfigSchema>;
       store: Store;
     }) => Promise<ProviderMessageRecord | undefined>;
-    startTyping?: (_: {
-      space: _ResolvedSpace & SpaceRef;
-      client: NoInferClient<_Client>;
-      config: z.infer<_ConfigSchema>;
-      store: Store;
-    }) => Promise<void>;
-    stopTyping?: (_: {
-      space: _ResolvedSpace & SpaceRef;
-      client: NoInferClient<_Client>;
-      config: z.infer<_ConfigSchema>;
-      store: Store;
-    }) => Promise<void>;
     editMessage?: (_: {
       space: _ResolvedSpace & SpaceRef;
       messageId: string;
@@ -222,10 +210,6 @@ export interface AnyPlatformDef {
   actions: {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     send: (_: any) => Promise<ProviderMessageRecord | undefined>;
-    // biome-ignore lint/suspicious/noExplicitAny: wildcard action
-    startTyping?: (_: any) => Promise<void>;
-    // biome-ignore lint/suspicious/noExplicitAny: wildcard action
-    stopTyping?: (_: any) => Promise<void>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     editMessage?: (_: any) => Promise<void>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -52,8 +52,8 @@ export type ProviderMessage<
 } & TExtra;
 
 /**
- * A message a provider produced — used for both inbound (`events.messages`,
- * `getMessage`) and outbound (`send`) flows. Providers return their native
+ * A message a provider produced — used for both inbound (`messages`,
+ * `actions.getMessage`) and outbound (`send`) flows. Providers return their native
  * record shape (including platform extras like `partIndex`/`parentId` for
  * iMessage) and the platform `wrapProviderMessage` pipeline turns it into a
  * fully-built Message.
@@ -108,6 +108,22 @@ export interface CreateClientContext<_ConfigSchema extends z.ZodType<object>> {
   store: Store;
 }
 
+/**
+ * The full definition of a platform adapter.
+ *
+ * Spectrum's platform API is shaped around the universal messaging contract:
+ * **`messages` (inbound stream) + `send` (outbound dispatcher)**. Together
+ * they handle 99% of what any platform integration needs to do — every
+ * higher-level affordance (`message.reply`, `message.react`, `space.edit`,
+ * `space.startTyping`, etc.) is sugar that routes through `send`.
+ *
+ * Everything beyond those two is optional: `getMessage` is a known capability
+ * that lives inside `actions?`; platform-specific event streams live inside
+ * `events?` and surface as flat properties on the platform instance.
+ *
+ * Minimum viable platform integration:
+ * `name`, `config`, `lifecycle`, `user`, `space`, `messages`, `send`.
+ */
 export interface PlatformDef<
   _Name extends string = string,
   _ConfigSchema extends z.ZodType<object> = z.ZodType<object>,
@@ -127,20 +143,25 @@ export interface PlatformDef<
     _ResolvedSpace,
     InferSchema<_MessageSchema>
   >,
-  _Events extends {
-    messages: EventProducer<_MessageType, _Client, z.infer<_ConfigSchema>>;
-  } = {
-    messages: EventProducer<_MessageType, _Client, z.infer<_ConfigSchema>>;
-  },
+  _Events extends
+    | (Record<
+        string,
+        EventProducer<unknown, _Client, z.infer<_ConfigSchema>>
+      > & { messages?: never })
+    | undefined = undefined,
 > {
-  actions: {
-    send: (_: {
-      space: _ResolvedSpace & SpaceRef;
-      content: Content;
-      client: NoInferClient<_Client>;
-      config: z.infer<_ConfigSchema>;
-      store: Store;
-    }) => Promise<ProviderMessageRecord | undefined>;
+  /**
+   * Optional escape hatch: platform actions beyond `send`. Currently the
+   * framework recognizes one slot:
+   *
+   * - **`getMessage?`** — fetch a message by id from a space. Powers
+   *   `space.getMessage(id)`. When omitted, `space.getMessage()` warns and
+   *   returns `undefined`.
+   *
+   * 99% of integrations don't need this — `messages` + `send` is the
+   * universal contract.
+   */
+  actions?: {
     getMessage?: (_: {
       space: _ResolvedSpace & SpaceRef;
       messageId: string;
@@ -152,7 +173,19 @@ export interface PlatformDef<
 
   config: _ConfigSchema;
 
-  events: _Events;
+  /**
+   * Optional escape hatch: platform-specific event streams beyond the core
+   * `messages` stream (e.g. presence updates, read receipts). Each producer
+   * is surfaced as a flat property on both `spectrum` and the platform
+   * instance (e.g. `spectrum.presence`, `slack.readReceipt`).
+   *
+   * The key `messages` is reserved — the core inbound stream lives at the
+   * top level, not inside `events?`.
+   *
+   * 99% of integrations don't need this — `messages` + `send` is the
+   * universal contract.
+   */
+  events?: _Events;
 
   lifecycle: {
     createClient: (ctx: CreateClientContext<_ConfigSchema>) => Promise<_Client>;
@@ -165,7 +198,37 @@ export interface PlatformDef<
   message?: {
     schema?: _MessageSchema;
   };
+
+  /**
+   * Inbound message stream. Returns an `AsyncIterable<ProviderMessageRecord>`
+   * — Spectrum wraps each emitted record into a fully-built `Message` and
+   * fans it out via `spectrum.messages`.
+   *
+   * One of the two universal platform contracts (along with `send`). 99% of
+   * integrations only need to implement `messages` + `send`.
+   */
+  messages: EventProducer<_MessageType, _Client, z.infer<_ConfigSchema>>;
   name: _Name;
+
+  /**
+   * Send a piece of `Content` to a space. The provider inspects
+   * `content.type` and dispatches accordingly — text, attachments, reactions,
+   * replies, edits, typing indicators, and any other content type all flow
+   * through this single action.
+   *
+   * Returns a `ProviderMessageRecord` (id + timestamp) for content that
+   * produces a message; returns `undefined` for fire-and-forget control
+   * signals (reactions, typing, edits) on platforms that don't return ids.
+   *
+   * One of the two universal platform contracts (along with `messages`).
+   */
+  send: (_: {
+    space: _ResolvedSpace & SpaceRef;
+    content: Content;
+    client: NoInferClient<_Client>;
+    config: z.infer<_ConfigSchema>;
+    store: Store;
+  }) => Promise<ProviderMessageRecord | undefined>;
 
   space: {
     schema?: _SpaceSchema;
@@ -199,16 +262,14 @@ export interface PlatformDef<
 // ---------------------------------------------------------------------------
 
 export interface AnyPlatformDef {
-  actions: {
-    // biome-ignore lint/suspicious/noExplicitAny: wildcard action
-    send: (_: any) => Promise<ProviderMessageRecord | undefined>;
+  actions?: {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     getMessage?: (_: any) => Promise<any>;
   };
   config: z.ZodType<object>;
-  events: {
-    // biome-ignore lint/suspicious/noExplicitAny: wildcard event
-    messages: (ctx: any) => AsyncIterable<any>;
+
+  // Optional escape hatches.
+  events?: {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard event
     [key: string]: (ctx: any) => AsyncIterable<any>;
   };
@@ -219,7 +280,13 @@ export interface AnyPlatformDef {
     destroyClient?: (ctx: any) => Promise<void>;
   };
   message?: { schema?: z.ZodType<object> };
+
+  // Required core message I/O — the universal contract.
+  // biome-ignore lint/suspicious/noExplicitAny: wildcard event
+  messages: (ctx: any) => AsyncIterable<any>;
   name: string;
+  // biome-ignore lint/suspicious/noExplicitAny: wildcard action
+  send: (_: any) => Promise<ProviderMessageRecord | undefined>;
   space: {
     schema?: z.ZodType<object>;
     params?: z.ZodType<object>;
@@ -273,14 +340,20 @@ interface ExtractDefByName<Name extends string> extends Fn {
 
 interface ExtractCustomEventNames extends Fn {
   return: this["arg0"] extends AnyPlatformDef
-    ? Exclude<keyof this["arg0"]["events"], "messages" | symbol | number>
+    ? this["arg0"]["events"] extends Record<string, unknown>
+      ? Exclude<keyof this["arg0"]["events"], symbol | number>
+      : never
     : never;
 }
 
 interface ToCustomEventVariant<EventName extends string> extends Fn {
   return: this["arg0"] extends PlatformProviderConfig<infer Def>
-    ? EventName extends keyof Def["events"]
-      ? InferEventPayload<Def["events"][EventName]> & { platform: Def["name"] }
+    ? Def["events"] extends Record<string, unknown>
+      ? EventName extends keyof Def["events"]
+        ? InferEventPayload<Def["events"][EventName]> & {
+            platform: Def["name"];
+          }
+        : never
       : never
     : never;
 }
@@ -307,7 +380,7 @@ export type ExtractProviderDef<
 >;
 
 // ---------------------------------------------------------------------------
-// AllCustomEventNames — union of all non-messages event names across providers
+// AllCustomEventNames — union of all custom event names across providers
 // ---------------------------------------------------------------------------
 
 type AllCustomEventNames<Providers extends PlatformProviderConfig[]> = Pipe<
@@ -416,14 +489,22 @@ export type PlatformInstance<Def extends AnyPlatformDef> = {
   >;
   space(...args: SpaceArgs<Def>): Promise<PlatformSpace<Def>>;
   user(userID: string): Promise<PlatformUser<Def>>;
-} & {
-  [K in Exclude<
-    keyof Def["events"],
-    "messages" | symbol | number
-  > as K extends ReservedNames ? never : K]: AsyncIterable<
-    InferEventPayload<Def["events"][K]>
-  >;
-};
+} & CustomEventInstanceProperties<Def>;
+
+// Project the optional `events?` slot onto the platform instance as flat
+// async-iterable properties. When `events` is undefined (the 99% case), this
+// resolves to `Record<never, never>` — no extra keys on the instance.
+type CustomEventInstanceProperties<Def extends AnyPlatformDef> =
+  Def["events"] extends Record<string, unknown>
+    ? {
+        [K in Exclude<
+          keyof Def["events"],
+          symbol | number
+        > as K extends ReservedNames ? never : K]: AsyncIterable<
+          InferEventPayload<NonNullable<Def["events"]>[K]>
+        >;
+      }
+    : Record<never, never>;
 
 // ---------------------------------------------------------------------------
 // SpectrumLike — minimal interface for platform narrowing

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -53,10 +53,10 @@ export type ProviderMessage<
 
 /**
  * A message a provider produced — used for both inbound (`events.messages`,
- * `getMessage`) and outbound (`send`, `replyToMessage`) flows. Providers
- * return their native record shape (including platform extras like
- * `partIndex`/`parentId` for iMessage) and the platform `wrapProviderMessage`
- * pipeline turns it into a fully-built Message.
+ * `getMessage`) and outbound (`send`) flows. Providers return their native
+ * record shape (including platform extras like `partIndex`/`parentId` for
+ * iMessage) and the platform `wrapProviderMessage` pipeline turns it into a
+ * fully-built Message.
  *
  * `sender` is optional because outbound sends often can't synthesize one
  * (the SDK doesn't surface the bot's own handle); inbound providers are
@@ -161,15 +161,6 @@ export interface PlatformDef<
       config: z.infer<_ConfigSchema>;
       store: Store;
     }) => Promise<void>;
-    replyToMessage?: (_: {
-      space: _ResolvedSpace & SpaceRef;
-      messageId: string;
-      target: _MessageType;
-      content: Content;
-      client: NoInferClient<_Client>;
-      config: z.infer<_ConfigSchema>;
-      store: Store;
-    }) => Promise<ProviderMessageRecord>;
     editMessage?: (_: {
       space: _ResolvedSpace & SpaceRef;
       messageId: string;
@@ -245,8 +236,6 @@ export interface AnyPlatformDef {
     stopTyping?: (_: any) => Promise<void>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     reactToMessage?: (_: any) => Promise<void>;
-    // biome-ignore lint/suspicious/noExplicitAny: wildcard action
-    replyToMessage?: (_: any) => Promise<ProviderMessageRecord>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action
     editMessage?: (_: any) => Promise<void>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard action

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -1,5 +1,6 @@
 import { createClient, MessageEffect } from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
+import type { Edit } from "../../content/edit";
 import { definePlatform } from "../../platform/define";
 import { UnsupportedError } from "../../utils/errors";
 
@@ -37,6 +38,27 @@ import {
 
 const isPollContent = (content: { type: string }): boolean =>
   content.type === "poll" || content.type === "poll_option";
+
+const handleEdit = async (
+  client: IMessageClient,
+  space: { id: string; phone: string },
+  content: Edit
+): Promise<void> => {
+  if (isLocal(client)) {
+    throw UnsupportedError.action("edit", "iMessage (local mode)");
+  }
+  if (content.content.type !== "text") {
+    // Mirrors `remoteEditMessage`'s own check — surface as an
+    // UnsupportedError so dispatchSend warn-and-skips uniformly.
+    throw UnsupportedError.content(
+      "edit",
+      "iMessage",
+      `only text content can be edited (got "${content.content.type}")`
+    );
+  }
+  const remote = clientForPhone(client, space.phone);
+  await remoteEditMessage(remote, space.id, content.target.id, content.content);
+};
 
 export const imessage = definePlatform("iMessage", {
   config: configSchema,
@@ -203,18 +225,15 @@ export const imessage = definePlatform("iMessage", {
         }
         return;
       }
+      if (content.type === "edit") {
+        await handleEdit(client, space, content);
+        return;
+      }
       if (isLocal(client)) {
         return await localSend(client, space.id, content);
       }
       const remote = clientForPhone(client, space.phone);
       return await remoteSend(remote, space.id, content);
-    },
-    editMessage: async ({ space, messageId, content, client }) => {
-      if (isLocal(client)) {
-        throw UnsupportedError.action("edit", "iMessage (local mode)");
-      }
-      const remote = clientForPhone(client, space.phone);
-      await remoteEditMessage(remote, space.id, messageId, content);
     },
     getMessage: async ({ space, messageId, client }) => {
       if (isLocal(client)) {

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -147,6 +147,25 @@ export const imessage = definePlatform("iMessage", {
 
   actions: {
     send: async ({ space, content, client }) => {
+      if (content.type === "reply") {
+        if (isLocal(client)) {
+          throw UnsupportedError.action("reply", "iMessage (local mode)");
+        }
+        if (isPollContent(content.target.content)) {
+          throw UnsupportedError.action(
+            "reply",
+            "iMessage",
+            "iMessage polls do not support replies"
+          );
+        }
+        const remote = clientForPhone(client, space.phone);
+        return await remoteReplyToMessage(
+          remote,
+          space.id,
+          content.target.id,
+          content.content
+        );
+      }
       if (isLocal(client)) {
         return await localSend(client, space.id, content);
       }
@@ -185,20 +204,6 @@ export const imessage = definePlatform("iMessage", {
         target as IMessageMessage,
         reaction
       );
-    },
-    replyToMessage: async ({ space, messageId, target, content, client }) => {
-      if (isLocal(client)) {
-        throw UnsupportedError.action("reply", "iMessage (local mode)");
-      }
-      if (isPollContent(target.content)) {
-        throw UnsupportedError.action(
-          "reply",
-          "iMessage",
-          "iMessage polls do not support replies"
-        );
-      }
-      const remote = clientForPhone(client, space.phone);
-      return await remoteReplyToMessage(remote, space.id, messageId, content);
     },
     editMessage: async ({ space, messageId, content, client }) => {
       if (isLocal(client)) {

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -189,25 +189,25 @@ export const imessage = definePlatform("iMessage", {
         );
         return;
       }
+      if (content.type === "typing") {
+        // Local mode has no typing API — silently no-op so callers can use
+        // `space.startTyping()` uniformly across modes.
+        if (isLocal(client)) {
+          return;
+        }
+        const remote = clientForPhone(client, space.phone);
+        if (content.state === "start") {
+          await remoteStartTyping(remote, space.id);
+        } else {
+          await remoteStopTyping(remote, space.id);
+        }
+        return;
+      }
       if (isLocal(client)) {
         return await localSend(client, space.id, content);
       }
       const remote = clientForPhone(client, space.phone);
       return await remoteSend(remote, space.id, content);
-    },
-    startTyping: async ({ space, client }) => {
-      if (isLocal(client)) {
-        return;
-      }
-      const remote = clientForPhone(client, space.phone);
-      await remoteStartTyping(remote, space.id);
-    },
-    stopTyping: async ({ space, client }) => {
-      if (isLocal(client)) {
-        return;
-      }
-      const remote = clientForPhone(client, space.phone);
-      await remoteStopTyping(remote, space.id);
     },
     editMessage: async ({ space, messageId, content, client }) => {
       if (isLocal(client)) {

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -166,6 +166,29 @@ export const imessage = definePlatform("iMessage", {
           content.content
         );
       }
+      if (content.type === "reaction") {
+        if (isLocal(client)) {
+          throw UnsupportedError.action("react", "iMessage (local mode)");
+        }
+        if (isPollContent(content.target.content)) {
+          throw UnsupportedError.action(
+            "react",
+            "iMessage",
+            "iMessage polls do not support reactions"
+          );
+        }
+        const remote = clientForPhone(client, space.phone);
+        // `content.target` is statically typed as the generic `Message`, but
+        // execution only reaches this iMessage `send` action when the target
+        // came from the iMessage stream — hence the unknown-cast widen.
+        await remoteReactToMessage(
+          remote,
+          space.id,
+          content.target as unknown as IMessageMessage,
+          content.emoji
+        );
+        return;
+      }
       if (isLocal(client)) {
         return await localSend(client, space.id, content);
       }
@@ -185,25 +208,6 @@ export const imessage = definePlatform("iMessage", {
       }
       const remote = clientForPhone(client, space.phone);
       await remoteStopTyping(remote, space.id);
-    },
-    reactToMessage: async ({ space, target, reaction, client }) => {
-      if (isLocal(client)) {
-        throw UnsupportedError.action("react", "iMessage (local mode)");
-      }
-      if (isPollContent(target.content)) {
-        throw UnsupportedError.action(
-          "react",
-          "iMessage",
-          "iMessage polls do not support reactions"
-        );
-      }
-      const remote = clientForPhone(client, space.phone);
-      await remoteReactToMessage(
-        remote,
-        space.id,
-        target as IMessageMessage,
-        reaction
-      );
     },
     editMessage: async ({ space, messageId, content, client }) => {
       if (isLocal(client)) {

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -162,79 +162,78 @@ export const imessage = definePlatform("iMessage", {
     schema: messageSchema,
   },
 
-  events: {
-    messages: ({ client }) =>
-      isLocal(client) ? localMessages(client) : remoteMessages(client),
+  messages: ({ client }) =>
+    isLocal(client) ? localMessages(client) : remoteMessages(client),
+
+  send: async ({ space, content, client }) => {
+    if (content.type === "reply") {
+      if (isLocal(client)) {
+        throw UnsupportedError.action("reply", "iMessage (local mode)");
+      }
+      if (isPollContent(content.target.content)) {
+        throw UnsupportedError.action(
+          "reply",
+          "iMessage",
+          "iMessage polls do not support replies"
+        );
+      }
+      const remote = clientForPhone(client, space.phone);
+      return await remoteReplyToMessage(
+        remote,
+        space.id,
+        content.target.id,
+        content.content
+      );
+    }
+    if (content.type === "reaction") {
+      if (isLocal(client)) {
+        throw UnsupportedError.action("react", "iMessage (local mode)");
+      }
+      if (isPollContent(content.target.content)) {
+        throw UnsupportedError.action(
+          "react",
+          "iMessage",
+          "iMessage polls do not support reactions"
+        );
+      }
+      const remote = clientForPhone(client, space.phone);
+      // `content.target` is statically typed as the generic `Message`, but
+      // execution only reaches this iMessage `send` action when the target
+      // came from the iMessage stream — hence the unknown-cast widen.
+      await remoteReactToMessage(
+        remote,
+        space.id,
+        content.target as unknown as IMessageMessage,
+        content.emoji
+      );
+      return;
+    }
+    if (content.type === "typing") {
+      // Local mode has no typing API — silently no-op so callers can use
+      // `space.startTyping()` uniformly across modes.
+      if (isLocal(client)) {
+        return;
+      }
+      const remote = clientForPhone(client, space.phone);
+      if (content.state === "start") {
+        await remoteStartTyping(remote, space.id);
+      } else {
+        await remoteStopTyping(remote, space.id);
+      }
+      return;
+    }
+    if (content.type === "edit") {
+      await handleEdit(client, space, content);
+      return;
+    }
+    if (isLocal(client)) {
+      return await localSend(client, space.id, content);
+    }
+    const remote = clientForPhone(client, space.phone);
+    return await remoteSend(remote, space.id, content);
   },
 
   actions: {
-    send: async ({ space, content, client }) => {
-      if (content.type === "reply") {
-        if (isLocal(client)) {
-          throw UnsupportedError.action("reply", "iMessage (local mode)");
-        }
-        if (isPollContent(content.target.content)) {
-          throw UnsupportedError.action(
-            "reply",
-            "iMessage",
-            "iMessage polls do not support replies"
-          );
-        }
-        const remote = clientForPhone(client, space.phone);
-        return await remoteReplyToMessage(
-          remote,
-          space.id,
-          content.target.id,
-          content.content
-        );
-      }
-      if (content.type === "reaction") {
-        if (isLocal(client)) {
-          throw UnsupportedError.action("react", "iMessage (local mode)");
-        }
-        if (isPollContent(content.target.content)) {
-          throw UnsupportedError.action(
-            "react",
-            "iMessage",
-            "iMessage polls do not support reactions"
-          );
-        }
-        const remote = clientForPhone(client, space.phone);
-        // `content.target` is statically typed as the generic `Message`, but
-        // execution only reaches this iMessage `send` action when the target
-        // came from the iMessage stream — hence the unknown-cast widen.
-        await remoteReactToMessage(
-          remote,
-          space.id,
-          content.target as unknown as IMessageMessage,
-          content.emoji
-        );
-        return;
-      }
-      if (content.type === "typing") {
-        // Local mode has no typing API — silently no-op so callers can use
-        // `space.startTyping()` uniformly across modes.
-        if (isLocal(client)) {
-          return;
-        }
-        const remote = clientForPhone(client, space.phone);
-        if (content.state === "start") {
-          await remoteStartTyping(remote, space.id);
-        } else {
-          await remoteStopTyping(remote, space.id);
-        }
-        return;
-      }
-      if (content.type === "edit") {
-        await handleEdit(client, space, content);
-        return;
-      }
-      if (isLocal(client)) {
-        return await localSend(client, space.id, content);
-      }
-      const remote = clientForPhone(client, space.phone);
-      return await remoteSend(remote, space.id, content);
-    },
     getMessage: async ({ space, messageId, client }) => {
       if (isLocal(client)) {
         return localGetMessage(client, messageId);

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -593,75 +593,71 @@ export const terminal = definePlatform("terminal", {
     },
   },
 
-  events: {
-    async *messages({ client }) {
-      for await (const evt of client.events) {
-        if (evt.kind === "message") {
-          const msg = evt.value;
-          client.knownChats.add(msg.spaceId);
-          yield {
-            id: msg.id,
-            content: protocolToSpectrum(msg.content),
-            sender: { id: msg.senderId },
-            space: { id: msg.spaceId },
-            timestamp: parseTimestamp(msg.timestamp),
-            // replyTo is a terminal-specific extra — agents inspect via a
-            // cast until Spectrum's message model grows first-class support.
-            ...(msg.replyTo ? { replyTo: msg.replyTo } : {}),
-          };
-          continue;
-        }
-        // Reactions ride the messages stream as first-class `reaction`
-        // content. The protocol only provides the target id, so synthesize a
-        // minimal raw target for core to wrap into a full Message at emit time.
-        const r = evt.value;
-        client.knownChats.add(r.spaceId);
+  async *messages({ client }) {
+    for await (const evt of client.events) {
+      if (evt.kind === "message") {
+        const msg = evt.value;
+        client.knownChats.add(msg.spaceId);
         yield {
-          id: `reaction:${r.messageId}:${r.reaction}:${r.timestamp}`,
-          content: reactionContentFromProtocol(r),
-          sender: { id: r.senderId },
-          space: { id: r.spaceId },
-          timestamp: parseTimestamp(r.timestamp),
+          id: msg.id,
+          content: protocolToSpectrum(msg.content),
+          sender: { id: msg.senderId },
+          space: { id: msg.spaceId },
+          timestamp: parseTimestamp(msg.timestamp),
+          // replyTo is a terminal-specific extra — agents inspect via a
+          // cast until Spectrum's message model grows first-class support.
+          ...(msg.replyTo ? { replyTo: msg.replyTo } : {}),
         };
+        continue;
       }
-    },
+      // Reactions ride the messages stream as first-class `reaction`
+      // content. The protocol only provides the target id, so synthesize a
+      // minimal raw target for core to wrap into a full Message at emit time.
+      const r = evt.value;
+      client.knownChats.add(r.spaceId);
+      yield {
+        id: `reaction:${r.messageId}:${r.reaction}:${r.timestamp}`,
+        content: reactionContentFromProtocol(r),
+        sender: { id: r.senderId },
+        space: { id: r.spaceId },
+        timestamp: parseTimestamp(r.timestamp),
+      };
+    }
   },
 
-  actions: {
-    send: async ({ client, content, space }) => {
-      if (content.type === "reply") {
-        const inner = await spectrumToProtocol(content.content);
-        const result = await client.session.request<{
-          id: string;
-          timestamp: string;
-        }>("replyToMessage", {
-          spaceId: space.id,
-          messageId: content.target.id,
-          content: inner,
-        });
-        return buildOutboundRecord(result, content.content, space.id);
-      }
-      if (content.type === "reaction") {
-        await client.session.request("reactToMessage", {
-          spaceId: space.id,
-          messageId: content.target.id,
-          reaction: content.emoji,
-        });
-        return;
-      }
-      if (content.type === "typing") {
-        // Tuichat exposes start/stop as separate notifications; we keep the
-        // wire protocol unchanged so existing binaries still work.
-        const method = content.state === "start" ? "startTyping" : "stopTyping";
-        await client.session.request(method, { spaceId: space.id });
-        return;
-      }
-      const proto = await spectrumToProtocol(content);
+  send: async ({ client, content, space }) => {
+    if (content.type === "reply") {
+      const inner = await spectrumToProtocol(content.content);
       const result = await client.session.request<{
         id: string;
         timestamp: string;
-      }>("send", { spaceId: space.id, content: proto });
-      return buildOutboundRecord(result, content, space.id);
-    },
+      }>("replyToMessage", {
+        spaceId: space.id,
+        messageId: content.target.id,
+        content: inner,
+      });
+      return buildOutboundRecord(result, content.content, space.id);
+    }
+    if (content.type === "reaction") {
+      await client.session.request("reactToMessage", {
+        spaceId: space.id,
+        messageId: content.target.id,
+        reaction: content.emoji,
+      });
+      return;
+    }
+    if (content.type === "typing") {
+      // Tuichat exposes start/stop as separate notifications; we keep the
+      // wire protocol unchanged so existing binaries still work.
+      const method = content.state === "start" ? "startTyping" : "stopTyping";
+      await client.session.request(method, { spaceId: space.id });
+      return;
+    }
+    const proto = await spectrumToProtocol(content);
+    const result = await client.session.request<{
+      id: string;
+      timestamp: string;
+    }>("send", { spaceId: space.id, content: proto });
+    return buildOutboundRecord(result, content, space.id);
   },
 });

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -641,6 +641,14 @@ export const terminal = definePlatform("terminal", {
         });
         return buildOutboundRecord(result, content.content, space.id);
       }
+      if (content.type === "reaction") {
+        await client.session.request("reactToMessage", {
+          spaceId: space.id,
+          messageId: content.target.id,
+          reaction: content.emoji,
+        });
+        return;
+      }
       const proto = await spectrumToProtocol(content);
       const result = await client.session.request<{
         id: string;
@@ -655,14 +663,6 @@ export const terminal = definePlatform("terminal", {
 
     stopTyping: async ({ client, space }) => {
       await client.session.request("stopTyping", { spaceId: space.id });
-    },
-
-    reactToMessage: async ({ client, space, target, reaction }) => {
-      await client.session.request("reactToMessage", {
-        spaceId: space.id,
-        messageId: target.id,
-        reaction,
-      });
     },
   },
 });

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -629,6 +629,18 @@ export const terminal = definePlatform("terminal", {
 
   actions: {
     send: async ({ client, content, space }) => {
+      if (content.type === "reply") {
+        const inner = await spectrumToProtocol(content.content);
+        const result = await client.session.request<{
+          id: string;
+          timestamp: string;
+        }>("replyToMessage", {
+          spaceId: space.id,
+          messageId: content.target.id,
+          content: inner,
+        });
+        return buildOutboundRecord(result, content.content, space.id);
+      }
       const proto = await spectrumToProtocol(content);
       const result = await client.session.request<{
         id: string;
@@ -651,15 +663,6 @@ export const terminal = definePlatform("terminal", {
         messageId: target.id,
         reaction,
       });
-    },
-
-    replyToMessage: async ({ client, space, messageId, content }) => {
-      const proto = await spectrumToProtocol(content);
-      const result = await client.session.request<{
-        id: string;
-        timestamp: string;
-      }>("replyToMessage", { spaceId: space.id, messageId, content: proto });
-      return buildOutboundRecord(result, content, space.id);
     },
   },
 });

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -649,20 +649,19 @@ export const terminal = definePlatform("terminal", {
         });
         return;
       }
+      if (content.type === "typing") {
+        // Tuichat exposes start/stop as separate notifications; we keep the
+        // wire protocol unchanged so existing binaries still work.
+        const method = content.state === "start" ? "startTyping" : "stopTyping";
+        await client.session.request(method, { spaceId: space.id });
+        return;
+      }
       const proto = await spectrumToProtocol(content);
       const result = await client.session.request<{
         id: string;
         timestamp: string;
       }>("send", { spaceId: space.id, content: proto });
       return buildOutboundRecord(result, content, space.id);
-    },
-
-    startTyping: async ({ client, space }) => {
-      await client.session.request("startTyping", { spaceId: space.id });
-    },
-
-    stopTyping: async ({ client, space }) => {
-      await client.session.request("stopTyping", { spaceId: space.id });
     },
   },
 });

--- a/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
@@ -71,12 +71,8 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
     },
   },
 
-  events: {
-    messages: ({ client }) => messages(client),
-  },
+  messages: ({ client }) => messages(client),
 
-  actions: {
-    send: async ({ space, content, client }) =>
-      await send(client, space.id, content),
-  },
+  send: async ({ space, content, client }) =>
+    await send(client, space.id, content),
 });

--- a/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
@@ -2,7 +2,7 @@ import { createClient } from "@photon-ai/whatsapp-business";
 import { definePlatform } from "../../platform/define";
 import { UnsupportedError } from "../../utils/errors";
 import { createCloudClients, disposeCloudAuth } from "./auth";
-import { messages, reactToMessage, replyToMessage, send } from "./messages";
+import { messages, reactToMessage, send } from "./messages";
 import {
   configSchema,
   isCloudConfig,
@@ -82,8 +82,5 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
     reactToMessage: async ({ space, target, reaction, client }) => {
       await reactToMessage(client, space.id, target.id, reaction);
     },
-
-    replyToMessage: async ({ space, messageId, content, client }) =>
-      await replyToMessage(client, space.id, messageId, content),
   },
 });

--- a/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
@@ -2,7 +2,7 @@ import { createClient } from "@photon-ai/whatsapp-business";
 import { definePlatform } from "../../platform/define";
 import { UnsupportedError } from "../../utils/errors";
 import { createCloudClients, disposeCloudAuth } from "./auth";
-import { messages, reactToMessage, send } from "./messages";
+import { messages, send } from "./messages";
 import {
   configSchema,
   isCloudConfig,
@@ -78,9 +78,5 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
   actions: {
     send: async ({ space, content, client }) =>
       await send(client, space.id, content),
-
-    reactToMessage: async ({ space, target, reaction, client }) => {
-      await reactToMessage(client, space.id, target.id, reaction);
-    },
   },
 });

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -508,6 +508,12 @@ export const send = async (
     await reactToMessage(clients, spaceId, content.target.id, content.emoji);
     return;
   }
+  if (content.type === "typing") {
+    // WhatsApp Business has no typing-indicator API. Silently ignore so
+    // `space.startTyping()` / `space.responding()` work portably across
+    // platforms — typing is a hint, not a critical message.
+    return;
+  }
   const client = primary(clients);
   switch (content.type) {
     case "text":

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -495,7 +495,7 @@ export const send = async (
   clients: WhatsAppClients,
   spaceId: string,
   content: Content
-): Promise<ProviderMessageRecord> => {
+): Promise<ProviderMessageRecord | undefined> => {
   if (content.type === "reply") {
     return await replyToMessage(
       clients,
@@ -503,6 +503,10 @@ export const send = async (
       content.target.id,
       content.content
     );
+  }
+  if (content.type === "reaction") {
+    await reactToMessage(clients, spaceId, content.target.id, content.emoji);
+    return;
   }
   const client = primary(clients);
   switch (content.type) {
@@ -569,7 +573,7 @@ export const send = async (
   }
 };
 
-export const reactToMessage = async (
+const reactToMessage = async (
   clients: WhatsAppClients,
   spaceId: string,
   messageId: string,

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -496,6 +496,14 @@ export const send = async (
   spaceId: string,
   content: Content
 ): Promise<ProviderMessageRecord> => {
+  if (content.type === "reply") {
+    return await replyToMessage(
+      clients,
+      spaceId,
+      content.target.id,
+      content.content
+    );
+  }
   const client = primary(clients);
   switch (content.type) {
     case "text":

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -167,7 +167,7 @@ export async function Spectrum<
     store: Store;
   }): ManagedStream<[Space, InboundMessage]> => {
     const { client, config, definition, store } = state;
-    const raw = definition.events.messages({
+    const raw = definition.messages({
       client,
       config,
       store,
@@ -298,7 +298,7 @@ export async function Spectrum<
       const providerStreams: ManagedStream<unknown>[] = [];
       for (const state of platformStates.values()) {
         const { client, config, definition, store } = state;
-        const producer = definition.events[eventName] as
+        const producer = definition.events?.[eventName] as
           | ((ctx: {
               client: unknown;
               config: unknown;

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -181,11 +181,11 @@ export async function Spectrum<
           ...msg.space,
           __platform: definition.name,
         };
-        const typingCtx = { space: spaceRef, client, config, store };
+        const actionCtx = { space: spaceRef, client, config, store };
         const space = buildSpace({
           spaceRef,
           extras: {},
-          typingCtx,
+          actionCtx,
           definition,
           client,
           config,


### PR DESCRIPTION
## Summary

Collapses the `PlatformDef` surface from seven action slots down to two universal contracts — **`messages`** (inbound stream) and **`send`** (outbound dispatcher) — by promoting every parallel action (`replyToMessage`, `reactToMessage`, `editMessage`, `startTyping`, `stopTyping`) into first-class `Content` types dispatched through `send`. `getMessage` stays as an optional capability inside `actions?`; custom platform events stay inside `events?`. Everything else is gone.

- **`reply`, `edit`, `typing`** are new content types alongside the existing `reaction`. Each comes with a builder (`reply()`, `edit()`, `typing()`) and a Zod schema; providers handle them inside their `send` action.
- **`message.reply` / `message.react` / `message.edit` / `space.startTyping` / `space.stopTyping` / `space.responding`** all become sugar that wraps the call in the corresponding content builder and routes through `space.send`. The public agent-facing API is unchanged.
- **`PlatformDef`** is restructured: `messages` and `send` are now top-level required fields; `actions?` is an optional escape hatch containing `getMessage?`; `events?` is an optional escape hatch for non-`messages` event streams.
- Providers (iMessage, terminal, WhatsApp Business) are rewritten against the new shape — each `send` action dispatches on `content.type` and falls through to its existing text/media path for default content.
- The `Content` discriminated union splits into `baseContentSchema` (everything except `reply`/`edit`) and `contentSchema` (full union including both), sidestepping a circular type alias for the wrappers' inner `content` field.

## Usage

The minimum viable platform integration now looks like:

```typescript
definePlatform("acme", {
  name: "acme",
  config: configSchema,
  lifecycle: { createClient },
  user: { /* ... */ },
  space: { /* ... */ },
  messages: ({ client }) => client.stream(),
  send: async ({ space, content, client }) => {
    if (content.type === "reply") { /* ... */ }
    if (content.type === "reaction") { /* ... */ }
    if (content.type === "typing") { /* ... */ }
    if (content.type === "edit") { /* ... */ }
    return await client.send(space.id, content);
  },
});
```

Agent-side ergonomics are unchanged, with the canonical form newly available:

```typescript
// Sugar (unchanged)
await message.react("👀");
await message.reply(text("ack"));
await space.responding(async () => { /* ... */ });

// Canonical: content + send
await space.send(reaction("✨", message));
await space.send(reply(text("ack"), message));
await space.send(typing("start"));
await space.send(edit(text("fixed"), prior));
```

## Changes

| File | Change |
|---|---|
| `packages/spectrum-ts/src/content/reply.ts` | **new** — `reply` content type + builder; rejects nested `reply`/`edit`/`reaction`/`group`/`typing` |
| `packages/spectrum-ts/src/content/edit.ts` | **new** — `edit` content type + builder; same reject-list as reply, target typed as `OutboundMessage` |
| `packages/spectrum-ts/src/content/typing.ts` | **new** — `typing` content type with `state: "start" \| "stop"` |
| `packages/spectrum-ts/src/content/reaction.ts` | reject reactions whose target is itself a reaction; mirror reply's reject-list |
| `packages/spectrum-ts/src/content/types.ts` | split into `baseContentSchema` (no reply/edit) and `contentSchema` (full union) to dodge circularity |
| `packages/spectrum-ts/src/index.ts` | re-export `reply`, `edit`, `typing` (plus their types) |
| `packages/spectrum-ts/src/platform/types.ts` | promote `messages` + `send` to top-level required fields; make `actions?` (just `getMessage?`) and `events?` optional escape hatches; `send` now returns `ProviderMessageRecord \| undefined` |
| `packages/spectrum-ts/src/platform/define.ts` | drop the reserved `messages` key inside `events`; widen `_Events` to `Record<string, EventProducer> \| undefined`; rename `typingCtx` → `actionCtx` |
| `packages/spectrum-ts/src/platform/build.ts` | route `message.reply`/`message.react`/`message.edit`/`space.edit`/`space.startTyping`/`space.stopTyping`/`space.responding` through `space.send`; recurse `findUnsupportedPlatformContent` into `reply`/`edit` wrappers; wrap nested `edit.target` as outbound; allow `void` returns from `send` for `reaction`/`typing`/`edit` |
| `packages/spectrum-ts/src/providers/imessage/index.ts` | move all dispatch into `send` action with `content.type` discrimination; new `handleEdit` helper for text-only edit constraint; local-mode typing silently no-ops |
| `packages/spectrum-ts/src/providers/terminal/index.ts` | flatten `events.messages` to top-level `messages`; merge `reactToMessage`/`replyToMessage`/`startTyping`/`stopTyping` into `send` while preserving the wire protocol |
| `packages/spectrum-ts/src/providers/whatsapp-business/index.ts` | drop `events`/`actions` wrappers; only `messages` + `send` |
| `packages/spectrum-ts/src/providers/whatsapp-business/messages.ts` | route `reply`/`reaction`/`typing` through `send`; typing silently no-ops (WhatsApp Business has no typing API); `reactToMessage` becomes module-private |
| `packages/spectrum-ts/src/spectrum.ts` | call `definition.messages(...)` and `definition.events?.[name]` against the new shape; rename `typingCtx` → `actionCtx` |
| `examples/basic/index.ts` | exercise both sugar and canonical forms for `reaction` and `reply` |

## Test plan

- [ ] `bun x ultracite check`
- [ ] `bun x tsc -p packages/spectrum-ts/tsconfig.json --noEmit`
- [ ] `bun run build`
- [ ] `examples/basic` round-trips: react sugar + canonical, reply sugar + canonical, plain echo, typing indicator via `space.responding()`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added message editing capability for previously-sent messages
  * Added reply functionality with target message references
  * Added typing indicator support (start/stop states)
  * Enhanced reaction validation to prevent targeting other reactions

* **Refactoring**
  * Consolidated message actions into a unified send interface across all platforms for a more streamlined API

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/55)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->