### PR TITLE
fix(terminal): align internal "terminal" literal with capitalized platform name

### DIFF
--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -454,7 +454,7 @@ async function spectrumToProtocol(
   // crashes the whole process.
   throw UnsupportedError.content(
     (content as { type: string }).type,
-    "terminal"
+    "Terminal"
   );
 }
 


### PR DESCRIPTION
## Summary

Hotfix for v1.13.0. The `definePlatform("Terminal", ...)` rename that landed in #80 set the runtime platform identifier to `"Terminal"`, but the `UnsupportedError.content(..., "terminal")` call at `terminal/index.ts:457` still passed the old lowercase string. That makes the error metadata internally inconsistent with `def.name` — a content type the Terminal provider doesn't support raises an error whose platform field disagrees with what `__platform` tags on messages and spaces report.

Caught by Copilot during PR #80 review. The alignment fix was on that PR's branch but landed *after* the squash-merge of #80, so it didn't make it into 1.13.0. This brings `main` into the consistent state.

```diff
   throw UnsupportedError.content(
     (content as { type: string }).type,
-    "terminal"
+    "Terminal"
   );
```

Pairs with a 1.13.1 patch release.

## Test plan

- [x] `grep '"terminal"\|'\''terminal'\''' packages/spectrum-ts/src` returns nothing after the fix
- [x] `bun run build` succeeds; `dist/manifest.json` still reports `"label": "Terminal"`
- [ ] Post-release: confirm `unpkg.com/spectrum-ts@1.13.1/manifest.json` matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782349041&installation_id=127326493&pr_number=81&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F81&signature=5d36994c7e82d8357980da0e5e903c4ab9ab3512674c129ecece8d45553f9727"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected capitalization in error messages for unsupported content types in the terminal provider.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->