### PR TITLE
fix(content): relax pollSchema.title for inbound iMessage polls

### DIFF
--- a/packages/spectrum-ts/src/content/poll.test.ts
+++ b/packages/spectrum-ts/src/content/poll.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "bun:test";
+import { ZodError } from "zod";
+import {
+  asPoll,
+  asPollOption,
+  poll,
+  pollChoiceSchema,
+  pollOptionSchema,
+  pollSchema,
+} from "./poll";
+
+const validOptions = [{ title: "Yes" }, { title: "No" }];
+
+describe("pollSchema", () => {
+  it("parses a poll with a normal title", () => {
+    const parsed = pollSchema.parse({
+      type: "poll",
+      title: "Lunch?",
+      options: validOptions,
+    });
+    expect(parsed.title).toBe("Lunch?");
+    expect(parsed.options).toHaveLength(2);
+  });
+
+  // Regression: real iMessage polls were dropped because the inbound parser
+  // rejected empty titles.
+  it("accepts an empty title (lenient on the wire)", () => {
+    const parsed = pollSchema.parse({
+      type: "poll",
+      title: "",
+      options: validOptions,
+    });
+    expect(parsed.title).toBe("");
+    expect(parsed.options).toHaveLength(2);
+  });
+
+  // Regression: partial inbound deltas can omit the title field entirely.
+  it("accepts a missing title (lenient on the wire)", () => {
+    const parsed = pollSchema.parse({
+      type: "poll",
+      options: validOptions,
+    });
+    expect(parsed.title).toBeUndefined();
+    expect(parsed.options).toHaveLength(2);
+  });
+
+  it("still rejects titles over 300 chars", () => {
+    expect(() =>
+      pollSchema.parse({
+        type: "poll",
+        title: "a".repeat(301),
+        options: validOptions,
+      })
+    ).toThrow(ZodError);
+  });
+
+  it("still requires at least 2 options", () => {
+    expect(() =>
+      pollSchema.parse({
+        type: "poll",
+        title: "Lunch?",
+        options: [{ title: "Only one" }],
+      })
+    ).toThrow(ZodError);
+  });
+});
+
+describe("pollChoiceSchema", () => {
+  it("accepts an empty option title (lenient on the wire)", () => {
+    const parsed = pollChoiceSchema.parse({ title: "" });
+    expect(parsed.title).toBe("");
+  });
+
+  it("accepts a normal option title", () => {
+    const parsed = pollChoiceSchema.parse({ title: "Pizza" });
+    expect(parsed.title).toBe("Pizza");
+  });
+});
+
+describe("pollOptionSchema", () => {
+  it("round-trips an empty-title option through the vote payload", () => {
+    const emptyOption = { title: "" };
+    const pollValue = pollSchema.parse({
+      type: "poll",
+      title: "",
+      options: [emptyOption, { title: "Other" }],
+    });
+    const parsed = pollOptionSchema.parse({
+      type: "poll_option",
+      option: emptyOption,
+      poll: pollValue,
+      selected: true,
+      title: "",
+    });
+    expect(parsed.title).toBe("");
+    expect(parsed.option.title).toBe("");
+    expect(parsed.selected).toBe(true);
+  });
+
+  it("rejects when the vote title disagrees with the option title", () => {
+    const pollValue = pollSchema.parse({
+      type: "poll",
+      title: "Lunch?",
+      options: validOptions,
+    });
+    expect(() =>
+      pollOptionSchema.parse({
+        type: "poll_option",
+        option: { title: "Yes" },
+        poll: pollValue,
+        selected: true,
+        title: "Different",
+      })
+    ).toThrow(ZodError);
+  });
+});
+
+describe("customer-facing poll builder", () => {
+  it("still produces a poll via asPoll with a title", () => {
+    const built = asPoll({ title: "Movie night?", options: validOptions });
+    expect(built.title).toBe("Movie night?");
+  });
+
+  it("still produces a poll via the poll() builder", async () => {
+    const builder = poll("Sushi?", [{ title: "Yes" }, { title: "No" }]);
+    const built = await builder.build();
+    expect(built.type).toBe("poll");
+    if (built.type === "poll") {
+      expect(built.title).toBe("Sushi?");
+      expect(built.options).toHaveLength(2);
+    }
+  });
+
+  it("round-trips an option through asPollOption", () => {
+    const built = asPoll({ title: "Sushi?", options: validOptions });
+    const choice = built.options[0];
+    if (!choice) {
+      throw new Error("expected an option");
+    }
+    const voted = asPollOption({ option: choice, poll: built, selected: true });
+    expect(voted.title).toBe(choice.title);
+  });
+});

