### PR TITLE
refactor(spectrum-ts): unify Message type and switch platform actions to async fns

### DIFF
--- a/packages/spectrum-ts/src/content/edit.ts
+++ b/packages/spectrum-ts/src/content/edit.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import type { Message, OutboundMessage } from "../types/message";
+import type { Message } from "../types/message";
 import { resolveContents } from "./resolve";
 import type { BaseContent, ContentBuilder, ContentInput } from "./types";
 
@@ -48,17 +48,18 @@ export const asEdit = (input: {
 /**
  * Construct an `edit` content value rewriting `target`'s content.
  *
- * `target` is typed as `OutboundMessage` because only messages you sent can
- * be edited; the schema field stays loose at `Message` (matching
- * reply/reaction) so providers receive the same shape regardless of
- * direction.
+ * Only outbound messages (those sent by the agent) can be edited; calling
+ * this with an inbound target throws at build time so the misuse surfaces
+ * before the send pipeline runs.
  */
-export function edit(
-  content: ContentInput,
-  target: OutboundMessage
-): ContentBuilder {
+export function edit(content: ContentInput, target: Message): ContentBuilder {
   return {
     build: async () => {
+      if (target.direction !== "outbound") {
+        throw new Error(
+          `edit() target must be an outbound message (got direction "${target.direction}", message id "${target.id}")`
+        );
+      }
       const [resolved] = await resolveContents([content]);
       if (!resolved) {
         throw new Error("edit() requires content");

--- a/packages/spectrum-ts/src/content/reaction.ts
+++ b/packages/spectrum-ts/src/content/reaction.ts
@@ -24,8 +24,8 @@ export const asReaction = (input: {
  * Construct a `reaction` content value targeting the given message.
  *
  * `space.send(reaction(emoji, message))` is sugar for `message.react(emoji)`.
- * Reactions are fire-and-forget — the returned `OutboundMessage` will be
- * `undefined` because platforms do not surface a message id for reactions.
+ * Reactions are fire-and-forget — the returned `Message` will be `undefined`
+ * because platforms do not surface a message id for reactions.
  *
  * To react to a message known only by id, resolve it first via
  * `space.getMessage(id)`.

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -34,7 +34,6 @@ export { definePlatform } from "./platform/define";
 export type {
   AnyPlatformDef,
   EventProducer,
-  InboundPlatformMessage,
   Platform,
   PlatformDef,
   PlatformInstance,
@@ -48,7 +47,7 @@ export type {
 export { Spectrum, type SpectrumInstance } from "./spectrum";
 export type { Message } from "./types/message";
 export type { Space } from "./types/space";
-export type { User } from "./types/user";
+export type { AgentSender, User } from "./types/user";
 export type {
   CloudPlatform,
   DedicatedTokenData,

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -5,12 +5,9 @@ import { reply as replyContent } from "../content/reply";
 import { resolveContents } from "../content/resolve";
 import type { Content, ContentBuilder, ContentInput } from "../content/types";
 import { typing as typingContent } from "../content/typing";
-import type {
-  InboundMessage,
-  Message,
-  OutboundMessage,
-} from "../types/message";
+import type { Message } from "../types/message";
 import type { Space } from "../types/space";
+import type { AgentSender } from "../types/user";
 import { UnsupportedError } from "../utils/errors";
 import type { Store } from "../utils/store";
 import { contentAttrs } from "../utils/telemetry";
@@ -257,16 +254,6 @@ const extractExtras = (
 export function wrapProviderMessage(
   raw: ProviderMessageRecord,
   ctx: WrapContext,
-  direction: "inbound"
-): InboundMessage;
-export function wrapProviderMessage(
-  raw: ProviderMessageRecord,
-  ctx: WrapContext,
-  direction: "outbound"
-): OutboundMessage;
-export function wrapProviderMessage(
-  raw: ProviderMessageRecord,
-  ctx: WrapContext,
   direction: "inbound" | "outbound"
 ): Message {
   const wrappedContent = wrapNestedContent(raw.content, ctx, direction);
@@ -369,7 +356,7 @@ export function buildSpace(params: BuildSpaceParams): Space {
 
   async function dispatchSend(
     item: Content
-  ): Promise<OutboundMessage | undefined> {
+  ): Promise<Message<string, AgentSender> | undefined> {
     return withSpan(
       "spectrum.message.send",
       {
@@ -414,16 +401,18 @@ export function buildSpace(params: BuildSpaceParams): Space {
           raw,
           { client, config, definition, space, spaceRef, store },
           "outbound"
-        );
+        ) as Message<string, AgentSender>;
       }
     );
   }
 
   async function sendImpl(
     ...content: [ContentInput, ...ContentInput[]]
-  ): Promise<OutboundMessage | OutboundMessage[] | undefined> {
+  ): Promise<
+    Message<string, AgentSender> | Message<string, AgentSender>[] | undefined
+  > {
     const resolved = await resolveContents(content);
-    const results: OutboundMessage[] = [];
+    const results: Message<string, AgentSender>[] = [];
     for (const item of resolved) {
       const sent = await dispatchSend(item);
       if (sent) {
@@ -490,7 +479,7 @@ export function buildSpace(params: BuildSpaceParams): Space {
   // `Exclude<…, keyof Space>` in `SpaceActionMethods`.
   const platformActions: Record<
     string,
-    (...args: unknown[]) => Promise<OutboundMessage | undefined>
+    (...args: unknown[]) => Promise<Message<string, AgentSender> | undefined>
   > = {};
   const declaredActions = (
     definition.space as {
@@ -513,12 +502,11 @@ export function buildSpace(params: BuildSpaceParams): Space {
     ...spaceRef,
     ...platformActions,
     send: sendImpl as Space["send"],
-    edit: async (
-      message: OutboundMessage,
-      newContent: ContentInput
-    ): Promise<void> => {
+    edit: async (message: Message, newContent: ContentInput): Promise<void> => {
       // Sugar for `space.send(edit(newContent, message))`. Edits are
-      // fire-and-forget; the (always-undefined) result is discarded.
+      // fire-and-forget; the (always-undefined) result is discarded. The
+      // `edit()` content builder enforces `direction === "outbound"` at the
+      // top, so invalid targets fail fast here too.
       await space.send(editContent(newContent, message));
     },
     getMessage: getMessageImpl,
@@ -543,23 +531,12 @@ export function buildSpace(params: BuildSpaceParams): Space {
   return space;
 }
 
-export function buildMessage(params: BuildInboundParams): InboundMessage;
-export function buildMessage(params: BuildOutboundParams): OutboundMessage;
 export function buildMessage(params: BuildMessageParams): Message {
   const { definition, space } = params;
 
   // Late-bound self reference so `react()` can pass the built Message as the
   // reaction target.
   let self: Message | undefined;
-
-  const react = async (emoji: string): Promise<void> => {
-    const target = requireBuiltMessage("react");
-    // Sugar for `space.send(reaction(emoji, target))`. The canonical form
-    // returns `OutboundMessage | undefined`; this surface discards it because
-    // reactions are fire-and-forget on most platforms (callers reach for the
-    // canonical form when they need the result).
-    await space.send(reactionContent(emoji, target));
-  };
 
   const requireBuiltMessage = (action: string): Message => {
     if (!self) {
@@ -570,15 +547,26 @@ export function buildMessage(params: BuildMessageParams): Message {
     return self;
   };
 
+  const react = async (emoji: string): Promise<void> => {
+    const target = requireBuiltMessage("react");
+    // Sugar for `space.send(reaction(emoji, target))`. The canonical form
+    // returns a `Message` (or `undefined`); this surface discards it because
+    // reactions are fire-and-forget on most platforms (callers reach for the
+    // canonical form when they need the result).
+    await space.send(reactionContent(emoji, target));
+  };
+
   async function reply(
     content: ContentInput
-  ): Promise<OutboundMessage | undefined>;
+  ): Promise<Message<string, AgentSender> | undefined>;
   async function reply(
     ...content: [ContentInput, ContentInput, ...ContentInput[]]
-  ): Promise<OutboundMessage[]>;
+  ): Promise<Message<string, AgentSender>[]>;
   async function reply(
     ...content: [ContentInput, ...ContentInput[]]
-  ): Promise<OutboundMessage | OutboundMessage[] | undefined> {
+  ): Promise<
+    Message<string, AgentSender> | Message<string, AgentSender>[] | undefined
+  > {
     const target = requireBuiltMessage("reply");
     const wrapped = content.map((c) => replyContent(c, target)) as [
       ContentInput,
@@ -590,14 +578,46 @@ export function buildMessage(params: BuildMessageParams): Message {
     return (
       space.send as (
         ...c: [ContentInput, ...ContentInput[]]
-      ) => Promise<OutboundMessage | OutboundMessage[] | undefined>
+      ) => Promise<
+        | Message<string, AgentSender>
+        | Message<string, AgentSender>[]
+        | undefined
+      >
     )(...wrapped);
   }
 
-  const senderWithPlatform =
-    params.sender === undefined
-      ? undefined
-      : { ...params.sender, __platform: definition.name };
+  const edit = async (newContent: ContentInput): Promise<void> => {
+    // Defense-in-depth: the `edit()` content builder enforces the same guard
+    // before resolution, but checking here gives a clearer call-site stack
+    // for the most common misuse (calling `.edit()` on an inbound message).
+    const target = requireBuiltMessage("edit");
+    if (target.direction !== "outbound") {
+      throw new Error(
+        `cannot edit message ${target.id}: only outbound messages can be edited (direction: "${target.direction}")`
+      );
+    }
+    await space.send(editContent(newContent, target));
+  };
+
+  // Outbound senders are structurally tagged with `kind: "agent"` so the
+  // runtime shape matches the `AgentSender` type advertised by `send()`
+  // / `reply()` returns. Inbound senders are passed through untouched.
+  const buildSenderWithPlatform = ():
+    | ({ id: string } & Record<string, unknown>)
+    | undefined => {
+    if (params.sender === undefined) {
+      return;
+    }
+    if (params.direction === "outbound") {
+      return {
+        ...params.sender,
+        __platform: definition.name,
+        kind: "agent" as const,
+      };
+    }
+    return { ...params.sender, __platform: definition.name };
+  };
+  const senderWithPlatform = buildSenderWithPlatform();
 
   // Platform-defined sugar methods declared via `PlatformDef.message.actions`.
   // Each factory takes `self` as its first argument; the wrapper supplies
@@ -633,44 +653,20 @@ export function buildMessage(params: BuildMessageParams): Message {
     }
   }
 
-  if (params.direction === "outbound") {
-    const outbound = {
-      ...params.extras,
-      ...messagePlatformActions,
-      id: params.id,
-      content: params.content,
-      direction: "outbound",
-      platform: definition.name,
-      react,
-      reply,
-      edit: async (newContent: ContentInput): Promise<void> => {
-        // Sugar for `space.send(edit(newContent, self))`. Unsupported-content
-        // checks, fire-and-forget dispatch, and provider delegation all flow
-        // through the canonical send pipeline.
-        const target = requireBuiltMessage("edit") as OutboundMessage;
-        await space.send(editContent(newContent, target));
-      },
-      sender: senderWithPlatform,
-      space,
-      timestamp: params.timestamp,
-    } as OutboundMessage;
-    self = outbound;
-    return outbound;
-  }
-
-  const inbound = {
+  const message = {
     ...params.extras,
     ...messagePlatformActions,
     id: params.id,
     content: params.content,
-    direction: "inbound",
+    direction: params.direction,
     platform: definition.name,
     react,
     reply,
-    sender: senderWithPlatform as InboundMessage["sender"],
+    edit,
+    sender: senderWithPlatform,
     space,
     timestamp: params.timestamp,
-  } as InboundMessage;
-  self = inbound;
-  return inbound;
+  } as Message;
+  self = message;
+  return message;
 }

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -3,7 +3,7 @@ import { edit as editContent } from "../content/edit";
 import { reaction as reactionContent } from "../content/reaction";
 import { reply as replyContent } from "../content/reply";
 import { resolveContents } from "../content/resolve";
-import type { Content, ContentBuilder, ContentInput } from "../content/types";
+import type { Content, ContentInput } from "../content/types";
 import { typing as typingContent } from "../content/typing";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
@@ -477,13 +477,14 @@ export function buildSpace(params: BuildSpaceParams): Space {
   // universal sugar (`send`, `edit`, …) so a platform action declared with
   // a reserved name is also overridden at the type level via the
   // `Exclude<…, keyof Space>` in `SpaceActionMethods`.
-  const platformActions: Record<
-    string,
-    (...args: unknown[]) => Promise<Message<string, AgentSender> | undefined>
-  > = {};
+  const platformActions: Record<string, (...args: unknown[]) => Promise<void>> =
+    {};
   const declaredActions = (
     definition.space as {
-      actions?: Record<string, (...args: unknown[]) => ContentBuilder>;
+      actions?: Record<
+        string,
+        (space: Space, ...args: unknown[]) => Promise<void>
+      >;
     }
   ).actions;
   if (declaredActions) {
@@ -492,8 +493,9 @@ export function buildSpace(params: BuildSpaceParams): Space {
         warnReservedAction("space", name, definition.name);
         continue;
       }
-      platformActions[name] = (...args: unknown[]) =>
-        space.send(factory(...args));
+      platformActions[name] = async (...args: unknown[]) => {
+        await factory(space, ...args);
+      };
     }
   }
 
@@ -635,7 +637,7 @@ export function buildMessage(params: BuildMessageParams): Message {
       | {
           actions?: Record<
             string,
-            (message: Message, ...args: unknown[]) => ContentBuilder
+            (message: Message, ...args: unknown[]) => Promise<void>
           >;
         }
       | undefined
@@ -648,7 +650,7 @@ export function buildMessage(params: BuildMessageParams): Message {
       }
       messagePlatformActions[name] = async (...args: unknown[]) => {
         const target = requireBuiltMessage(name);
-        await space.send(factory(target, ...args));
+        await factory(target, ...args);
       };
     }
   }

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -9,7 +9,6 @@ import type {
   AnyPlatformDef,
   CreateClientContext,
   EventProducer,
-  InboundPlatformMessage,
   MessageActionFactory,
   Platform,
   PlatformDef,
@@ -208,13 +207,13 @@ function createPlatformInstance<
   // Lazily subscribe to the platform's message broadcast on first read.
   // Cached so `for await (const x of im.messages)` twice doesn't double-subscribe.
   let messagesIterable:
-    | AsyncIterable<[PlatformSpace<Def>, InboundPlatformMessage<Def>]>
+    | AsyncIterable<[PlatformSpace<Def>, PlatformMessage<Def>]>
     | undefined;
   Object.defineProperty(base, "messages", {
     enumerable: true,
     get() {
       messagesIterable ??= runtime.subscribeMessages() as AsyncIterable<
-        [PlatformSpace<Def>, InboundPlatformMessage<Def>]
+        [PlatformSpace<Def>, PlatformMessage<Def>]
       >;
       return messagesIterable;
     },

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -9,7 +9,7 @@ import type {
   AnyPlatformDef,
   CreateClientContext,
   EventProducer,
-  MessageActionFactory,
+  MessageActionFn,
   Platform,
   PlatformDef,
   PlatformInstance,
@@ -19,7 +19,7 @@ import type {
   PlatformSpace,
   PlatformUser,
   ProviderMessage,
-  SpaceActionFactory,
+  SpaceActionFn,
   SpectrumLike,
 } from "./types";
 
@@ -252,11 +252,8 @@ export function definePlatform<
       > & { messages?: never })
     | undefined = undefined,
   _Static extends Record<string, unknown> = Record<never, never>,
-  _SpaceActions extends Record<string, SpaceActionFactory> = Record<
-    never,
-    never
-  >,
-  _MessageActions extends Record<string, MessageActionFactory> = Record<
+  _SpaceActions extends Record<string, SpaceActionFn> = Record<never, never>,
+  _MessageActions extends Record<string, MessageActionFn> = Record<
     never,
     never
   >,

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -1,13 +1,9 @@
 import type { Fn, Pipe, Tuples } from "hotscript";
 import type z from "zod";
 import type { Content, ContentBuilder } from "../content/types";
-import type {
-  InboundMessage,
-  Message,
-  OutboundMessage,
-} from "../types/message";
+import type { Message } from "../types/message";
 import type { Space } from "../types/space";
-import type { User } from "../types/user";
+import type { AgentSender, User } from "../types/user";
 import type { Store } from "../utils/store";
 import type { ManagedStream } from "../utils/stream";
 
@@ -310,7 +306,7 @@ export interface PlatformDef<
      *
      * Each entry is a `ContentBuilder` factory; `buildSpace` injects a thin
      * wrapper that calls `space.send(factory(...args))`. The wrapper is
-     * typed as `(...args) => Promise<OutboundMessage | undefined>` on
+     * typed as `(...args) => Promise<Message<string, AgentSender> | undefined>` on
      * `PlatformSpace<Def>` via `SpaceActionMethods<Def>`.
      *
      * Mirrors the top-level `PlatformDef.actions` slot — `actions` lives at
@@ -552,7 +548,7 @@ type SpaceActionFactories<Def extends AnyPlatformDef> = Def["space"] extends {
 export type SpaceActionMethods<Def extends AnyPlatformDef> = {
   [K in Exclude<keyof SpaceActionFactories<Def>, keyof Space>]: (
     ...args: Parameters<SpaceActionFactories<Def>[K]>
-  ) => Promise<OutboundMessage | undefined>;
+  ) => Promise<Message<string, AgentSender> | undefined>;
 };
 
 // Methods derived from `PlatformDef.message.actions`. Each factory's first
@@ -610,13 +606,6 @@ export type PlatformMessage<Def extends AnyPlatformDef> = Omit<
   Message<Def["name"], PlatformUser<Def>, PlatformSpace<Def>> &
   MessageActionMethods<Def>;
 
-export type InboundPlatformMessage<Def extends AnyPlatformDef> = Omit<
-  SchemaInfer<Def["message"]>,
-  keyof InboundMessage | keyof MessageActionMethods<Def>
-> &
-  InboundMessage<Def["name"], PlatformUser<Def>, PlatformSpace<Def>> &
-  MessageActionMethods<Def>;
-
 export type PlatformUser<Def extends AnyPlatformDef> = Omit<
   ResolvedUserOf<Def>,
   keyof User
@@ -628,9 +617,7 @@ export type PlatformUser<Def extends AnyPlatformDef> = Omit<
 // ---------------------------------------------------------------------------
 
 export type PlatformInstance<Def extends AnyPlatformDef> = {
-  readonly messages: AsyncIterable<
-    [PlatformSpace<Def>, InboundPlatformMessage<Def>]
-  >;
+  readonly messages: AsyncIterable<[PlatformSpace<Def>, PlatformMessage<Def>]>;
   space(...args: SpaceArgs<Def>): Promise<PlatformSpace<Def>>;
   user(userID: string): Promise<PlatformUser<Def>>;
 } & CustomEventInstanceProperties<Def>;
@@ -659,7 +646,7 @@ export interface PlatformRuntime {
   config: unknown;
   definition: AnyPlatformDef;
   store: Store;
-  subscribeMessages: () => ManagedStream<[Space, InboundMessage]>;
+  subscribeMessages: () => ManagedStream<[Space, Message]>;
 }
 
 export interface SpectrumLike<

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -1,40 +1,42 @@
 import type { Fn, Pipe, Tuples } from "hotscript";
 import type z from "zod";
-import type { Content, ContentBuilder } from "../content/types";
+import type { Content } from "../content/types";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
-import type { AgentSender, User } from "../types/user";
+import type { User } from "../types/user";
 import type { Store } from "../utils/store";
 import type { ManagedStream } from "../utils/stream";
 
 /**
- * A platform-defined sugar method on `Space`. Each entry is a content-builder
- * factory; the runtime injects a thin wrapper that calls
- * `space.send(factory(...args))` and returns the result.
+ * A platform-defined method on `Space`. The first parameter is bound to the
+ * built `Space` at construction time, so callers only pass the trailing args.
+ * Actions are plain functions returning `Promise<void>` — they can delegate
+ * through `space.send(...)`, call the underlying SDK, or perform any other
+ * side effect.
  *
  * Names that collide with reserved `Space` keys (`send`, `edit`,
  * `getMessage`, `startTyping`, `stopTyping`, `responding`, `id`,
  * `__platform`) are skipped at runtime with a warning and excluded at the
  * type level via `Exclude<…, keyof Space>`.
  */
-export type SpaceActionFactory = (...args: never[]) => ContentBuilder;
+export type SpaceActionFn = (space: Space, ...args: never[]) => Promise<void>;
 
 /**
- * A platform-defined sugar method on `Message`. The first parameter is bound
- * to the message itself (`self`) at build time, so callers only pass the
- * trailing args. The runtime injects a thin wrapper that calls
- * `space.send(factory(self, ...args))` — actions are fire-and-forget and
- * return `Promise<void>`.
+ * A platform-defined method on `Message`. The first parameter is bound to
+ * the message itself (`self`) at build time, so callers only pass the
+ * trailing args. Actions are plain functions returning `Promise<void>` —
+ * they can delegate through `message.space.send(...)`, call the underlying
+ * SDK, or perform any other side effect.
  *
  * Names that collide with reserved `Message` keys (`react`, `reply`, `edit`,
  * `id`, `space`, `sender`, `content`, `platform`, `direction`, `timestamp`)
  * are skipped at runtime with a warning and excluded at the type level via
  * `Exclude<…, keyof Message>`.
  */
-export type MessageActionFactory = (
+export type MessageActionFn = (
   message: Message,
   ...args: never[]
-) => ContentBuilder;
+) => Promise<void>;
 
 type ResolvedSpace = Pick<Space, "id">;
 type SpaceRef = Pick<Space, "id" | "__platform">;
@@ -178,11 +180,8 @@ export interface PlatformDef<
         EventProducer<unknown, _Client, z.infer<_ConfigSchema>>
       > & { messages?: never })
     | undefined = undefined,
-  _SpaceActions extends Record<string, SpaceActionFactory> = Record<
-    never,
-    never
-  >,
-  _MessageActions extends Record<string, MessageActionFactory> = Record<
+  _SpaceActions extends Record<string, SpaceActionFn> = Record<never, never>,
+  _MessageActions extends Record<string, MessageActionFn> = Record<
     never,
     never
   >,
@@ -302,16 +301,18 @@ export interface PlatformDef<
       store: Store;
     }) => Promise<_ResolvedSpace>;
     /**
-     * Optional platform-specific sugar methods bound to `PlatformSpace<Def>`.
+     * Optional platform-specific methods bound to `PlatformSpace<Def>`.
      *
-     * Each entry is a `ContentBuilder` factory; `buildSpace` injects a thin
-     * wrapper that calls `space.send(factory(...args))`. The wrapper is
-     * typed as `(...args) => Promise<Message<string, AgentSender> | undefined>` on
-     * `PlatformSpace<Def>` via `SpaceActionMethods<Def>`.
+     * Each entry is a plain async function `(space, ...args) => Promise<void>`;
+     * `buildSpace` injects the built `PlatformSpace<Def>` as the first
+     * argument and exposes the trailing args as the public surface. Action
+     * implementations choose how to dispatch — `space.send(...)`, a direct
+     * SDK call, or any other side effect — and always return `Promise<void>`
+     * to callers.
      *
      * Mirrors the top-level `PlatformDef.actions` slot — `actions` lives at
      * the platform level for capabilities (e.g. `getMessage`); `space.actions`
-     * lives here for sugar that delegates through `send`.
+     * lives here for platform-specific surface area.
      *
      * Names that collide with reserved `Space` keys (`send`, `edit`,
      * `getMessage`, `startTyping`, `stopTyping`, `responding`, `id`,
@@ -356,7 +357,7 @@ export interface AnyPlatformDef {
   };
   message?: {
     schema?: z.ZodType<object>;
-    actions?: Record<string, MessageActionFactory>;
+    actions?: Record<string, MessageActionFn>;
   };
 
   // Required core message I/O — the universal contract.
@@ -370,7 +371,7 @@ export interface AnyPlatformDef {
     params?: z.ZodType<object>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard resolver
     resolve: (_: any) => Promise<any>;
-    actions?: Record<string, SpaceActionFactory>;
+    actions?: Record<string, SpaceActionFn>;
   };
   user: {
     schema?: z.ZodType<object>;
@@ -534,40 +535,17 @@ type SpaceArgs<Def extends AnyPlatformDef> =
   | SpaceArrayArgs<Def>
   | SpaceVarargArgs<Def>;
 
-// Methods derived from `PlatformDef.space.actions`. Each factory becomes a
-// space method that delegates through `space.send`. Reserved `Space` keys
-// (`send`, `edit`, …) are filtered out so universal sugar always wins.
-type SpaceActionFactories<Def extends AnyPlatformDef> = Def["space"] extends {
+// Methods derived from `PlatformDef.space.actions`. The first parameter
+// (`space`) is bound to the built `PlatformSpace<Def>` at construction time,
+// so the public surface drops it. Reserved `Space` keys (`send`, `edit`, …)
+// are filtered out so universal sugar always wins.
+type SpaceActionFns<Def extends AnyPlatformDef> = Def["space"] extends {
   actions?: infer A;
 }
-  ? A extends Record<string, SpaceActionFactory>
+  ? A extends Record<string, SpaceActionFn>
     ? A
     : Record<string, never>
   : Record<string, never>;
-
-export type SpaceActionMethods<Def extends AnyPlatformDef> = {
-  [K in Exclude<keyof SpaceActionFactories<Def>, keyof Space>]: (
-    ...args: Parameters<SpaceActionFactories<Def>[K]>
-  ) => Promise<Message<string, AgentSender> | undefined>;
-};
-
-// Methods derived from `PlatformDef.message.actions`. Each factory's first
-// parameter is bound to the message itself at build time, so the public
-// surface drops it. Reserved `Message` keys (`react`, `reply`, `edit`, …)
-// are filtered out so universal sugar always wins.
-// `NonNullable<Def["message"]>` strips the `undefined` introduced by the
-// optional `message?:` slot — without it, the outer conditional
-// (`Def["message"] extends { actions?: infer A }`) fails because `undefined`
-// is not assignable to `{ actions?: … }`, and the whole type collapses to
-// the empty fallback, losing every declared action.
-type MessageActionFactories<Def extends AnyPlatformDef> =
-  NonNullable<Def["message"]> extends {
-    actions?: infer A;
-  }
-    ? A extends Record<string, MessageActionFactory>
-      ? A
-      : Record<string, never>
-    : Record<string, never>;
 
 type TailArgs<T extends readonly unknown[]> = T extends readonly [
   unknown,
@@ -576,9 +554,33 @@ type TailArgs<T extends readonly unknown[]> = T extends readonly [
   ? Rest
   : [];
 
+export type SpaceActionMethods<Def extends AnyPlatformDef> = {
+  [K in Exclude<keyof SpaceActionFns<Def>, keyof Space>]: (
+    ...args: TailArgs<Parameters<SpaceActionFns<Def>[K]>>
+  ) => Promise<void>;
+};
+
+// Methods derived from `PlatformDef.message.actions`. The first parameter
+// (`message`) is bound to the built message at construction time, so the
+// public surface drops it. Reserved `Message` keys (`react`, `reply`,
+// `edit`, …) are filtered out so universal sugar always wins.
+// `NonNullable<Def["message"]>` strips the `undefined` introduced by the
+// optional `message?:` slot — without it, the outer conditional
+// (`Def["message"] extends { actions?: infer A }`) fails because `undefined`
+// is not assignable to `{ actions?: … }`, and the whole type collapses to
+// the empty fallback, losing every declared action.
+type MessageActionFns<Def extends AnyPlatformDef> =
+  NonNullable<Def["message"]> extends {
+    actions?: infer A;
+  }
+    ? A extends Record<string, MessageActionFn>
+      ? A
+      : Record<string, never>
+    : Record<string, never>;
+
 export type MessageActionMethods<Def extends AnyPlatformDef> = {
-  [K in Exclude<keyof MessageActionFactories<Def>, keyof Message>]: (
-    ...args: TailArgs<Parameters<MessageActionFactories<Def>[K]>>
+  [K in Exclude<keyof MessageActionFns<Def>, keyof Message>]: (
+    ...args: TailArgs<Parameters<MessageActionFns<Def>[K]>>
   ) => Promise<void>;
 };
 

--- a/packages/spectrum-ts/src/providers/imessage/content/read.ts
+++ b/packages/spectrum-ts/src/providers/imessage/content/read.ts
@@ -53,12 +53,18 @@ export const isRead = (v: unknown): v is Read =>
  */
 export function read(target: Message): ContentBuilder {
   return {
-    build: async () =>
-      readSchema.parse({
+    build: async () => {
+      if (target.direction !== "inbound") {
+        throw new Error(
+          `read() target must be an inbound message (got direction "${target.direction}", message id "${target.id}")`
+        );
+      }
+      return readSchema.parse({
         type: "read",
         __platform: "iMessage",
         __fireAndForget: true,
         target,
-      }) as unknown as Content,
+      }) as unknown as Content;
+    },
   };
 }

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -2,6 +2,8 @@ import { createClient, MessageEffect } from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
 import type { Edit } from "../../content/edit";
 import { definePlatform } from "../../platform/define";
+import type { Message } from "../../types/message";
+import type { Space } from "../../types/space";
 import { UnsupportedError } from "../../utils/errors";
 
 // biome-ignore lint/performance/noBarrelFile: provider entrypoint exports its public helpers
@@ -12,6 +14,7 @@ export { read } from "./content/read";
 import { createCloudClients, disposeCloudAuth } from "./auth";
 import {
   type Background,
+  type BackgroundInput,
   background as backgroundContent,
   isBackground,
 } from "./content/background";
@@ -199,23 +202,32 @@ export const imessage = definePlatform("iMessage", {
     },
     actions: {
       // Sugar: `space.background(input, opts?)` →
-      // `space.send(background(input, opts?))`. Wired through the universal
+      // `space.send(background(input, opts?))`. Routed through the universal
       // send pipeline so the unsupported-content + warn-and-skip path on
       // local-mode iMessage is identical to the canonical form.
-      background: backgroundContent,
-      // Sugar: `space.read(message)` → `space.send(read(message))`. Same
-      // routing as `background` — the canonical form is the long-form
-      // `space.send(read(message))`.
-      read: readContent,
+      background: async (
+        space: Space,
+        input: BackgroundInput,
+        opts?: { mimeType?: string }
+      ) => {
+        await space.send(backgroundContent(input as never, opts));
+      },
+      // Sugar: `space.read(message)` → `space.send(read(message))`.
+      read: async (space: Space, message: Message) => {
+        await space.send(readContent(message));
+      },
     },
   },
 
   message: {
     schema: messageSchema,
     actions: {
-      // Sugar: `message.read()` → `space.send(read(self))`. `buildMessage`
-      // injects `self` as the first argument; callers pass nothing.
-      read: readContent,
+      // Sugar: `message.read()` → `message.space.send(read(self))`.
+      // `buildMessage` injects the message as the first argument; callers
+      // pass nothing.
+      read: async (message: Message) => {
+        await message.space.send(readContent(message));
+      },
     },
   },
 

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -19,8 +19,9 @@ import type {
   PlatformRuntime,
   SpectrumLike,
 } from "./platform/types";
-import type { InboundMessage, OutboundMessage } from "./types/message";
+import type { Message } from "./types/message";
 import type { Space } from "./types/space";
+import type { AgentSender } from "./types/user";
 import { createStore, type Store } from "./utils/store";
 import {
   type Broadcaster,
@@ -47,17 +48,17 @@ export type SpectrumInstance<
   Providers extends PlatformProviderConfig[] = PlatformProviderConfig[],
 > = SpectrumLike<Providers> &
   CustomEventStreams<Providers> & {
-    readonly messages: AsyncIterable<[Space, InboundMessage]>;
+    readonly messages: AsyncIterable<[Space, Message]>;
     stop(): Promise<void>;
     send(
       space: Space,
       content: ContentInput
-    ): Promise<OutboundMessage | undefined>;
+    ): Promise<Message<string, AgentSender> | undefined>;
     send(
       space: Space,
       ...content: [ContentInput, ContentInput, ...ContentInput[]]
-    ): Promise<OutboundMessage[]>;
-    edit(message: OutboundMessage, newContent: ContentInput): Promise<void>;
+    ): Promise<Message<string, AgentSender>[]>;
+    edit(message: Message, newContent: ContentInput): Promise<void>;
     responding<T>(space: Space, fn: () => T | Promise<T>): Promise<T>;
   };
 
@@ -178,10 +179,7 @@ export async function Spectrum<
   const platformStates = new Map<string, PlatformRuntime>();
 
   // Per-platform message broadcasters (lazy: created on first subscribe).
-  const messageBroadcasters = new Map<
-    string,
-    Broadcaster<[Space, InboundMessage]>
-  >();
+  const messageBroadcasters = new Map<string, Broadcaster<[Space, Message]>>();
 
   // Custom event streams keyed by event name
   const customEventStreams = new Map<string, ManagedStream<unknown>>();
@@ -216,7 +214,7 @@ export async function Spectrum<
     config: unknown;
     definition: AnyPlatformDef;
     store: Store;
-  }): ManagedStream<[Space, InboundMessage]> => {
+  }): ManagedStream<[Space, Message]> => {
     const { client, config, definition, store } = state;
     const raw = definition.messages({
       client,
@@ -224,9 +222,7 @@ export async function Spectrum<
       store,
     }) as AsyncIterable<ProviderMessageRecord>;
 
-    const bindSend = async function* (): AsyncIterable<
-      [Space, InboundMessage]
-    > {
+    const bindSend = async function* (): AsyncIterable<[Space, Message]> {
       for await (const msg of raw) {
         const built = await withSpan(
           "spectrum.message.receive",
@@ -270,10 +266,7 @@ export async function Spectrum<
         const { space, normalizedMessage } = built;
         if (flattenGroups && normalizedMessage.content.type === "group") {
           for (const item of normalizedMessage.content.items) {
-            // Group items in the inbound flow are wrapped via wrapProviderMessage,
-            // which always produces InboundMessages — Group.items is just the
-            // wider Message type at the schema level.
-            yield [space, item as InboundMessage];
+            yield [space, item];
           }
           continue;
         }
@@ -289,7 +282,7 @@ export async function Spectrum<
     config: unknown;
     definition: AnyPlatformDef;
     store: Store;
-  }): Broadcaster<[Space, InboundMessage]> => {
+  }): Broadcaster<[Space, Message]> => {
     if (stopped) {
       throw new Error(
         `Spectrum instance has been stopped; cannot subscribe to "${state.definition.name}" messages`
@@ -360,8 +353,8 @@ export async function Spectrum<
     telemetry: telemetry === true,
   });
 
-  const createMessagesStream = (): ManagedStream<[Space, InboundMessage]> =>
-    stream<[Space, InboundMessage]>((emit, end) => {
+  const createMessagesStream = (): ManagedStream<[Space, Message]> =>
+    stream<[Space, Message]>((emit, end) => {
       const merged = mergeStreams(
         Array.from(platformStates.values(), (runtime) =>
           runtime.subscribeMessages()
@@ -499,7 +492,7 @@ export async function Spectrum<
   process.on("SIGINT", handleSignal);
   process.on("SIGTERM", handleSignal);
 
-  const messages: AsyncIterable<[Space, InboundMessage]> = messagesStream;
+  const messages: AsyncIterable<[Space, Message]> = messagesStream;
 
   // Proxy for flat custom event access (app.typing, app.readReceipt, etc.)
   const customEventProxy = new Proxy(
@@ -524,13 +517,15 @@ export async function Spectrum<
     send: (async (
       space: Space,
       ...content: [ContentInput, ...ContentInput[]]
-    ): Promise<OutboundMessage | OutboundMessage[] | undefined> =>
+    ): Promise<
+      Message<string, AgentSender> | Message<string, AgentSender>[] | undefined
+    > =>
       content.length === 1
         ? await space.send(content[0])
         : await space.send(
             ...(content as [ContentInput, ContentInput, ...ContentInput[]])
           )) as SpectrumInstance["send"],
-    edit: async (message: OutboundMessage, newContent: ContentInput) => {
+    edit: async (message: Message, newContent: ContentInput) => {
       await message.edit(newContent);
     },
     responding: async <T>(space: Space, fn: () => T | Promise<T>): Promise<T> =>

--- a/packages/spectrum-ts/src/types/message.ts
+++ b/packages/spectrum-ts/src/types/message.ts
@@ -1,49 +1,25 @@
 import type { Content, ContentInput } from "../content/types";
 import type { Space } from "./space";
-import type { User } from "./user";
+import type { AgentSender, User } from "./user";
 
-interface BaseMessage<
+export interface Message<
   TPlatform extends string = string,
   TSender extends User = User,
   TSpace extends Space = Space,
 > {
   content: Content;
+  direction: "inbound" | "outbound";
+  edit(newContent: ContentInput): Promise<void>;
   readonly id: string;
   platform: TPlatform;
   react(reaction: string): Promise<void>;
   reply(
     content: ContentInput
-  ): Promise<OutboundMessage<TPlatform, TSender, TSpace> | undefined>;
+  ): Promise<Message<TPlatform, AgentSender, TSpace> | undefined>;
   reply(
     ...content: [ContentInput, ContentInput, ...ContentInput[]]
-  ): Promise<OutboundMessage<TPlatform, TSender, TSpace>[]>;
+  ): Promise<Message<TPlatform, AgentSender, TSpace>[]>;
+  sender: TSender | undefined;
   space: TSpace;
   timestamp: Date;
 }
-
-export interface InboundMessage<
-  TPlatform extends string = string,
-  TSender extends User = User,
-  TSpace extends Space = Space,
-> extends BaseMessage<TPlatform, TSender, TSpace> {
-  direction: "inbound";
-  sender: TSender;
-}
-
-export interface OutboundMessage<
-  TPlatform extends string = string,
-  TSender extends User = User,
-  TSpace extends Space = Space,
-> extends BaseMessage<TPlatform, TSender, TSpace> {
-  direction: "outbound";
-  edit(newContent: ContentInput): Promise<void>;
-  sender: TSender | undefined;
-}
-
-export type Message<
-  TPlatform extends string = string,
-  TSender extends User = User,
-  TSpace extends Space = Space,
-> =
-  | InboundMessage<TPlatform, TSender, TSpace>
-  | OutboundMessage<TPlatform, TSender, TSpace>;

--- a/packages/spectrum-ts/src/types/space.ts
+++ b/packages/spectrum-ts/src/types/space.ts
@@ -1,9 +1,10 @@
 import type { ContentInput } from "../content/types";
-import type { Message, OutboundMessage } from "./message";
+import type { Message } from "./message";
+import type { AgentSender } from "./user";
 
 export interface Space<_Def = unknown> {
   readonly __platform: string;
-  edit(message: OutboundMessage, newContent: ContentInput): Promise<void>;
+  edit(message: Message, newContent: ContentInput): Promise<void>;
   /**
    * Look up a message in this space by its id. Returns `undefined` if the
    * platform has no way to resolve the id (e.g. cache miss with no by-id
@@ -13,10 +14,12 @@ export interface Space<_Def = unknown> {
   getMessage(id: string): Promise<Message | undefined>;
   readonly id: string;
   responding<T>(fn: () => T | Promise<T>): Promise<T>;
-  send(content: ContentInput): Promise<OutboundMessage | undefined>;
+  send(
+    content: ContentInput
+  ): Promise<Message<string, AgentSender> | undefined>;
   send(
     ...content: [ContentInput, ContentInput, ...ContentInput[]]
-  ): Promise<OutboundMessage[]>;
+  ): Promise<Message<string, AgentSender>[]>;
   startTyping(): Promise<void>;
   stopTyping(): Promise<void>;
 }

--- a/packages/spectrum-ts/src/types/user.ts
+++ b/packages/spectrum-ts/src/types/user.ts
@@ -1,4 +1,9 @@
 export interface User {
   readonly __platform: string;
   readonly id: string;
+  readonly kind?: "agent";
+}
+
+export interface AgentSender extends User {
+  readonly kind: "agent";
 }


### PR DESCRIPTION
## Summary

- Collapses `InboundMessage` / `OutboundMessage` into a single `Message` interface. `direction: "inbound" | "outbound"` and `sender: User | undefined` now live directly on `Message`, and `edit()` is a method on every message (the runtime guards against editing inbound messages — see below).
- Outbound messages are now structurally tagged via `AgentSender` (`User & { kind: "agent" }`). `space.send(...)`, `space.reply(...)`, and friends return `Message<string, AgentSender>` instead of the old `OutboundMessage` interface.
- Replaces the `ContentBuilder`-factory shape of platform actions (`SpaceActionFactory` / `MessageActionFactory`) with plain async functions (`SpaceActionFn` / `MessageActionFn`). Each action receives the built `Space` / `Message` as its first argument and returns `Promise<void>`; the runtime no longer hard-wires every action through `space.send(...)`.
- `edit()` now lives on the unified `Message` and throws at call time if the target is inbound — the misuse used to be caught by the type system; this PR moves the check to runtime (with defense-in-depth in both `edit()` content builder and `buildMessage`'s `edit` method) so it surfaces as a clear error instead of a silent type widening.
- `read()` (iMessage) gains an inbound-only guard mirroring `edit()`.

## Motivation

[ENG-1500](https://linear.app/photon-codes/issue/ENG-1500) — drop the type-level `InboundMessage` / `OutboundMessage` split. The two interfaces diverged only by `direction`, `sender` nullability, and an `edit` method; the discriminated union forced every consumer to narrow before touching common fields, and platform-action factories had to be overloaded across both shapes. Unifying them simplifies the public surface and the `PlatformDef` action declaration.

## Breaking changes

- `InboundMessage` and `OutboundMessage` are removed from the public exports. Use `Message` everywhere; narrow on `message.direction === "outbound"` when you need the outbound shape.
- `InboundPlatformMessage<Def>` is removed; `PlatformInstance<Def>.messages` now yields `[PlatformSpace<Def>, PlatformMessage<Def>]`.
- `User` gains an optional `readonly kind?: "agent"` discriminator. New `AgentSender` type narrows it to `"agent"`.
- `PlatformDef.space.actions` / `PlatformDef.message.actions` entries are now `(scope, ...args) => Promise<void>` instead of `(...args) => ContentBuilder`. Existing iMessage `space.read` / `space.background` / `message.read` actions were migrated in-tree.

## Changes

| File | Change |
|------|--------|
| `types/message.ts` | Collapses `BaseMessage` / `InboundMessage` / `OutboundMessage` into a single `Message` interface with `direction`, `sender: TSender \| undefined`, and `edit()`. `reply()` now returns `Message<…, AgentSender, …>`. |
| `types/user.ts` | Adds `kind?: "agent"` to `User` and new `AgentSender extends User` with `kind: "agent"`. |
| `types/space.ts` | `send` / `edit` signatures updated to `Message<string, AgentSender>` and `Message`. |
| `index.ts` | Removes `InboundPlatformMessage` from the public exports; adds `AgentSender`. |
| `platform/types.ts` | Renames `SpaceActionFactory` / `MessageActionFactory` to `SpaceActionFn` / `MessageActionFn`, signature changed to `(scope, ...args) => Promise<void>`. `SpaceActionMethods` now strips the bound first arg via `TailArgs` (mirroring how message actions already worked). Removes `InboundPlatformMessage`; `PlatformInstance.messages` yields `PlatformMessage<Def>`. `PlatformRuntime.subscribeMessages` is `ManagedStream<[Space, Message]>`. |
| `platform/define.ts` | Threads renamed action types; switches `messagesIterable` to `PlatformMessage<Def>`. |
| `platform/build.ts` | Drops the inbound/outbound overloads on `wrapProviderMessage` and `buildMessage`. `buildMessage` now produces a single object literal regardless of direction; tags outbound senders with `kind: "agent"` so the runtime shape matches `AgentSender`. `space.edit` and `message.edit` both delegate to the `edit()` content builder, which throws on inbound targets. Space/message action factories are now invoked directly (`factory(scope, ...args)`) instead of wrapped in `space.send(factory(...))`. |
| `content/edit.ts` | `edit(content, target)` now accepts `Message` (was `OutboundMessage`) and throws at build time if `target.direction !== "outbound"`. Defense-in-depth alongside `buildMessage`'s `edit`. |
| `content/reaction.ts` | Doc comment updated — references `Message` instead of `OutboundMessage`. |
| `providers/imessage/content/read.ts` | `read(target)` now throws at build time if `target.direction !== "inbound"`. |
| `providers/imessage/index.ts` | Migrates `space.actions.{background,read}` and `message.actions.read` from `ContentBuilder` factories to async action fns. |
| `spectrum.ts` | `SpectrumInstance.messages` is `AsyncIterable<[Space, Message]>`; `send` / `edit` signatures updated. Broadcaster / stream types collapsed onto `Message`. |

## Test plan

- [ ] `bun x ultracite check` passes
- [ ] `tsc --noEmit` passes (verifies the new `Message<…, AgentSender, …>` return types and `SpaceActionFn` / `MessageActionFn` inference)
- [ ] Smoke test against remote iMessage: `message.reply(...)` returns a `Message` whose `sender.kind === "agent"`
- [ ] Smoke test against remote iMessage: `message.edit(newContent)` on an outbound message works; calling `.edit()` on an inbound message throws a clear error
- [ ] Smoke test against remote iMessage: `message.read()` on an inbound message marks the chat as read; calling `read()` on an outbound message throws a clear error
- [ ] Existing platform sugar (`space.background`, `space.read`, `message.read`) still routes through the unsupported-content path on local-mode iMessage

Linear: [ENG-1500](https://linear.app/photon-codes/issue/ENG-1500)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782092889&installation_id=127326493&pr_number=74&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F74&signature=1c07407b73224636c4aaa2a8f930202cbe32f6357877d04a7b630bf7bbc33286"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Unified message typing: `Message` now includes a `direction` property ("inbound" or "outbound") instead of separate message types.
  * Platform action handlers now return `Promise<void>` instead of content builders, with execution routed through the standard send pipeline.
  * Updated public API exports to use unified `Message` type across all message-related methods.

* **Bug Fixes**
  * Added runtime validation to message operations to ensure correct direction (inbound for read operations, outbound for edit operations); errors now include direction and message ID details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->