### PR TITLE
feat(spectrum-ts): auto-generate provider manifest at build time

### DIFF
--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -33,7 +33,8 @@
       "bun": "./src/providers/*/index.ts",
       "types": "./src/providers/*/index.ts",
       "default": "./dist/providers/*/index.js"
-    }
+    },
+    "./manifest.json": "./dist/manifest.json"
   },
   "publishConfig": {
     "exports": {
@@ -48,14 +49,16 @@
       "./providers/*": {
         "types": "./dist/providers/*/index.d.ts",
         "default": "./dist/providers/*/index.js"
-      }
+      },
+      "./manifest.json": "./dist/manifest.json"
     }
   },
   "scripts": {
-    "build": "bun scripts/prepare-package.ts && tsup",
+    "build": "bun scripts/prepare-package.ts && tsup && bun scripts/generate-manifest.ts",
     "dev": "tsup --watch",
     "generate:emoji": "bun scripts/generate-emoji.ts",
-    "prepack": "bun scripts/prepare-package.ts --publish && tsup && bun scripts/prepare-package.ts"
+    "generate:manifest": "bun scripts/generate-manifest.ts",
+    "prepack": "bun scripts/prepare-package.ts --publish && tsup && bun scripts/generate-manifest.ts && bun scripts/prepare-package.ts"
   },
   "dependencies": {
     "@photon-ai/advanced-imessage": "^0.8.0",

--- a/packages/spectrum-ts/scripts/generate-manifest.ts
+++ b/packages/spectrum-ts/scripts/generate-manifest.ts
@@ -10,10 +10,13 @@
  * `definePlatform(...)` is the `label`. No hand-curated list to drift out
  * of sync.
  *
- * Run as part of `bun run build`, after `tsup`.
+ * Run as part of `bun run build`, after `tsup`. Standalone-safe — creates
+ * `dist/` if missing — but a manifest entry whose compiled artifact
+ * (`dist/providers/<key>/index.js`) is absent will fail the script, since
+ * shipping such an entry would point consumers at code that doesn't exist.
  */
 
-import { readdir, readFile, writeFile } from "node:fs/promises";
+import { access, mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -27,10 +30,20 @@ interface ManifestEntry {
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PKG_ROOT = dirname(HERE);
 const PROVIDERS_DIR = join(PKG_ROOT, "src", "providers");
+const DIST_PROVIDERS_DIR = join(PKG_ROOT, "dist", "providers");
 const OUT_PATH = join(PKG_ROOT, "dist", "manifest.json");
 
 const DEFINE_PLATFORM_RE =
   /^export\s+const\s+(\w+)\s*=\s*definePlatform\(\s*"([^"]+)"/m;
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 async function buildManifest(): Promise<ManifestEntry[]> {
   const entries = await readdir(PROVIDERS_DIR, { withFileTypes: true });
@@ -46,15 +59,25 @@ async function buildManifest(): Promise<ManifestEntry[]> {
     const match = source.match(DEFINE_PLATFORM_RE);
     if (!match) {
       throw new Error(
-        `Provider "${key}" at ${sourcePath} does not match the expected ` +
-          `\`export const <name> = definePlatform("<label>", ...)\` pattern. ` +
-          "If you intentionally renamed the call, update generate-manifest.ts."
+        `Provider "${key}" at ${sourcePath} does not match the expected \`export const <name> = definePlatform("<label>", ...)\` pattern. If you intentionally renamed the call, update generate-manifest.ts.`
       );
     }
     const [, importName, label] = match;
     if (!(importName && label)) {
       throw new Error(`Failed to parse provider "${key}"`);
     }
+
+    // Guard against the manifest declaring a provider that tsup didn't
+    // actually compile (e.g. someone added src/providers/foo/ without also
+    // adding it to tsup.config.ts's entry list). Shipping such an entry
+    // would have downstream consumers fail to resolve the import path.
+    const compiled = join(DIST_PROVIDERS_DIR, key, "index.js");
+    if (!(await fileExists(compiled))) {
+      throw new Error(
+        `Provider "${key}" has source at ${sourcePath} but no compiled output at ${compiled}. Add it to tsup.config.ts's entry list (or run \`bun run build\` first if invoking generate:manifest standalone).`
+      );
+    }
+
     manifest.push({
       key,
       import: importName,
@@ -69,6 +92,10 @@ async function buildManifest(): Promise<ManifestEntry[]> {
 }
 
 const manifest = await buildManifest();
+// `mkdir … { recursive: true }` is a no-op when `dist/` already exists (the
+// normal case during `bun run build`), and creates it when running the
+// script standalone before tsup has populated the directory.
+await mkdir(dirname(OUT_PATH), { recursive: true });
 await writeFile(OUT_PATH, `${JSON.stringify(manifest, null, 2)}\n`);
 process.stdout.write(
   `Wrote ${manifest.length} provider entries to ${OUT_PATH}\n`

--- a/packages/spectrum-ts/scripts/generate-manifest.ts
+++ b/packages/spectrum-ts/scripts/generate-manifest.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env bun
+/**
+ * Generates `dist/manifest.json` — a small public surface describing every
+ * provider in `src/providers/`. Consumed by external tooling (e.g.
+ * `create-spectrum-app`) so adding a provider here is enough; downstream
+ * scaffolders pick it up automatically.
+ *
+ * Each entry derives from the provider's own source: the directory name is
+ * the `key`, the exported `const` is the `import`, and the first argument to
+ * `definePlatform(...)` is the `label`. No hand-curated list to drift out
+ * of sync.
+ *
+ * Run as part of `bun run build`, after `tsup`.
+ */
+
+import { readdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface ManifestEntry {
+  import: string;
+  key: string;
+  label: string;
+  path: string;
+}
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = dirname(HERE);
+const PROVIDERS_DIR = join(PKG_ROOT, "src", "providers");
+const OUT_PATH = join(PKG_ROOT, "dist", "manifest.json");
+
+const DEFINE_PLATFORM_RE =
+  /^export\s+const\s+(\w+)\s*=\s*definePlatform\(\s*"([^"]+)"/m;
+
+async function buildManifest(): Promise<ManifestEntry[]> {
+  const entries = await readdir(PROVIDERS_DIR, { withFileTypes: true });
+  const manifest: ManifestEntry[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const key = entry.name;
+    const sourcePath = join(PROVIDERS_DIR, key, "index.ts");
+    const source = await readFile(sourcePath, "utf8");
+    const match = source.match(DEFINE_PLATFORM_RE);
+    if (!match) {
+      throw new Error(
+        `Provider "${key}" at ${sourcePath} does not match the expected ` +
+          `\`export const <name> = definePlatform("<label>", ...)\` pattern. ` +
+          "If you intentionally renamed the call, update generate-manifest.ts."
+      );
+    }
+    const [, importName, label] = match;
+    if (!(importName && label)) {
+      throw new Error(`Failed to parse provider "${key}"`);
+    }
+    manifest.push({
+      key,
+      import: importName,
+      path: `spectrum-ts/providers/${key}`,
+      label,
+    });
+  }
+
+  // Deterministic order so the file diff is stable across machines / FS orderings.
+  manifest.sort((a, b) => a.key.localeCompare(b.key));
+  return manifest;
+}
+
+const manifest = await buildManifest();
+await writeFile(OUT_PATH, `${JSON.stringify(manifest, null, 2)}\n`);
+process.stdout.write(
+  `Wrote ${manifest.length} provider entries to ${OUT_PATH}\n`
+);

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -537,7 +537,7 @@ function protocolToSpectrum(p: ProtocolContent): SpectrumContent {
 
 // ----- the provider -----
 
-export const terminal = definePlatform("terminal", {
+export const terminal = definePlatform("Terminal", {
   config: z.object({
     commands: z.array(commandSchema).optional(),
   }),


### PR DESCRIPTION
## Summary

- Adds `scripts/generate-manifest.ts`, which scans `src/providers/*/index.ts` and writes `dist/manifest.json` from the actual provider sources (key from directory, import name + label from each `definePlatform(...)` call).
- Hooks into both `build` and `prepack` after `tsup`, so the manifest is always in sync with the providers that actually ship — adding a new provider is just a directory, the manifest updates itself.
- Exposes `"./manifest.json"` in both `exports` and `publishConfig.exports`, so downstream tooling (next up: `create-spectrum-app`) can either subpath-import it or fetch `unpkg.com/spectrum-ts/manifest.json` at runtime.
- Capitalizes the terminal provider's label (`"terminal"` → `"Terminal"`) so it matches the casing of the other providers (`iMessage`, `Slack`, `WhatsApp Business`) once the manifest surfaces labels to downstream consumers.

The generator throws loudly if any provider doesn't match the expected `export const X = definePlatform("Y", ...)` shape — so a refactor of the convention fails the build instead of silently shipping a wrong manifest.

Current generated output (4 providers):

```json
[
  { "key": "imessage",          "import": "imessage",         "path": "spectrum-ts/providers/imessage",          "label": "iMessage" },
  { "key": "slack",             "import": "slack",            "path": "spectrum-ts/providers/slack",             "label": "Slack" },
  { "key": "terminal",          "import": "terminal",         "path": "spectrum-ts/providers/terminal",          "label": "Terminal" },
  { "key": "whatsapp-business", "import": "whatsappBusiness", "path": "spectrum-ts/providers/whatsapp-business", "label": "WhatsApp Business" }
]
```

## Test plan

- [x] `bun run build` runs end-to-end and writes a valid `dist/manifest.json` with all 4 providers
- [x] `bun x ultracite check` clean on the new script + package.json
- [x] `bun run prepack` produces the same manifest in publish-prep state; package.json is restored cleanly after
- [x] Manually breaking a provider's `definePlatform("...")` signature (e.g. swapping the string literal for a variable) fails the build with a clear error naming the file and the expected pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package manifest (manifest.json) is now included in package exports to improve provider discovery and integration.

* **Chores**
  * Build and publish workflows now automatically generate the manifest during build/prepack.
  * Platform identifier naming standardized for consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->