### PR TITLE
feat: add `message.actions` and iMessage `message.read()` sugar

### DIFF
--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -67,8 +67,29 @@ const RESERVED_SPACE_KEYS: ReadonlySet<string> = new Set([
   "responding",
 ]);
 
-const warnReservedAction = (name: string, platform: string) => {
-  const body = `[spectrum-ts] ${platform} declared space action "${name}" which collides with a reserved Space key; skipping.`;
+// Reserved keys on `Message` — platform-defined `message.actions` entries
+// with these names are skipped at runtime (with a warning) so the universal
+// sugar (`react`, `reply`, `edit`, …) always wins. The same names are
+// excluded from `MessageActionMethods<Def>` at the type level.
+const RESERVED_MESSAGE_KEYS: ReadonlySet<string> = new Set([
+  "content",
+  "direction",
+  "edit",
+  "id",
+  "platform",
+  "react",
+  "reply",
+  "sender",
+  "space",
+  "timestamp",
+]);
+
+const warnReservedAction = (
+  scope: "space" | "message",
+  name: string,
+  platform: string
+) => {
+  const body = `[spectrum-ts] ${platform} declared ${scope} action "${name}" which collides with a reserved ${scope === "space" ? "Space" : "Message"} key; skipping.`;
   console.warn(
     supportsAnsiColor() ? `${ANSI_YELLOW}${body}${ANSI_RESET}` : body
   );
@@ -479,7 +500,7 @@ export function buildSpace(params: BuildSpaceParams): Space {
   if (declaredActions) {
     for (const [name, factory] of Object.entries(declaredActions)) {
       if (RESERVED_SPACE_KEYS.has(name)) {
-        warnReservedAction(name, definition.name);
+        warnReservedAction("space", name, definition.name);
         continue;
       }
       platformActions[name] = (...args: unknown[]) =>
@@ -540,7 +561,7 @@ export function buildMessage(params: BuildMessageParams): Message {
     await space.send(reactionContent(emoji, target));
   };
 
-  const requireBuiltMessage = (action: "react" | "reply" | "edit"): Message => {
+  const requireBuiltMessage = (action: string): Message => {
     if (!self) {
       throw new Error(
         `${action}() called before message construction completed (internal bug)`
@@ -578,9 +599,44 @@ export function buildMessage(params: BuildMessageParams): Message {
       ? undefined
       : { ...params.sender, __platform: definition.name };
 
+  // Platform-defined sugar methods declared via `PlatformDef.message.actions`.
+  // Each factory takes `self` as its first argument; the wrapper supplies
+  // `self` lazily (via `requireBuiltMessage`) so it sees the constructed
+  // object, then calls `space.send(factory(self, ...args))`. Spread order
+  // below mirrors `buildSpace` — actions go *before* the hardcoded universal
+  // sugar (`react`, `reply`, `edit`) so a same-named action loses both at
+  // runtime and at the type level (via `Exclude<…, keyof Message>`).
+  const messagePlatformActions: Record<
+    string,
+    (...args: unknown[]) => Promise<void>
+  > = {};
+  const declaredMessageActions = (
+    definition.message as
+      | {
+          actions?: Record<
+            string,
+            (message: Message, ...args: unknown[]) => ContentBuilder
+          >;
+        }
+      | undefined
+  )?.actions;
+  if (declaredMessageActions) {
+    for (const [name, factory] of Object.entries(declaredMessageActions)) {
+      if (RESERVED_MESSAGE_KEYS.has(name)) {
+        warnReservedAction("message", name, definition.name);
+        continue;
+      }
+      messagePlatformActions[name] = async (...args: unknown[]) => {
+        const target = requireBuiltMessage(name);
+        await space.send(factory(target, ...args));
+      };
+    }
+  }
+
   if (params.direction === "outbound") {
     const outbound = {
       ...params.extras,
+      ...messagePlatformActions,
       id: params.id,
       content: params.content,
       direction: "outbound",
@@ -604,6 +660,7 @@ export function buildMessage(params: BuildMessageParams): Message {
 
   const inbound = {
     ...params.extras,
+    ...messagePlatformActions,
     id: params.id,
     content: params.content,
     direction: "inbound",

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -10,6 +10,7 @@ import type {
   CreateClientContext,
   EventProducer,
   InboundPlatformMessage,
+  MessageActionFactory,
   Platform,
   PlatformDef,
   PlatformInstance,
@@ -19,6 +20,7 @@ import type {
   PlatformSpace,
   PlatformUser,
   ProviderMessage,
+  SpaceActionFactory,
   SpectrumLike,
 } from "./types";
 
@@ -251,6 +253,14 @@ export function definePlatform<
       > & { messages?: never })
     | undefined = undefined,
   _Static extends Record<string, unknown> = Record<never, never>,
+  _SpaceActions extends Record<string, SpaceActionFactory> = Record<
+    never,
+    never
+  >,
+  _MessageActions extends Record<string, MessageActionFactory> = Record<
+    never,
+    never
+  >,
 >(
   name: _Name,
   def: {
@@ -275,7 +285,9 @@ export function definePlatform<
       _ResolvedSpace,
       _MessageSchema,
       _MessageType,
-      _Events
+      _Events,
+      _SpaceActions,
+      _MessageActions
     >,
     "lifecycle" | "name"
   > & { static?: _Static }
@@ -291,7 +303,9 @@ export function definePlatform<
     _ResolvedSpace,
     _MessageSchema,
     _MessageType,
-    _Events
+    _Events,
+    _SpaceActions,
+    _MessageActions
   >
 > &
   Readonly<_Static> {
@@ -306,7 +320,9 @@ export function definePlatform<
     _ResolvedSpace,
     _MessageSchema,
     _MessageType,
-    _Events
+    _Events,
+    _SpaceActions,
+    _MessageActions
   >;
 
   const fullDef = { name, ...def };

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -23,6 +23,23 @@ import type { ManagedStream } from "../utils/stream";
  */
 export type SpaceActionFactory = (...args: never[]) => ContentBuilder;
 
+/**
+ * A platform-defined sugar method on `Message`. The first parameter is bound
+ * to the message itself (`self`) at build time, so callers only pass the
+ * trailing args. The runtime injects a thin wrapper that calls
+ * `space.send(factory(self, ...args))` — actions are fire-and-forget and
+ * return `Promise<void>`.
+ *
+ * Names that collide with reserved `Message` keys (`react`, `reply`, `edit`,
+ * `id`, `space`, `sender`, `content`, `platform`, `direction`, `timestamp`)
+ * are skipped at runtime with a warning and excluded at the type level via
+ * `Exclude<…, keyof Message>`.
+ */
+export type MessageActionFactory = (
+  message: Message,
+  ...args: never[]
+) => ContentBuilder;
+
 type ResolvedSpace = Pick<Space, "id">;
 type SpaceRef = Pick<Space, "id" | "__platform">;
 type ResolvedUser = Pick<User, "id">;
@@ -165,6 +182,14 @@ export interface PlatformDef<
         EventProducer<unknown, _Client, z.infer<_ConfigSchema>>
       > & { messages?: never })
     | undefined = undefined,
+  _SpaceActions extends Record<string, SpaceActionFactory> = Record<
+    never,
+    never
+  >,
+  _MessageActions extends Record<string, MessageActionFactory> = Record<
+    never,
+    never
+  >,
 > {
   /**
    * Optional escape hatch: platform actions beyond `send`. Currently the
@@ -213,6 +238,26 @@ export interface PlatformDef<
 
   message?: {
     schema?: _MessageSchema;
+    /**
+     * Optional platform-specific sugar methods bound to `PlatformMessage<Def>`.
+     *
+     * Each entry is a `ContentBuilder` factory whose **first parameter** is
+     * the message itself (`self`); `buildMessage` injects a thin wrapper
+     * that supplies `self` and calls `space.send(factory(self, ...args))`.
+     * The wrapper is typed as `(...args) => Promise<void>` on
+     * `PlatformMessage<Def>` via `MessageActionMethods<Def>`.
+     *
+     * Mirrors `space.actions` — `space.actions` lives on the space slot for
+     * chat-level sugar (e.g. `space.background(...)`); `message.actions`
+     * lives here for per-message sugar that needs `self` (e.g.
+     * `message.read()`).
+     *
+     * Names that collide with reserved `Message` keys (`react`, `reply`,
+     * `edit`, `id`, `space`, `sender`, `content`, `platform`, `direction`,
+     * `timestamp`) are skipped at runtime with a warning and excluded at
+     * the type level.
+     */
+    actions?: _MessageActions;
   };
 
   /**
@@ -277,7 +322,7 @@ export interface PlatformDef<
      * `__platform`) are skipped at runtime with a warning and excluded at
      * the type level.
      */
-    actions?: Record<string, SpaceActionFactory>;
+    actions?: _SpaceActions;
   };
 
   user: {
@@ -313,7 +358,10 @@ export interface AnyPlatformDef {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard lifecycle
     destroyClient?: (ctx: any) => Promise<void>;
   };
-  message?: { schema?: z.ZodType<object> };
+  message?: {
+    schema?: z.ZodType<object>;
+    actions?: Record<string, MessageActionFactory>;
+  };
 
   // Required core message I/O — the universal contract.
   // biome-ignore lint/suspicious/noExplicitAny: wildcard event
@@ -507,6 +555,37 @@ export type SpaceActionMethods<Def extends AnyPlatformDef> = {
   ) => Promise<OutboundMessage | undefined>;
 };
 
+// Methods derived from `PlatformDef.message.actions`. Each factory's first
+// parameter is bound to the message itself at build time, so the public
+// surface drops it. Reserved `Message` keys (`react`, `reply`, `edit`, …)
+// are filtered out so universal sugar always wins.
+// `NonNullable<Def["message"]>` strips the `undefined` introduced by the
+// optional `message?:` slot — without it, the outer conditional
+// (`Def["message"] extends { actions?: infer A }`) fails because `undefined`
+// is not assignable to `{ actions?: … }`, and the whole type collapses to
+// the empty fallback, losing every declared action.
+type MessageActionFactories<Def extends AnyPlatformDef> =
+  NonNullable<Def["message"]> extends {
+    actions?: infer A;
+  }
+    ? A extends Record<string, MessageActionFactory>
+      ? A
+      : Record<string, never>
+    : Record<string, never>;
+
+type TailArgs<T extends readonly unknown[]> = T extends readonly [
+  unknown,
+  ...infer Rest,
+]
+  ? Rest
+  : [];
+
+export type MessageActionMethods<Def extends AnyPlatformDef> = {
+  [K in Exclude<keyof MessageActionFactories<Def>, keyof Message>]: (
+    ...args: TailArgs<Parameters<MessageActionFactories<Def>[K]>>
+  ) => Promise<void>;
+};
+
 // Both `keyof Space` and `keyof SpaceActionMethods<Def>` are removed from the
 // schema shape before merging — at runtime `buildSpace` spreads
 // `platformActions` after `extras`/`spaceRef`, so an action with the same
@@ -519,17 +598,24 @@ export type PlatformSpace<Def extends AnyPlatformDef> = Omit<
   Space &
   SpaceActionMethods<Def>;
 
+// Both `keyof Message` and `keyof MessageActionMethods<Def>` are removed from
+// the schema shape before merging — at runtime `buildMessage` spreads
+// `platformActions` after `extras`, so an action with the same name as a
+// schema field overrides the field. Stripping both at the type level mirrors
+// that and avoids an impossible `field & method` intersection.
 export type PlatformMessage<Def extends AnyPlatformDef> = Omit<
   SchemaInfer<Def["message"]>,
-  keyof Message
+  keyof Message | keyof MessageActionMethods<Def>
 > &
-  Message<Def["name"], PlatformUser<Def>, PlatformSpace<Def>>;
+  Message<Def["name"], PlatformUser<Def>, PlatformSpace<Def>> &
+  MessageActionMethods<Def>;
 
 export type InboundPlatformMessage<Def extends AnyPlatformDef> = Omit<
   SchemaInfer<Def["message"]>,
-  keyof InboundMessage
+  keyof InboundMessage | keyof MessageActionMethods<Def>
 > &
-  InboundMessage<Def["name"], PlatformUser<Def>, PlatformSpace<Def>>;
+  InboundMessage<Def["name"], PlatformUser<Def>, PlatformSpace<Def>> &
+  MessageActionMethods<Def>;
 
 export type PlatformUser<Def extends AnyPlatformDef> = Omit<
   ResolvedUserOf<Def>,

--- a/packages/spectrum-ts/src/providers/imessage/content/read.ts
+++ b/packages/spectrum-ts/src/providers/imessage/content/read.ts
@@ -1,0 +1,64 @@
+import z from "zod";
+import type { Content, ContentBuilder } from "../../../content/types";
+import type { Message } from "../../../types/message";
+
+const isMessage = (v: unknown): v is Message =>
+  typeof v === "object" && v !== null && "id" in v && "content" in v;
+
+/**
+ * iMessage-only "mark as read" content. Lives entirely under the iMessage
+ * provider — never enters the universal `Content` discriminated union. The
+ * framework recognizes it via two generic content-level contracts:
+ *
+ * 1. `__platform: "iMessage"` — `findUnsupportedPlatformContent` reads this
+ *    tag and warns-and-skips when a different platform receives it.
+ * 2. `__fireAndForget: true` — `dispatchSend`'s fire-and-forget check treats
+ *    this as a side-effecting send that returns no message id, the same way
+ *    it treats `reaction` / `typing` / `edit` / `background`.
+ *
+ * iMessage's `send` handler narrows back to `Read` via the `isRead` type
+ * guard before dispatching to `chats.markRead`.
+ */
+export const readSchema = z.object({
+  type: z.literal("read"),
+  __platform: z.literal("iMessage"),
+  __fireAndForget: z.literal(true),
+  target: z.custom<Message>(isMessage, {
+    message: "read target must be a Message",
+  }),
+});
+
+export type Read = z.infer<typeof readSchema>;
+
+export const isRead = (v: unknown): v is Read =>
+  readSchema.safeParse(v).success;
+
+/**
+ * Mark the chat containing `target` as read. iMessage-only, remote-only.
+ *
+ * Implemented via `chats.markRead(chatGuid)`, which marks **every unread
+ * message in the chat** as read — there is no per-message read receipt in
+ * the SDK. `target` is used only to identify the chat (and to give
+ * `message.read()` something to pass), so passing any message from a chat
+ * marks the whole chat as read.
+ *
+ * `space.send(read(message))` is the canonical form; `space.read(message)`
+ * and `message.read()` are sugar attached via the iMessage platform's
+ * `space.actions` / `message.actions` slots.
+ *
+ * `Read` is intentionally not a member of the universal `Content` union —
+ * the `as unknown as Content` cast keeps the builder shape compatible with
+ * the framework's `ContentBuilder.build(): Promise<Content>` signature. The
+ * framework treats it as a fire-and-forget control signal at runtime.
+ */
+export function read(target: Message): ContentBuilder {
+  return {
+    build: async () =>
+      readSchema.parse({
+        type: "read",
+        __platform: "iMessage",
+        __fireAndForget: true,
+        target,
+      }) as unknown as Content,
+  };
+}

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -7,6 +7,7 @@ import { UnsupportedError } from "../../utils/errors";
 // biome-ignore lint/performance/noBarrelFile: provider entrypoint exports its public helpers
 export { type BackgroundInput, background } from "./content/background";
 export { effect, type IMessageMessageEffect } from "./content/effect";
+export { read } from "./content/read";
 
 import { createCloudClients, disposeCloudAuth } from "./auth";
 import {
@@ -14,6 +15,7 @@ import {
   background as backgroundContent,
   isBackground,
 } from "./content/background";
+import { isRead, read as readContent } from "./content/read";
 import {
   getMessage as localGetMessage,
   messages as localMessages,
@@ -22,6 +24,7 @@ import {
 import {
   editMessage as remoteEditMessage,
   getMessage as remoteGetMessage,
+  markRead as remoteMarkRead,
   messages as remoteMessages,
   reactToMessage as remoteReactToMessage,
   replyToMessage as remoteReplyToMessage,
@@ -81,6 +84,21 @@ const handleBackground = async (
   }
   const remote = clientForPhone(client, space.phone);
   await remoteSetBackground(remote, space.id, content);
+};
+
+const handleRead = async (
+  client: IMessageClient,
+  space: { id: string; phone: string }
+): Promise<void> => {
+  if (isLocal(client)) {
+    throw UnsupportedError.action(
+      "read",
+      "iMessage (local mode)",
+      "marking chats as read requires remote iMessage"
+    );
+  }
+  const remote = clientForPhone(client, space.phone);
+  await remoteMarkRead(remote, space.id);
 };
 
 export const imessage = definePlatform("iMessage", {
@@ -185,11 +203,20 @@ export const imessage = definePlatform("iMessage", {
       // send pipeline so the unsupported-content + warn-and-skip path on
       // local-mode iMessage is identical to the canonical form.
       background: backgroundContent,
+      // Sugar: `space.read(message)` → `space.send(read(message))`. Same
+      // routing as `background` — the canonical form is the long-form
+      // `space.send(read(message))`.
+      read: readContent,
     },
   },
 
   message: {
     schema: messageSchema,
+    actions: {
+      // Sugar: `message.read()` → `space.send(read(self))`. `buildMessage`
+      // injects `self` as the first argument; callers pass nothing.
+      read: readContent,
+    },
   },
 
   messages: ({ client }) =>
@@ -256,12 +283,16 @@ export const imessage = definePlatform("iMessage", {
       await handleEdit(client, space, content);
       return;
     }
-    // `Background` is iMessage-only and lives outside the universal `Content`
-    // union — narrow via the runtime guard rather than a `content.type ===`
-    // check (which would not typecheck since `"background"` isn't a member
-    // of `Content["type"]`).
+    // `Background` and `Read` are iMessage-only and live outside the
+    // universal `Content` union — narrow via runtime guards rather than
+    // `content.type ===` checks (those literals aren't members of
+    // `Content["type"]`).
     if (isBackground(content)) {
       await handleBackground(client, space, content);
+      return;
+    }
+    if (isRead(content)) {
+      await handleRead(client, space);
       return;
     }
     if (isLocal(client)) {

--- a/packages/spectrum-ts/src/providers/imessage/remote/api.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/api.ts
@@ -7,6 +7,7 @@ import type { IMessageMessage, RemoteClient } from "../types";
 import { setBackground as setRemoteBackground } from "./background";
 import { getMessage as getRemoteMessage } from "./inbound";
 import { reactToMessage as reactToRemoteMessage } from "./reactions";
+import { markRead as markRemoteRead } from "./read";
 import {
   editMessage as editRemoteMessage,
   replyToMessage as replyToRemoteMessage,
@@ -27,6 +28,13 @@ export const setBackground = async (
   spaceId: string,
   content: Background
 ): Promise<void> => setRemoteBackground(remote, spaceId, content);
+
+export const markRead = async (
+  remote: AdvancedIMessage,
+  spaceId: string
+): Promise<void> => {
+  await markRemoteRead(remote, spaceId);
+};
 
 export const startTyping = async (
   remote: AdvancedIMessage,

--- a/packages/spectrum-ts/src/providers/imessage/remote/read.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/read.ts
@@ -1,0 +1,17 @@
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import { toChatGuid } from "./ids";
+
+/**
+ * Mark every unread message in the chat as read.
+ *
+ * The SDK exposes only a chat-level `chats.markRead(chatGuid)` — there is no
+ * per-message API. The `Read` content's `target` is used by the caller to
+ * derive the chat, which `send` has already resolved into `spaceId` by the
+ * time the dispatcher reaches here.
+ */
+export const markRead = async (
+  remote: AdvancedIMessage,
+  spaceId: string
+): Promise<void> => {
+  await remote.chats.markRead(toChatGuid(spaceId));
+};


### PR DESCRIPTION
## Summary

- Adds a new `message.actions` slot to `PlatformDef`, mirroring the existing `space.actions` slot but bound to a `Message` (`self`). Platforms can now declare per-message sugar that compiles down to `space.send(factory(self, ...args))`.
- Adds an iMessage-only `read` content + `chats.markRead` handler, surfaced as both `space.read(message)` and `message.read()` sugar (and `space.send(read(message))` as the canonical form).
- Local-mode iMessage rejects `read` with `UnsupportedError` — marking chats as read requires the remote gRPC client.

## Usage

```ts
import { Spectrum } from "spectrum-ts";
import { imessage } from "spectrum-ts/providers/imessage";

const app = await Spectrum({
  projectId: process.env.PROJECT_ID,
  projectSecret: process.env.PROJECT_SECRET,
  providers: [imessage.config()],
});

for await (const [space, message] of app.messages) {
  if (message.direction === "inbound") {
    // Per-message sugar — first arg is bound to `self`.
    await message.read();

    // Equivalent canonical forms:
    // await space.read(message);
    // await space.send(read(message));
  }
}
```

`chats.markRead` is chat-level — every unread message in the chat is marked read. The `target` is used only to identify the chat.

## Changes

| File | Change |
|------|--------|
| `platform/types.ts` | New `MessageActionFactory` type, `_MessageActions` generic on `PlatformDef`, `MessageActionMethods<Def>` derivation, `PlatformMessage` / `InboundPlatformMessage` extended with action methods (and reserved `Message` keys stripped from the schema shape). |
| `platform/define.ts` | New `_SpaceActions` / `_MessageActions` generics threaded into `definePlatform`, so per-platform action factories keep precise types. |
| `platform/build.ts` | `buildMessage` now resolves `definition.message.actions`, wraps each factory with `self`-injection (`requireBuiltMessage`), and spreads `messagePlatformActions` before the universal sugar (`react` / `reply` / `edit`) for both inbound and outbound paths. New `RESERVED_MESSAGE_KEYS` warns-and-skips collisions. `warnReservedAction` now takes a `scope` arg shared with `buildSpace`. |
| `providers/imessage/content/read.ts` | New `Read` content type (`__platform: "iMessage"`, `__fireAndForget: true`) and `read(target)` builder. Lives outside the universal `Content` union; framework routes it via the existing platform-tag + fire-and-forget checks. |
| `providers/imessage/remote/read.ts` | New `markRead(remote, spaceId)` wrapping `chats.markRead(toChatGuid(spaceId))`. |
| `providers/imessage/remote/api.ts` | Re-exports `markRead`. |
| `providers/imessage/index.ts` | Wires `read` into the iMessage platform: exports the builder, adds `handleRead` (rejects on local mode), routes `isRead(content)` in the `send` switch, and declares `space.actions.read` + `message.actions.read` sugar. |

## Test plan

- [ ] `bun x ultracite check` passes
- [ ] `tsc --noEmit` passes (verifies `MessageActionMethods<Def>` type inference)
- [ ] Smoke test against remote iMessage: `message.read()` on an inbound message marks the chat as read on-device
- [ ] Smoke test against remote iMessage: `space.read(message)` behaves identically
- [ ] Smoke test against remote iMessage: `space.send(read(message))` behaves identically
- [ ] Local-mode iMessage: calling `message.read()` throws `UnsupportedError`
- [ ] Cross-platform: sending `read(message)` to a non-iMessage space warns-and-skips (existing `findUnsupportedPlatformContent` path)
- [ ] Reserved-key collision: a platform declaring `message.actions.reply` emits a warning at build time and the universal `reply` wins

Linear: [ENG-1461](https://linear.app/photon-codes/issue/ENG-1461)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782081559&installation_id=127326493&pr_number=70&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F70&signature=65ec53d823d687f8ad65c8b5bbcebf833f57c12f3b91b3de552dddf7007ee0cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message-scoped actions framework, enabling platform-specific operations on messages.
  * iMessage users can now mark messages as read through the new message actions interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->