--- a/packages/spectrum-ts/src/content/poll.ts
+++ b/packages/spectrum-ts/src/content/poll.ts
@@ -1,13 +1,25 @@
 import z from "zod";
 import type { ContentBuilder } from "./types";
 
+// Lenient on the wire: iMessage's PollOption.text is a proto3 string, which
+// defaults to "" and carries no non-empty guarantee from the source. Strict
+// parsing here would silently drop entire polls if any option arrived with
+// empty text. If outbound construction needs to require non-empty options,
+// gate that at the customer-facing builder rather than this inbound parser.
 export const pollChoiceSchema = z.object({
-  title: z.string().nonempty(),
+  title: z.string(),
 });
 
+// Lenient on the wire: iMessage can deliver polls with empty or missing
+// titles (untitled polls, or partial deltas for `optionAdded` events that
+// don't always re-carry the title in practice). Strict `.nonempty()` parsing
+// dropped real customer polls silently — see
+// https://github.com/photon-hq/spectrum-ts (fix/poll-schema-allow-empty-title).
+// If outbound construction needs to require a title, gate that at the
+// customer-facing builder rather than this inbound parser.
 export const pollSchema = z.object({
   type: z.literal("poll"),
-  title: z.string().nonempty().max(300),
+  title: z.string().max(300).optional(),
   options: z.array(pollChoiceSchema).min(2).max(10),
 });
 
@@ -17,7 +29,10 @@ export const pollOptionSchema = z
     option: pollChoiceSchema,
     poll: pollSchema,
     selected: z.boolean(),
