### PR TITLE
feat(spectrum-ts): add rename() and avatar() universal content types

### DIFF
--- a/packages/spectrum-ts/src/content/avatar.ts
+++ b/packages/spectrum-ts/src/content/avatar.ts
@@ -1,0 +1,57 @@
+import z from "zod";
+import {
+  buildPhotoAction,
+  type PhotoInput,
+  photoActionSchema,
+} from "../utils/photo-content";
+import type { ContentBuilder } from "./types";
+
+/**
+ * Set or clear the chat avatar (group icon). Universal content — providers
+ * dispatch by `content.type === "avatar"` in their `send` action and decide
+ * their own support story (e.g. iMessage only supports it for remote group
+ * chats).
+ *
+ * `space.send(avatar(...))` is the canonical form; `space.avatar(...)` is
+ * universal sugar that delegates here. Per-platform constraints (e.g.
+ * group-only, remote-only) surface as `UnsupportedError` from the provider's
+ * `send` action so the canonical and sugar forms share one error path.
+ */
+export const avatarSchema = z.object({
+  type: z.literal("avatar"),
+  action: photoActionSchema,
+});
+
+export type Avatar = z.infer<typeof avatarSchema>;
+
+export type AvatarInput = PhotoInput;
+
+/**
+ * Build an `Avatar` content value.
+ *
+ * - `avatar("clear")` — remove the current chat avatar.
+ * - `avatar("./icon.png")` — set avatar from a filesystem path. MIME type is
+ *   inferred from the extension; override with `options.mimeType`.
+ * - `avatar(buffer, { mimeType })` — set avatar from in-memory bytes.
+ *   `options.mimeType` is required.
+ *
+ * `"clear"` is a reserved string-literal sentinel. If you have a file
+ * literally named `clear` with no extension, pass `"./clear"` or load it as a
+ * Buffer.
+ */
+export function avatar(input: "clear"): ContentBuilder;
+export function avatar(
+  input: string | Buffer,
+  options?: { mimeType?: string }
+): ContentBuilder;
+export function avatar(
+  input: AvatarInput,
+  options?: { mimeType?: string }
+): ContentBuilder {
+  // Snapshot the action at builder construction so (a) a missing MIME type
+  // fails fast and (b) the read is cached across repeated `build()` calls.
+  const action = buildPhotoAction(input, options, "avatar");
+  return {
+    build: async () => avatarSchema.parse({ type: "avatar", action }),
+  };
+}

--- a/packages/spectrum-ts/src/content/avatar.ts
+++ b/packages/spectrum-ts/src/content/avatar.ts
@@ -33,16 +33,19 @@ export type AvatarInput = PhotoInput;
  * - `avatar("./icon.png")` — set avatar from a filesystem path. MIME type is
  *   inferred from the extension; override with `options.mimeType`.
  * - `avatar(buffer, { mimeType })` — set avatar from in-memory bytes.
- *   `options.mimeType` is required.
+ *   `options.mimeType` is required (enforced at the type level).
  *
  * `"clear"` is a reserved string-literal sentinel. If you have a file
  * literally named `clear` with no extension, pass `"./clear"` or load it as a
  * Buffer.
  */
