### PR TITLE
ci(release): opt into npm OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: read
+  id-token: write
 
 jobs:
   release:
@@ -16,6 +17,7 @@ jobs:
       working-directory: packages/spectrum-ts
       build-command: "bun run build"
       publish-command: "bunx clean-publish --package-manager npm"
+      use-oidc: true
       dry-run: false
     secrets: inherit
 


### PR DESCRIPTION
## Summary

Token-based npm publishing has been silently failing for `spectrum-ts` since `v1.10.0`. The org-level `NPM_TOKEN` was invalidated on the npm.com side sometime between 2026-05-19 and 2026-05-21, and `bunx clean-publish` swallowed the resulting `npm error code E404` exit, so four GitHub releases (`v1.10.0`, `v1.10.1`, `v1.11.0`, `v1.11.1`) shipped to GitHub but never landed on npm — npm `latest` is still `1.9.2`.

This PR moves `spectrum-ts` to **npm OIDC Trusted Publishing** so future releases authenticate with a per-run GitHub-issued OIDC token instead of a long-lived secret. No more rotating-token-secret class of failure.

## Changes

- `permissions:` add `id-token: write` (required for the runner to mint the OIDC token).
- `with:` add `use-oidc: true` so buildspace's `typescript-service-release` workflow routes through the OIDC publish job.

The buildspace `publish-npm` block already prefers OIDC when `id-token` is available and falls back to `NPM_TOKEN` otherwise, so this is safe — if Trusted Publisher isn't configured yet on the npm side, the publish silently no-ops the way it has been (until photon-hq/buildspace#82 lands, which makes that case hard-fail).

## Required pre-merge action on npmjs.com

Trusted Publisher must be configured for the `spectrum-ts` package **before** this PR is merged with a `release` label, otherwise OIDC will fail and the publish will fall back to the still-broken token. As maintainer `photon_dev`:

1. Visit https://www.npmjs.com/package/spectrum-ts/access
2. Scroll to **Trusted Publisher** → **Add publisher**
3. Fill in:
   - Publisher: **GitHub Actions**
   - Organization or user: `photon-hq`
   - Repository: `spectrum-ts`
   - Workflow filename: `release.yaml`
   - Environment: *(leave blank)*
4. Save

## Test plan

- [ ] Configure Trusted Publisher on npmjs.com (above)
- [ ] Merge this PR (no `release` label) — confirms workflow YAML still parses on push to main
- [ ] Open a follow-up no-op PR (e.g., a docs tweak) with the `release` label
- [ ] Watch the release run: `npm-publish-oidc` job should run instead of `npm-publish`, and the verify-on-registry step (after photon-hq/buildspace#82) should report `<name>@<version> is live on the npm registry`
- [ ] Confirm `curl https://registry.npmjs.org/spectrum-ts | jq '."dist-tags".latest'` shows the new version

## Background

Detailed root-cause analysis: every release run since `v1.10.0` shows `npm error 404 - PUT https://registry.npmjs.org/spectrum-ts - Not found` (npm returns 404 instead of 401/403 for auth failures), but the step still reports `[success]` because `bunx clean-publish` doesn't propagate npm's non-zero exit. Counter-evidence: org-level `NPM_TOKEN` secret's `updated_at` is `2026-05-11`, well before `1.9.2` published cleanly on `2026-05-19`, so the GitHub-side secret value never changed — the token itself was invalidated on npm.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782155882&installation_id=127326493&pr_number=76&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F76&signature=e0bdf1c3337013378abb6754c617f61fff9aa12dbddad3910d5f7209743cc7ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow security configuration to enhance deployment processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->