-    title: z.string().nonempty(),
+    // Mirrors pollChoiceSchema.title — the superRefine below still enforces
+    // structural equality with option.title, so empty strings round-trip
+    // correctly without silently dropping the vote.
+    title: z.string(),
   })
   .superRefine((value, ctx) => {
     if (value.title !== value.option.title) {

--- a/packages/spectrum-ts/src/providers/imessage/remote/polls.test.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/polls.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "bun:test";
+import type { PollEvent, PollOption } from "@photon-ai/advanced-imessage";
+import { PollCache } from "../cache";
+import { cachePollEvent } from "./polls";
+
+const option = (text: string, optionIdentifier: string): PollOption => ({
+  text,
+  optionIdentifier,
+});
+
+const createdEvent = (
+  overrides: Partial<{
+    title: string;
+    options: readonly PollOption[];
+    pollMessageGuid: string;
+  }> = {}
+): PollEvent => ({
+  type: "poll.changed",
+  chatGuid: "iMessage;-;chat-1",
+  pollMessageGuid: overrides.pollMessageGuid ?? "poll-msg-1",
+  sequence: 1,
+  occurredAt: new Date("2025-01-01T00:00:00Z"),
+  isFromMe: false,
+  delta: {
+    type: "created",
+    title: overrides.title ?? "Lunch?",
+    options: overrides.options ?? [
+      option("Pizza", "opt-1"),
+      option("Burgers", "opt-2"),
+    ],
+  },
+});
+
+const optionAddedEvent = (title: string): PollEvent => ({
+  type: "poll.changed",
+  chatGuid: "iMessage;-;chat-1",
+  pollMessageGuid: "poll-msg-2",
+  sequence: 2,
+  occurredAt: new Date("2025-01-01T00:00:01Z"),
+  isFromMe: false,
+  delta: {
+    type: "optionAdded",
+    title,
+    options: [
+      option("Pizza", "opt-1"),
+      option("Burgers", "opt-2"),
+      option("Salad", "opt-3"),
+    ],
+  },
+});
+
+describe("cachePollEvent", () => {
+  it("caches a created poll with a normal title", () => {
+    const cache = new PollCache();
+    const cached = cachePollEvent(cache, createdEvent({ title: "Lunch?" }));
+    expect(cached).toBeDefined();
+    expect(cached?.poll.title).toBe("Lunch?");
+    expect(cached?.poll.options).toHaveLength(2);
+    expect(cache.get("poll-msg-1")).toBeDefined();
+  });
+
+  // Regression: real iMessage polls with empty titles were being silently
+  // dropped by the inbound parser. The fix relaxes pollSchema.title to
+  // accept "" (and undefined) so these polls now cache successfully.
+  it("caches a created poll whose delta carries an empty title", () => {
+    const cache = new PollCache();
+    const cached = cachePollEvent(cache, createdEvent({ title: "" }));
+    if (!cached) {
+      throw new Error("expected cachePollEvent to return a cached poll");
+    }
+    expect(cached.poll.title).toBe("");
+    expect(cached.poll.options).toHaveLength(2);
+    expect(cache.get("poll-msg-1")).toBe(cached);
+  });
+
+  it("caches an optionAdded delta with an empty title", () => {
+    const cache = new PollCache();
+    const cached = cachePollEvent(cache, optionAddedEvent(""));
+    if (!cached) {
+      throw new Error("expected cachePollEvent to return a cached poll");
+    }
+    expect(cached.poll.title).toBe("");
+    expect(cached.poll.options).toHaveLength(3);
+    expect(cache.get("poll-msg-2")).toBe(cached);
+  });
+
+  it("caches a created poll even when an option text is empty", () => {
+    const cache = new PollCache();
+    const cached = cachePollEvent(
+      cache,
+      createdEvent({
+        title: "Pick one",
+        options: [option("", "opt-1"), option("Burgers", "opt-2")],
+      })
+    );
+    expect(cached).toBeDefined();
+    expect(cached?.poll.options).toHaveLength(2);
+    expect(cached?.poll.options[0]?.title).toBe("");
+    expect(cached?.poll.options[1]?.title).toBe("Burgers");
+  });
+
+  it("returns undefined for voted/unvoted deltas (no cache write)", () => {
+    const cache = new PollCache();
+    const votedEvent: PollEvent = {
+      type: "poll.changed",
+      chatGuid: "iMessage;-;chat-1",
+      pollMessageGuid: "poll-msg-3",
+      sequence: 3,
+      occurredAt: new Date(),
+      isFromMe: false,
+      delta: { type: "voted", optionIdentifier: "opt-1" },
+    };
+    expect(cachePollEvent(cache, votedEvent)).toBeUndefined();
+    expect(cache.get("poll-msg-3")).toBeUndefined();
+  });
+});

--- a/packages/spectrum-ts/src/providers/imessage/remote/send.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/send.ts
@@ -217,7 +217,7 @@ const sendContent = async (
         spaceId,
         await remote.polls.create(
           chat,
-          content.title,
+          content.title ?? "",
           content.options.map((option) => option.title)
         ),
         content

--- a/packages/spectrum-ts/src/providers/whatsapp-business/poll.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/poll.ts
@@ -13,13 +13,14 @@ const LIST_SECTION_TITLE = "Options";
 export const pollOptionId = (index: number): string => `opt_${index}`;
 
 export const pollToInteractive = (content: Poll): InteractiveInput => {
+  const body = content.title ?? "";
   if (content.options.length <= MAX_BUTTON_OPTIONS) {
     return buttons(
-      content.title,
+      body,
       ...content.options.map((o, i) => button(pollOptionId(i), o.title))
     );
   }
-  return list(content.title, LIST_BUTTON_TEXT).section(
+  return list(body, LIST_BUTTON_TEXT).section(
     LIST_SECTION_TITLE,
     content.options.map((o, i) => ({ id: pollOptionId(i), title: o.title }))
   );


### PR DESCRIPTION
## Symptom

Real iMessage polls were being silently dropped in production by the inbound parser in `providers/imessage/remote/polls.ts`. Every `created` / `optionAdded` poll event with an empty or missing title got swallowed by the `try { … } catch (e) { console.error(…) }` in `cachePollEvent` (and the same shape in `resolvePoll`):

```
[spectrum-ts][imessage][poll] failed to cache poll ZodError: [
  { origin: "string", code: "too_small", minimum: 1, path: ["title"],
    message: "Too small: expected string to have >=1 characters" }
]
[spectrum-ts][imessage][poll] failed to resolve poll ZodError: [ … same … ]
```

Root cause: `pollSchema.title` was `z.string().nonempty().max(300)`, but the upstream `PollChangeDelta` (`created` / `optionAdded`) from `@photon-ai/advanced-imessage` carries a proto3 `string title` field, which defaults to `""` and isn't guaranteed to be present on partial deltas. Strict `.nonempty()` parsing was the wrong contract for the wire.

## Fix

Schemas touched in `packages/spectrum-ts/src/content/poll.ts`:

| Schema | Before | After | Reason |
|---|---|---|---|
| `pollSchema.title` | `z.string().nonempty().max(300)` | `z.string().max(300).optional()` | The reported failure. `.optional()` covers both empty-string and missing-key deltas. |
| `pollChoiceSchema.title` | `z.string().nonempty()` | `z.string()` | Upstream `PollOption.text` is the same proto3 string shape — dropping the entire poll because one option has empty text would compound the same bug. |
| `pollOptionSchema.title` | `z.string().nonempty()` | `z.string()` | Mirrors `pollChoiceSchema.title`; the `superRefine` equality check still enforces `value.title === value.option.title`. |

### `.optional()` vs `.default("")`

Went with `.optional()`. The resulting `Poll.title: string | undefined` is the honest shape of what iMessage actually delivers, and the cascade was tiny — only two SDK-internal forwarders had to coalesce: `providers/imessage/remote/send.ts` (when calling `remote.polls.create(chat, title, …)`) and `providers/whatsapp-business/poll.ts` (when calling `buttons(body, …)` / `list(body, …)`). Both now do `content.title ?? ""`, preserving their existing string contract.

The customer-facing `PollInput` interface and the `poll(title, …)` builder still require `title: string`, so outbound construction continues to be strict — only inbound parsing is permissive. If a strict-outbound wrapper is wanted later, that's a separate concern.

## Test changes

There was no existing test file for the poll schema or the iMessage poll provider; both are new. They run under `bun test`.

- `packages/spectrum-ts/src/content/poll.test.ts` — covers `pollSchema` (normal / empty / missing title; still rejects >300 chars and <2 options), `pollChoiceSchema` (empty + normal), `pollOptionSchema` (round-trips empty title, still rejects title/option mismatch), and the customer-facing `asPoll` / `asPollOption` / `poll(…)` builder.
- `packages/spectrum-ts/src/providers/imessage/remote/polls.test.ts` — `cachePollEvent` with `created` / `optionAdded` deltas whose `title` is `""`; with an empty option text; and confirms `voted` / `unvoted` deltas still return undefined without writing the cache.

## Verification

- `bun test packages/spectrum-ts/src/content/poll.test.ts packages/spectrum-ts/src/providers/imessage/remote/polls.test.ts` → 17 pass, 0 fail (35 expect calls).
- `bun test` (whole repo) → same 17 pass, 0 fail. No other tests exist in the repo to regress.
- `bunx tsc --noEmit` → clean.
- `bunx ultracite check` on touched files and on `packages/spectrum-ts/src` → clean.

## Notes

- Permissive on the way IN only. Customer code that constructs polls via `poll(…)` / `asPoll(…)` still gets the same compile-time guarantee that a title is required.
- `Poll.title` is now `string | undefined` — this is a TypeScript-visible change for SDK consumers reading poll content. Consumers that previously called `poll.title.toUpperCase()` etc. will need `poll.title?.toUpperCase()` or `poll.title ?? ""`. The two such call sites inside this repo are patched in this PR.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782535424&installation_id=127326493&pr_number=91&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F91&signature=1131cfb3a5b6f1d2b6d9247a6e5bf76974175f87dcfe3a674b3e6b1a73616c2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites validating poll schemas, caching behavior, and provider-specific formatting across iMessage and WhatsApp platforms.

* **Bug Fixes**
  * Improved handling of empty poll titles to prevent validation failures; polls with missing or empty titles now round-trip correctly across messaging providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->