-export function avatar(input: "clear"): ContentBuilder;
 export function avatar(
-  input: string | Buffer,
+  input: string,
   options?: { mimeType?: string }
+): ContentBuilder;
+export function avatar(
+  input: Buffer,
+  options: { mimeType: string }
 ): ContentBuilder;
 export function avatar(
   input: AvatarInput,

--- a/packages/spectrum-ts/src/content/edit.ts
+++ b/packages/spectrum-ts/src/content/edit.ts
@@ -70,7 +70,8 @@ export function edit(content: ContentInput, target: Message): ContentBuilder {
         resolved.type === "reaction" ||
         resolved.type === "group" ||
         resolved.type === "typing" ||
-        resolved.type === "rename"
+        resolved.type === "rename" ||
+        resolved.type === "avatar"
       ) {
         throw new Error(`edit() cannot wrap "${resolved.type}" content`);
       }

--- a/packages/spectrum-ts/src/content/edit.ts
+++ b/packages/spectrum-ts/src/content/edit.ts
@@ -69,7 +69,8 @@ export function edit(content: ContentInput, target: Message): ContentBuilder {
         resolved.type === "reply" ||
         resolved.type === "reaction" ||
         resolved.type === "group" ||
-        resolved.type === "typing"
+        resolved.type === "typing" ||
+        resolved.type === "rename"
       ) {
         throw new Error(`edit() cannot wrap "${resolved.type}" content`);
       }

--- a/packages/spectrum-ts/src/content/edit.ts
+++ b/packages/spectrum-ts/src/content/edit.ts
@@ -26,7 +26,8 @@ const isContent = (v: unknown): boolean =>
  * them inside their `send` action and the resolved value is `undefined`
  * (no new message id is produced; the existing message mutates in place).
  *
- * Edit cannot wrap `edit`, `reply`, `reaction`, `group`, or `typing`.
+ * Edit cannot wrap `edit`, `reply`, `reaction`, `group`, `typing`, `rename`,
+ * or `avatar` content.
  */
 export const editSchema = z.object({
   type: z.literal("edit"),

--- a/packages/spectrum-ts/src/content/rename.ts
+++ b/packages/spectrum-ts/src/content/rename.ts
@@ -1,0 +1,28 @@
+import z from "zod";
+import type { ContentBuilder } from "./types";
+
+/**
+ * Rename the current chat. Universal content — providers dispatch by
+ * `content.type === "rename"` in their `send` action and decide their own
+ * support story (e.g. iMessage only supports it for remote group chats).
+ *
+ * `space.send(rename("New Name"))` is the canonical form; `space.rename(...)`
+ * is universal sugar that delegates here.
+ *
+ * Throws at build time if `displayName` is empty. Per-platform constraints
+ * (e.g. group-only, remote-only) surface as `UnsupportedError` from the
+ * provider's `send` action so the canonical and sugar forms share one
+ * error path.
+ */
+export const renameSchema = z.object({
+  type: z.literal("rename"),
+  displayName: z.string().min(1, "rename() displayName must be non-empty"),
+});
+
+export type Rename = z.infer<typeof renameSchema>;
+
+export function rename(displayName: string): ContentBuilder {
+  return {
+    build: async () => renameSchema.parse({ type: "rename", displayName }),
+  };
+}

--- a/packages/spectrum-ts/src/content/reply.ts
+++ b/packages/spectrum-ts/src/content/reply.ts
@@ -56,7 +56,8 @@ export function reply(content: ContentInput, target: Message): ContentBuilder {
         resolved.type === "edit" ||
         resolved.type === "reaction" ||
         resolved.type === "group" ||
-        resolved.type === "typing"
+        resolved.type === "typing" ||
+        resolved.type === "rename"
       ) {
         throw new Error(`reply() cannot wrap "${resolved.type}" content`);
       }

--- a/packages/spectrum-ts/src/content/reply.ts
+++ b/packages/spectrum-ts/src/content/reply.ts
@@ -25,7 +25,8 @@ const isContent = (v: unknown): boolean =>
  * `message.reply(content)` is sugar that delegates here. Providers see
  * `reply` like any other content type and route to a threaded send.
  *
- * Reply cannot wrap `reply`, `reaction`, or `group` content.
+ * Reply cannot wrap `reply`, `edit`, `reaction`, `group`, `typing`, `rename`,
+ * or `avatar` content.
  */
 export const replySchema = z.object({
   type: z.literal("reply"),

--- a/packages/spectrum-ts/src/content/reply.ts
+++ b/packages/spectrum-ts/src/content/reply.ts
@@ -57,7 +57,8 @@ export function reply(content: ContentInput, target: Message): ContentBuilder {
         resolved.type === "reaction" ||
         resolved.type === "group" ||
         resolved.type === "typing" ||
-        resolved.type === "rename"
+        resolved.type === "rename" ||
+        resolved.type === "avatar"
       ) {
         throw new Error(`reply() cannot wrap "${resolved.type}" content`);
       }

--- a/packages/spectrum-ts/src/content/types.ts
+++ b/packages/spectrum-ts/src/content/types.ts
@@ -7,6 +7,7 @@ import { messageEffectSchema } from "./effect";
 import { groupSchema } from "./group";
 import { pollOptionSchema, pollSchema } from "./poll";
 import { reactionSchema } from "./reaction";
+import { renameSchema } from "./rename";
 import { replySchema } from "./reply";
 import { richlinkSchema } from "./richlink";
 import { textSchema } from "./text";
@@ -31,6 +32,7 @@ const baseContentSchemas = [
   pollOptionSchema,
   messageEffectSchema,
   typingSchema,
+  renameSchema,
 ] as const;
 
 export const baseContentSchema = z.discriminatedUnion(

--- a/packages/spectrum-ts/src/content/types.ts
+++ b/packages/spectrum-ts/src/content/types.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 import { attachmentSchema } from "./attachment";
+import { avatarSchema } from "./avatar";
 import { contactSchema } from "./contact";
 import { customSchema } from "./custom";
 import { editSchema } from "./edit";
@@ -33,6 +34,7 @@ const baseContentSchemas = [
   messageEffectSchema,
   typingSchema,
   renameSchema,
+  avatarSchema,
 ] as const;
 
 export const baseContentSchema = z.discriminatedUnion(

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -1,4 +1,5 @@
 export { attachment } from "./content/attachment";
+export { type Avatar, type AvatarInput, avatar } from "./content/avatar";
 export {
   type Contact,
   type ContactAddress,

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -22,6 +22,7 @@ export {
   poll,
 } from "./content/poll";
 export { type Reaction, reaction } from "./content/reaction";
+export { type Rename, rename } from "./content/rename";
 export { type Reply, reply } from "./content/reply";
 export { resolveContents } from "./content/resolve";
 export { type Richlink, richlink } from "./content/richlink";

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -1,4 +1,5 @@
 import { createLogger, withSpan } from "@photon-ai/otel";
+import { type AvatarInput, avatar as avatarContent } from "../content/avatar";
 import { edit as editContent } from "../content/edit";
 import { reaction as reactionContent } from "../content/reaction";
 import { rename as renameContent } from "../content/rename";
@@ -45,6 +46,7 @@ const FIRE_AND_FORGET_TYPES: ReadonlySet<string> = new Set([
   "typing",
   "edit",
   "rename",
+  "avatar",
 ]);
 
 const isFireAndForget = (item: Content): boolean =>
@@ -62,6 +64,7 @@ const RESERVED_SPACE_KEYS: ReadonlySet<string> = new Set([
   "edit",
   "getMessage",
   "rename",
+  "avatar",
   "startTyping",
   "stopTyping",
   "responding",
@@ -521,6 +524,15 @@ export function buildSpace(params: BuildSpaceParams): Space {
       // constraints live in each provider's `send` action.
       await space.send(renameContent(displayName));
     },
+    avatar: (async (
+      input: AvatarInput,
+      options?: { mimeType?: string }
+    ): Promise<void> => {
+      // Sugar for `space.send(avatar(input, options?))`. Fire-and-forget; the
+      // (always-undefined) result is discarded. Per-platform support and
+      // constraints live in each provider's `send` action.
+      await space.send(avatarContent(input as never, options));
+    }) as Space["avatar"],
     startTyping: async () => {
       // Sugar for `space.send(typing("start"))`. Typing is fire-and-forget;
       // providers handle it inside their `send` action and any platforms

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -1,6 +1,7 @@
 import { createLogger, withSpan } from "@photon-ai/otel";
 import { edit as editContent } from "../content/edit";
 import { reaction as reactionContent } from "../content/reaction";
+import { rename as renameContent } from "../content/rename";
 import { reply as replyContent } from "../content/reply";
 import { resolveContents } from "../content/resolve";
 import type { Content, ContentInput } from "../content/types";
@@ -43,6 +44,7 @@ const FIRE_AND_FORGET_TYPES: ReadonlySet<string> = new Set([
   "reaction",
   "typing",
   "edit",
+  "rename",
 ]);
 
 const isFireAndForget = (item: Content): boolean =>
@@ -59,6 +61,7 @@ const RESERVED_SPACE_KEYS: ReadonlySet<string> = new Set([
   "send",
   "edit",
   "getMessage",
+  "rename",
   "startTyping",
   "stopTyping",
   "responding",
@@ -512,6 +515,12 @@ export function buildSpace(params: BuildSpaceParams): Space {
       await space.send(editContent(newContent, message));
     },
     getMessage: getMessageImpl,
+    rename: async (displayName: string): Promise<void> => {
+      // Sugar for `space.send(rename(displayName))`. Fire-and-forget; the
+      // (always-undefined) result is discarded. Per-platform support and
+      // constraints live in each provider's `send` action.
+      await space.send(renameContent(displayName));
+    },
     startTyping: async () => {
       // Sugar for `space.send(typing("start"))`. Typing is fire-and-forget;
       // providers handle it inside their `send` action and any platforms

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -531,7 +531,19 @@ export function buildSpace(params: BuildSpaceParams): Space {
       // Sugar for `space.send(avatar(input, options?))`. Fire-and-forget; the
       // (always-undefined) result is discarded. Per-platform support and
       // constraints live in each provider's `send` action.
-      await space.send(avatarContent(input as never, options));
+      //
+      // Branch by input shape so `avatarContent`'s narrow overloads pick the
+      // right signature (string vs Buffer + required mimeType) without a cast.
+      if (typeof input === "string") {
+        await space.send(avatarContent(input, options));
+        return;
+      }
+      if (!options?.mimeType) {
+        throw new Error(
+          "space.avatar(Buffer) requires options.mimeType — pass { mimeType: '...' }"
+        );
+      }
+      await space.send(avatarContent(input, { mimeType: options.mimeType }));
     }) as Space["avatar"],
     startTyping: async () => {
       // Sugar for `space.send(typing("start"))`. Typing is fire-and-forget;

--- a/packages/spectrum-ts/src/providers/imessage/content/background.ts
+++ b/packages/spectrum-ts/src/providers/imessage/content/background.ts
@@ -1,9 +1,10 @@
-import { readFile } from "node:fs/promises";
-import { basename } from "node:path";
-import { lookup as lookupMimeType } from "mime-types";
 import z from "zod";
 import type { Content, ContentBuilder } from "../../../content/types";
-import { readSchema } from "../../../utils/io";
+import {
+  buildPhotoAction,
+  type PhotoInput,
+  photoActionSchema,
+} from "../../../utils/photo-content";
 
 /**
  * iMessage-only chat background content. Lives entirely under the iMessage
@@ -20,20 +21,11 @@ import { readSchema } from "../../../utils/io";
  * iMessage's `send` handler narrows back to `Background` via the `isBackground`
  * type guard before dispatching to `chats.setBackground` / `removeBackground`.
  */
-const backgroundActionSchema = z.discriminatedUnion("kind", [
-  z.object({
-    kind: z.literal("set"),
-    read: readSchema,
-    mimeType: z.string().nonempty(),
-  }),
-  z.object({ kind: z.literal("clear") }),
-]);
-
 export const backgroundSchema = z.object({
   type: z.literal("background"),
   __platform: z.literal("iMessage"),
   __fireAndForget: z.literal(true),
-  action: backgroundActionSchema,
+  action: photoActionSchema,
 });
 
 export type Background = z.infer<typeof backgroundSchema>;
@@ -41,34 +33,7 @@ export type Background = z.infer<typeof backgroundSchema>;
 export const isBackground = (v: unknown): v is Background =>
   backgroundSchema.safeParse(v).success;
 
-const CLEAR_SENTINEL = "clear" as const;
-export type BackgroundInput = typeof CLEAR_SENTINEL | string | Buffer;
-
-const resolveMimeType = (input: string | Buffer, mimeType?: string): string => {
-  if (mimeType) {
-    return mimeType;
-  }
-  if (typeof input === "string") {
-    const resolved = lookupMimeType(basename(input));
-    if (resolved) {
-      return resolved;
-    }
-  }
-  throw new Error(
-    "Unable to resolve MIME type for background. Pass options.mimeType explicitly."
-  );
-};
-
-const cachedRead = (read: () => Promise<Buffer>): (() => Promise<Buffer>) => {
-  let cached: Promise<Buffer> | undefined;
-  return () => {
-    cached ??= read().catch((err: unknown) => {
-      cached = undefined;
-      throw err;
-    });
-    return cached;
-  };
-};
+export type BackgroundInput = PhotoInput;
 
 /**
  * Set or clear the chat background. iMessage-only, remote-only.
@@ -100,32 +65,16 @@ export function background(
   input: BackgroundInput,
   options?: { mimeType?: string }
 ): ContentBuilder {
-  if (input === CLEAR_SENTINEL) {
-    return {
-      build: async () =>
-        backgroundSchema.parse({
-          type: "background",
-          __platform: "iMessage",
-          __fireAndForget: true,
-          action: { kind: "clear" },
-        }) as unknown as Content,
-    };
-  }
-  // Snapshot the reader and MIME type at builder construction so that
-  // (a) re-invoking `build()` reuses the same cached read and (b) a missing
-  // MIME type fails fast rather than at send time.
-  const mimeType = resolveMimeType(input, options?.mimeType);
-  const read =
-    typeof input === "string"
-      ? cachedRead(() => readFile(input))
-      : cachedRead(async () => input);
+  // Snapshot the action at builder construction so (a) a missing MIME type
+  // fails fast and (b) the read is cached across repeated `build()` calls.
+  const action = buildPhotoAction(input, options, "background");
   return {
     build: async () =>
       backgroundSchema.parse({
         type: "background",
         __platform: "iMessage",
         __fireAndForget: true,
-        action: { kind: "set", read, mimeType },
+        action,
       }) as unknown as Content,
   };
 }

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -1,6 +1,7 @@
 import { createClient, MessageEffect } from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
 import type { Edit } from "../../content/edit";
+import type { Rename } from "../../content/rename";
 import { definePlatform } from "../../platform/define";
 import type { Message } from "../../types/message";
 import type { Space } from "../../types/space";
@@ -33,6 +34,7 @@ import {
   replyToMessage as remoteReplyToMessage,
   send as remoteSend,
   setBackground as remoteSetBackground,
+  setDisplayName as remoteSetDisplayName,
   startTyping as remoteStartTyping,
   stopTyping as remoteStopTyping,
 } from "./remote/api";
@@ -102,6 +104,47 @@ const handleRead = async (
   }
   const remote = clientForPhone(client, space.phone);
   await remoteMarkRead(remote, space.id);
+};
+
+const handleTyping = async (
+  client: IMessageClient,
+  space: { id: string; phone: string },
+  state: "start" | "stop"
+): Promise<void> => {
+  // Local mode has no typing API — silently no-op so callers can use
+  // `space.startTyping()` uniformly across modes.
+  if (isLocal(client)) {
+    return;
+  }
+  const remote = clientForPhone(client, space.phone);
+  if (state === "start") {
+    await remoteStartTyping(remote, space.id);
+  } else {
+    await remoteStopTyping(remote, space.id);
+  }
+};
+
+const handleRename = async (
+  client: IMessageClient,
+  space: { id: string; phone: string; type: "dm" | "group" },
+  content: Rename
+): Promise<void> => {
+  if (isLocal(client)) {
+    throw UnsupportedError.action(
+      "rename",
+      "iMessage (local mode)",
+      "renaming chats requires remote iMessage"
+    );
+  }
+  if (space.type !== "group") {
+    throw UnsupportedError.action(
+      "rename",
+      "iMessage",
+      "only group chats can be renamed (this space is a DM)"
+    );
+  }
+  const remote = clientForPhone(client, space.phone);
+  await remoteSetDisplayName(remote, space.id, content);
 };
 
 export const imessage = definePlatform("iMessage", {
@@ -278,21 +321,15 @@ export const imessage = definePlatform("iMessage", {
       return;
     }
     if (content.type === "typing") {
-      // Local mode has no typing API — silently no-op so callers can use
-      // `space.startTyping()` uniformly across modes.
-      if (isLocal(client)) {
-        return;
-      }
-      const remote = clientForPhone(client, space.phone);
-      if (content.state === "start") {
-        await remoteStartTyping(remote, space.id);
-      } else {
-        await remoteStopTyping(remote, space.id);
-      }
+      await handleTyping(client, space, content.state);
       return;
     }
     if (content.type === "edit") {
       await handleEdit(client, space, content);
+      return;
+    }
+    if (content.type === "rename") {
+      await handleRename(client, space, content);
       return;
     }
     // `Background` and `Read` are iMessage-only and live outside the

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -1,5 +1,6 @@
 import { createClient, MessageEffect } from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
+import type { Avatar } from "../../content/avatar";
 import type { Edit } from "../../content/edit";
 import type { Rename } from "../../content/rename";
 import { definePlatform } from "../../platform/define";
@@ -35,6 +36,7 @@ import {
   send as remoteSend,
   setBackground as remoteSetBackground,
   setDisplayName as remoteSetDisplayName,
+  setIcon as remoteSetIcon,
   startTyping as remoteStartTyping,
   stopTyping as remoteStopTyping,
 } from "./remote/api";
@@ -145,6 +147,29 @@ const handleRename = async (
   }
   const remote = clientForPhone(client, space.phone);
   await remoteSetDisplayName(remote, space.id, content);
+};
+
+const handleAvatar = async (
+  client: IMessageClient,
+  space: { id: string; phone: string; type: "dm" | "group" },
+  content: Avatar
+): Promise<void> => {
+  if (isLocal(client)) {
+    throw UnsupportedError.action(
+      "avatar",
+      "iMessage (local mode)",
+      "setting group avatars requires remote iMessage"
+    );
+  }
+  if (space.type !== "group") {
+    throw UnsupportedError.action(
+      "avatar",
+      "iMessage",
+      "only group chats have avatars (this space is a DM)"
+    );
+  }
+  const remote = clientForPhone(client, space.phone);
+  await remoteSetIcon(remote, space.id, content);
 };
 
 export const imessage = definePlatform("iMessage", {
@@ -330,6 +355,10 @@ export const imessage = definePlatform("iMessage", {
     }
     if (content.type === "rename") {
       await handleRename(client, space, content);
+      return;
+    }
+    if (content.type === "avatar") {
+      await handleAvatar(client, space, content);
       return;
     }
     // `Background` and `Read` are iMessage-only and live outside the

--- a/packages/spectrum-ts/src/providers/imessage/remote/api.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/api.ts
@@ -1,10 +1,12 @@
 import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { Avatar } from "../../../content/avatar";
 import type { Rename } from "../../../content/rename";
 import type { Content } from "../../../content/types";
 import type { ProviderMessageRecord } from "../../../platform/types";
 import type { ManagedStream } from "../../../utils/stream";
 import type { Background } from "../content/background";
 import type { IMessageMessage, RemoteClient } from "../types";
+import { setIcon as setRemoteIcon } from "./avatar";
 import { setBackground as setRemoteBackground } from "./background";
 import { getMessage as getRemoteMessage } from "./inbound";
 import { reactToMessage as reactToRemoteMessage } from "./reactions";
@@ -36,6 +38,12 @@ export const setDisplayName = async (
   spaceId: string,
   content: Rename
 ): Promise<void> => setRemoteDisplayName(remote, spaceId, content);
+
+export const setIcon = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  content: Avatar
+): Promise<void> => setRemoteIcon(remote, spaceId, content);
 
 export const markRead = async (
   remote: AdvancedIMessage,

--- a/packages/spectrum-ts/src/providers/imessage/remote/api.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/api.ts
@@ -1,4 +1,5 @@
 import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { Rename } from "../../../content/rename";
 import type { Content } from "../../../content/types";
 import type { ProviderMessageRecord } from "../../../platform/types";
 import type { ManagedStream } from "../../../utils/stream";
@@ -8,6 +9,7 @@ import { setBackground as setRemoteBackground } from "./background";
 import { getMessage as getRemoteMessage } from "./inbound";
 import { reactToMessage as reactToRemoteMessage } from "./reactions";
 import { markRead as markRemoteRead } from "./read";
+import { setDisplayName as setRemoteDisplayName } from "./rename";
 import {
   editMessage as editRemoteMessage,
   replyToMessage as replyToRemoteMessage,
@@ -28,6 +30,12 @@ export const setBackground = async (
   spaceId: string,
   content: Background
 ): Promise<void> => setRemoteBackground(remote, spaceId, content);
+
+export const setDisplayName = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  content: Rename
+): Promise<void> => setRemoteDisplayName(remote, spaceId, content);
 
 export const markRead = async (
   remote: AdvancedIMessage,

--- a/packages/spectrum-ts/src/providers/imessage/remote/avatar.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/avatar.ts
@@ -1,0 +1,28 @@
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { Avatar } from "../../../content/avatar";
+import { toChatGuid } from "./ids";
+
+/**
+ * Apply an `Avatar` content value to a remote iMessage group chat.
+ *
+ * `set` uploads the icon bytes via `groups.setIcon`; `clear` removes the
+ * current icon via `groups.removeIcon`. Both surfaces are fire-and-forget —
+ * no message id is produced. The caller (`handleAvatar` in the iMessage
+ * provider) is responsible for the group-only / remote-only guards.
+ */
+export const setIcon = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  content: Avatar
+): Promise<void> => {
+  const chat = toChatGuid(spaceId);
+  if (content.action.kind === "clear") {
+    await remote.groups.removeIcon(chat);
+    return;
+  }
+  const buffer = await content.action.read();
+  await remote.groups.setIcon(
+    chat,
+    new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+  );
+};

--- a/packages/spectrum-ts/src/providers/imessage/remote/rename.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/rename.ts
@@ -1,0 +1,15 @@
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { Rename } from "../../../content/rename";
+import { toChatGuid } from "./ids";
+
+/**
+ * Apply a `Rename` content value to a remote iMessage group chat.
+ * Fire-and-forget — the `Chat` returned by `setDisplayName` is discarded.
+ */
+export const setDisplayName = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  content: Rename
+): Promise<void> => {
+  await remote.groups.setDisplayName(toChatGuid(spaceId), content.displayName);
+};

--- a/packages/spectrum-ts/src/types/space.ts
+++ b/packages/spectrum-ts/src/types/space.ts
@@ -4,6 +4,24 @@ import type { AgentSender } from "./user";
 
 export interface Space<_Def = unknown> {
   readonly __platform: string;
+  /**
+   * Set or clear the current chat's avatar (group icon). Sugar for
+   * `send(avatar(input, options?))`.
+   *
+   * - `space.avatar("clear")` — remove the current avatar.
+   * - `space.avatar("./icon.png")` — set from a filesystem path; MIME type
+   *   is inferred from the extension.
+   * - `space.avatar(buffer, { mimeType })` — set from in-memory bytes;
+   *   `mimeType` is required.
+   *
+   * Universal API; per-platform constraints (e.g. iMessage: remote + group
+   * only) surface as `UnsupportedError` from the provider's send action.
+   */
+  avatar(input: "clear"): Promise<void>;
+  avatar(
+    input: string | Buffer,
+    options?: { mimeType?: string }
+  ): Promise<void>;
   edit(message: Message, newContent: ContentInput): Promise<void>;
   /**
    * Look up a message in this space by its id. Returns `undefined` if the

--- a/packages/spectrum-ts/src/types/space.ts
+++ b/packages/spectrum-ts/src/types/space.ts
@@ -13,6 +13,13 @@ export interface Space<_Def = unknown> {
    */
   getMessage(id: string): Promise<Message | undefined>;
   readonly id: string;
+  /**
+   * Rename the current chat. Sugar for `send(rename(displayName))`.
+   *
+   * Universal API; per-platform constraints (e.g. iMessage: remote + group
+   * only) surface as `UnsupportedError` from the provider's send action.
+   */
+  rename(displayName: string): Promise<void>;
   responding<T>(fn: () => T | Promise<T>): Promise<T>;
   send(
     content: ContentInput

--- a/packages/spectrum-ts/src/types/space.ts
+++ b/packages/spectrum-ts/src/types/space.ts
@@ -12,16 +12,13 @@ export interface Space<_Def = unknown> {
    * - `space.avatar("./icon.png")` — set from a filesystem path; MIME type
    *   is inferred from the extension.
    * - `space.avatar(buffer, { mimeType })` — set from in-memory bytes;
-   *   `mimeType` is required.
+   *   `mimeType` is required (enforced at the type level).
    *
    * Universal API; per-platform constraints (e.g. iMessage: remote + group
    * only) surface as `UnsupportedError` from the provider's send action.
    */
-  avatar(input: "clear"): Promise<void>;
-  avatar(
-    input: string | Buffer,
-    options?: { mimeType?: string }
-  ): Promise<void>;
+  avatar(input: string, options?: { mimeType?: string }): Promise<void>;
+  avatar(input: Buffer, options: { mimeType: string }): Promise<void>;
   edit(message: Message, newContent: ContentInput): Promise<void>;
   /**
    * Look up a message in this space by its id. Returns `undefined` if the

--- a/packages/spectrum-ts/src/utils/photo-content.ts
+++ b/packages/spectrum-ts/src/utils/photo-content.ts
@@ -1,0 +1,89 @@
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+import { lookup as lookupMimeType } from "mime-types";
+import z from "zod";
+import { readSchema } from "./io";
+
+/**
+ * Shared building blocks for photo-style content (chat background, group
+ * avatar/icon, …) whose builders all share the same `set | clear` shape and
+ * the same `"clear"` reserved-string sentinel.
+ *
+ * Keeping the action schema and `buildPhotoAction` factory here means both
+ * `background()` and `avatar()` parse against the same structural definition
+ * and any DX fix (mime inference, read caching, sentinel docs) lands once.
+ */
+
+export const CLEAR_SENTINEL = "clear" as const;
+
+export type PhotoInput = typeof CLEAR_SENTINEL | string | Buffer;
+
+export const photoActionSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("set"),
+    read: readSchema,
+    mimeType: z.string().nonempty(),
+  }),
+  z.object({ kind: z.literal("clear") }),
+]);
+
+export type PhotoAction = z.infer<typeof photoActionSchema>;
+
+const resolveMimeType = (
+  input: string | Buffer,
+  mimeType: string | undefined,
+  contentLabel: string
+): string => {
+  if (mimeType) {
+    return mimeType;
+  }
+  if (typeof input === "string") {
+    const resolved = lookupMimeType(basename(input));
+    if (resolved) {
+      return resolved;
+    }
+  }
+  throw new Error(
+    `Unable to resolve MIME type for ${contentLabel}. Pass options.mimeType explicitly.`
+  );
+};
+
+const cachedRead = (read: () => Promise<Buffer>): (() => Promise<Buffer>) => {
+  let cached: Promise<Buffer> | undefined;
+  return () => {
+    cached ??= read().catch((err: unknown) => {
+      cached = undefined;
+      throw err;
+    });
+    return cached;
+  };
+};
+
+/**
+ * Convert a photo-content input into the discriminated `PhotoAction` shape.
+ *
+ * - `"clear"` → `{ kind: "clear" }` (reserved sentinel — to send a literal
+ *   file named `clear`, pass `"./clear"` or load it as a `Buffer`).
+ * - `string` path → reads the file lazily via `node:fs/promises.readFile`;
+ *   MIME type inferred from the filename extension.
+ * - `Buffer` → in-memory bytes; `options.mimeType` is required.
+ *
+ * Called at builder-construction time so a missing MIME type fails fast
+ * rather than at send time. The returned `read()` is memoized so repeated
+ * `build()` / send cycles don't re-read the same file.
+ */
+export const buildPhotoAction = (
+  input: PhotoInput,
+  options: { mimeType?: string } | undefined,
+  contentLabel: string
+): PhotoAction => {
+  if (input === CLEAR_SENTINEL) {
+    return { kind: "clear" };
+  }
+  const mimeType = resolveMimeType(input, options?.mimeType, contentLabel);
+  const read =
+    typeof input === "string"
+      ? cachedRead(() => readFile(input))
+      : cachedRead(async () => input);
+  return { kind: "set", read, mimeType };
+};

--- a/packages/spectrum-ts/src/utils/photo-content.ts
+++ b/packages/spectrum-ts/src/utils/photo-content.ts
@@ -81,9 +81,15 @@ export const buildPhotoAction = (
     return { kind: "clear" };
   }
   const mimeType = resolveMimeType(input, options?.mimeType, contentLabel);
-  const read =
-    typeof input === "string"
-      ? cachedRead(() => readFile(input))
-      : cachedRead(async () => input);
+  let read: () => Promise<Buffer>;
+  if (typeof input === "string") {
+    read = cachedRead(() => readFile(input));
+  } else {
+    // Snapshot the bytes at builder-construction time so callers can safely
+    // mutate or reuse their Buffer after building (the cached read would
+    // otherwise surface any later writes through the same reference).
+    const snapshot = Buffer.from(input);
+    read = cachedRead(async () => snapshot);
+  }
   return { kind: "set", read, mimeType };
 };


### PR DESCRIPTION
## Summary

- Adds two new universal content types: `rename` (set a chat's display name) and `avatar` (set or clear a chat's icon). Both are exported from `spectrum-ts` and dispatched by providers in their `send` action via `content.type === "rename" | "avatar"`.
- Adds `space.rename(displayName)` and `space.avatar(input, options?)` sugar on the universal `Space` interface — straight delegates to `space.send(rename(...))` / `space.send(avatar(...))` for the canonical form.
- Wires the iMessage provider to handle both: remote-only, group-only. Local mode and DMs throw `UnsupportedError` from the provider's `send` action so canonical and sugar forms share one error path.
- Extracts the shared `set | clear` photo-content scaffolding (`"clear"` sentinel, MIME inference, cached lazy read) into `utils/photo-content.ts` and reuses it for both the new universal `avatar` content and the existing iMessage-only `background` content.

## Motivation

[ENG-1501](https://linear.app/photon-codes/issue/ENG-1501) — Spectrum had no universal way to change a group chat's name or icon. iMessage already exposes both via `advanced-imessage` (`groups.setDisplayName`, `groups.setIcon` / `removeIcon`) and other providers will follow, so the API needs to live at the universal layer rather than only behind iMessage-only content like `background`.

The `avatar` builder shares the same `set | clear` shape and the same `"clear"` reserved-string sentinel as `background`, so the underlying action schema, MIME-type resolution, and read-caching are extracted once into `utils/photo-content.ts` — any DX fix lands for both at the same time.

## Usage

```typescript
import { avatar, rename } from "spectrum-ts";

// Canonical form
await space.send(rename("Team Photon"));
await space.send(avatar("./team-icon.png"));
await space.send(avatar("clear"));

// Universal sugar
await space.rename("Team Photon");
await space.avatar("./team-icon.png");
await space.avatar(buffer, { mimeType: "image/png" });
await space.avatar("clear");
```

On iMessage, both throw `UnsupportedError` against a DM or in local mode.

## Changes

| File | Change |
|------|--------|
| `content/rename.ts` *(new)* | `rename(displayName)` content builder. Throws at build time if `displayName` is empty. |
| `content/avatar.ts` *(new)* | `avatar(input, options?)` content builder. Delegates to `buildPhotoAction` for the `set | clear` action shape. `"clear"` is the reserved sentinel for removing the avatar. |
| `utils/photo-content.ts` *(new)* | Shared `photoActionSchema`, `PhotoInput`, and `buildPhotoAction` factory. Snapshots MIME type and lazy reader at builder construction (fails fast on missing MIME, memoizes the read). |
| `content/types.ts` | Adds `renameSchema` and `avatarSchema` to `baseContentSchemas` so both are members of the universal `Content` discriminated union. |
| `content/edit.ts`, `content/reply.ts` | Reject wrapping `rename` and `avatar` — they're fire-and-forget chat-state mutations, not message-bound content. |
| `platform/build.ts` | Adds `"rename"` and `"avatar"` to `FIRE_AND_FORGET_TYPES` and to `RESERVED_SPACE_KEYS`. Implements `space.rename` / `space.avatar` sugar by delegating to `space.send(...)`. |
| `types/space.ts` | Adds `rename(displayName)` and overloaded `avatar(...)` methods to the universal `Space` interface. |
| `providers/imessage/index.ts` | Adds `handleRename` and `handleAvatar` (remote-only + group-only guards via `UnsupportedError`). Dispatches `content.type === "rename" | "avatar"` in the `send` action. Extracts the existing `typing` body into a `handleTyping` helper for consistency. |
| `providers/imessage/remote/rename.ts` *(new)* | Thin remote-side wrapper around `groups.setDisplayName`. Fire-and-forget. |
| `providers/imessage/remote/avatar.ts` *(new)* | Thin remote-side wrapper: dispatches to `groups.setIcon` (with the buffer converted to a `Uint8Array` view) or `groups.removeIcon` based on `content.action.kind`. |
| `providers/imessage/remote/api.ts` | Re-exports `setDisplayName` and `setIcon` alongside the existing remote actions. |
| `providers/imessage/content/background.ts` | Migrates to `photoActionSchema` / `buildPhotoAction`; drops the now-duplicated local `backgroundActionSchema`, `resolveMimeType`, and `cachedRead` helpers. `BackgroundInput` re-exported as `PhotoInput` for source compatibility. |
| `index.ts` | Re-exports `rename`, `Rename`, `avatar`, `Avatar`, `AvatarInput`. |

## Test plan

- [ ] `bun x ultracite check` passes
- [ ] `tsc --noEmit` passes (verifies the new `Space.rename` / `Space.avatar` overloads and the discriminated-union members)
- [ ] Smoke test against remote iMessage: `space.rename("New name")` on a group chat updates the display name
- [ ] Smoke test against remote iMessage: `space.avatar("./icon.png")` on a group chat sets the icon; `space.avatar("clear")` removes it
- [ ] Smoke test against remote iMessage: `space.rename(...)` / `space.avatar(...)` on a DM throws `UnsupportedError` mentioning "only group chats"
- [ ] Smoke test against local-mode iMessage: both throw `UnsupportedError` mentioning "remote iMessage"
- [ ] Smoke test: `space.avatar(buffer)` without `options.mimeType` fails at builder construction (not at send time) with a clear "Unable to resolve MIME type" error
- [ ] Smoke test: `space.send(edit(rename("x"), msg))` and `space.send(reply(avatar("./x.png"), msg))` both throw `edit() / reply() cannot wrap "..." content`
- [ ] Existing `space.background(...)` flow still works after the shared-helper extraction

Linear: [ENG-1501](https://linear.app/photon-codes/issue/ENG-1501)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782126125&installation_id=127326493&pr_number=75&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F75&signature=f74910cc52e5cdd0d8023c092ecf71e4a2b5e658826ad1240e71f8c7d212273c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Set or clear chat avatars using files or bytes; rename chats with a new display-name action.
  * Avatar and rename actions available on iMessage group chats.
  * New Space.avatar() and Space.rename() convenience methods.

* **Behavior**
  * Replies and edits now disallow nesting rename or avatar actions to prevent invalid payloads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->