### PR TITLE
feat(imessage): add chat background content type and `space.background` sugar

### DIFF
--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -2,7 +2,7 @@ import { edit as editContent } from "../content/edit";
 import { reaction as reactionContent } from "../content/reaction";
 import { reply as replyContent } from "../content/reply";
 import { resolveContents } from "../content/resolve";
-import type { Content, ContentInput } from "../content/types";
+import type { Content, ContentBuilder, ContentInput } from "../content/types";
 import { typing as typingContent } from "../content/typing";
 import type {
   InboundMessage,
@@ -31,6 +31,43 @@ const supportsAnsiColor = (): boolean => {
     return force !== "" && force !== "0" && force !== "false";
   }
   return Boolean(process.stderr?.isTTY);
+};
+
+// Built-in content types whose provider `send` may return `void`/no id
+// because they're side-effects (reaction, typing indicator, edit), not new
+// messages. Provider-only content types opt into the same semantics by
+// setting `__fireAndForget: true` on the content value — see `isFireAndForget`
+// below — so the framework doesn't need to know their `type` literal.
+const FIRE_AND_FORGET_TYPES: ReadonlySet<string> = new Set([
+  "reaction",
+  "typing",
+  "edit",
+]);
+
+const isFireAndForget = (item: Content): boolean =>
+  FIRE_AND_FORGET_TYPES.has(item.type) ||
+  (item as { __fireAndForget?: unknown }).__fireAndForget === true;
+
+// Reserved keys on `Space` — platform-defined `space.actions` entries with
+// these names are skipped at runtime (with a warning) so the universal sugar
+// (`send`, `edit`, `startTyping`, …) always wins. The same names are excluded
+// from `SpaceActionMethods<Def>` at the type level.
+const RESERVED_SPACE_KEYS: ReadonlySet<string> = new Set([
+  "__platform",
+  "id",
+  "send",
+  "edit",
+  "getMessage",
+  "startTyping",
+  "stopTyping",
+  "responding",
+]);
+
+const warnReservedAction = (name: string, platform: string) => {
+  const body = `[spectrum-ts] ${platform} declared space action "${name}" which collides with a reserved Space key; skipping.`;
+  console.warn(
+    supportsAnsiColor() ? `${ANSI_YELLOW}${body}${ANSI_RESET}` : body
+  );
 };
 
 const warnUnsupported = (err: UnsupportedError, fallbackPlatform: string) => {
@@ -327,11 +364,12 @@ export function buildSpace(params: BuildSpaceParams): Space {
       // Reactions, typing indicators, and edits are fire-and-forget control
       // signals — providers may return `void` from `send` for them. Every
       // other content type must produce a message id.
-      if (
-        item.type === "reaction" ||
-        item.type === "typing" ||
-        item.type === "edit"
-      ) {
+      // Fire-and-forget control signals — providers may return `void`/no id
+      // for these because they don't produce a new message. Built-in types
+      // (reaction/typing/edit) live in the universal union and are matched
+      // by literal; provider-only types opt in by setting `__fireAndForget`
+      // on their content value.
+      if (isFireAndForget(item)) {
         return;
       }
       throw new Error(
@@ -397,9 +435,37 @@ export function buildSpace(params: BuildSpaceParams): Space {
     );
   }
 
+  // Platform-defined sugar methods declared via `PlatformDef.space.actions`.
+  // Each factory becomes `space.<name>(...args) = space.send(factory(...args))`.
+  // Spread order is load-bearing: actions go *after* `extras`/`spaceRef`
+  // (so schema fields can't clobber the sugar) and *before* the hardcoded
+  // universal sugar (`send`, `edit`, …) so a platform action declared with
+  // a reserved name is also overridden at the type level via the
+  // `Exclude<…, keyof Space>` in `SpaceActionMethods`.
+  const platformActions: Record<
+    string,
+    (...args: unknown[]) => Promise<OutboundMessage | undefined>
+  > = {};
+  const declaredActions = (
+    definition.space as {
+      actions?: Record<string, (...args: unknown[]) => ContentBuilder>;
+    }
+  ).actions;
+  if (declaredActions) {
+    for (const [name, factory] of Object.entries(declaredActions)) {
+      if (RESERVED_SPACE_KEYS.has(name)) {
+        warnReservedAction(name, definition.name);
+        continue;
+      }
+      platformActions[name] = (...args: unknown[]) =>
+        space.send(factory(...args));
+    }
+  }
+
   space = {
     ...extras,
     ...spaceRef,
+    ...platformActions,
     send: sendImpl as Space["send"],
     edit: async (
       message: OutboundMessage,

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -507,9 +507,14 @@ export type SpaceActionMethods<Def extends AnyPlatformDef> = {
   ) => Promise<OutboundMessage | undefined>;
 };
 
+// Both `keyof Space` and `keyof SpaceActionMethods<Def>` are removed from the
+// schema shape before merging — at runtime `buildSpace` spreads
+// `platformActions` after `extras`/`spaceRef`, so an action with the same
+// name as a schema field overrides the field. Stripping both at the type
+// level mirrors that and avoids an impossible `field & method` intersection.
 export type PlatformSpace<Def extends AnyPlatformDef> = Omit<
   SpaceShapeOf<Def>,
-  keyof Space
+  keyof Space | keyof SpaceActionMethods<Def>
 > &
   Space &
   SpaceActionMethods<Def>;

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -1,11 +1,27 @@
 import type { Fn, Pipe, Tuples } from "hotscript";
 import type z from "zod";
-import type { Content } from "../content/types";
-import type { InboundMessage, Message } from "../types/message";
+import type { Content, ContentBuilder } from "../content/types";
+import type {
+  InboundMessage,
+  Message,
+  OutboundMessage,
+} from "../types/message";
 import type { Space } from "../types/space";
 import type { User } from "../types/user";
 import type { Store } from "../utils/store";
 import type { ManagedStream } from "../utils/stream";
+
+/**
+ * A platform-defined sugar method on `Space`. Each entry is a content-builder
+ * factory; the runtime injects a thin wrapper that calls
+ * `space.send(factory(...args))` and returns the result.
+ *
+ * Names that collide with reserved `Space` keys (`send`, `edit`,
+ * `getMessage`, `startTyping`, `stopTyping`, `responding`, `id`,
+ * `__platform`) are skipped at runtime with a warning and excluded at the
+ * type level via `Exclude<…, keyof Space>`.
+ */
+export type SpaceActionFactory = (...args: never[]) => ContentBuilder;
 
 type ResolvedSpace = Pick<Space, "id">;
 type SpaceRef = Pick<Space, "id" | "__platform">;
@@ -244,6 +260,24 @@ export interface PlatformDef<
       config: z.infer<_ConfigSchema>;
       store: Store;
     }) => Promise<_ResolvedSpace>;
+    /**
+     * Optional platform-specific sugar methods bound to `PlatformSpace<Def>`.
+     *
+     * Each entry is a `ContentBuilder` factory; `buildSpace` injects a thin
+     * wrapper that calls `space.send(factory(...args))`. The wrapper is
+     * typed as `(...args) => Promise<OutboundMessage | undefined>` on
+     * `PlatformSpace<Def>` via `SpaceActionMethods<Def>`.
+     *
+     * Mirrors the top-level `PlatformDef.actions` slot — `actions` lives at
+     * the platform level for capabilities (e.g. `getMessage`); `space.actions`
+     * lives here for sugar that delegates through `send`.
+     *
+     * Names that collide with reserved `Space` keys (`send`, `edit`,
+     * `getMessage`, `startTyping`, `stopTyping`, `responding`, `id`,
+     * `__platform`) are skipped at runtime with a warning and excluded at
+     * the type level.
+     */
+    actions?: Record<string, SpaceActionFactory>;
   };
 
   user: {
@@ -292,6 +326,7 @@ export interface AnyPlatformDef {
     params?: z.ZodType<object>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard resolver
     resolve: (_: any) => Promise<any>;
+    actions?: Record<string, SpaceActionFactory>;
   };
   user: {
     schema?: z.ZodType<object>;
@@ -455,11 +490,29 @@ type SpaceArgs<Def extends AnyPlatformDef> =
   | SpaceArrayArgs<Def>
   | SpaceVarargArgs<Def>;
 
+// Methods derived from `PlatformDef.space.actions`. Each factory becomes a
+// space method that delegates through `space.send`. Reserved `Space` keys
+// (`send`, `edit`, …) are filtered out so universal sugar always wins.
+type SpaceActionFactories<Def extends AnyPlatformDef> = Def["space"] extends {
+  actions?: infer A;
+}
+  ? A extends Record<string, SpaceActionFactory>
+    ? A
+    : Record<string, never>
+  : Record<string, never>;
+
+export type SpaceActionMethods<Def extends AnyPlatformDef> = {
+  [K in Exclude<keyof SpaceActionFactories<Def>, keyof Space>]: (
+    ...args: Parameters<SpaceActionFactories<Def>[K]>
+  ) => Promise<OutboundMessage | undefined>;
+};
+
 export type PlatformSpace<Def extends AnyPlatformDef> = Omit<
   SpaceShapeOf<Def>,
   keyof Space
 > &
-  Space;
+  Space &
+  SpaceActionMethods<Def>;
 
 export type PlatformMessage<Def extends AnyPlatformDef> = Omit<
   SchemaInfer<Def["message"]>,

--- a/packages/spectrum-ts/src/providers/imessage/content/background.ts
+++ b/packages/spectrum-ts/src/providers/imessage/content/background.ts
@@ -1,0 +1,129 @@
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { lookup as lookupMimeType } from "mime-types";
+import z from "zod";
+import type { Content, ContentBuilder } from "../../../content/types";
+import { readSchema } from "../../../utils/io";
+
+/**
+ * iMessage-only chat background content. Lives entirely under the iMessage
+ * provider — never enters the universal `Content` discriminated union. The
+ * framework recognizes it via two generic content-level contracts:
+ *
+ * 1. `__platform: "iMessage"` — `findUnsupportedPlatformContent` in
+ *    `platform/build.ts` reads this tag and warns-and-skips when a different
+ *    platform receives it.
+ * 2. `__fireAndForget: true` — `dispatchSend`'s fire-and-forget check
+ *    treats this as a side-effecting send that returns no message id, the
+ *    same way it treats `reaction` / `typing` / `edit`.
+ *
+ * iMessage's `send` handler narrows back to `Background` via the `isBackground`
+ * type guard before dispatching to `chats.setBackground` / `removeBackground`.
+ */
+const backgroundActionSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("set"),
+    read: readSchema,
+    mimeType: z.string().nonempty(),
+  }),
+  z.object({ kind: z.literal("clear") }),
+]);
+
+export const backgroundSchema = z.object({
+  type: z.literal("background"),
+  __platform: z.literal("iMessage"),
+  __fireAndForget: z.literal(true),
+  action: backgroundActionSchema,
+});
+
+export type Background = z.infer<typeof backgroundSchema>;
+
+export const isBackground = (v: unknown): v is Background =>
+  backgroundSchema.safeParse(v).success;
+
+const CLEAR_SENTINEL = "clear" as const;
+export type BackgroundInput = typeof CLEAR_SENTINEL | string | Buffer;
+
+const resolveMimeType = (input: string | Buffer, mimeType?: string): string => {
+  if (mimeType) {
+    return mimeType;
+  }
+  if (typeof input === "string") {
+    const resolved = lookupMimeType(basename(input));
+    if (resolved) {
+      return resolved;
+    }
+  }
+  throw new Error(
+    "Unable to resolve MIME type for background. Pass options.mimeType explicitly."
+  );
+};
+
+const cachedRead = (read: () => Promise<Buffer>): (() => Promise<Buffer>) => {
+  let cached: Promise<Buffer> | undefined;
+  return () => {
+    cached ??= read().catch((err: unknown) => {
+      cached = undefined;
+      throw err;
+    });
+    return cached;
+  };
+};
+
+/**
+ * Set or clear the chat background. iMessage-only, remote-only.
+ *
+ * - `background("clear")` — remove the current chat background.
+ * - `background("./photo.jpg")` — set background from a filesystem path.
+ *   MIME type is inferred from the extension; override with `options.mimeType`.
+ * - `background(buffer, { mimeType })` — set background from in-memory bytes.
+ *   `options.mimeType` is required.
+ *
+ * `"clear"` is a reserved string-literal sentinel. If you have a file literally
+ * named `clear` with no extension, pass `"./clear"` or load it as a Buffer.
+ *
+ * `space.send(background(...))` is the canonical form; `space.background(...)`
+ * is sugar attached via `PlatformDef.space.actions` (only typed on
+ * `PlatformSpace<IMessageDef>`).
+ *
+ * `Background` is intentionally not a member of the universal `Content`
+ * union — the `as unknown as Content` cast keeps the builder shape compatible
+ * with the framework's `ContentBuilder.build(): Promise<Content>` signature.
+ * The framework treats it as a fire-and-forget control signal at runtime.
+ */
+export function background(input: "clear"): ContentBuilder;
+export function background(
+  input: string | Buffer,
+  options?: { mimeType?: string }
+): ContentBuilder;
+export function background(
+  input: BackgroundInput,
+  options?: { mimeType?: string }
+): ContentBuilder {
+  if (input === CLEAR_SENTINEL) {
+    return {
+      build: async () =>
+        backgroundSchema.parse({
+          type: "background",
+          __platform: "iMessage",
+          __fireAndForget: true,
+          action: { kind: "clear" },
+        }) as unknown as Content,
+    };
+  }
+  return {
+    build: async () => {
+      const mimeType = resolveMimeType(input, options?.mimeType);
+      const read =
+        typeof input === "string"
+          ? cachedRead(() => readFile(input))
+          : cachedRead(async () => input);
+      return backgroundSchema.parse({
+        type: "background",
+        __platform: "iMessage",
+        __fireAndForget: true,
+        action: { kind: "set", read, mimeType },
+      }) as unknown as Content;
+    },
+  };
+}

