### PR TITLE
feat(stop): add per-phase timing instrumentation to Spectrum.stopOnce

### DIFF
--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -452,7 +452,12 @@ export async function Spectrum<
     process.off("SIGINT", handleSignal);
     process.off("SIGTERM", handleSignal);
 
+    // Phase 1: stream cascade
+    const streamCloseStart = performance.now();
     await Promise.allSettled(streamShutdowns);
+    const streamCloseMs = Math.round(performance.now() - streamCloseStart);
+
+    // Phase 2: destroy clients
     const clientShutdowns: Promise<void>[] = [];
     for (const state of platformStates.values()) {
       const destroy = state.definition.lifecycle.destroyClient;
@@ -473,11 +478,18 @@ export async function Spectrum<
         )
       );
     }
+    const clientCloseStart = performance.now();
     await Promise.allSettled(clientShutdowns);
+    const clientCloseMs = Math.round(performance.now() - clientCloseStart);
+
     customEventStreams.clear();
     messageBroadcasters.clear();
     platformStates.clear();
-    lifecycleLog.info("Spectrum stopped", { providers: providerNames });
+    lifecycleLog.info("Spectrum stopped", {
+      providers: providerNames,
+      streamCloseMs,
+      clientCloseMs,
+    });
     if (otelHandle) {
       await otelHandle.shutdown();
     }


### PR DESCRIPTION
## Motivation

`Spectrum.stopOnce()` runs two phases sequentially:

1. **Phase 1** — drain in-process streams (`messagesStream`, custom event streams, message broadcasters).
2. **Phase 2** — destroy provider clients (`destroyClient` lifecycle hook — e.g. gRPC channel close for iMessage, REST client teardown, etc.).

Downstream consumers wrap `stop()` in a hard timeout (e.g. `spectrum-webhook` uses `POOL_STOP_TIMEOUT_MS` ≈ 1.5–5s). When stop is slow we have no way to tell which phase ate the budget — today the only signal is the single `"Spectrum stopped"` lifecycle log, which has no timing data.

This PR adds the minimum viable observability needed to make a data-driven decision before considering any structural changes to the shutdown path.

## Change

`packages/spectrum-ts/src/spectrum.ts` — `stopOnce()`:

- Wrap each `await Promise.allSettled(...)` with `performance.now()` measurements.
- Round results to integer ms with `Math.round`.
- Add two fields to the existing `lifecycleLog.info("Spectrum stopped", ...)` call:
  - `streamCloseMs` — Phase 1 (stream cascade) duration
  - `clientCloseMs` — Phase 2 (destroyClient) duration
- Preserve all existing log fields (`providers`).

Diff is +13 / −1 lines, scoped to a single file.

## Non-goal — explicit

**This PR does NOT reorder phases.** The original order (streams first, clients second) is preserved verbatim.

A separate draft PR previously proposed swapping the phases (close clients before draining streams) under the hypothesis that orphan gRPC subscriptions on the upstream relay were stealing routing. That hypothesis turned out to be incomplete — upstream broadcasts to all subscribers — so the reorder solved a non-problem and is being deferred. We want production timing data from this PR before reconsidering any structural change to shutdown.

## Test plan

- [x] `bun run check` (ultracite) — clean across all 98 files
- [x] `bun x tsc --noEmit -p packages/spectrum-ts/tsconfig.json` — clean
- [x] `bun test` — no test files in repo; nothing to break (purely additive logging, no behavior change)
- [ ] After merge / deploy, verify in production logs that the `Spectrum stopped` event now carries `streamCloseMs` and `clientCloseMs` fields and that values look sane (positive integers, typically small)

## Follow-ups (not in this PR)

Once we have a week or two of production data:
- Decide whether either phase is a real bottleneck.
- If so, decide whether to address it with a timeout, parallelization, reorder, or other structural change — informed by actual numbers rather than guessing.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/85"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782432492&installation_id=127326493&pr_number=85&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F85&signature=3554487786c9009c3132bf83fd0b6c47502c01220a349c951fcdde9ceef57be5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced shutdown logging with elapsed time metrics for stream and client shutdown phases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->