### PR TITLE
fix(spectrum-ts): use SPECTRUM_CLOUD_URL env value verbatim

### DIFF
--- a/packages/spectrum-ts/src/utils/cloud.ts
+++ b/packages/spectrum-ts/src/utils/cloud.ts
@@ -1,4 +1,5 @@
-export const SPECTRUM_CLOUD_URL = `https://${process.env.SPECTRUM_CLOUD_URL ?? "spectrum.photon.codes"}`;
+export const SPECTRUM_CLOUD_URL =
+  process.env.SPECTRUM_CLOUD_URL ?? "https://spectrum.photon.codes";
 
 // ---------------------------------------------------------------------------
 // API response types (aligned with OpenAPI spec)


### PR DESCRIPTION
## Summary

Stop prepending a hardcoded `https://` to `SPECTRUM_CLOUD_URL`. The env value is now used as the full URL, so you can point at any scheme — `http://localhost:3000` for local dev, `https://...` for prod, or anything else.

- **Before**: `SPECTRUM_CLOUD_URL=spectrum.photon.codes` → fetched as `https://spectrum.photon.codes`. Setting `http://localhost:3000` produced `https://http://localhost:3000` — unusable.
- **After**: `SPECTRUM_CLOUD_URL` is taken verbatim. Default when unset stays `https://spectrum.photon.codes`, so existing deployments that *don't* set the var are unaffected.

⚠️ Deployments that currently set `SPECTRUM_CLOUD_URL` to a bare hostname (e.g. `spectrum.photon.codes`) will need to update the env value to include the scheme (`https://spectrum.photon.codes`).

## Changes

| File | Change |
|---|---|
| `packages/spectrum-ts/src/utils/cloud.ts` | `SPECTRUM_CLOUD_URL` now reads `process.env.SPECTRUM_CLOUD_URL` verbatim with a default of `https://spectrum.photon.codes`, instead of prepending `https://` to whatever the env contains. |

## Test plan

- [ ] `bun x ultracite check`
- [ ] `bun x tsc -p packages/spectrum-ts/tsconfig.json --noEmit`
- [ ] Unset env → cloud requests hit `https://spectrum.photon.codes/...`
- [ ] `SPECTRUM_CLOUD_URL=http://localhost:3000` → cloud requests hit `http://localhost:3000/...`
- [ ] `SPECTRUM_CLOUD_URL=https://staging.example.com` → cloud requests hit `https://staging.example.com/...`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cloud URL configuration handling to expect full URLs (including scheme) in the SPECTRUM_CLOUD_URL environment variable, rather than only domain names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/60)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->