### PR TITLE
ENG-1490: iMessage custom event producers (readReceipt, chatRead, messageEdit, messageUnsend, reactionRemoved, groupChange)

### DIFF
--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -1,12 +1,22 @@
 import { createClient, MessageEffect } from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
+import type { z } from "zod";
 import type { Edit } from "../../content/edit";
 import { definePlatform } from "../../platform/define";
 import { UnsupportedError } from "../../utils/errors";
+import type { Store } from "../../utils/store";
 
 // biome-ignore lint/performance/noBarrelFile: provider entrypoint exports its public helpers
 export { type BackgroundInput, background } from "./content/background";
 export { effect, type IMessageMessageEffect } from "./content/effect";
+export type {
+  ChatRead,
+  GroupChangeEvent,
+  MessageEdit,
+  MessageUnsend,
+  ReactionRemoved,
+  ReadReceipt,
+} from "./remote/events";
 
 import { createCloudClients, disposeCloudAuth } from "./auth";
 import {
@@ -31,6 +41,14 @@ import {
   stopTyping as remoteStopTyping,
 } from "./remote/api";
 import { clientForPhone, isSharedMode, randomPhone } from "./remote/client";
+import {
+  chatReadEvents,
+  groupChangeEvents,
+  messageEditEvents,
+  messageUnsendEvents,
+  reactionRemovedEvents,
+  readReceiptEvents,
+} from "./remote/events";
 import { dmChatGuid } from "./remote/ids";
 import {
   configSchema,
@@ -38,6 +56,7 @@ import {
   type IMessageMessage,
   isLocal,
   messageSchema,
+  type RemoteClient,
   SHARED_PHONE,
   spaceParamsSchema,
   spaceSchema,
@@ -45,6 +64,44 @@ import {
 
 const isPollContent = (content: { type: string }): boolean =>
   content.type === "poll" || content.type === "poll_option";
+
+// Local-mode iMessage doesn't expose any of the custom event streams.
+// Returning a one-shot empty async iterable lets the producers stay
+// uniform across modes while costing nothing at runtime.
+const emptyAsyncIterable = <T>(): AsyncIterable<T> => ({
+  [Symbol.asyncIterator]() {
+    return {
+      next: () => Promise.resolve({ done: true, value: undefined as never }),
+    };
+  },
+});
+
+type IMessageEventProducer<T> = (ctx: {
+  client: IMessageClient;
+  config: z.infer<typeof configSchema>;
+  store: Store;
+}) => AsyncIterable<T>;
+
+/**
+ * Wrap a remote-only event producer so the `events:` slot can declare a
+ * uniform `EventProducer<...>` shape across modes. In local mode the
+ * producer is bypassed and an empty async iterable is returned.
+ */
+const remoteOnlyEvent =
+  <T>(
+    producer: (clients: RemoteClient[], store: Store) => AsyncIterable<T>
+  ): IMessageEventProducer<T> =>
+  ({ client, store }) =>
+    isLocal(client) ? emptyAsyncIterable<T>() : producer(client, store);
+
+const imessageEvents = {
+  readReceipt: remoteOnlyEvent(readReceiptEvents),
+  chatRead: remoteOnlyEvent(chatReadEvents),
+  messageEdit: remoteOnlyEvent(messageEditEvents),
+  messageUnsend: remoteOnlyEvent(messageUnsendEvents),
+  reactionRemoved: remoteOnlyEvent(reactionRemovedEvents),
+  groupChange: remoteOnlyEvent(groupChangeEvents),
+};
 
 const handleEdit = async (
   client: IMessageClient,
@@ -194,6 +251,24 @@ export const imessage = definePlatform("iMessage", {
 
   messages: ({ client }) =>
     isLocal(client) ? localMessages(client) : remoteMessages(client),
+
+  // The `_Events` generic on `definePlatform` defaults to `undefined`,
+  // and TypeScript's holistic inference fails to widen it from this slot
+  // when several adjacent generics (`_Client`, `_MessageType`,
+  // `_Events`) are resolved together — even though each producer in
+  // `imessageEvents` structurally satisfies `EventProducer<unknown,
+  // IMessageClient, _>`. Allowing `_Events = undefined` keeps the rest
+  // of the def inferring cleanly; the cast then keeps the *runtime*
+  // events record intact in `fullDef` (define.ts spreads `...def`
+  // verbatim) so spectrum-ts and the webhook both discover and execute
+  // every producer below. The trade-off is consumer-side: typed access
+  // via `imessage(spectrum).readReceipt` currently surfaces as
+  // `AsyncIterable<unknown>` rather than `AsyncIterable<ReadReceipt>`.
+  // Consumers needing the narrow type cast at the call site using the
+  // exported event payload types (`ReadReceipt`, `ChatRead`, …). A
+  // follow-up to the spectrum-ts core can smooth the `_Events`
+  // inference and remove this cast.
+  events: imessageEvents as unknown as undefined,
 
   send: async ({ space, content, client }) => {
     if (content.type === "reply") {

--- a/packages/spectrum-ts/src/providers/imessage/remote/events.test.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/events.test.ts
@@ -1,0 +1,485 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  AdvancedIMessage,
+  ChatEvent,
+  GroupEvent,
+  MessageEvent,
+} from "@photon-ai/advanced-imessage";
+import { createStore } from "../../../utils/store";
+import type { RemoteClient } from "../types";
+import {
+  chatReadEvents,
+  groupChangeEvents,
+  messageEditEvents,
+  messageUnsendEvents,
+  reactionRemovedEvents,
+  readReceiptEvents,
+} from "./events";
+
+// ---------------------------------------------------------------------------
+// Fake AdvancedIMessage harness
+//
+// We mock just the three resources every producer subscribes to:
+//   - client.messages.subscribeEvents()
+//   - client.chats.subscribeEvents()
+//   - client.groups.subscribeEvents()
+//
+// Each returns a TypedEventStream-shaped object (async iterable + close()).
+// Tests push events through a queue and assert that the producer yields
+// the expected projected payload.
+// ---------------------------------------------------------------------------
+
+interface FakeStream<T> {
+  endAll(): void;
+  push(value: T): void;
+  stream: {
+    [Symbol.asyncIterator](): AsyncIterator<T>;
+    close(): Promise<void>;
+  };
+}
+
+const createFakeStream = <T>(): FakeStream<T> => {
+  const queue: T[] = [];
+  const waiters: ((value: IteratorResult<T>) => void)[] = [];
+  let closed = false;
+
+  const next = (): Promise<IteratorResult<T>> => {
+    if (queue.length > 0) {
+      const value = queue.shift() as T;
+      return Promise.resolve({ done: false, value });
+    }
+    if (closed) {
+      return Promise.resolve({ done: true, value: undefined as never });
+    }
+    return new Promise<IteratorResult<T>>((resolve) => {
+      waiters.push(resolve);
+    });
+  };
+
+  return {
+    push(value): void {
+      const waiter = waiters.shift();
+      if (waiter) {
+        waiter({ done: false, value });
+      } else {
+        queue.push(value);
+      }
+    },
+    endAll(): void {
+      closed = true;
+      for (const waiter of waiters.splice(0)) {
+        waiter({ done: true, value: undefined as never });
+      }
+    },
+    stream: {
+      [Symbol.asyncIterator]() {
+        return { next };
+      },
+      close: () => {
+        closed = true;
+        for (const waiter of waiters.splice(0)) {
+          waiter({ done: true, value: undefined as never });
+        }
+        return Promise.resolve();
+      },
+    },
+  };
+};
+
+interface FakeClient {
+  chats: FakeStream<ChatEvent>;
+  client: AdvancedIMessage;
+  groups: FakeStream<GroupEvent>;
+  messages: FakeStream<MessageEvent>;
+}
+
+const createFakeClient = (): FakeClient => {
+  const messages = createFakeStream<MessageEvent>();
+  const chats = createFakeStream<ChatEvent>();
+  const groups = createFakeStream<GroupEvent>();
+  const client = {
+    messages: {
+      subscribeEvents: () => messages.stream,
+    },
+    chats: {
+      subscribeEvents: () => chats.stream,
+    },
+    groups: {
+      subscribeEvents: () => groups.stream,
+    },
+  } as unknown as AdvancedIMessage;
+  return { chats, client, groups, messages };
+};
+
+const oneClient = (fake: FakeClient): RemoteClient[] => [
+  { client: fake.client, phone: "+15555550100" },
+];
+
+// Pull `n` items off an AsyncIterable, with a short generous timeout so a
+// hung producer fails the test instead of hanging it.
+const collect = async <T>(
+  iter: AsyncIterable<T>,
+  n: number,
+  timeoutMs = 250
+): Promise<T[]> => {
+  const items: T[] = [];
+  const iterator = iter[Symbol.asyncIterator]();
+  const deadline = Date.now() + timeoutMs;
+  while (items.length < n) {
+    if (Date.now() > deadline) {
+      throw new Error(`collect timed out after ${items.length}/${n} items`);
+    }
+    const next = iterator.next();
+    const race = await Promise.race([
+      next,
+      new Promise<IteratorResult<T>>((resolve) =>
+        setTimeout(() => resolve({ done: true, value: undefined as never }), 50)
+      ),
+    ]);
+    if (race.done) {
+      if (items.length >= n) {
+        break;
+      }
+      continue;
+    }
+    items.push(race.value);
+  }
+  await iterator.return?.();
+  return items;
+};
+
+// Event fixtures
+const readEvent = (overrides: Partial<MessageEvent> = {}): MessageEvent =>
+  ({
+    actor: { address: "+15550100", service: "iMessage" },
+    chatGuid: "any;-;+15550100",
+    messageGuid: "guid-1",
+    occurredAt: new Date("2026-05-06T12:00:00.000Z"),
+    readAt: new Date("2026-05-06T12:01:00.000Z"),
+    sequence: 1,
+    type: "message.read",
+    ...overrides,
+  }) as MessageEvent;
+
+const editEvent = (): MessageEvent =>
+  ({
+    actor: { address: "+15550100", service: "iMessage" },
+    chatGuid: "any;-;+15550100",
+    content: {
+      attachments: [],
+      formatting: [],
+      mentions: [],
+      text: "hello, edited",
+    },
+    editedAt: new Date("2026-05-06T12:02:00.000Z"),
+    messageGuid: "guid-1",
+    occurredAt: new Date("2026-05-06T12:02:00.000Z"),
+    sequence: 2,
+    type: "message.edited",
+  }) as unknown as MessageEvent;
+
+const unsendEvent = (): MessageEvent =>
+  ({
+    actor: { address: "+15550100", service: "iMessage" },
+    chatGuid: "any;-;+15550100",
+    messageGuid: "guid-1",
+    occurredAt: new Date("2026-05-06T12:03:00.000Z"),
+    retractedAt: new Date("2026-05-06T12:03:00.000Z"),
+    sequence: 3,
+    type: "message.unsent",
+  }) as MessageEvent;
+
+const reactionRemovedEvent = (): MessageEvent =>
+  ({
+    actor: { address: "+15550100", service: "iMessage" },
+    chatGuid: "any;-;+15550100",
+    messageGuid: "guid-1",
+    occurredAt: new Date("2026-05-06T12:04:00.000Z"),
+    reaction: { kind: "love" },
+    sequence: 4,
+    targetPartIndex: 0,
+    type: "message.reactionRemoved",
+  }) as MessageEvent;
+
+const chatMarkedReadEvent = (): ChatEvent =>
+  ({
+    actor: { address: "+15550100", service: "iMessage" },
+    chatGuid: "any;-;+15550100",
+    occurredAt: new Date("2026-05-06T12:05:00.000Z"),
+    sequence: 5,
+    type: "chat.markedRead",
+  }) as ChatEvent;
+
+const groupNameChangeEvent = (): GroupEvent =>
+  ({
+    actor: { address: "+15550100", service: "iMessage" },
+    change: {
+      displayName: "new name",
+      type: "displayNameChanged",
+    },
+    chatGuid: "any;+;chat-1",
+    occurredAt: new Date("2026-05-06T12:06:00.000Z"),
+    sequence: 6,
+    type: "group.changed",
+  }) as unknown as GroupEvent;
+
+const groupParticipantAddedEvent = (): GroupEvent =>
+  ({
+    actor: { address: "+15550100", service: "iMessage" },
+    change: {
+      participant: { address: "+15550200", service: "iMessage" },
+      type: "participantAdded",
+    },
+    chatGuid: "any;+;chat-1",
+    occurredAt: new Date("2026-05-06T12:07:00.000Z"),
+    sequence: 7,
+    type: "group.changed",
+  }) as unknown as GroupEvent;
+
+const groupParticipantLeftEvent = (): GroupEvent =>
+  ({
+    change: {
+      participant: { address: "+15550200", service: "iMessage" },
+      type: "participantLeft",
+    },
+    chatGuid: "any;+;chat-1",
+    occurredAt: new Date("2026-05-06T12:08:00.000Z"),
+    sequence: 8,
+    type: "group.changed",
+  }) as unknown as GroupEvent;
+
+describe("readReceiptEvents", () => {
+  test("yields one ReadReceipt per message.read event", async () => {
+    const fake = createFakeClient();
+    const store = createStore();
+    const iter = readReceiptEvents(oneClient(fake), store);
+    fake.messages.push(readEvent());
+
+    const [receipt] = await collect(iter, 1);
+    expect(receipt?.messageId).toBe("guid-1");
+    expect(receipt?.spaceId).toBe("any;-;+15550100");
+    expect(receipt?.readBy.id).toBe("+15550100");
+    expect(receipt?.readAt).toEqual(new Date("2026-05-06T12:01:00.000Z"));
+
+    fake.messages.endAll();
+  });
+
+  test("ignores other message events", async () => {
+    const fake = createFakeClient();
+    const store = createStore();
+    const iter = readReceiptEvents(oneClient(fake), store);
+    fake.messages.push(editEvent());
+    fake.messages.push(readEvent());
+
+    const [receipt] = await collect(iter, 1);
+    expect(receipt?.messageId).toBe("guid-1");
+    expect(receipt?.readAt).toBeDefined();
+
+    fake.messages.endAll();
+  });
+
+  test("drops events with no actor address (we'd have nothing to attribute)", async () => {
+    const fake = createFakeClient();
+    const store = createStore();
+    const iter = readReceiptEvents(oneClient(fake), store);
+    // No actor — should be skipped
+    fake.messages.push(readEvent({ actor: undefined }));
+    // Valid follow-up — should reach the consumer
+    fake.messages.push(readEvent({ messageGuid: "guid-2" }));
+
+    const [receipt] = await collect(iter, 1);
+    expect(receipt?.messageId).toBe("guid-2");
+
+    fake.messages.endAll();
+  });
+});
+
+describe("chatReadEvents", () => {
+  test("yields a ChatRead per chat.markedRead event", async () => {
+    const fake = createFakeClient();
+    const store = createStore();
+    const iter = chatReadEvents(oneClient(fake), store);
+    fake.chats.push(chatMarkedReadEvent());
+
+    const [evt] = await collect(iter, 1);
+    expect(evt?.spaceId).toBe("any;-;+15550100");
+    expect(evt?.readBy.id).toBe("+15550100");
+    expect(evt?.readAt).toEqual(new Date("2026-05-06T12:05:00.000Z"));
+
+    fake.chats.endAll();
+  });
+});
+
+describe("messageEditEvents", () => {
+  test("projects new content as spectrum text Content", async () => {
+    const fake = createFakeClient();
+    const store = createStore();
+    const iter = messageEditEvents(oneClient(fake), store);
+    fake.messages.push(editEvent());
+
+    const [evt] = await collect(iter, 1);
+    expect(evt?.messageId).toBe("guid-1");
+    expect(evt?.newContent.type).toBe("text");
+    expect((evt?.newContent as { text: string }).text).toBe("hello, edited");
+    expect(evt?.editedAt).toEqual(new Date("2026-05-06T12:02:00.000Z"));
+
+    fake.messages.endAll();
+  });
+});
+
+describe("messageUnsendEvents", () => {
+  test("yields the projected unsend payload", async () => {
+    const fake = createFakeClient();
+    const store = createStore();
+    const iter = messageUnsendEvents(oneClient(fake), store);
+    fake.messages.push(unsendEvent());
+
+    const [evt] = await collect(iter, 1);
+    expect(evt?.messageId).toBe("guid-1");
+    expect(evt?.unsentAt).toEqual(new Date("2026-05-06T12:03:00.000Z"));
+
+    fake.messages.endAll();
+  });
+});
+
+describe("reactionRemovedEvents", () => {
+  test("maps tapback kind to the canonical emoji", async () => {
+    const fake = createFakeClient();
+    const store = createStore();
+    const iter = reactionRemovedEvents(oneClient(fake), store);
+    fake.messages.push(reactionRemovedEvent());
+
+    const [evt] = await collect(iter, 1);
+    expect(evt?.messageId).toBe("guid-1");
+    expect(evt?.emoji).toBe("❤️");
+    expect(evt?.reactor.id).toBe("+15550100");
+    expect(evt?.targetPartIndex).toBe(0);
+
+    fake.messages.endAll();
+  });
+});
+
+describe("groupChangeEvents", () => {
+  test("displayNameChanged → kind=displayNameChanged + newDisplayName", async () => {
+    const fake = createFakeClient();
+    const store = createStore();
+    const iter = groupChangeEvents(oneClient(fake), store);
+    fake.groups.push(groupNameChangeEvent());
+
+    const [evt] = await collect(iter, 1);
+    expect(evt?.kind).toBe("displayNameChanged");
+    if (evt?.kind !== "displayNameChanged") {
+      throw new Error("expected displayNameChanged");
+    }
+    expect(evt.newDisplayName).toBe("new name");
+    expect(evt.actor.id).toBe("+15550100");
+
+    fake.groups.endAll();
+  });
+
+  test("participantAdded carries actor and participant", async () => {
+    const fake = createFakeClient();
+    const store = createStore();
+    const iter = groupChangeEvents(oneClient(fake), store);
+    fake.groups.push(groupParticipantAddedEvent());
+
+    const [evt] = await collect(iter, 1);
+    if (evt?.kind !== "participantAdded") {
+      throw new Error(`expected participantAdded, got ${evt?.kind}`);
+    }
+    expect(evt.actor.id).toBe("+15550100");
+    expect(evt.participant.id).toBe("+15550200");
+
+    fake.groups.endAll();
+  });
+
+  test("participantLeft has participant but no actor (by design)", async () => {
+    const fake = createFakeClient();
+    const store = createStore();
+    const iter = groupChangeEvents(oneClient(fake), store);
+    fake.groups.push(groupParticipantLeftEvent());
+
+    const [evt] = await collect(iter, 1);
+    if (evt?.kind !== "participantLeft") {
+      throw new Error(`expected participantLeft, got ${evt?.kind}`);
+    }
+    expect(evt.participant.id).toBe("+15550200");
+    // @ts-expect-error — participantLeft variant has no `actor`
+    expect(evt.actor).toBeUndefined();
+
+    fake.groups.endAll();
+  });
+});
+
+describe("shared broadcaster", () => {
+  test("two producers on the same phone share one upstream subscription", async () => {
+    const fake = createFakeClient();
+    let subscribeCount = 0;
+    const baseStream = fake.messages.stream;
+    const wrappedClient = {
+      ...fake.client,
+      messages: {
+        subscribeEvents: () => {
+          subscribeCount += 1;
+          return baseStream;
+        },
+      },
+    } as unknown as AdvancedIMessage;
+    const clients: RemoteClient[] = [
+      { client: wrappedClient, phone: "+15555550100" },
+    ];
+    const store = createStore();
+
+    // Spin up two producers; both should funnel through the single
+    // broadcaster created on first subscribe.
+    const reads = readReceiptEvents(clients, store);
+    const edits = messageEditEvents(clients, store);
+
+    // Touch both — start iterating so the broadcaster's pump kicks in.
+    const readIter = reads[Symbol.asyncIterator]();
+    const editIter = edits[Symbol.asyncIterator]();
+    const readNext = readIter.next();
+    const editNext = editIter.next();
+
+    fake.messages.push(readEvent());
+    fake.messages.push(editEvent());
+
+    const readResult = await Promise.race([
+      readNext,
+      new Promise<IteratorResult<unknown>>((resolve) =>
+        setTimeout(() => resolve({ done: true, value: undefined }), 100)
+      ),
+    ]);
+    const editResult = await Promise.race([
+      editNext,
+      new Promise<IteratorResult<unknown>>((resolve) =>
+        setTimeout(() => resolve({ done: true, value: undefined }), 100)
+      ),
+    ]);
+    expect(readResult.done).toBe(false);
+    expect(editResult.done).toBe(false);
+    expect(subscribeCount).toBe(1);
+
+    await readIter.return?.();
+    await editIter.return?.();
+    fake.messages.endAll();
+  });
+});
+
+describe("local-mode bypass (provider-level)", () => {
+  test("each producer wrapped via remoteOnlyEvent yields nothing for local clients", async () => {
+    // This is exercised at the provider definition site (`imessage/index.ts`).
+    // Here we sanity-check that calling the remote producers with an empty
+    // client array also yields nothing — that's the surface the local
+    // bypass relies on staying inert.
+    const store = createStore();
+    const iter = readReceiptEvents([], store);
+    const result = await Promise.race([
+      iter[Symbol.asyncIterator]().next(),
+      new Promise<IteratorResult<unknown>>((resolve) =>
+        setTimeout(() => resolve({ done: true, value: undefined }), 50)
+      ),
+    ]);
+    expect(result.done).toBe(true);
+  });
+});

--- a/packages/spectrum-ts/src/providers/imessage/remote/events.test.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/events.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, test } from "bun:test";
-import type {
-  AdvancedIMessage,
-  ChatEvent,
-  GroupEvent,
-  MessageEvent,
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  type AdvancedIMessage,
+  AuthenticationError,
+  type ChatEvent,
+  type GroupEvent,
+  IMessageError,
+  type MessageEvent,
 } from "@photon-ai/advanced-imessage";
 import { createStore } from "../../../utils/store";
 import type { RemoteClient } from "../types";
@@ -15,6 +17,24 @@ import {
   reactionRemovedEvents,
   readReceiptEvents,
 } from "./events";
+
+// Silence `console.warn`/`console.error` during these tests — the
+// resume-on-error wrapper logs every reconnect attempt, and our test
+// harness intentionally triggers fake "upstream ended" closures to
+// terminate fixtures. Tests that *want* to assert on retry behavior
+// keep their own counter via the subscribe thunk; logs are noise.
+let originalWarn: typeof console.warn;
+let originalError: typeof console.error;
+beforeEach(() => {
+  originalWarn = console.warn;
+  originalError = console.error;
+  console.warn = () => undefined;
+  console.error = () => undefined;
+});
+afterEach(() => {
+  console.warn = originalWarn;
+  console.error = originalError;
+});
 
 // ---------------------------------------------------------------------------
 // Fake AdvancedIMessage harness
@@ -115,34 +135,38 @@ const oneClient = (fake: FakeClient): RemoteClient[] => [
   { client: fake.client, phone: "+15555550100" },
 ];
 
-// Pull `n` items off an AsyncIterable, with a short generous timeout so a
-// hung producer fails the test instead of hanging it.
+// Pull `n` items off an AsyncIterable, with one global timeout so a hung
+// producer fails the test instead of hanging it. The previous version's
+// per-call race triggered a subtle bug: a slow `next()` would leak past
+// the per-call timer, so a value that arrived after the reconnect delay
+// (500ms with jitter) showed up as "no events delivered" to the test.
 const collect = async <T>(
   iter: AsyncIterable<T>,
   n: number,
-  timeoutMs = 250
+  timeoutMs = 1000
 ): Promise<T[]> => {
   const items: T[] = [];
   const iterator = iter[Symbol.asyncIterator]();
-  const deadline = Date.now() + timeoutMs;
+  let timedOut = false;
+  const timeout = new Promise<{ kind: "timeout" }>((resolve) => {
+    setTimeout(() => {
+      timedOut = true;
+      resolve({ kind: "timeout" });
+    }, timeoutMs);
+  });
+
   while (items.length < n) {
-    if (Date.now() > deadline) {
+    const race = await Promise.race([
+      iterator.next().then((r) => ({ kind: "next" as const, value: r })),
+      timeout,
+    ]);
+    if (race.kind === "timeout" || timedOut) {
       throw new Error(`collect timed out after ${items.length}/${n} items`);
     }
-    const next = iterator.next();
-    const race = await Promise.race([
-      next,
-      new Promise<IteratorResult<T>>((resolve) =>
-        setTimeout(() => resolve({ done: true, value: undefined as never }), 50)
-      ),
-    ]);
-    if (race.done) {
-      if (items.length >= n) {
-        break;
-      }
-      continue;
+    if (race.value.done) {
+      break;
     }
-    items.push(race.value);
+    items.push(race.value.value);
   }
   await iterator.return?.();
   return items;
@@ -481,5 +505,169 @@ describe("local-mode bypass (provider-level)", () => {
       ),
     ]);
     expect(result.done).toBe(true);
+  });
+});
+
+describe("resume-on-error", () => {
+  test("reconnects after a transient upstream error and keeps delivering", async () => {
+    // First subscribe yields an IMessageError on first next(); second
+    // subscribe yields a valid event. The producer must reconnect and
+    // deliver the event from the second subscription.
+    const phone = "+15555550199";
+    let subscribeCount = 0;
+    const events: MessageEvent[] = [readEvent({ messageGuid: "after-retry" })];
+
+    const subscribe = (): {
+      [Symbol.asyncIterator](): AsyncIterator<MessageEvent>;
+      close(): Promise<void>;
+    } => {
+      subscribeCount += 1;
+      const callCount = subscribeCount;
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            next(): Promise<IteratorResult<MessageEvent>> {
+              if (callCount === 1) {
+                return Promise.reject(
+                  new IMessageError("transient gRPC blip", {
+                    code: "UNAVAILABLE" as never,
+                    grpcCode: 14,
+                    retryable: true,
+                  })
+                );
+              }
+              const value = events.shift();
+              if (value) {
+                return Promise.resolve({ done: false, value });
+              }
+              return new Promise<IteratorResult<MessageEvent>>(() => undefined);
+            },
+          };
+        },
+        close: () => Promise.resolve(),
+      };
+    };
+
+    const fakeClient = {
+      chats: { subscribeEvents: () => createFakeStream<ChatEvent>().stream },
+      groups: { subscribeEvents: () => createFakeStream<GroupEvent>().stream },
+      messages: { subscribeEvents: subscribe },
+    } as unknown as AdvancedIMessage;
+    const clients: RemoteClient[] = [{ client: fakeClient, phone }];
+    const store = createStore();
+
+    const iter = readReceiptEvents(clients, store);
+    const [receipt] = await collect(iter, 1, 3000);
+    expect(receipt?.messageId).toBe("after-retry");
+    expect(subscribeCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test("stops permanently on a non-retryable upstream error (AuthenticationError)", async () => {
+    const phone = "+15555550299";
+    let subscribeCount = 0;
+    const subscribe = (): {
+      [Symbol.asyncIterator](): AsyncIterator<MessageEvent>;
+      close(): Promise<void>;
+    } => {
+      subscribeCount += 1;
+      return {
+        [Symbol.asyncIterator]() {
+          return {
+            next: () =>
+              Promise.reject(
+                new AuthenticationError("bad token", {
+                  code: "UNAUTHENTICATED" as never,
+                  grpcCode: 16,
+                  retryable: false,
+                })
+              ),
+          };
+        },
+        close: () => Promise.resolve(),
+      };
+    };
+
+    const fakeClient = {
+      chats: { subscribeEvents: () => createFakeStream<ChatEvent>().stream },
+      groups: { subscribeEvents: () => createFakeStream<GroupEvent>().stream },
+      messages: { subscribeEvents: subscribe },
+    } as unknown as AdvancedIMessage;
+    const clients: RemoteClient[] = [{ client: fakeClient, phone }];
+    const store = createStore();
+
+    const iter = readReceiptEvents(clients, store);
+    // Pull next() once — should reject (non-retryable propagates) OR finish
+    // (done: true after error end). Either way, no retry storm.
+    const iterator = iter[Symbol.asyncIterator]();
+    const result = await Promise.race([
+      iterator
+        .next()
+        .then((r) => ({ kind: "result" as const, value: r }))
+        .catch((error) => ({ error, kind: "error" as const })),
+      new Promise<{ kind: "timeout" }>((resolve) =>
+        setTimeout(() => resolve({ kind: "timeout" }), 500)
+      ),
+    ]);
+    // Either an error bubbled or the stream terminated; what must NOT happen
+    // is unbounded retries (timeout).
+    expect(result.kind).not.toBe("timeout");
+    // Exactly one subscribe attempt — no reconnect after AuthenticationError.
+    expect(subscribeCount).toBe(1);
+    await iterator.return?.();
+  });
+
+  test("a clean upstream end is treated as retryable (reconnect, not terminate)", async () => {
+    // The upstream `TypedEventStream` can iterate to completion if the
+    // server closes the gRPC stream cleanly. We should NOT permanently
+    // shut down the broadcaster on that — reconnect.
+    const phone = "+15555550399";
+    let subscribeCount = 0;
+    const subscribe = (): {
+      [Symbol.asyncIterator](): AsyncIterator<MessageEvent>;
+      close(): Promise<void>;
+    } => {
+      subscribeCount += 1;
+      const callCount = subscribeCount;
+      return {
+        [Symbol.asyncIterator]() {
+          let yielded = false;
+          return {
+            next(): Promise<IteratorResult<MessageEvent>> {
+              if (callCount === 1) {
+                // Immediately end the first subscription.
+                return Promise.resolve({
+                  done: true,
+                  value: undefined as never,
+                });
+              }
+              if (yielded) {
+                return new Promise<IteratorResult<MessageEvent>>(
+                  () => undefined
+                );
+              }
+              yielded = true;
+              return Promise.resolve({
+                done: false,
+                value: readEvent({ messageGuid: "after-clean-end" }),
+              });
+            },
+          };
+        },
+        close: () => Promise.resolve(),
+      };
+    };
+
+    const fakeClient = {
+      chats: { subscribeEvents: () => createFakeStream<ChatEvent>().stream },
+      groups: { subscribeEvents: () => createFakeStream<GroupEvent>().stream },
+      messages: { subscribeEvents: subscribe },
+    } as unknown as AdvancedIMessage;
+    const clients: RemoteClient[] = [{ client: fakeClient, phone }];
+    const store = createStore();
+
+    const iter = readReceiptEvents(clients, store);
+    const [receipt] = await collect(iter, 1, 3000);
+    expect(receipt?.messageId).toBe("after-clean-end");
+    expect(subscribeCount).toBeGreaterThanOrEqual(2);
   });
 });

--- a/packages/spectrum-ts/src/providers/imessage/remote/events.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/events.ts
@@ -1,9 +1,13 @@
-import type {
-  AdvancedIMessage,
-  ChatEvent,
-  GroupChange,
-  GroupEvent,
-  MessageEvent,
+import {
+  type AdvancedIMessage,
+  AuthenticationError,
+  type ChatEvent,
+  type GroupChange,
+  type GroupEvent,
+  IMessageError,
+  type MessageEvent,
+  NotFoundError,
+  ValidationError,
 } from "@photon-ai/advanced-imessage";
 import { asCustom } from "../../../content/custom";
 import { asText } from "../../../content/text";
@@ -16,6 +20,17 @@ import {
   stream,
 } from "../../../utils/stream";
 import type { RemoteClient } from "../types";
+
+// Lightweight logger that mirrors `console.warn` from `inbound.ts`. Using
+// `@photon-ai/otel`'s `createLogger` would be more uniform, but it's not
+// in the workspace's test runtime; reconnect telemetry will be picked
+// up via these stderr lines until otel-everywhere lands.
+const warn = (message: string, fields: Record<string, unknown>): void => {
+  console.warn(`[spectrum-ts][imessage.events] ${message}`, fields);
+};
+const errorLog = (message: string, fields: Record<string, unknown>): void => {
+  console.error(`[spectrum-ts][imessage.events] ${message}`, fields);
+};
 
 // ---------------------------------------------------------------------------
 // Public event payload shapes — what spectrum-ts emits on each stream
@@ -119,33 +134,196 @@ type AnyEvent = MessageEvent | ChatEvent | GroupEvent;
 const broadcasterStoreKey = (phone: string): string =>
   `imessage:eventBroadcast:${phone}`;
 
-/**
- * Adapt one of advanced-imessage's `TypedEventStream`s into a ManagedStream.
- * The upstream class already implements `AsyncIterable` and `close()`; we
- * just pump values into a `Repeater`-backed `ManagedStream` so it composes
- * with the rest of spectrum-ts's stream plumbing.
- */
-const adaptTyped = <T>(source: {
-  [Symbol.asyncIterator]: () => AsyncIterator<T>;
+interface LiveSource<T> extends AsyncIterable<T> {
   close(): Promise<void>;
-}): ManagedStream<T> =>
-  stream<T>((emit, end) => {
-    const iter = source[Symbol.asyncIterator]();
-    const pump = (async () => {
-      try {
-        let result = await iter.next();
-        while (!result.done) {
-          await emit(result.value);
-          result = await iter.next();
-        }
-        end();
-      } catch (error) {
-        end(error);
+}
+
+/**
+ * Mirror the retry classification used by the messages stream
+ * (`remote/stream.ts:isRetryableIMessageStreamError`). Auth, NotFound, and
+ * Validation are configuration / contract bugs and don't heal on retry;
+ * everything else (transient gRPC errors, server restarts, connection
+ * resets, plain stream-ended-prematurely) is worth backing off and
+ * reconnecting on.
+ */
+const isRetryableUpstreamError = (error: unknown): boolean => {
+  if (
+    error instanceof AuthenticationError ||
+    error instanceof NotFoundError ||
+    error instanceof ValidationError
+  ) {
+    return false;
+  }
+  if (error instanceof IMessageError) {
+    return true;
+  }
+  // Non-IMessageError errors (network, generic Error, "stream ended
+  // unexpectedly") are also retryable — they typically indicate a
+  // transient disconnect.
+  return true;
+};
+
+const RECONNECT_INITIAL_DELAY_MS = 500;
+const RECONNECT_MAX_DELAY_MS = 30_000;
+const RECONNECT_RESET_AFTER_MS = 30_000;
+
+const jitter = (delayMs: number): number => Math.random() * delayMs;
+
+/**
+ * Subscribe to a live `TypedEventStream`-shaped upstream and yield its
+ * events into a `ManagedStream`, reconnecting with exponential backoff on
+ * transient errors. Without this wrapper, a single gRPC hiccup would
+ * permanently kill every consumer of the broadcaster until the worker
+ * restarts — see comment in `getEventBroadcaster` for the broader
+ * lifecycle.
+ *
+ * Live-only by design: no cursor or catch-up. Events delivered while the
+ * stream is reconnecting are lost. Use `client.events.catchUp(since)`
+ * via the messages stream for durable replay; this wrapper exists so
+ * a transient blip doesn't take readReceipt / chatRead / etc. offline.
+ */
+interface ResumeState<T> {
+  activeSource: LiveSource<T> | undefined;
+  closed: boolean;
+  delayMs: number;
+  initialDelayMs: number;
+  maxDelayMs: number;
+  resetAfterMs: number;
+  sleepTimer: ReturnType<typeof setTimeout> | undefined;
+  wakeSleep: (() => void) | undefined;
+}
+
+const cancelSleep = <T>(state: ResumeState<T>): void => {
+  if (state.sleepTimer) {
+    clearTimeout(state.sleepTimer);
+    state.sleepTimer = undefined;
+  }
+  state.wakeSleep?.();
+  state.wakeSleep = undefined;
+};
+
+const sleepWithCancel = <T>(
+  state: ResumeState<T>,
+  ms: number
+): Promise<void> => {
+  if (ms <= 0 || state.closed) {
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    state.wakeSleep = resolve;
+    state.sleepTimer = setTimeout(resolve, jitter(ms));
+  }).then(() => {
+    state.sleepTimer = undefined;
+    state.wakeSleep = undefined;
+  });
+};
+
+const nextBackoffDelay = <T>(state: ResumeState<T>): number => {
+  const current = state.delayMs;
+  state.delayMs = Math.min(state.delayMs * 2, state.maxDelayMs);
+  return current;
+};
+
+const consumeOnce = async <T>(
+  state: ResumeState<T>,
+  subscribe: () => LiveSource<T>,
+  label: string,
+  emit: (value: T) => Promise<void>
+): Promise<void> => {
+  const source = subscribe();
+  state.activeSource = source;
+  const connectedAt = Date.now();
+  try {
+    for await (const value of source) {
+      if (state.closed) {
+        return;
       }
-    })();
+      // If we've been delivering successfully past the reset window,
+      // forget the prior backoff so the next disconnect retries fast.
+      if (Date.now() - connectedAt >= state.resetAfterMs) {
+        state.delayMs = state.initialDelayMs;
+      }
+      await emit(value);
+    }
+    // Source ended cleanly — treat like a retryable disconnect so we
+    // reconnect rather than terminating the whole broadcaster.
+    throw new Error(`upstream ${label} ended; reconnecting`);
+  } finally {
+    if (state.activeSource === source) {
+      state.activeSource = undefined;
+    }
+    await source.close().catch(() => undefined);
+  }
+};
+
+const handleConsumeError = <T>(
+  state: ResumeState<T>,
+  error: unknown,
+  label: string,
+  end: (error?: unknown) => void
+): number | undefined => {
+  if (state.closed) {
+    return;
+  }
+  if (!isRetryableUpstreamError(error)) {
+    errorLog("upstream errored fatally; ending stream", {
+      error: error instanceof Error ? error.message : String(error),
+      label,
+    });
+    end(error);
+    return;
+  }
+  const wait = nextBackoffDelay(state);
+  warn("upstream errored; reconnecting", {
+    delayMs: wait,
+    error: error instanceof Error ? error.message : String(error),
+    label,
+  });
+  return wait;
+};
+
+const resumableLiveStream = <T>(
+  subscribe: () => LiveSource<T>,
+  label: string,
+  options: {
+    initialDelayMs?: number;
+    maxDelayMs?: number;
+    /** Time of stable delivery after which the backoff resets to initial. */
+    resetAfterMs?: number;
+  } = {}
+): ManagedStream<T> =>
+  stream<T>((emit, end) => {
+    const state: ResumeState<T> = {
+      activeSource: undefined,
+      closed: false,
+      delayMs: options.initialDelayMs ?? RECONNECT_INITIAL_DELAY_MS,
+      initialDelayMs: options.initialDelayMs ?? RECONNECT_INITIAL_DELAY_MS,
+      maxDelayMs: options.maxDelayMs ?? RECONNECT_MAX_DELAY_MS,
+      resetAfterMs: options.resetAfterMs ?? RECONNECT_RESET_AFTER_MS,
+      sleepTimer: undefined,
+      wakeSleep: undefined,
+    };
+
+    const run = async () => {
+      while (!state.closed) {
+        try {
+          await consumeOnce(state, subscribe, label, emit);
+        } catch (error) {
+          const wait = handleConsumeError(state, error, label, end);
+          if (wait === undefined) {
+            return;
+          }
+          await sleepWithCancel(state, wait);
+        }
+      }
+    };
+
+    const pump = run();
 
     return async () => {
-      await source.close().catch(() => undefined);
+      state.closed = true;
+      cancelSleep(state);
+      await state.activeSource?.close().catch(() => undefined);
       await pump.catch(() => undefined);
     };
   });
@@ -193,10 +371,13 @@ const mergeUnion = (
  * and stashed in `store` so every custom-event producer (`readReceipt`,
  * `chatRead`, …) shares one upstream subscription instead of opening six.
  *
- * Live-only: the worker's existing `messages` stream already drives
- * `events.catchUp(since)` for durable replay of the same underlying log,
- * and these event producers don't promise durability in the spectrum-ts
- * docs yet. A future PR can layer catch-up onto this broadcaster.
+ * Each upstream subscription is wrapped in `resumableLiveStream` so a
+ * transient gRPC error or server restart doesn't take the broadcaster
+ * permanently offline. Catch-up replay across the disconnect window is
+ * NOT performed — events delivered while reconnecting are dropped. The
+ * existing `messages` stream still drives `events.catchUp(since)` for
+ * durable replay of the same underlying log; a future PR can layer
+ * catch-up onto this broadcaster.
  */
 const getEventBroadcaster = (
   store: Store,
@@ -209,9 +390,18 @@ const getEventBroadcaster = (
     return existing;
   }
   const merged = mergeUnion([
-    adaptTyped<MessageEvent>(client.messages.subscribeEvents()),
-    adaptTyped<ChatEvent>(client.chats.subscribeEvents()),
-    adaptTyped<GroupEvent>(client.groups.subscribeEvents()),
+    resumableLiveStream<MessageEvent>(
+      () => client.messages.subscribeEvents(),
+      `messages:${phone}`
+    ),
+    resumableLiveStream<ChatEvent>(
+      () => client.chats.subscribeEvents(),
+      `chats:${phone}`
+    ),
+    resumableLiveStream<GroupEvent>(
+      () => client.groups.subscribeEvents(),
+      `groups:${phone}`
+    ),
   ]);
   const broadcaster = broadcast(merged);
   store.set(key, broadcaster);

--- a/packages/spectrum-ts/src/providers/imessage/remote/events.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/events.ts
@@ -1,0 +1,500 @@
+import type {
+  AdvancedIMessage,
+  ChatEvent,
+  GroupChange,
+  GroupEvent,
+  MessageEvent,
+} from "@photon-ai/advanced-imessage";
+import { asCustom } from "../../../content/custom";
+import { asText } from "../../../content/text";
+import type { Content } from "../../../content/types";
+import type { Store } from "../../../utils/store";
+import {
+  type Broadcaster,
+  broadcast,
+  type ManagedStream,
+  stream,
+} from "../../../utils/stream";
+import type { RemoteClient } from "../types";
+
+// ---------------------------------------------------------------------------
+// Public event payload shapes — what spectrum-ts emits on each stream
+// ---------------------------------------------------------------------------
+
+interface UserRef {
+  id: string;
+}
+
+export interface ReadReceipt {
+  messageId: string;
+  readAt: Date;
+  readBy: UserRef;
+  spaceId: string;
+}
+
+export interface ChatRead {
+  readAt: Date;
+  readBy: UserRef;
+  spaceId: string;
+}
+
+export interface MessageEdit {
+  editedAt: Date;
+  messageId: string;
+  newContent: Content;
+  spaceId: string;
+}
+
+export interface MessageUnsend {
+  messageId: string;
+  spaceId: string;
+  unsentAt: Date;
+}
+
+export interface ReactionRemoved {
+  emoji: string;
+  messageId: string;
+  reactor: UserRef;
+  removedAt: Date;
+  spaceId: string;
+  targetPartIndex?: number;
+}
+
+export type GroupChangeEvent =
+  | {
+      kind: "displayNameChanged";
+      spaceId: string;
+      newDisplayName: string;
+      actor: UserRef;
+      at: Date;
+    }
+  | {
+      kind: "participantAdded";
+      spaceId: string;
+      participant: UserRef;
+      actor: UserRef;
+      at: Date;
+    }
+  | {
+      kind: "participantRemoved";
+      spaceId: string;
+      participant: UserRef;
+      actor: UserRef;
+      at: Date;
+    }
+  | {
+      kind: "participantLeft";
+      spaceId: string;
+      participant: UserRef;
+      at: Date;
+    }
+  | { kind: "iconChanged"; spaceId: string; actor: UserRef; at: Date }
+  | { kind: "iconRemoved"; spaceId: string; actor: UserRef; at: Date };
+
+// ---------------------------------------------------------------------------
+// Tapback emoji mapping (mirrors `remote/reactions.ts`)
+// ---------------------------------------------------------------------------
+
+const TAPBACK_TO_EMOJI: Readonly<Record<string, string>> = {
+  love: "❤️",
+  like: "👍",
+  dislike: "👎",
+  laugh: "😂",
+  emphasize: "‼️",
+  question: "❓",
+};
+
+const reactionToEmoji = (reaction: {
+  kind: string;
+  emoji?: string;
+}): string | undefined =>
+  reaction.kind === "emoji" ? reaction.emoji : TAPBACK_TO_EMOJI[reaction.kind];
+
+// ---------------------------------------------------------------------------
+// Shared per-phone broadcaster
+// ---------------------------------------------------------------------------
+
+type AnyEvent = MessageEvent | ChatEvent | GroupEvent;
+
+const broadcasterStoreKey = (phone: string): string =>
+  `imessage:eventBroadcast:${phone}`;
+
+/**
+ * Adapt one of advanced-imessage's `TypedEventStream`s into a ManagedStream.
+ * The upstream class already implements `AsyncIterable` and `close()`; we
+ * just pump values into a `Repeater`-backed `ManagedStream` so it composes
+ * with the rest of spectrum-ts's stream plumbing.
+ */
+const adaptTyped = <T>(source: {
+  [Symbol.asyncIterator]: () => AsyncIterator<T>;
+  close(): Promise<void>;
+}): ManagedStream<T> =>
+  stream<T>((emit, end) => {
+    const iter = source[Symbol.asyncIterator]();
+    const pump = (async () => {
+      try {
+        let result = await iter.next();
+        while (!result.done) {
+          await emit(result.value);
+          result = await iter.next();
+        }
+        end();
+      } catch (error) {
+        end(error);
+      }
+    })();
+
+    return async () => {
+      await source.close().catch(() => undefined);
+      await pump.catch(() => undefined);
+    };
+  });
+
+/**
+ * Merge multiple ManagedStreams of heterogeneous-but-related event types
+ * into a single ManagedStream of their union. `mergeStreams` requires the
+ * same element type across all inputs; this thin wrapper lets us union
+ * `MessageEvent`, `ChatEvent`, and `GroupEvent` without a structural cast
+ * dance at every callsite.
+ */
+const mergeUnion = (
+  sources: ManagedStream<AnyEvent>[]
+): ManagedStream<AnyEvent> =>
+  stream<AnyEvent>((emit, end) => {
+    if (sources.length === 0) {
+      end();
+      return;
+    }
+    let open = sources.length;
+    const workers = sources.map(async (source) => {
+      try {
+        for await (const value of source) {
+          await emit(value);
+        }
+      } catch (error) {
+        end(error);
+      } finally {
+        open -= 1;
+        if (open === 0) {
+          end();
+        }
+      }
+    });
+
+    return async () => {
+      await Promise.allSettled(sources.map((s) => s.close()));
+      await Promise.allSettled(workers).catch(() => undefined);
+    };
+  });
+
+/**
+ * Per-phone broadcaster across every event family this provider exposes
+ * beyond the core `messages` stream. Lazily constructed on first subscribe
+ * and stashed in `store` so every custom-event producer (`readReceipt`,
+ * `chatRead`, …) shares one upstream subscription instead of opening six.
+ *
+ * Live-only: the worker's existing `messages` stream already drives
+ * `events.catchUp(since)` for durable replay of the same underlying log,
+ * and these event producers don't promise durability in the spectrum-ts
+ * docs yet. A future PR can layer catch-up onto this broadcaster.
+ */
+const getEventBroadcaster = (
+  store: Store,
+  client: AdvancedIMessage,
+  phone: string
+): Broadcaster<AnyEvent> => {
+  const key = broadcasterStoreKey(phone);
+  const existing = store.get(key) as Broadcaster<AnyEvent> | undefined;
+  if (existing) {
+    return existing;
+  }
+  const merged = mergeUnion([
+    adaptTyped<MessageEvent>(client.messages.subscribeEvents()),
+    adaptTyped<ChatEvent>(client.chats.subscribeEvents()),
+    adaptTyped<GroupEvent>(client.groups.subscribeEvents()),
+  ]);
+  const broadcaster = broadcast(merged);
+  store.set(key, broadcaster);
+  return broadcaster;
+};
+
+/**
+ * Build a per-producer stream for a single remote client.
+ *
+ * `filterAndProject` returns the public payload for events it handles, or
+ * `undefined` to skip an upstream event that doesn't belong to this
+ * producer's family.
+ */
+const projectEvents = <T>(
+  source: ManagedStream<AnyEvent>,
+  filterAndProject: (event: AnyEvent) => T | undefined
+): ManagedStream<T> =>
+  stream<T>((emit, end) => {
+    const pump = (async () => {
+      try {
+        for await (const event of source) {
+          const projected = filterAndProject(event);
+          if (projected !== undefined) {
+            await emit(projected);
+          }
+        }
+        end();
+      } catch (error) {
+        end(error);
+      }
+    })();
+
+    return async () => {
+      await source.close();
+      await pump.catch(() => undefined);
+    };
+  });
+
+/**
+ * Merge a per-producer stream across every phone the iMessage config
+ * exposes. Each phone has its own shared broadcaster; one subscriber per
+ * phone is enough to reach every event family there.
+ */
+const perPhoneStream = <T>(
+  clients: RemoteClient[],
+  store: Store,
+  filterAndProject: (event: AnyEvent) => T | undefined
+): ManagedStream<T> => {
+  const sources = clients.map((entry) =>
+    projectEvents(
+      getEventBroadcaster(store, entry.client, entry.phone).subscribe(),
+      filterAndProject
+    )
+  );
+  return stream<T>((emit, end) => {
+    if (sources.length === 0) {
+      end();
+      return;
+    }
+    let open = sources.length;
+    const workers = sources.map(async (source) => {
+      try {
+        for await (const value of source) {
+          await emit(value);
+        }
+      } catch (error) {
+        end(error);
+      } finally {
+        open -= 1;
+        if (open === 0) {
+          end();
+        }
+      }
+    });
+    return async () => {
+      await Promise.allSettled(sources.map((s) => s.close()));
+      await Promise.allSettled(workers).catch(() => undefined);
+    };
+  });
+};
+
+// ---------------------------------------------------------------------------
+// Per-event projections
+// ---------------------------------------------------------------------------
+
+const projectReadReceipt = (event: AnyEvent): ReadReceipt | undefined => {
+  if (event.type !== "message.read") {
+    return;
+  }
+  const address = event.actor?.address;
+  if (!address) {
+    return;
+  }
+  return {
+    messageId: event.messageGuid,
+    readAt: event.readAt,
+    readBy: { id: address },
+    spaceId: event.chatGuid,
+  };
+};
+
+const projectChatRead = (event: AnyEvent): ChatRead | undefined => {
+  if (event.type !== "chat.markedRead") {
+    return;
+  }
+  const address = event.actor?.address;
+  if (!address) {
+    return;
+  }
+  return {
+    readAt: event.occurredAt,
+    readBy: { id: address },
+    spaceId: event.chatGuid,
+  };
+};
+
+const projectMessageEdit = (event: AnyEvent): MessageEdit | undefined => {
+  if (event.type !== "message.edited") {
+    return;
+  }
+  // Edits only support text content on iMessage (see `handleEdit` in
+  // `imessage/index.ts`). When `event.content.text` is present we project
+  // to spectrum's text content; if not, we fall back to `asCustom` so the
+  // consumer still sees something rather than a silently-dropped event.
+  const text = event.content.text;
+  const newContent: Content = text ? asText(text) : asCustom(event.content);
+  return {
+    editedAt: event.editedAt,
+    messageId: event.messageGuid,
+    newContent,
+    spaceId: event.chatGuid,
+  };
+};
+
+const projectMessageUnsend = (event: AnyEvent): MessageUnsend | undefined => {
+  if (event.type !== "message.unsent") {
+    return;
+  }
+  return {
+    messageId: event.messageGuid,
+    spaceId: event.chatGuid,
+    unsentAt: event.retractedAt,
+  };
+};
+
+const projectReactionRemoved = (
+  event: AnyEvent
+): ReactionRemoved | undefined => {
+  if (event.type !== "message.reactionRemoved") {
+    return;
+  }
+  const address = event.actor?.address;
+  if (!address) {
+    return;
+  }
+  const emoji = reactionToEmoji(event.reaction);
+  if (!emoji) {
+    return;
+  }
+  const result: ReactionRemoved = {
+    emoji,
+    messageId: event.messageGuid,
+    reactor: { id: address },
+    removedAt: event.occurredAt,
+    spaceId: event.chatGuid,
+  };
+  if (typeof event.targetPartIndex === "number") {
+    result.targetPartIndex = event.targetPartIndex;
+  }
+  return result;
+};
+
+const projectGroupChange = (
+  change: GroupChange,
+  spaceId: string,
+  actor: string | undefined,
+  at: Date
+): GroupChangeEvent | undefined => {
+  switch (change.type) {
+    case "displayNameChanged":
+      if (!actor) {
+        return;
+      }
+      return {
+        actor: { id: actor },
+        at,
+        kind: "displayNameChanged",
+        newDisplayName: change.displayName,
+        spaceId,
+      };
+    case "participantAdded":
+      if (!actor) {
+        return;
+      }
+      return {
+        actor: { id: actor },
+        at,
+        kind: "participantAdded",
+        participant: { id: change.participant.address },
+        spaceId,
+      };
+    case "participantRemoved":
+      if (!actor) {
+        return;
+      }
+      return {
+        actor: { id: actor },
+        at,
+        kind: "participantRemoved",
+        participant: { id: change.participant.address },
+        spaceId,
+      };
+    case "participantLeft":
+      return {
+        at,
+        kind: "participantLeft",
+        participant: { id: change.participant.address },
+        spaceId,
+      };
+    case "iconChanged":
+      if (!actor) {
+        return;
+      }
+      return { actor: { id: actor }, at, kind: "iconChanged", spaceId };
+    case "iconRemoved":
+      if (!actor) {
+        return;
+      }
+      return { actor: { id: actor }, at, kind: "iconRemoved", spaceId };
+    default:
+      return;
+  }
+};
+
+const projectGroupChangeEvent = (
+  event: AnyEvent
+): GroupChangeEvent | undefined => {
+  if (event.type !== "group.changed") {
+    return;
+  }
+  return projectGroupChange(
+    event.change,
+    event.chatGuid,
+    event.actor?.address,
+    event.occurredAt
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Public producers
+// ---------------------------------------------------------------------------
+
+export const readReceiptEvents = (
+  clients: RemoteClient[],
+  store: Store
+): AsyncIterable<ReadReceipt> =>
+  perPhoneStream(clients, store, projectReadReceipt);
+
+export const chatReadEvents = (
+  clients: RemoteClient[],
+  store: Store
+): AsyncIterable<ChatRead> => perPhoneStream(clients, store, projectChatRead);
+
+export const messageEditEvents = (
+  clients: RemoteClient[],
+  store: Store
+): AsyncIterable<MessageEdit> =>
+  perPhoneStream(clients, store, projectMessageEdit);
+
+export const messageUnsendEvents = (
+  clients: RemoteClient[],
+  store: Store
+): AsyncIterable<MessageUnsend> =>
+  perPhoneStream(clients, store, projectMessageUnsend);
+
+export const reactionRemovedEvents = (
+  clients: RemoteClient[],
+  store: Store
+): AsyncIterable<ReactionRemoved> =>
+  perPhoneStream(clients, store, projectReactionRemoved);
+
+export const groupChangeEvents = (
+  clients: RemoteClient[],
+  store: Store
+): AsyncIterable<GroupChangeEvent> =>
+  perPhoneStream(clients, store, projectGroupChangeEvent);


### PR DESCRIPTION
## Summary

PR 2 of [ENG-1490](https://linear.app/photon). Adds an `events:` block to the iMessage `definePlatform()` declaring six new custom event producers. These appear as `app.readReceipt`, `app.chatRead`, etc. on a Spectrum instance and — once [spectrum-webhook#4](https://github.com/photon-hq/spectrum-webhook/pull/4) (PR 1) deploys — flow through the dynamic webhook automatically.

| Event | Upstream source | Payload |
|---|---|---|
| `readReceipt` | `MessageEvent { type: "message.read" }` | `{ messageId, spaceId, readBy: { id }, readAt }` |
| `chatRead` | `ChatEvent { type: "chat.markedRead" }` | `{ spaceId, readBy: { id }, readAt }` |
| `messageEdit` | `MessageEvent { type: "message.edited" }` | `{ messageId, spaceId, newContent: Content, editedAt }` |
| `messageUnsend` | `MessageEvent { type: "message.unsent" }` | `{ messageId, spaceId, unsentAt }` |
| `reactionRemoved` | `MessageEvent { type: "message.reactionRemoved" }` | `{ messageId, spaceId, reactor: { id }, emoji, targetPartIndex?, removedAt }` |
| `groupChange` | `GroupEvent { type: "group.changed" }` | discriminated union by `kind` (`displayNameChanged` / `participantAdded` / `participantRemoved` / `participantLeft` / `iconChanged` / `iconRemoved`) |

## Architecture

- **One upstream subscription per phone**, not six. Per phone, a lazy `Broadcaster<MessageEvent | ChatEvent | GroupEvent>` lives in the platform `Store` keyed by `imessage:eventBroadcast:<phone>`. All six producers subscribe through it, so wire usage and cursor stay unified. A test verifies that two producers on the same phone share one subscription.
- **Multi-phone fan-out** for accounts configured with multiple `clients`.
- **Local mode bypass** via a `remoteOnlyEvent` wrapper — `IMessageSDK` doesn't expose subscription APIs for these event families, so each producer returns an empty async iterable when `isLocal(client)`.
- **Live-only** — the existing `messages` stream still drives `events.catchUp(since)` for durable replay; these producers run off `subscribeEvents()` only. Layering catch-up onto the shared broadcaster is a follow-up.
- **Tapback emoji mapping** mirrors `remote/reactions.ts` so a removed tapback surfaces as the same canonical emoji (`love → ❤️`, etc.) as a `reactionAdded` carried on the `messages` stream.

## Open questions / decisions made

1. **Where does the broadcaster live?** In the platform `Store` keyed by phone (`imessage:eventBroadcast:<phone>`). This matches how `remote/cache.ts` already stashes the poll cache per platform.
2. **Why live-only?** Catch-up is non-trivial cursor work and the new events aren't promised durable in the spectrum-ts docs. Future PR can extend.
3. **\`reactionAdded\` not added as a separate event.** Already folded into the `messages` stream as a `reaction`-content message — see `remote/stream.ts:68-83`. Only `reactionRemoved` is added here to close the asymmetry. Bigger refactor is a future ticket.
4. **TS-inference workaround.** The `_Events` generic on `definePlatform` collapses to its `undefined` default when several adjacent generics are inferred together — even though each producer in `imessageEvents` structurally satisfies `EventProducer<unknown, IMessageClient, _>`. To keep the rest of the def inferring cleanly, the `events:` slot is assigned via `as unknown as undefined`. The runtime is unaffected (the SDK spreads `def` into the platform definition verbatim) and the rendered webhook fan-out works end to end. Trade-off: consumer-side, typed access via `imessage(spectrum).readReceipt` currently surfaces as `AsyncIterable<unknown>` rather than the narrow payload type. Consumers needing the narrow type cast at the call site using the exported payload types (`ReadReceipt`, `ChatRead`, …). A follow-up to spectrum-ts core can smooth the `_Events` inference and remove the cast.

## Test plan

- [x] 12 new tests cover each producer's happy path, type filtering, actor attribution, group-change projection, and shared-broadcaster reuse.
- [x] `bun test` passes.
- [x] `bun x ultracite check` clean for files this PR touches.
- [x] `bun x tsc --noEmit` clean (modulo pre-existing `@photon-ai/otel` resolution errors unrelated to this PR).
- [ ] Smoke once PR 1 deploys: register a webhook and confirm each new event arm lands with `event` + `platform: \"iMessage\"`.

## Out of scope (deliberately)

- **Inbound typing** — not exposed by the iMessage SDK or proto today.
- **Refactoring the existing `messages` flow to use the new shared broadcaster** — risky and unnecessary for this PR. Left untouched.
- **Per-webhook event subscription filtering** — handled at the webhook layer, follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->