### PR TITLE
feat(spectrum-ts): export SDK_NAME and SDK_HOMEPAGE identity constants

### DIFF
--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -45,6 +45,7 @@ export type {
   PlatformUser,
   SchemaMessage,
 } from "./platform/types";
+export { SDK_HOMEPAGE, SDK_NAME } from "./sdk-info";
 export { Spectrum, type SpectrumInstance } from "./spectrum";
 export type { Message } from "./types/message";
 export type { Space } from "./types/space";

--- a/packages/spectrum-ts/src/sdk-info.ts
+++ b/packages/spectrum-ts/src/sdk-info.ts
@@ -1,0 +1,17 @@
+/**
+ * Static SDK identity constants. Useful for log lines, telemetry tags,
+ * and diagnostic dumps when multiple SDK versions or processes might be
+ * running side by side and the operator needs to confirm which build
+ * produced a particular event.
+ *
+ * Kept deliberately minimal — anything that varies per build (the
+ * `version`) should be sourced from `package.json` at the call site
+ * rather than baked in here, to avoid drift between this file and the
+ * published package metadata.
+ */
+
+/** The published npm package name for this SDK. */
+export const SDK_NAME = "spectrum-ts" as const;
+
+/** The canonical homepage / source URL for this SDK. */
+export const SDK_HOMEPAGE = "https://github.com/photon-hq/spectrum-ts" as const;


### PR DESCRIPTION
## Summary

Single additive change: new `src/sdk-info` module re-exported from the package root with two static identity constants.

```ts
import { SDK_NAME, SDK_HOMEPAGE } from "spectrum-ts";
console.log(`${SDK_NAME} (${SDK_HOMEPAGE})`);
```

Useful for log lines, telemetry tags, and diagnostic dumps when multiple SDK versions or processes might be running side by side and the operator needs to confirm which build produced a particular event. Additive, no breaking changes. Version-specific data is deliberately NOT included — the SDK version string lives in `package.json` and should be sourced from there at the call site to avoid drift.

## Note: release-workflow change moved elsewhere

An earlier revision of this PR also flipped `release.yaml` to point at `photon-hq/buildspace-private/typescript-service-release.yaml` to pick up the notify-on-release job. That doesn't work — GitHub blocks PUBLIC → INTERNAL reusable-workflow `uses:` at the platform level.

The notify job is now being added to the PUBLIC `photon-hq/buildspace/typescript-service-release.yaml` instead, in **photon-hq/buildspace#76**. After that PR merges, this repo's existing `uses: photon-hq/buildspace/...@main` automatically picks up the notify pipeline on the next major/minor release with no further change here.

So this PR is now purely the SDK exports; the workflow file is untouched.

## What happens after BOTH this PR and buildspace#76 merge

1. `release-info` runs the AI to compute version + notes → expected `minor` → 1.9.2 → **1.10.0**
2. `bump-version` commits the package.json bump to main
3. `github-release` creates the v1.10.0 tag + GitHub release
4. `npm-publish` ships `spectrum-ts@1.10.0` to npm
5. **new `notify` job** (from buildspace#76):
   - joins tailnet as `tag:ci`
   - POSTs to `http://email-monkey/notify-release` (staging)
   - email-monkey reconciles dashboard users into the Resend audience (~18 desired:true accounts) and broadcasts

## Test plan / how to verify

- [ ] Merge **photon-hq/buildspace#76** first
- [ ] Merge this PR (requires the `release` label, already set)
- [ ] Watch the `release` workflow; should now run 5 jobs (added `notify` at the end)
- [ ] After `notify` completes, check:
  - **GitHub**: `gh api repos/photon-hq/spectrum-ts/git/refs/tags/emailed-v1.10.0` returns 200 (marker tag claimed by email-monkey)
  - **Resend dashboard** → Broadcasts → `spectrum-ts v1.10.0` exists with status `delivering` or `sent`
  - **Inbox**: yan@photon.codes, ryan@photon.codes, yanyam.xue@gmail.com (+ 15 others) receive the broadcast