--- a/packages/spectrum-ts/src/providers/imessage/content/background.ts
+++ b/packages/spectrum-ts/src/providers/imessage/content/background.ts
@@ -111,19 +111,21 @@ export function background(
         }) as unknown as Content,
     };
   }
+  // Snapshot the reader and MIME type at builder construction so that
+  // (a) re-invoking `build()` reuses the same cached read and (b) a missing
+  // MIME type fails fast rather than at send time.
+  const mimeType = resolveMimeType(input, options?.mimeType);
+  const read =
+    typeof input === "string"
+      ? cachedRead(() => readFile(input))
+      : cachedRead(async () => input);
   return {
-    build: async () => {
-      const mimeType = resolveMimeType(input, options?.mimeType);
-      const read =
-        typeof input === "string"
-          ? cachedRead(() => readFile(input))
-          : cachedRead(async () => input);
-      return backgroundSchema.parse({
+    build: async () =>
+      backgroundSchema.parse({
         type: "background",
         __platform: "iMessage",
         __fireAndForget: true,
         action: { kind: "set", read, mimeType },
-      }) as unknown as Content;
-    },
+      }) as unknown as Content,
   };
 }

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -4,10 +4,16 @@ import type { Edit } from "../../content/edit";
 import { definePlatform } from "../../platform/define";
 import { UnsupportedError } from "../../utils/errors";
 
