### PR TITLE
fix(spectrum.stop): close gRPC channels before draining streams to eliminate orphan subscriptions

### DIFF
--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -439,20 +439,11 @@ export async function Spectrum<
     }
     stopped = true;
 
-    const streamShutdowns = [
-      messagesStream.close(),
-      ...Array.from(customEventStreams.values(), (eventStream) =>
-        eventStream.close()
-      ),
-      ...Array.from(messageBroadcasters.values(), (broadcaster) =>
-        broadcaster.close()
-      ),
-    ];
-
     process.off("SIGINT", handleSignal);
     process.off("SIGTERM", handleSignal);
 
-    await Promise.allSettled(streamShutdowns);
+    // Phase 1: close clients
+    const clientCloseStart = performance.now();
     const clientShutdowns: Promise<void>[] = [];
     for (const state of platformStates.values()) {
       const destroy = state.definition.lifecycle.destroyClient;
@@ -474,10 +465,29 @@ export async function Spectrum<
       );
     }
     await Promise.allSettled(clientShutdowns);
+    const clientCloseEnd = performance.now();
+
+    // Phase 2: drain streams
+    const streamShutdowns = [
+      messagesStream.close(),
+      ...Array.from(customEventStreams.values(), (eventStream) =>
+        eventStream.close()
+      ),
+      ...Array.from(messageBroadcasters.values(), (broadcaster) =>
+        broadcaster.close()
+      ),
+    ];
+    await Promise.allSettled(streamShutdowns);
+    const streamCloseEnd = performance.now();
+
     customEventStreams.clear();
     messageBroadcasters.clear();
     platformStates.clear();
-    lifecycleLog.info("Spectrum stopped", { providers: providerNames });
+    lifecycleLog.info("Spectrum stopped", {
+      providers: providerNames,
+      clientCloseMs: Math.round(clientCloseEnd - clientCloseStart),
+      streamCloseMs: Math.round(streamCloseEnd - clientCloseEnd),
+    });
     if (otelHandle) {
       await otelHandle.shutdown();
     }


### PR DESCRIPTION
## Summary

Reorder `Spectrum.stopOnce()` so the provider client close runs FIRST (TCP-RSTs the upstream gRPC subscription within milliseconds), and the in-process stream cascade drains SECOND. Eliminates the orphan-subscription window that lets a dying SDK instance's upstream sub outlive `stop()` and race a newly-started instance for the same project. Also adds per-phase timing instrumentation (`clientCloseMs`, `streamCloseMs`) on the `Spectrum stopped` lifecycle log so we can verify in prod and watch for regressions.

## Background

On 2026-05-25, MindStudio customer (project `03009890`) experienced ~23 hours of silent webhook delivery. Root cause: race condition between `pool.stop` and `Spectrum.stopOnce` teardown:

- `pool.stop` wraps `Spectrum.stop` in a 1500ms timeout
- `Spectrum.stop` consistently exceeds 1500ms (verified 22/22 timeout rate in 23-hour log window)
- When the timeout fires, the SDK keeps its upstream gRPC subscription alive in a background closure
- The next `pool.start` opens a new subscription — two subscribers race for the same project
- Upstream routed to the orphan for ~23 hours; new instance received zero events
- Worker restart (already performed) resolved the immediate incident

## What this PR changes

- `packages/spectrum-ts/src/spectrum.ts`:
  - Phase 1 (NEW order): iterate `platformStates` and call each provider's `destroyClient` first. For gRPC providers this closes the channel and TCP-RSTs the upstream subscription immediately.
  - Phase 2 (NEW order): close `messagesStream`, `customEventStreams`, and `messageBroadcasters` after the channel is gone. In-flight `live` iterations inside resumable streams observe a channel-closed error rather than clean EOF; the resumable cleanup sets `closed` and `cancelSleep()` so the next loop iteration exits cleanly via `end()`.
  - `process.off` for `SIGINT`/`SIGTERM` is hoisted above phase 1 so we don't keep handling signals during teardown.
  - `Spectrum stopped` log now includes `clientCloseMs` and `streamCloseMs` measured via `performance.now()` deltas, so we can confirm phase 1 is the fast path and detect any regression that re-introduces a slow client close.

## Deploy ordering

**Independent — ships anytime.** Once this PR is deployed (i.e. when consumers pull a new SDK version), the orphan-overlap window is structurally closed at the SDK layer via immediate TCP RST. No coordination required with the companion PRs.

The companion PRs (`spectrum-cloud` timeout bump + `spectrum-webhook` defense in depth) provide additional safety from the consumer side and are coordinated against each other, but this one is fully self-contained.

## Test plan

- [ ] Lint passes
- [ ] Typecheck passes
- [ ] All tests pass
- [ ] After deploy: confirm `clientCloseMs` and `streamCloseMs` fields appear on `Spectrum stopped` log lines in prod; expect `clientCloseMs` to dominate `streamCloseMs` for the iMessage provider on the unhappy path, and the total to be well under 1s on the happy path.
- [ ] After deploy: in spectrum-webhook prod logs, the 22/22 `pool.stop` timeout rate from the 23-hour incident window should drop toward zero as the SDK update rolls out.

## Related PRs

This is one of three coordinated PRs:
- spectrum-ts (structural fix): https://github.com/photon-hq/spectrum-ts/pull/84 ← this PR
- spectrum-cloud (timeout bump): https://github.com/photon-hq/spectrum-cloud/pull/55
- spectrum-webhook (defense in depth): https://github.com/photon-hq/spectrum-webhook/pull/30