### PR TITLE
feat(content): accept URL inputs for attachment, voice, avatar, and background

### DIFF
--- a/packages/spectrum-ts/src/content/attachment.ts
+++ b/packages/spectrum-ts/src/content/attachment.ts
@@ -4,7 +4,12 @@ import { basename } from "node:path";
 import { Readable } from "node:stream";
 import { lookup as lookupMimeType } from "mime-types";
 import z from "zod";
-import { bufferToStream, readSchema, streamSchema } from "../utils/io";
+import {
+  bufferToStream,
+  fetchUrlBytes,
+  readSchema,
+  streamSchema,
+} from "../utils/io";
 import type { ContentBuilder } from "./types";
 
 const DEFAULT_ATTACHMENT_NAME = "attachment";
@@ -20,9 +25,23 @@ export const attachmentSchema = z.object({
 
 export type Attachment = z.infer<typeof attachmentSchema>;
 
-const resolveAttachmentName = (input: string | Buffer, name?: string): string =>
-  name ||
-  (typeof input === "string" ? basename(input) : DEFAULT_ATTACHMENT_NAME);
+export type AttachmentInput = string | Buffer | URL;
+
+const resolveAttachmentName = (
+  input: AttachmentInput,
+  name?: string
+): string => {
+  if (name) {
+    return name;
+  }
+  if (input instanceof URL) {
+    return basename(input.pathname) || DEFAULT_ATTACHMENT_NAME;
+  }
+  if (typeof input === "string") {
+    return basename(input);
+  }
+  return DEFAULT_ATTACHMENT_NAME;
+};
 
 const resolveAttachmentMimeType = (name: string, mimeType?: string): string => {
   if (mimeType) {
@@ -68,13 +87,21 @@ export const asAttachment = (input: {
 };
 
 export function attachment(
-  input: string | Buffer,
+  input: AttachmentInput,
   options?: { mimeType?: string; name?: string }
 ): ContentBuilder {
   return {
     build: async () => {
       const name = resolveAttachmentName(input, options?.name);
       const mimeType = resolveAttachmentMimeType(name, options?.mimeType);
+
+      if (input instanceof URL) {
+        return asAttachment({
+          name,
+          mimeType,
+          read: async () => (await fetchUrlBytes(input)).data,
+        });
+      }
 
       if (typeof input === "string") {
         const stats = await stat(input);

--- a/packages/spectrum-ts/src/content/avatar.ts
+++ b/packages/spectrum-ts/src/content/avatar.ts
@@ -32,6 +32,10 @@ export type AvatarInput = PhotoInput;
  * - `avatar("clear")` — remove the current chat avatar.
  * - `avatar("./icon.png")` — set avatar from a filesystem path. MIME type is
  *   inferred from the extension; override with `options.mimeType`.
+ * - `avatar(new URL("https://…/icon.png"))` — fetch the avatar lazily over
+ *   the network. Bytes stay in memory (safe in read-only environments). MIME
+ *   type is inferred from the URL pathname extension; override with
+ *   `options.mimeType` when the URL has no usable extension.
  * - `avatar(buffer, { mimeType })` — set avatar from in-memory bytes.
  *   `options.mimeType` is required (enforced at the type level).
  *
@@ -40,7 +44,7 @@ export type AvatarInput = PhotoInput;
  * Buffer.
  */
 export function avatar(
-  input: string,
+  input: string | URL,
   options?: { mimeType?: string }
 ): ContentBuilder;
 export function avatar(

--- a/packages/spectrum-ts/src/content/voice.ts
+++ b/packages/spectrum-ts/src/content/voice.ts
@@ -4,7 +4,12 @@ import { basename } from "node:path";
 import { Readable } from "node:stream";
 import { lookup as lookupMimeType } from "mime-types";
 import z from "zod";
-import { bufferToStream, readSchema, streamSchema } from "../utils/io";
+import {
+  bufferToStream,
+  fetchUrlBytes,
+  readSchema,
+  streamSchema,
+} from "../utils/io";
 import type { ContentBuilder } from "./types";
 
 const AUDIO_MIME_PATTERN = /^audio\//i;
@@ -26,17 +31,35 @@ export const voiceSchema = z.object({
 
 export type Voice = z.infer<typeof voiceSchema>;
 
+export type VoiceInput = string | Buffer | URL;
+
 const resolveVoiceName = (
-  input: string | Buffer,
+  input: VoiceInput,
   name?: string
 ): string | undefined => {
   if (name) {
     return name;
   }
+  if (input instanceof URL) {
+    return basename(input.pathname) || undefined;
+  }
   if (typeof input === "string") {
     return basename(input);
   }
   return;
+};
+
+const resolveVoiceMimeHint = (
+  input: VoiceInput,
+  name: string | undefined
+): string | undefined => {
+  if (input instanceof URL) {
+    return basename(input.pathname) || undefined;
+  }
+  if (typeof input === "string") {
+    return basename(input);
+  }
+  return name;
 };
 
 const resolveVoiceMimeType = (
@@ -98,14 +121,23 @@ export const asVoice = (input: {
 };
 
 export function voice(
-  input: string | Buffer,
+  input: VoiceInput,
   options?: { mimeType?: string; name?: string; duration?: number }
 ): ContentBuilder {
   return {
     build: async () => {
       const name = resolveVoiceName(input, options?.name);
-      const mimeHint = typeof input === "string" ? basename(input) : name;
+      const mimeHint = resolveVoiceMimeHint(input, name);
       const mimeType = resolveVoiceMimeType(mimeHint, options?.mimeType);
+
+      if (input instanceof URL) {
+        return asVoice({
+          name,
+          mimeType,
+          duration: options?.duration,
+          read: async () => (await fetchUrlBytes(input)).data,
+        });
+      }
 
       if (typeof input === "string") {
         const stats = await stat(input);

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -533,8 +533,9 @@ export function buildSpace(params: BuildSpaceParams): Space {
       // constraints live in each provider's `send` action.
       //
       // Branch by input shape so `avatarContent`'s narrow overloads pick the
-      // right signature (string vs Buffer + required mimeType) without a cast.
-      if (typeof input === "string") {
+      // right signature (string | URL vs Buffer + required mimeType) without a
+      // cast.
+      if (typeof input === "string" || input instanceof URL) {
         await space.send(avatarContent(input, options));
         return;
       }

--- a/packages/spectrum-ts/src/providers/imessage/content/background.ts
+++ b/packages/spectrum-ts/src/providers/imessage/content/background.ts
@@ -41,6 +41,10 @@ export type BackgroundInput = PhotoInput;
  * - `background("clear")` — remove the current chat background.
  * - `background("./photo.jpg")` — set background from a filesystem path.
  *   MIME type is inferred from the extension; override with `options.mimeType`.
+ * - `background(new URL("https://…/photo.jpg"))` — fetch the background
+ *   lazily over the network. Bytes stay in memory (safe in read-only
+ *   environments). MIME type is inferred from the URL pathname extension;
+ *   override with `options.mimeType` when the URL has no usable extension.
  * - `background(buffer, { mimeType })` — set background from in-memory bytes.
  *   `options.mimeType` is required.
  *
@@ -58,7 +62,7 @@ export type BackgroundInput = PhotoInput;
  */
 export function background(input: "clear"): ContentBuilder;
 export function background(
-  input: string | Buffer,
+  input: string | Buffer | URL,
   options?: { mimeType?: string }
 ): ContentBuilder;
 export function background(

--- a/packages/spectrum-ts/src/types/space.ts
+++ b/packages/spectrum-ts/src/types/space.ts
@@ -11,13 +11,16 @@ export interface Space<_Def = unknown> {
    * - `space.avatar("clear")` — remove the current avatar.
    * - `space.avatar("./icon.png")` — set from a filesystem path; MIME type
    *   is inferred from the extension.
+   * - `space.avatar(new URL("https://…/icon.png"))` — fetch the avatar
+   *   lazily over the network. Bytes stay in memory (safe in read-only
+   *   environments); MIME type is inferred from the URL pathname extension.
    * - `space.avatar(buffer, { mimeType })` — set from in-memory bytes;
    *   `mimeType` is required (enforced at the type level).
    *
    * Universal API; per-platform constraints (e.g. iMessage: remote + group
    * only) surface as `UnsupportedError` from the provider's send action.
    */
-  avatar(input: string, options?: { mimeType?: string }): Promise<void>;
+  avatar(input: string | URL, options?: { mimeType?: string }): Promise<void>;
   avatar(input: Buffer, options: { mimeType: string }): Promise<void>;
   edit(message: Message, newContent: ContentInput): Promise<void>;
   /**

--- a/packages/spectrum-ts/src/utils/io.ts
+++ b/packages/spectrum-ts/src/utils/io.ts
@@ -17,3 +17,40 @@ export const bufferToStream = (buf: Buffer): ReadableStream<Uint8Array> =>
       controller.close();
     },
   });
+
+export interface FetchedBytes {
+  data: Buffer;
+  mimeType?: string;
+}
+
+const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * Fetch URL bytes into memory — never touches the filesystem, so callers
+ * remain safe in read-only environments. Returns the response's Content-Type
+ * alongside the bytes so callers that want a soft MIME fallback can use it.
+ */
+export const fetchUrlBytes = async (
+  url: URL,
+  options?: { timeoutMs?: number; headers?: Record<string, string> }
+): Promise<FetchedBytes> => {
+  const controller = new AbortController();
+  const timer = setTimeout(
+    () => controller.abort(),
+    options?.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS
+  );
+  try {
+    const res = await fetch(url, {
+      signal: controller.signal,
+      headers: options?.headers,
+    });
+    if (!res.ok) {
+      throw new Error(`URL fetch ${url.toString()} returned ${res.status}`);
+    }
+    const data = Buffer.from(await res.arrayBuffer());
+    const mimeType = res.headers.get("content-type") ?? undefined;
+    return { data, mimeType };
+  } finally {
+    clearTimeout(timer);
+  }
+};

--- a/packages/spectrum-ts/src/utils/link-metadata.ts
+++ b/packages/spectrum-ts/src/utils/link-metadata.ts
@@ -1,4 +1,5 @@
 import ogs from "open-graph-scraper";
+import { type FetchedBytes, fetchUrlBytes } from "./io";
 
 export interface LinkMetadata {
   image?: { mimeType?: string; url: string };
@@ -6,10 +7,7 @@ export interface LinkMetadata {
   title?: string;
 }
 
-export interface FetchedImage {
-  data: Buffer;
-  mimeType?: string;
-}
+export type FetchedImage = FetchedBytes;
 
 const DEFAULT_TIMEOUT_MS = 5000;
 const USER_AGENT =
@@ -77,21 +75,8 @@ export const fetchLinkMetadata = async (url: string): Promise<LinkMetadata> => {
   }
 };
 
-export const fetchImage = async (url: string): Promise<FetchedImage> => {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
-  try {
-    const res = await fetch(url, {
-      signal: controller.signal,
-      headers: { "User-Agent": USER_AGENT },
-    });
-    if (!res.ok) {
-      throw new Error(`image fetch ${url} returned ${res.status}`);
-    }
-    const data = Buffer.from(await res.arrayBuffer());
-    const mimeType = res.headers.get("content-type") ?? undefined;
-    return { data, mimeType };
-  } finally {
-    clearTimeout(timer);
-  }
-};
+export const fetchImage = (url: string): Promise<FetchedImage> =>
+  fetchUrlBytes(new URL(url), {
+    timeoutMs: DEFAULT_TIMEOUT_MS,
+    headers: { "User-Agent": USER_AGENT },
+  });

--- a/packages/spectrum-ts/src/utils/photo-content.ts
+++ b/packages/spectrum-ts/src/utils/photo-content.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 import { lookup as lookupMimeType } from "mime-types";
 import z from "zod";
-import { readSchema } from "./io";
+import { fetchUrlBytes, readSchema } from "./io";
 
 /**
  * Shared building blocks for photo-style content (chat background, group
@@ -16,7 +16,7 @@ import { readSchema } from "./io";
 
 export const CLEAR_SENTINEL = "clear" as const;
 
-export type PhotoInput = typeof CLEAR_SENTINEL | string | Buffer;
+export type PhotoInput = typeof CLEAR_SENTINEL | string | Buffer | URL;
 
 export const photoActionSchema = z.discriminatedUnion("kind", [
   z.object({
@@ -30,14 +30,19 @@ export const photoActionSchema = z.discriminatedUnion("kind", [
 export type PhotoAction = z.infer<typeof photoActionSchema>;
 
 const resolveMimeType = (
-  input: string | Buffer,
+  input: string | Buffer | URL,
   mimeType: string | undefined,
   contentLabel: string
 ): string => {
   if (mimeType) {
     return mimeType;
   }
-  if (typeof input === "string") {
+  if (input instanceof URL) {
+    const resolved = lookupMimeType(basename(input.pathname));
+    if (resolved) {
+      return resolved;
+    }
+  } else if (typeof input === "string") {
     const resolved = lookupMimeType(basename(input));
     if (resolved) {
       return resolved;
@@ -66,6 +71,10 @@ const cachedRead = (read: () => Promise<Buffer>): (() => Promise<Buffer>) => {
  *   file named `clear`, pass `"./clear"` or load it as a `Buffer`).
  * - `string` path → reads the file lazily via `node:fs/promises.readFile`;
  *   MIME type inferred from the filename extension.
+ * - `URL` → fetched lazily over the network into memory; never touches the
+ *   filesystem, so it works in read-only environments. MIME type is inferred
+ *   from the URL pathname extension at build time (override with
+ *   `options.mimeType` if the URL has no usable extension).
  * - `Buffer` → in-memory bytes; `options.mimeType` is required.
  *
  * Called at builder-construction time so a missing MIME type fails fast
@@ -82,7 +91,9 @@ export const buildPhotoAction = (
   }
   const mimeType = resolveMimeType(input, options?.mimeType, contentLabel);
   let read: () => Promise<Buffer>;
-  if (typeof input === "string") {
+  if (input instanceof URL) {
+    read = cachedRead(async () => (await fetchUrlBytes(input)).data);
+  } else if (typeof input === "string") {
     read = cachedRead(() => readFile(input));
   } else {
     // Snapshot the bytes at builder-construction time so callers can safely


### PR DESCRIPTION
## Summary

- Extends `attachment()`, `voice()`, `avatar()`, and `background()` (plus the shared `photo-content` builder) to accept a `URL` alongside the existing `string` (filesystem path) and `Buffer` inputs.
- Adds a shared `fetchUrlBytes()` helper in `utils/io.ts` that fetches remote bytes into memory with a default 10s timeout. The filesystem is never touched, so URL inputs are safe in read-only environments.
- Refactors `utils/link-metadata.ts` to reuse `fetchUrlBytes` (its `fetchImage`/`FetchedImage` are now thin wrappers around the shared helper) — no behavioral change to link-metadata callers.
- Widens `Space.avatar` and the build-side dispatch in `platform/build.ts` so the URL overload narrows cleanly without casts.

## Usage

```ts
import { attachment, voice } from "spectrum-ts";

// Attachment from a remote URL — name + MIME inferred from the pathname.
await space.send(attachment(new URL("https://example.com/report.pdf")));

// Voice note from a remote URL.
await space.send(voice(new URL("https://example.com/clip.m4a")));

// Avatar / background (chat-level) from a remote URL.
await space.avatar(new URL("https://example.com/icon.png"));
await space.send(background(new URL("https://example.com/photo.jpg")));
```

For all URL inputs, MIME type is inferred from the URL pathname extension; pass `options.mimeType` to override when the URL has no usable extension.

## Changes

| File | Change |
|------|--------|
| `utils/io.ts` | New `fetchUrlBytes()` + `FetchedBytes` interface — shared HTTP-to-Buffer helper with timeout and optional headers. |
| `utils/link-metadata.ts` | `fetchImage`/`FetchedImage` now delegate to `fetchUrlBytes`, preserving the existing 5s timeout and user-agent. |
| `utils/photo-content.ts` | `PhotoInput` widened to include `URL`; MIME inferred from pathname; bytes fetched lazily via `fetchUrlBytes` (cached). |
| `content/attachment.ts` | New `AttachmentInput = string \| Buffer \| URL`; URL branch fetches bytes lazily and uses pathname `basename` for the name. |
| `content/voice.ts` | New `VoiceInput = string \| Buffer \| URL`; URL branch fetches bytes lazily; MIME hint pulled from pathname. |
| `content/avatar.ts` | String overload widened to `string \| URL`; doc comment updated. |
| `providers/imessage/content/background.ts` | Path overload widened to `string \| Buffer \| URL`; doc comment updated. |
| `types/space.ts` | `Space.avatar` string overload widened to `string \| URL`. |
| `platform/build.ts` | `space.avatar` dispatch checks `typeof input === "string" || input instanceof URL` so the URL overload is picked without a cast. |

## Test plan

- [ ] `bun x ultracite check` passes.
- [ ] Type-check passes (`tsc --noEmit` or the project's equivalent).
- [ ] Sending `attachment(new URL(...))`, `voice(new URL(...))`, `background(new URL(...))`, and `avatar(new URL(...))` works against a real provider end-to-end.
- [ ] Fetch errors (non-2xx, timeout) surface as a thrown `Error` from the builder's `read()` rather than crashing earlier.
- [ ] `fetchLinkMetadata`/`fetchImage` continue to work for link previews (regression check on the shared helper).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782519198&installation_id=127326493&pr_number=89&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F89&signature=4bbc1b7089873ce7ee4fd89fb87d96a48bc1b6d81643ca9f8439d39808b4498d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added support for passing remote URLs directly when creating attachments, avatars, voice content, backgrounds, and photos
* Remote assets are fetched lazily over the network when needed
* MIME types are automatically inferred from URL pathname extensions
* You can override inferred MIME types using the options parameter

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->