### PR TITLE
docs: explain Spectrum.stopOnce phase ordering — deferred structural fix

### DIFF
--- a/docs/stop-once-teardown-design.md
+++ b/docs/stop-once-teardown-design.md
@@ -1,0 +1,146 @@
+# `Spectrum.stopOnce` teardown — deferred structural fix
+
+## Summary
+
+In production, `Spectrum.stopOnce()` consistently exceeds downstream
+consumers' shutdown budgets (e.g. `spectrum-webhook`'s 1500ms
+`POOL_STOP_TIMEOUT_MS`) for the iMessage provider. The 100% timeout
+rate leaves an orphan SDK instance running in a background closure
+until its teardown eventually completes.
+
+The straightforward structural fix — reorder `stopOnce` to close the
+provider client (TCP-RST the upstream gRPC channel) before draining
+the in-process stream cascade — was attempted in
+[#84](https://github.com/photon-hq/spectrum-ts/pull/84) and
+deferred. This doc captures why, so the next engineer who looks at
+the timeout doesn't re-litigate the same conclusion.
+
+## What's actually happening
+
+`stopOnce` runs two sequential phases:
+
+1. **Phase 1 — drain in-process streams** (`messagesStream`, custom
+   event streams, message broadcasters).
+2. **Phase 2 — destroy provider clients** (`destroyClient` lifecycle
+   hook; for iMessage this is where the gRPC channel close runs).
+
+The iMessage provider's `messages` async iterator does not honor
+`return()` cooperatively. The flow:
+
+- Phase 1 calls `.return()` on the merged iterator stack.
+- Inner Repeater layers honor return; the outermost
+  `client.messages.subscribeEvents()` gRPC call does not — it sits
+  awaiting the next frame from the upstream stream.
+- Phase 1 hangs.
+- The downstream consumer's outer timeout fires (1500ms for
+  `spectrum-webhook`); the consumer abandons the promise.
+- Phase 2 never runs in the consumer's wait window.
+- Eventually (seconds to minutes later), the upstream gRPC stream
+  errors out for other reasons (heartbeat, server-side close,
+  connection refresh) and the iterator finally returns. Phase 2
+  runs, the channel closes, the SDK is gone.
+
+That eventual completion is visible in production logs as the
+bare `[spectrum.lifecycle] Spectrum stopped` lines that appear
+seconds after the *next* instance has already started — the dying
+orphan finally finished.
+
+## Why the reorder fix was deferred
+
+PR [#84](https://github.com/photon-hq/spectrum-ts/pull/84) proposed
+running Phase 2 first (close channels, then drain streams). The
+hypothesis was: with the gRPC channel closed up front, the upstream
+relay would observe disconnect within milliseconds and reroute
+subsequent events to the newly-started SDK instance for the same
+project.
+
+That hypothesis turned out to be **incomplete**.
+
+### The relay broadcasts; orphans don't starve
+
+`spectrum-imessage` (the proxy in front of the Mac fleet) is a
+fan-out broadcaster, not a single-subscriber router. When N
+downstream subscribers register for the same project's events, the
+proxy delivers each upstream event to all N via independent
+filtered streams (see `connection-registry.ts:activeEventSubscriptions`
+— a `Set`, not a slot).
+
+Consequence: an orphan SDK and a freshly-started SDK both receive
+every event for their shared project. Neither one starves the
+other. Both call their respective `onMessage` callbacks. The
+downstream consumer's store is keyed by project, so both dispatch
+paths end up posting to the same customer webhook URL.
+
+The webhook protocol is at-least-once. The orphan never causes
+message loss — only (rare, bounded) double-delivery during the
+overlap window before the orphan dies.
+
+### What an orphan *does* cost
+
+- A few seconds to a few minutes of held-open gRPC stream + iterator
+  state in the SDK process memory, until the underlying stream errors
+  out and Phase 2 runs.
+- Log noise: every `pool.stop` for an iMessage project logs as
+  `timedOut=true`.
+- Theoretical double-delivery during the overlap window
+  (mostly invisible in production logs; the orphan's stream
+  appears to lose events to other concurrent SDK behaviors before
+  it would deliver them).
+
+None of these are customer-facing. The original josh-incident
+diagnosis that pinned 23 hours of webhook silence on this orphan
+was traced to a different root cause (`spectrum-imessage`'s
+[`resilientStream`](https://github.com/photon-hq/spectrum-imessage/pull/26)
+retry policy giving up on non-whitelisted gRPC errors).
+
+### Why "tolerable" doesn't mean "fine forever"
+
+There are scenarios where the orphan window matters:
+
+- **Memory pressure under high churn** — if a worker has many
+  rapid stop/start cycles (e.g. a customer iterating on their
+  ngrok tunnel URL with DELETE/INSERT bursts), orphans accumulate
+  faster than they die. Production is nowhere near that bound
+  today, but it's worth measuring.
+- **Token rotation across orphan boundary** — the orphan's gRPC
+  stream holds an auth token issued at start time. If a project
+  secret rotation happens during the orphan's lifetime, the
+  orphan still consumes events under the old auth. Currently
+  benign because the proxy doesn't re-validate per event, but a
+  future security feature that did would observe odd behavior.
+- **Double-delivery to non-idempotent customer endpoints** —
+  customers should be coded for at-least-once, but not all are.
+
+The current decision: ship instrumentation
+([#85](https://github.com/photon-hq/spectrum-ts/pull/85)), gather a
+few weeks of production timing data on `clientCloseMs` /
+`streamCloseMs`, then decide whether the structural cost is real
+enough to warrant the reorder.
+
+## Criteria for revisiting the structural fix
+
+Reopen the reorder discussion when **any** of these hold:
+
+1. **`clientCloseMs` p99 is consistently > 100ms**. If the channel
+   close itself is slow (not the stream drain), the reorder solves
+   nothing — fix that first.
+2. **Production memory growth correlates with stop frequency**.
+   Indicates orphans accumulate faster than they die.
+3. **A customer-reported double-delivery incident** is traced to
+   the overlap window (would require correlated log timestamps from
+   webhook + proxy + customer endpoint).
+4. **The `messages` iterator becomes return()-honoring upstream**
+   in `@photon-ai/advanced-imessage`. At that point the entire
+   teardown completes cleanly within the existing budget and the
+   reorder discussion becomes moot.
+
+## Reference: the code
+
+- `packages/spectrum-ts/src/spectrum.ts` — `stopOnce` definition;
+  current order is stream-drain → client-destroy, instrumented
+  with `streamCloseMs` / `clientCloseMs` timings.
+- `packages/spectrum-ts/src/providers/imessage/remote/stream.ts`
+  — the `withClose` wrapper; uses optional chaining
+  (`source.close?.()`), which silently no-ops when the upstream
+  gRPC call lacks a callable `close()`. This is the layer where
+  a future iterator-return fix would land.


### PR DESCRIPTION
## Summary

Captures the analytical history and design decision behind tolerating the 100% iMessage `stopOnce` timeout in production, so the next engineer who looks at the timeout rate doesn't re-litigate the same conclusion from scratch.

**Docs only — no code change.**

## Background

In production, every `pool.stop` for iMessage projects hits the downstream consumer's outer timeout (1500ms for `spectrum-webhook`). The orphan SDK keeps its upstream gRPC subscription alive in a background closure until the stream eventually errors out and Phase 2 (`destroyClient`) finally runs.

PR history on this:
- **#84** proposed reordering `stopOnce` phases (close client first, drain streams second) to eliminate the orphan window — closed.
- **#85** added per-phase timing instrumentation (`clientCloseMs`, `streamCloseMs`) on the `Spectrum stopped` log so we can data-drive any future decision — merged.

The deferral was deliberate but the reasoning lives in a closed PR description and a Slack thread — neither lasts. This doc moves it into the repo where it'll survive PR-thread decay.

## What the doc covers

- The actual two-phase flow of `stopOnce` and where the iMessage iterator hangs
- Why PR #84's reorder hypothesis turned out to be incomplete (`spectrum-imessage` broadcasts to all subscribers, so orphans don't starve the new SDK and there's no message loss)
- What the orphan **does** cost (memory, log noise, theoretical double-delivery during the overlap window — all bounded, none customer-facing)
- The original josh-incident misattribution (the 23h silence was actually `spectrum-imessage`'s `resilientStream` retry policy, not the orphan — fix shipped in `spectrum-imessage` #26)
- Concrete criteria for when to revisit the structural fix:
  1. `clientCloseMs` p99 > 100ms (channel close itself is slow → reorder solves nothing)
  2. Memory growth correlates with stop frequency (orphans accumulating)
  3. Customer-reported double-delivery traced to the overlap window
  4. Upstream `advanced-imessage` iterator becomes `return()`-honoring (makes the discussion moot)

## Where it lives

New `docs/` folder at the repo root; pattern borrowed from `spectrum-imessage/docs/background-listener-retry-incident.md`. First file in the folder.

## Test plan

- [x] Docs-only — no code changes
- [x] Markdown renders correctly in GitHub preview
- [x] All cross-references to PRs/files resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782524768&installation_id=127326493&pr_number=90&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F90&signature=63087d655c7020b007a61ffd431893c2b4460e994104ebb490b67608556a8671"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed documentation explaining shutdown sequence behavior, current operational characteristics, and design considerations for potential future improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->