### PR TITLE
refactor(imessage): drop chat arg from messages.get call sites

### DIFF
--- a/packages/spectrum-ts/src/providers/imessage/remote/inbound.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/inbound.ts
@@ -14,7 +14,7 @@ import { fromVCard } from "../../../utils/vcard";
 import { getMessageCache, type MessageCache } from "../cache";
 import { isVCardAttachment } from "../shared/vcard";
 import type { IMessageMessage } from "../types";
-import { formatChildId, parseChildId, toChatGuid, toMessageGuid } from "./ids";
+import { formatChildId, parseChildId, toMessageGuid } from "./ids";
 
 const URL_BALLOON_BUNDLE_ID = "com.apple.messages.URLBalloonProvider";
 
@@ -383,7 +383,6 @@ export const getMessage = async (
   if (childRef) {
     try {
       const fetched = await remote.messages.get(
-        toChatGuid(spaceId),
         toMessageGuid(childRef.parentGuid)
       );
       const parent = await rebuildFromAppleMessage(
@@ -407,10 +406,7 @@ export const getMessage = async (
   }
 
   try {
-    const fetched = await remote.messages.get(
-      toChatGuid(spaceId),
-      toMessageGuid(msgId)
-    );
+    const fetched = await remote.messages.get(toMessageGuid(msgId));
     const rebuilt = await rebuildFromAppleMessage(
       remote,
       fetched,

--- a/packages/spectrum-ts/src/providers/imessage/remote/reactions.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/reactions.ts
@@ -64,10 +64,7 @@ const resolveReactionTarget = async (
   let candidate = cache.get(targetGuid);
   if (!candidate) {
     try {
-      const fetched = await client.messages.get(
-        toChatGuid(chat),
-        toMessageGuid(targetGuid)
-      );
+      const fetched = await client.messages.get(toMessageGuid(targetGuid));
       candidate = await rebuildFromAppleMessage(client, fetched, phone, chat);
       cacheMessage(cache, candidate);
     } catch {


### PR DESCRIPTION
## Summary

Drops the `chat` argument from the three `client.messages.get(...)` call sites in the iMessage provider.

## Dependency

Blocked on a release of `@photon-ai/advanced-imessage` that drops the parameter (photon-hq/advanced-imessage-ts#35). Opened as **draft** until that SDK release lands and is bumped here.

## Why

`GetMessageRequest.chat_guid` is unused on the server (see photon-hq/advanced-imessage-server-v2#95). Dropping it from the SDK and the provider keeps the call shape honest.

## Changes

- `providers/imessage/remote/inbound.ts`: two `messages.get` calls; drop unused `toChatGuid` import.
- `providers/imessage/remote/reactions.ts`: one `messages.get` call; `toChatGuid` import preserved (still used elsewhere in the file).

## Test plan

- [x] `bunx tsc --noEmit` clean
- [ ] Re-verify after SDK release lands in node_modules

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782542440&installation_id=127326493&pr_number=92&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F92&signature=c6b5d0106286387225cbd96e246c7d22f857037a115ff984b670cfa449b92509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->