-// biome-ignore lint/performance/noBarrelFile: provider entrypoint exports its public helper
+// biome-ignore lint/performance/noBarrelFile: provider entrypoint exports its public helpers
+export { type BackgroundInput, background } from "./content/background";
 export { effect, type IMessageMessageEffect } from "./content/effect";
 
 import { createCloudClients, disposeCloudAuth } from "./auth";
+import {
+  type Background,
+  background as backgroundContent,
+  isBackground,
+} from "./content/background";
 import {
   getMessage as localGetMessage,
   messages as localMessages,
@@ -20,6 +26,7 @@ import {
   reactToMessage as remoteReactToMessage,
   replyToMessage as remoteReplyToMessage,
   send as remoteSend,
+  setBackground as remoteSetBackground,
   startTyping as remoteStartTyping,
   stopTyping as remoteStopTyping,
 } from "./remote/api";
@@ -58,6 +65,22 @@ const handleEdit = async (
   }
   const remote = clientForPhone(client, space.phone);
   await remoteEditMessage(remote, space.id, content.target.id, content.content);
+};
+
+const handleBackground = async (
+  client: IMessageClient,
+  space: { id: string; phone: string },
+  content: Background
+): Promise<void> => {
+  if (isLocal(client)) {
+    throw UnsupportedError.action(
+      "background",
+      "iMessage (local mode)",
+      "chat backgrounds require remote iMessage"
+    );
+  }
+  const remote = clientForPhone(client, space.phone);
+  await remoteSetBackground(remote, space.id, content);
 };
 
 export const imessage = definePlatform("iMessage", {
@@ -156,6 +179,13 @@ export const imessage = definePlatform("iMessage", {
       const { chat } = await remote.chats.create(addresses);
       return { id: chat.guid as string, type: "group" as const, phone };
     },
+    actions: {
+      // Sugar: `space.background(input, opts?)` →
+      // `space.send(background(input, opts?))`. Wired through the universal
+      // send pipeline so the unsupported-content + warn-and-skip path on
+      // local-mode iMessage is identical to the canonical form.
+      background: backgroundContent,
+    },
   },
 
   message: {
@@ -224,6 +254,14 @@ export const imessage = definePlatform("iMessage", {
     }
     if (content.type === "edit") {
       await handleEdit(client, space, content);
+      return;
+    }
+    // `Background` is iMessage-only and lives outside the universal `Content`
+    // union — narrow via the runtime guard rather than a `content.type ===`
+    // check (which would not typecheck since `"background"` isn't a member
+    // of `Content["type"]`).
+    if (isBackground(content)) {
+      await handleBackground(client, space, content);
       return;
     }
     if (isLocal(client)) {

--- a/packages/spectrum-ts/src/providers/imessage/remote/api.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/api.ts
@@ -2,7 +2,9 @@ import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
 import type { Content } from "../../../content/types";
 import type { ProviderMessageRecord } from "../../../platform/types";
 import type { ManagedStream } from "../../../utils/stream";
+import type { Background } from "../content/background";
 import type { IMessageMessage, RemoteClient } from "../types";
+import { setBackground as setRemoteBackground } from "./background";
 import { getMessage as getRemoteMessage } from "./inbound";
 import { reactToMessage as reactToRemoteMessage } from "./reactions";
 import {
@@ -19,6 +21,12 @@ import {
 export const messages = (
   clients: RemoteClient[]
 ): ManagedStream<IMessageMessage> => remoteMessages(clients);
+
+export const setBackground = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  content: Background
+): Promise<void> => setRemoteBackground(remote, spaceId, content);
 
 export const startTyping = async (
   remote: AdvancedIMessage,

--- a/packages/spectrum-ts/src/providers/imessage/remote/background.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/background.ts
@@ -1,0 +1,28 @@
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { Background } from "../content/background";
+import { toChatGuid } from "./ids";
+
+/**
+ * Apply a `Background` content value to a remote iMessage chat.
+ *
+ * `set` uploads the photo bytes via `chats.setBackground`; `clear` removes
+ * any current background via `chats.removeBackground`. Both surfaces are
+ * fire-and-forget — no message id is produced.
+ */
+export const setBackground = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  content: Background
+): Promise<void> => {
+  const chat = toChatGuid(spaceId);
+  if (content.action.kind === "clear") {
+    await remote.chats.removeBackground(chat);
+    return;
+  }
+  const buffer = await content.action.read();
+  await remote.chats.setBackground(
+    chat,
+    new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength),
+    content.action.mimeType
+  );
+};


### PR DESCRIPTION
## Summary

Adds a new iMessage-only `background` content type for setting or clearing a chat's background photo, plus a `PlatformDef.space.actions` slot that lets a provider declare typed sugar methods on `Space` without hardcoding them in `buildSpace`. `space.background(...)` is wired through this slot — it desugars to `space.send(background(...))` and reuses the universal send pipeline (including the existing unsupported-content warn-and-skip path when the same content reaches the wrong platform).

- **`background` content type** is iMessage-only and intentionally lives *outside* the universal `Content` discriminated union. The framework recognizes it via two generic content-level contracts already understood by `buildSpace`:
  - `__platform: "iMessage"` — `findUnsupportedPlatformContent` reads this tag and warns-and-skips if a different platform receives it.
  - `__fireAndForget: true` — `dispatchSend`'s fire-and-forget check treats it as a side-effecting send that returns no message id, the same way it treats `reaction` / `typing` / `edit`.
- **`PlatformDef.space.actions`** is a new optional slot: a record of `(...args) => ContentBuilder` factories. `buildSpace` injects a thin wrapper that calls `space.send(factory(...args))` and types it as `(...args) => Promise<OutboundMessage | undefined>` on `PlatformSpace<Def>` via the new `SpaceActionMethods<Def>` mapped type.
- **Reserved-key collision handling** — names that collide with reserved `Space` keys (`send`, `edit`, `getMessage`, `startTyping`, `stopTyping`, `responding`, `id`, `__platform`) are skipped at runtime with a yellow warning and excluded at the type level via `Exclude<…, keyof Space>` so universal sugar always wins.
- **Fire-and-forget generalization** — the hardcoded `item.type === "reaction" | "typing" | "edit"` check in `dispatchSend` is replaced with `isFireAndForget`, which keeps the built-in literals via `FIRE_AND_FORGET_TYPES` and also honors `__fireAndForget: true` on provider-only content. No change in behavior for the existing universal types.
- **Remote-only** — local-mode iMessage throws `UnsupportedError.action("background", …)` because chat backgrounds require the remote gRPC surface (`chats.setBackground` / `chats.removeBackground`).

## Usage

```typescript
import { Spectrum } from "spectrum-ts";
import { background, imessage } from "spectrum-ts/providers/imessage";

const app = await Spectrum({
  projectId: process.env.PROJECT_ID,
  projectSecret: process.env.PROJECT_SECRET,
  providers: [imessage.config()],
});

for await (const [space, message] of app.messages) {
  // Sugar — only typed on `PlatformSpace<IMessageDef>`
  await space.background("./sunset.jpg");
  await space.background(buffer, { mimeType: "image/png" });
  await space.background("clear");

  // Canonical — equivalent, works for any platform via `space.send`
  await space.send(background("./sunset.jpg"));
  await space.send(background("clear"));
}
```

`"clear"` is a reserved string-literal sentinel. If you have a file literally named `clear` with no extension, pass `"./clear"` or load it as a `Buffer`. MIME type is inferred from the path extension when `input` is a string; pass `options.mimeType` explicitly for buffers or when the extension is ambiguous.

## Changes

| File | Change |
|---|---|
| `packages/spectrum-ts/src/providers/imessage/content/background.ts` | **new** — `backgroundSchema` (discriminated union on `action.kind: "set" \| "clear"`), `Background` type, `isBackground` runtime guard, and the `background()` builder with overloads for `"clear"` / path / `Buffer`. Reads are cached on the first `build()` so retries don't re-hit disk. |
| `packages/spectrum-ts/src/providers/imessage/remote/background.ts` | **new** — `setBackground(remote, spaceId, content)`: dispatches to `remote.chats.removeBackground` for `clear`, or uploads bytes via `remote.chats.setBackground(chat, Uint8Array, mimeType)` for `set`. |
| `packages/spectrum-ts/src/providers/imessage/remote/api.ts` | re-export `setBackground` alongside the other remote-API surface. |
| `packages/spectrum-ts/src/providers/imessage/index.ts` | export `background` + `BackgroundInput`; add `handleBackground` that throws `UnsupportedError.action` in local mode and otherwise dispatches to `remoteSetBackground`; narrow via `isBackground` in `send` *before* falling through to the default text/media path (the literal `"background"` isn't a member of `Content["type"]`, so a `content.type ===` check would not typecheck); register `background` under `space.actions` so `space.background(...)` is auto-wired. |
| `packages/spectrum-ts/src/platform/build.ts` | replace the hardcoded `reaction \| typing \| edit` check in `dispatchSend` with `isFireAndForget` (built-in literals via `FIRE_AND_FORGET_TYPES` + `__fireAndForget: true` opt-in for provider-only content); read `definition.space.actions` and inject each factory as `space.send(factory(...args))`, with collision warnings for reserved keys via `RESERVED_SPACE_KEYS` + `warnReservedAction`. Spread order is load-bearing — platform actions go *after* `extras`/`spaceRef` and *before* the hardcoded universal sugar, so reserved-name collisions are also lost at the type level. |
| `packages/spectrum-ts/src/platform/types.ts` | add `SpaceActionFactory`, the optional `space.actions?` slot on `PlatformDef`/`AnyPlatformDef`, and `SpaceActionMethods<Def>` (mapped over `SpaceActionFactories<Def>` with `Exclude<…, keyof Space>`); intersect it into `PlatformSpace<Def>`. |

## Test plan

- [ ] `bun x ultracite check`
- [ ] `bun x tsc -p packages/spectrum-ts/tsconfig.json --noEmit`
- [ ] `bun run build`
- [ ] Remote iMessage round-trip: `space.background("./photo.jpg")`, `space.background(buf, { mimeType })`, `space.background("clear")` — all return `undefined` and apply to the chat.
- [ ] Canonical form: `space.send(background("./photo.jpg"))` behaves identically to the sugar.
- [ ] Local-mode iMessage: `space.background(...)` throws `UnsupportedError.action("background", "iMessage (local mode)", …)`.
- [ ] Cross-platform: routing a `background` content into a non-iMessage `space.send` triggers the existing `__platform` warn-and-skip path (no thrown error).
- [ ] Reserved-key collision: declaring `space.actions.send` on a test platform emits the yellow warning and the universal `space.send` is unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom platform-defined space actions: platforms can expose shortcut actions as space.<name>(...) for provider-specific features.
  * iMessage chat backgrounds: set or clear conversation backgrounds with automatic MIME/type handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/57)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->