### PR TITLE
ci: trigger spectrum-webhook Renovate on spectrum-ts release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,3 +18,43 @@ jobs:
       publish-command: "bunx clean-publish --package-manager npm"
       dry-run: false
     secrets: inherit
+
+  # After a real publish (release-labelled PR), poke spectrum-webhook's
+  # self-hosted Renovate so it picks up the new spectrum-ts version within
+  # seconds instead of waiting for its hourly cron. Runs after `release`
+  # completes, so npm already has the new version by the time Renovate looks.
+  bump-webhook:
+    needs: release
+    if: needs.release.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Was this a publish? (check the merged PR's release label)
+        id: labels
+        uses: photon-hq/buildspace/.github/blocks/check-pr-label@main
+        with:
+          labels: '["release"]'
+
+      # repository_dispatch to another repo needs a token with contents:write on
+      # the target; the default GITHUB_TOKEN can't reach spectrum-webhook.
+      - name: Generate App token for spectrum-webhook
+        if: fromJSON(steps.labels.outputs.labels).release
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: photon-hq
+          repositories: spectrum-webhook
+
+      - name: Dispatch Renovate run on spectrum-webhook
+        if: fromJSON(steps.labels.outputs.labels).release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/photon-hq/spectrum-webhook/dispatches \
+            --method POST \
+            -f event_type=spectrum-ts-released
+          echo "Dispatched spectrum-ts-released -> photon-hq/spectrum-webhook"


### PR DESCRIPTION
## What

When `spectrum-ts` publishes a new version, automatically trigger `spectrum-webhook`'s self-hosted Renovate so the bump (and prod deploy) happens within seconds instead of waiting on the hourly cron.

## How

Adds a `bump-webhook` job to the release workflow that:
1. Runs **after** the `release` job finishes (so npm already has the new version — no race with `npm-publish`).
2. Confirms a real publish happened via the merged PR's `release` label (same gate the publish itself uses), so it does **not** fire on ordinary pushes to `main`.
3. Mints a Photon Action Bot token scoped to `spectrum-webhook` and sends a `repository_dispatch` (`event_type: spectrum-ts-released`).

`spectrum-webhook`'s Renovate workflow already listens for that event (`repository_dispatch: [spectrum-ts-released]`), so it runs immediately, opens the pinned `spectrum-ts` bump, automerges it, and ships to prod.

## Depends on
- `photon-hq/spectrum-webhook` PR #10 (the self-hosted Renovate workflow that handles the dispatch). Merge that first.

## Prereq
- Photon Action Bot needs **contents: write** on `spectrum-webhook` (required for cross-repo `repository_dispatch`) — the same permission PR #10 needs.

## Note
Fires only on a `release`-labelled merge; non-release pushes run the cheap label-check step and stop. The hourly cron in spectrum-webhook remains as a fallback if a dispatch is ever missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782086489&installation_id=127326493&pr_number=72&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F72&signature=394e0b1de0599fc8ed5d8ad89614cde2d47565c3a16ffb9dce06db4b7ef33c0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->