### PR TITLE
fix(package): add repository field for npm OIDC provenance

### DIFF
--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -1,6 +1,16 @@
 {
   "name": "spectrum-ts",
   "version": "1.11.2",
+  "description": "Bring agents to any interface — unified messaging SDK for TypeScript.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/photon-hq/spectrum-ts.git",
+    "directory": "packages/spectrum-ts"
+  },
+  "homepage": "https://photon.codes/spectrum",
+  "bugs": {
+    "url": "https://github.com/photon-hq/spectrum-ts/issues"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",


### PR DESCRIPTION
## Summary

The v1.11.2 OIDC publish failed at the provenance verification step:

```text
npm error code E422
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/spectrum-ts
Error verifying sigstore provenance bundle: Failed to validate repository
information: package.json: "repository.url" is "", expected to match
"https://github.com/photon-hq/spectrum-ts" from provenance
```

When OIDC Trusted Publishing is used with `--provenance` (which `npm publish` adds automatically when an OIDC id-token is present), npm cross-checks `package.json#repository.url` against the GitHub repository the OIDC token was issued from. The values must match — npm's way of asserting that the provenance attestation actually pertains to *this* package.

Our `package.json` had no `repository` field at all, so the comparison saw `""` vs `https://github.com/photon-hq/spectrum-ts` and rejected the publish with `E422`. The verify-on-registry step (from photon-hq/buildspace#82, just merged) caught the silent failure cleanly — Layer 2 of the new defense did its job.

## Changes

Adds `repository` (with the `directory` field for monorepo packages), `homepage`, and `bugs` to `packages/spectrum-ts/package.json`:

```json
"repository": {
  "type": "git",
  "url": "git+https://github.com/photon-hq/spectrum-ts.git",
  "directory": "packages/spectrum-ts"
},
"homepage": "https://photon.codes/spectrum",
"bugs": {
  "url": "https://github.com/photon-hq/spectrum-ts/issues"
}
```

The `git+https://github.com/photon-hq/spectrum-ts.git` URL normalizes (after stripping `git+` and `.git`) to exactly the GitHub URL the provenance statement carries, satisfying npm's check.

`description` is also added since most npm metadata tooling expects it.

## Test plan

- [x] JSON validates (`python3 -m json.tool` passes)
- [ ] Merge with the `release` label so the next release fires
- [ ] Watch the run: `npm-publish-oidc` should now succeed, `Verify publish landed on registry` should report `✅ <name>@<version> is live on the npm registry`
- [ ] `curl -s https://registry.npmjs.org/spectrum-ts | jq -r '."dist-tags".latest'` returns the new version

## Notes

- v1.11.2 is a "ghost" version: GitHub tag exists, npm has nothing. Same shape as 1.10.0..1.11.1. The next release will pick `1.11.3` (or whatever the AI chooses) and that one will publish cleanly to both. The 1.11.2 ghost is harmless — consumers will install `latest` and get whatever publishes next.
- This depends on npm OIDC Trusted Publisher being configured for `spectrum-ts` (it already is — that's why the publish got far enough to sign provenance and fail at the verify step).

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782158063&installation_id=127326493&pr_number=77&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F77&signature=81182dbf3b1f3fb21f425737939125ca8ffa0609f62f2cd1b1948f2b9f24226c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to reflect product description.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->