### PR TITLE
fix: consume option-level poll deltas

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,9 +19,9 @@
     },
     "packages/spectrum-ts": {
       "name": "spectrum-ts",
-      "version": "1.7.2",
+      "version": "1.9.0",
       "dependencies": {
-        "@photon-ai/advanced-imessage": "^0.7.0",
+        "@photon-ai/advanced-imessage": "^0.7.2",
         "@photon-ai/imessage-kit": "^3.0.0",
         "@photon-ai/otel": "^0.1.1",
         "@photon-ai/whatsapp-business": "^0.1.1",
@@ -174,7 +174,7 @@
 
     "@parseaple/typedstream": ["@parseaple/typedstream@2.0.2", "", { "dependencies": { "@parseaple/bplist": "1.0.1" } }, "sha512-bzKNZjiBtZN2T2U7Nqq/hhv+EezkPnaWoB5WvPuBwNpQvOr3EI0XrDTkFnAzsA9DKdu57es/gcb1d2ctd1u8xw=="],
 
-    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.7.0", "", { "dependencies": { "@bufbuild/protobuf": "^2.11.0", "@grpc/grpc-js": "^1.12.6", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2" } }, "sha512-IMVS5feYPMEsTJY0fDTztSkUyftdcDV1pb8Gtvq8D0CVgcAY2vyHye4IRcEhFZv6n0iEP1XcA7rnH2ztgKuBoA=="],
+    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.7.2", "", { "dependencies": { "@bufbuild/protobuf": "^2.11.0", "@grpc/grpc-js": "^1.12.6", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2" } }, "sha512-pWB+eTGfbrHxyppyuz22zvvt2uwyJcEleLwt3MyuDn/gxZ/RPLxJ5RDugj4TqStdX1VCniLf/it4lkjTdD/CGQ=="],
 
     "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-GGDETlRbrPXP5eaRvswaead7MCBGQkm8f7d3aVbx8+rXhB4GEyPiw7Q1/yz5ix53rmxqKRevWywOfG7n+kZDBw=="],
 

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -48,7 +48,7 @@
     "prepack": "bun scripts/prepare-package.ts --publish && tsup && bun scripts/prepare-package.ts"
   },
   "dependencies": {
-    "@photon-ai/advanced-imessage": "^0.7.0",
+    "@photon-ai/advanced-imessage": "^0.7.2",
     "@photon-ai/imessage-kit": "^3.0.0",
     "@photon-ai/otel": "^0.1.1",
     "@photon-ai/whatsapp-business": "^0.1.1",

--- a/packages/spectrum-ts/scripts/prepare-package.ts
+++ b/packages/spectrum-ts/scripts/prepare-package.ts
@@ -1,12 +1,13 @@
 #!/usr/bin/env bun
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { file, write } from "bun";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packageRoot = join(here, "..");
 const repoRoot = join(packageRoot, "..", "..");
 
-const pkg = (await Bun.file(join(packageRoot, "package.json")).json()) as {
+const pkg = (await file(join(packageRoot, "package.json")).json()) as {
   version: string;
 };
 
@@ -28,14 +29,8 @@ export const SPECTRUM_SDK_VERSION = "${sdkVersion}";
 export const SPECTRUM_BUILD_ENV: "development" | "production" = "${buildEnv}";
 `;
 
-await Bun.write(join(packageRoot, "src/build-env.ts"), buildEnvFile);
-await Bun.write(
-  join(packageRoot, "README.md"),
-  Bun.file(join(repoRoot, "README.md"))
-);
-await Bun.write(
-  join(packageRoot, "LICENSE"),
-  Bun.file(join(repoRoot, "LICENSE"))
-);
+await write(join(packageRoot, "src/build-env.ts"), buildEnvFile);
+await write(join(packageRoot, "README.md"), file(join(repoRoot, "README.md")));
+await write(join(packageRoot, "LICENSE"), file(join(repoRoot, "LICENSE")));
 
 console.log(`Prepared spectrum-ts v${sdkVersion} (env=${buildEnv})`);

--- a/packages/spectrum-ts/src/providers/imessage/cache.ts
+++ b/packages/spectrum-ts/src/providers/imessage/cache.ts
@@ -8,11 +8,6 @@ export interface CachedPoll {
   readonly poll: Poll;
 }
 
-export interface PollSelectionDelta {
-  readonly optionId: string;
-  readonly selected: boolean;
-}
-
 /**
  * Bounded insertion-order cache of recently-seen iMessage messages, keyed by
  * guid. Provides O(1) lookup for reaction target resolution. When capacity is
@@ -60,14 +55,6 @@ export class MessageCache {
 export class PollCache {
   private readonly map = new Map<string, CachedPoll>();
   private readonly max: number;
-  private readonly selectionEventTimesByPoll = new Map<
-    string,
-    Map<string, number>
-  >();
-  private readonly selectionsByPoll = new Map<
-    string,
-    Map<string, Set<string>>
-  >();
 
   constructor(max = DEFAULT_MAX) {
     this.max = max;
@@ -86,90 +73,12 @@ export class PollCache {
       const first = this.map.keys().next().value;
       if (first !== undefined) {
         this.map.delete(first);
-        this.selectionEventTimesByPoll.delete(first);
-        this.selectionsByPoll.delete(first);
       }
     }
   }
 
   clear(): void {
     this.map.clear();
-    this.selectionEventTimesByPoll.clear();
-    this.selectionsByPoll.clear();
-  }
-
-  actorSelectionDeltas(
-    pollId: string,
-    actorId: string,
-    optionIds: readonly string[]
-  ): PollSelectionDelta[] {
-    const previous = this.selectionsByPoll.get(pollId)?.get(actorId);
-    if (!previous) {
-      return optionIds.map((optionId) => ({ optionId, selected: true }));
-    }
-    const current = new Set(optionIds);
-    const selected = optionIds
-      .filter((optionId) => !previous.has(optionId))
-      .map((optionId) => ({ optionId, selected: true }));
-    const deselected = [...previous]
-      .filter((optionId) => !current.has(optionId))
-      .map((optionId) => ({ optionId, selected: false }));
-    return [...selected, ...deselected];
-  }
-
-  clearedActorSelectionDeltas(
-    pollId: string,
-    actorId: string
-  ): PollSelectionDelta[] {
-    const previous = this.selectionsByPoll.get(pollId)?.get(actorId);
-    if (!previous) {
-      return [];
-    }
-    return [...previous].map((optionId) => ({ optionId, selected: false }));
-  }
-
-  actorSelection(pollId: string, actorId: string): string[] | undefined {
-    const selection = this.selectionsByPoll.get(pollId)?.get(actorId);
-    return selection ? [...selection] : undefined;
-  }
-
-  commitActorSelection(
-    pollId: string,
-    actorId: string,
-    optionIds: readonly string[],
-    at?: Date
-  ): void {
-    let selections = this.selectionsByPoll.get(pollId);
-    if (!selections) {
-      selections = new Map<string, Set<string>>();
-      this.selectionsByPoll.set(pollId, selections);
-    }
-    selections.set(actorId, new Set(optionIds));
-
-    if (!at) {
-      return;
-    }
-    let eventTimes = this.selectionEventTimesByPoll.get(pollId);
-    if (!eventTimes) {
-      eventTimes = new Map<string, number>();
-      this.selectionEventTimesByPoll.set(pollId, eventTimes);
-    }
-    const eventTime = at.getTime();
-    const previousTime = eventTimes.get(actorId);
-    if (previousTime === undefined || eventTime >= previousTime) {
-      eventTimes.set(actorId, eventTime);
-    }
-  }
-
-  isStaleActorSelectionEvent(
-    pollId: string,
-    actorId: string,
-    at: Date
-  ): boolean {
-    const previousTime = this.selectionEventTimesByPoll
-      .get(pollId)
-      ?.get(actorId);
-    return previousTime !== undefined && at.getTime() < previousTime;
   }
 }
 

--- a/packages/spectrum-ts/src/providers/imessage/remote/polls.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/polls.ts
@@ -6,7 +6,7 @@ import type {
   PollEvent,
 } from "@photon-ai/advanced-imessage";
 import { asPoll, asPollOption, type PollChoice } from "../../../content/poll";
-import type { CachedPoll, PollCache, PollSelectionDelta } from "../cache";
+import type { CachedPoll, PollCache } from "../cache";
 import type { IMessageMessage } from "../types";
 
 type VotedPollEvent = PollEvent & {
@@ -29,15 +29,6 @@ interface PollOptionMessageInput {
   optionId: string;
   phone: string;
   selected: boolean;
-  senderAddress: string;
-}
-
-interface PollOptionMessagesInput {
-  cached: CachedPoll;
-  chatGuid: string;
-  deltas: readonly PollSelectionDelta[];
-  event: Pick<PollEvent, "occurredAt" | "pollMessageGuid">;
-  phone: string;
   senderAddress: string;
 }
 
@@ -108,11 +99,11 @@ const resolvePoll = async (
   cache: PollCache,
   event: PollEvent
 ): Promise<CachedPoll | undefined> => {
-  const pollId = event.pollMessageGuid;
-  const cached = cache.get(pollId);
+  const cached = cache.get(event.pollMessageGuid);
   if (cached) {
     return cached;
   }
+
   try {
     const info = await client.polls.get(event.pollMessageGuid);
     return cachePollInfo(cache, info);
@@ -149,37 +140,10 @@ const buildPollOptionMessage = (
   };
 };
 
-const buildPollOptionMessages = (
-  input: PollOptionMessagesInput
-): IMessageMessage[] => {
-  const messages: IMessageMessage[] = [];
-  for (const delta of input.deltas) {
-    const message = buildPollOptionMessage({
-      cached: input.cached,
-      chatGuid: input.chatGuid,
-      event: input.event,
-      optionId: delta.optionId,
-      phone: input.phone,
-      selected: delta.selected,
-      senderAddress: input.senderAddress,
-    });
-    if (message) {
-      messages.push(message);
-    }
-  }
-  return messages;
-};
-
-const allOptionIdsKnown = (
-  cached: CachedPoll,
-  optionIds: readonly string[]
-): boolean =>
-  optionIds.every((optionId) => cached.optionsByIdentifier.has(optionId));
-
 const refreshPollMetadata = async (
   client: AdvancedIMessage,
   pollCache: PollCache,
-  event: VotedPollEvent
+  event: VotedPollEvent | UnvotedPollEvent
 ): Promise<CachedPoll | undefined> => {
   const info = await fetchPollInfo(client, pollCache, event);
   if (!info) {
@@ -188,109 +152,41 @@ const refreshPollMetadata = async (
   return pollCache.get(info.pollMessageGuid);
 };
 
-const toPollVoteMessages = async (
+const toPollOptionMessage = async (
   client: AdvancedIMessage,
   pollCache: PollCache,
-  event: VotedPollEvent,
+  event: VotedPollEvent | UnvotedPollEvent,
   phone: string
 ): Promise<IMessageMessage[]> => {
   const senderAddress = event.actor?.address;
-  if (!senderAddress) {
+  const optionId = event.delta.optionIdentifier;
+  if (!(senderAddress && optionId)) {
     return [];
   }
-  const pollId = event.pollMessageGuid;
-  if (
-    pollCache.isStaleActorSelectionEvent(
-      pollId,
-      senderAddress,
-      event.occurredAt
-    )
-  ) {
-    return [];
-  }
-  const cached = await resolvePoll(client, pollCache, event);
+
+  let cached = await resolvePoll(client, pollCache, event);
   if (!cached) {
     return [];
   }
-  const chatGuidStr = event.chatGuid;
-  const currentOptionIds = [event.delta.optionIdentifier];
-  let resolvedPoll = cached;
 
-  if (
-    currentOptionIds.some(
-      (optionId) => !resolvedPoll.optionsByIdentifier.has(optionId)
-    )
-  ) {
-    const snapshot = await refreshPollMetadata(client, pollCache, event);
-    if (snapshot) {
-      resolvedPoll = snapshot;
+  if (!cached.optionsByIdentifier.has(optionId)) {
+    const refreshed = await refreshPollMetadata(client, pollCache, event);
+    if (refreshed) {
+      cached = refreshed;
     }
   }
 
-  if (!allOptionIdsKnown(resolvedPoll, currentOptionIds)) {
-    return [];
-  }
-
-  const deltas = pollCache.actorSelectionDeltas(
-    pollId,
-    senderAddress,
-    currentOptionIds
-  );
-  const messages = buildPollOptionMessages({
-    cached: resolvedPoll,
-    chatGuid: chatGuidStr,
-    deltas,
-    event,
-    phone,
-    senderAddress,
-  });
-
-  pollCache.commitActorSelection(
-    pollId,
-    senderAddress,
-    currentOptionIds,
-    event.occurredAt
-  );
-
-  return messages;
-};
-
-const toPollUnvoteMessages = async (
-  client: AdvancedIMessage,
-  pollCache: PollCache,
-  event: UnvotedPollEvent,
-  phone: string
-): Promise<IMessageMessage[]> => {
-  const senderAddress = event.actor?.address;
-  if (!senderAddress) {
-    return [];
-  }
-  const pollId = event.pollMessageGuid;
-  if (
-    pollCache.isStaleActorSelectionEvent(
-      pollId,
-      senderAddress,
-      event.occurredAt
-    )
-  ) {
-    return [];
-  }
-  const cached = await resolvePoll(client, pollCache, event);
-  if (!cached) {
-    return [];
-  }
-  const chatGuidStr = event.chatGuid;
-  const deltas = pollCache.clearedActorSelectionDeltas(pollId, senderAddress);
-  const messages = buildPollOptionMessages({
+  const message = buildPollOptionMessage({
     cached,
-    chatGuid: chatGuidStr,
-    deltas,
+    chatGuid: event.chatGuid,
     event,
+    optionId,
     phone,
+    selected: event.delta.type === "voted",
     senderAddress,
   });
-  pollCache.commitActorSelection(pollId, senderAddress, [], event.occurredAt);
-  return messages;
+
+  return message ? [message] : [];
 };
 
 export const toPollDeltaMessages = async (
@@ -300,10 +196,10 @@ export const toPollDeltaMessages = async (
   phone: string
 ): Promise<IMessageMessage[]> => {
   if (isVotedPollEvent(event)) {
-    return toPollVoteMessages(client, pollCache, event, phone);
+    return toPollOptionMessage(client, pollCache, event, phone);
   }
   if (isUnvotedPollEvent(event)) {
-    return toPollUnvoteMessages(client, pollCache, event, phone);
+    return toPollOptionMessage(client, pollCache, event, phone);
   }
   return [];
 };

--- a/packages/spectrum-ts/src/providers/imessage/remote/stream.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/stream.ts
@@ -39,12 +39,13 @@ const isRetryableIMessageStreamError = (error: unknown): boolean => {
 };
 
 const isEventFromCurrentAccount = (
-  event: Pick<MessageEvent | PollEvent, "actor">,
+  event: Pick<MessageEvent | PollEvent, "actor" | "isFromMe">,
   phone: string
 ): boolean =>
-  phone !== SHARED_PHONE &&
-  event.actor?.address !== undefined &&
-  event.actor.address === phone;
+  event.isFromMe ||
+  (phone !== SHARED_PHONE &&
+    event.actor?.address !== undefined &&
+    event.actor.address === phone);
 
 const toMessageItem = async (
   client: AdvancedIMessage,


### PR DESCRIPTION
## Summary
- upgrade @photon-ai/advanced-imessage to the SDK version that exposes optionIdentifier on unvoted poll deltas
- remove local poll selection snapshot diffing and map voted/unvoted deltas directly to poll_option messages
- use event isFromMe when filtering current-account poll and reaction events
- import Bun file APIs explicitly in the package preparation script so repository checks pass on current main

## Validation
- bun install --frozen-lockfile
- bun run check
- bun run build
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to patch versions for enhanced stability.
  * Refactored internal poll and event handling mechanisms for improved performance and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->