### PR TITLE
feat(platform): two-tier platform actions + iMessage getAttachment

### DIFF
--- a/packages/spectrum-ts/src/content/attachment.ts
+++ b/packages/spectrum-ts/src/content/attachment.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { readFile, stat } from "node:fs/promises";
 import { basename } from "node:path";
@@ -16,6 +17,7 @@ const DEFAULT_ATTACHMENT_NAME = "attachment";
 
 export const attachmentSchema = z.object({
   type: z.literal("attachment"),
+  id: z.string().nonempty(),
   name: z.string().nonempty(),
   mimeType: z.string().nonempty(),
   size: z.number().int().nonnegative().optional(),
@@ -59,6 +61,7 @@ const resolveAttachmentMimeType = (name: string, mimeType?: string): string => {
 };
 
 export const asAttachment = (input: {
+  id?: string;
   name: string;
   mimeType: string;
   size?: number;
@@ -78,6 +81,7 @@ export const asAttachment = (input: {
 
   return attachmentSchema.parse({
     type: "attachment",
+    id: input.id ?? randomUUID(),
     name: input.name,
     mimeType: input.mimeType,
     size: input.size,
@@ -88,15 +92,17 @@ export const asAttachment = (input: {
 
 export function attachment(
   input: AttachmentInput,
-  options?: { mimeType?: string; name?: string }
+  options?: { id?: string; mimeType?: string; name?: string }
 ): ContentBuilder {
   return {
     build: async () => {
+      const id = options?.id;
       const name = resolveAttachmentName(input, options?.name);
       const mimeType = resolveAttachmentMimeType(name, options?.mimeType);
 
       if (input instanceof URL) {
         return asAttachment({
+          id,
           name,
           mimeType,
           read: async () => (await fetchUrlBytes(input)).data,
@@ -106,6 +112,7 @@ export function attachment(
       if (typeof input === "string") {
         const stats = await stat(input);
         return asAttachment({
+          id,
           name,
           mimeType,
           size: stats.size,
@@ -118,6 +125,7 @@ export function attachment(
       }
 
       return asAttachment({
+        id,
         name,
         mimeType,
         size: input.byteLength,

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -1,4 +1,8 @@
-export { attachment } from "./content/attachment";
+export {
+  type Attachment,
+  type AttachmentInput,
+  attachment,
+} from "./content/attachment";
 export { type Avatar, type AvatarInput, avatar } from "./content/avatar";
 export {
   type Contact,

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -13,7 +13,11 @@ import type { AgentSender } from "../types/user";
 import { UnsupportedError } from "../utils/errors";
 import type { Store } from "../utils/store";
 import { contentAttrs } from "../utils/telemetry";
-import type { AnyPlatformDef, ProviderMessageRecord } from "./types";
+import type {
+  AnyPlatformDef,
+  PlatformWiseActionKey,
+  ProviderMessageRecord,
+} from "./types";
 
 const platformLog = createLogger("spectrum.platform");
 
@@ -70,6 +74,14 @@ const RESERVED_SPACE_KEYS: ReadonlySet<string> = new Set([
   "responding",
 ]);
 
+// Framework-known action keys with default behavior. Used by `define.ts` to
+// distinguish platform-wise overrides from platform-specific extensions, and
+// to wire the same set onto every `PlatformInstance` regardless of override
+// status. The runtime list must stay in sync with `PlatformWiseActions` in
+// `types.ts` — the typed `satisfies` here catches typos at the element level.
+export const PLATFORM_WISE_ACTION_KEYS: ReadonlySet<PlatformWiseActionKey> =
+  new Set(["getMessage"] satisfies readonly PlatformWiseActionKey[]);
+
 // Reserved keys on `Message` — platform-defined `message.actions` entries
 // with these names are skipped at runtime (with a warning) so the universal
 // sugar (`react`, `reply`, `edit`, …) always wins. The same names are
@@ -87,12 +99,22 @@ const RESERVED_MESSAGE_KEYS: ReadonlySet<string> = new Set([
   "timestamp",
 ]);
 
-const warnReservedAction = (
-  scope: "space" | "message",
+const scopeLabel = (scope: "space" | "message" | "instance"): string => {
+  if (scope === "space") {
+    return "Space";
+  }
+  if (scope === "message") {
+    return "Message";
+  }
+  return "PlatformInstance";
+};
+
+export const warnReservedAction = (
+  scope: "space" | "message" | "instance",
   name: string,
   platform: string
 ) => {
-  const body = `[spectrum-ts] ${platform} declared ${scope} action "${name}" which collides with a reserved ${scope === "space" ? "Space" : "Message"} key; skipping.`;
+  const body = `[spectrum-ts] ${platform} declared ${scope} action "${name}" which collides with a reserved ${scopeLabel(scope)} key; skipping.`;
   console.warn(
     supportsAnsiColor() ? `${ANSI_YELLOW}${body}${ANSI_RESET}` : body
   );
@@ -434,11 +456,10 @@ export function buildSpace(params: BuildSpaceParams): Space {
   async function getMessageImpl(id: string): Promise<Message | undefined> {
     const getMessage = definition.actions?.getMessage;
     if (!getMessage) {
-      warnUnsupported(
-        UnsupportedError.action("getMessage", definition.name),
-        definition.name
-      );
-      return;
+      // Default behavior when the provider hasn't implemented the
+      // platform-wise `getMessage` action: throw `UnsupportedError`. Mirrors
+      // the same default the `PlatformInstance` wires for `im.getMessage`.
+      throw UnsupportedError.action("getMessage", definition.name);
     }
     return withSpan(
       "spectrum.message.get",
@@ -448,22 +469,11 @@ export function buildSpace(params: BuildSpaceParams): Space {
         "spectrum.message.id": id,
       },
       async () => {
-        let raw: ProviderMessageRecord | undefined;
-        try {
-          raw = (await getMessage({
-            space: spaceRef,
-            messageId: id,
-            client,
-            config,
-            store,
-          })) as ProviderMessageRecord | undefined;
-        } catch (err) {
-          if (err instanceof UnsupportedError) {
-            warnUnsupported(err, definition.name);
-            return;
-          }
-          throw err;
-        }
+        const raw = (await getMessage(
+          { client, config, store },
+          spaceRef,
+          id
+        )) as ProviderMessageRecord | undefined;
         if (!raw) {
           return;
         }

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -2,13 +2,19 @@ import { withSpan } from "@photon-ai/otel";
 import type z from "zod";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
+import { UnsupportedError } from "../utils/errors";
 import { classifyIdentifier as classifySingle } from "../utils/identifier";
 import type { Store } from "../utils/store";
-import { buildSpace } from "./build";
+import {
+  buildSpace,
+  PLATFORM_WISE_ACTION_KEYS,
+  warnReservedAction,
+} from "./build";
 import type {
   AnyPlatformDef,
   CreateClientContext,
   EventProducer,
+  InstanceActionFn,
   MessageActionFn,
   Platform,
   PlatformDef,
@@ -18,6 +24,7 @@ import type {
   PlatformRuntime,
   PlatformSpace,
   PlatformUser,
+  PlatformWiseActionKey,
   ProviderMessage,
   SpaceActionFn,
   SpectrumLike,
@@ -43,6 +50,60 @@ function classifySpaceIdentifier(args: unknown[]): {
 }
 
 type NoInferValue<T> = [T][T extends unknown ? 0 : never];
+
+type RawActionFactory = (
+  ctx: { client: unknown; config: unknown; store: Store },
+  ...rest: unknown[]
+) => Promise<unknown>;
+
+// Build the per-instance action map for one platform. Splits `def.actions`
+// into the two tiers and dispatches each entry accordingly:
+//
+// - **Platform-wise** (`PLATFORM_WISE_ACTION_KEYS`) — wired on every
+//   instance. Calls the provider's override if declared, else falls back
+//   to a default that throws `UnsupportedError`.
+// - **Platform-specific** — wired only when declared. Reserved-name
+//   collisions emit a warning and are skipped.
+//
+// Both tiers receive `{ client, config, store }` as the first arg before
+// the user-supplied trailing args.
+function buildInstanceActions(
+  platformName: string,
+  declared: Record<string, RawActionFactory> | undefined,
+  reservedKeys: ReadonlySet<string>,
+  buildCtx: () => { client: unknown; config: unknown; store: Store }
+): Record<string, (...args: unknown[]) => Promise<unknown>> {
+  const out: Record<string, (...args: unknown[]) => Promise<unknown>> = {};
+
+  for (const key of PLATFORM_WISE_ACTION_KEYS) {
+    const override = declared?.[key];
+    if (override && typeof override === "function") {
+      out[key] = (...args: unknown[]) => override(buildCtx(), ...args);
+    } else {
+      out[key] = () => {
+        throw UnsupportedError.action(key, platformName);
+      };
+    }
+  }
+
+  if (!declared) {
+    return out;
+  }
+  for (const [name, factory] of Object.entries(declared)) {
+    if (PLATFORM_WISE_ACTION_KEYS.has(name as PlatformWiseActionKey)) {
+      continue;
+    }
+    if (reservedKeys.has(name)) {
+      warnReservedAction("instance", name, platformName);
+      continue;
+    }
+    if (typeof factory !== "function") {
+      continue;
+    }
+    out[name] = (...args: unknown[]) => factory(buildCtx(), ...args);
+  }
+  return out;
+}
 
 function createPlatformInstance<
   Def extends AnyPlatformDef,
@@ -219,7 +280,32 @@ function createPlatformInstance<
     },
   });
 
-  return Object.assign(base, eventProperties) as PlatformInstance<Def>;
+  // Project `PlatformDef.actions` onto the platform instance via the helper
+  // above. See `buildInstanceActions` for the two-tier semantics.
+  const instanceActions = buildInstanceActions(
+    def.name,
+    (def as { actions?: Record<string, RawActionFactory> }).actions,
+    new Set<string>([
+      "user",
+      "space",
+      "messages",
+      ...Object.keys(customEvents),
+    ]),
+    () => ({
+      client: runtime.client,
+      config: runtime.config,
+      store: runtime.store,
+    })
+  );
+
+  // Spread order: actions first, events last — an event stream cannot be
+  // silently shadowed by an action of the same name (the reserved-key check
+  // above already skips such actions, so this is belt-and-braces).
+  return Object.assign(
+    base,
+    instanceActions,
+    eventProperties
+  ) as PlatformInstance<Def>;
 }
 
 export function definePlatform<
@@ -257,6 +343,7 @@ export function definePlatform<
     never,
     never
   >,
+  _Actions extends Record<string, InstanceActionFn> = Record<never, never>,
 >(
   name: _Name,
   def: {
@@ -283,7 +370,8 @@ export function definePlatform<
       _MessageType,
       _Events,
       _SpaceActions,
-      _MessageActions
+      _MessageActions,
+      _Actions
     >,
     "lifecycle" | "name"
   > & { static?: _Static }
@@ -301,7 +389,8 @@ export function definePlatform<
     _MessageType,
     _Events,
     _SpaceActions,
-    _MessageActions
+    _MessageActions,
+    _Actions
   >
 > &
   Readonly<_Static> {
@@ -318,7 +407,8 @@ export function definePlatform<
     _MessageType,
     _Events,
     _SpaceActions,
-    _MessageActions
+    _MessageActions,
+    _Actions
   >;
 
   const fullDef = { name, ...def };

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -38,6 +38,71 @@ export type MessageActionFn = (
   ...args: never[]
 ) => Promise<void>;
 
+/**
+ * A platform-defined method projected onto the value returned by
+ * `provider(spectrum)` (e.g. `imessage(spectrum).getAttachment(guid)`). The
+ * first parameter is an injected runtime context (`{ client, config, store }`);
+ * `createPlatformInstance` supplies it so callers only pass the trailing args.
+ *
+ * Unlike `SpaceActionFn` / `MessageActionFn` (which always return
+ * `Promise<void>` because they dispatch through `send`), instance actions
+ * return arbitrary data — the public signature preserves the declared return
+ * type via `InstanceActionMethods<Def>`.
+ *
+ * Two tiers live in the same `actions?` slot:
+ *
+ * - **Platform-wise actions** — fixed framework-known names (currently just
+ *   `getMessage`) whose signatures are defined by `PlatformWiseActions`. They
+ *   power universal sugar (`space.getMessage(id)`) AND surface on the
+ *   platform instance. If a provider omits one, the framework wires a
+ *   default that throws `UnsupportedError`.
+ * - **Platform-specific actions** — free-form keys each platform declares
+ *   for its own ergonomics (e.g. iMessage's `getAttachment`). Surface on
+ *   the platform instance only.
+ *
+ * Names that collide with reserved instance keys (`user`, `space`, `messages`,
+ * plus any declared `events` key) are skipped at runtime with a warning and
+ * excluded at the type level.
+ */
+export type InstanceActionFn = (
+  // biome-ignore lint/suspicious/noExplicitAny: ctx is `any` so providers can annotate it with their platform's typed client without fighting contravariance; the runtime always passes `{ client, config, store }`
+  ctx: any,
+  // biome-ignore lint/suspicious/noExplicitAny: trailing args are user-defined
+  ...args: any[]
+) => Promise<unknown>;
+
+/**
+ * Framework-known action names that every platform implicitly has.
+ *
+ * Each entry's signature lives here; the framework wires the corresponding
+ * method onto the `PlatformInstance` for every platform — providers override
+ * by declaring the key inside their `actions` slot, and platforms that omit
+ * the key get a default that throws `UnsupportedError`.
+ *
+ * Add a new platform-wise capability by extending this record (and the
+ * runtime list in `define.ts`); the corresponding instance method will be
+ * surfaced on every `PlatformInstance` automatically.
+ */
+export interface PlatformWiseActions<
+  _ResolvedSpace extends { id: string },
+  _MessageType,
+  _Client,
+  _Config,
+> {
+  getMessage: (
+    ctx: { client: _Client; config: _Config; store: Store },
+    space: _ResolvedSpace & { id: string; __platform: string },
+    messageId: string
+  ) => Promise<_MessageType | undefined>;
+}
+
+export type PlatformWiseActionKey = keyof PlatformWiseActions<
+  { id: string },
+  unknown,
+  unknown,
+  unknown
+>;
+
 type ResolvedSpace = Pick<Space, "id">;
 type SpaceRef = Pick<Space, "id" | "__platform">;
 type ResolvedUser = Pick<User, "id">;
@@ -185,27 +250,39 @@ export interface PlatformDef<
     never,
     never
   >,
+  _Actions extends Record<string, InstanceActionFn> = Record<never, never>,
 > {
   /**
-   * Optional escape hatch: platform actions beyond `send`. Currently the
-   * framework recognizes one slot:
+   * Provider-defined methods exposed on the platform instance.
    *
-   * - **`getMessage?`** — fetch a message by id from a space. Powers
-   *   `space.getMessage(id)`. When omitted, `space.getMessage()` warns and
-   *   returns `undefined`.
+   * Two tiers share this slot:
    *
-   * 99% of integrations don't need this — `messages` + `send` is the
-   * universal contract.
+   * 1. **Platform-wise actions** (`getMessage`) — framework-recognized names
+   *    declared in `PlatformWiseActions`. Override by declaring the key here
+   *    with the matching signature. The framework injects `ctx = { client,
+   *    config, store }` as the first arg and surfaces the method on the
+   *    platform instance (`im.getMessage(space, id)`). If omitted, the
+   *    framework wires a default that throws `UnsupportedError`. Powers
+   *    universal sugar like `space.getMessage(id)`.
+   *
+   * 2. **Platform-specific actions** — free-form keys like `getAttachment`.
+   *    Each gets `ctx = { client, config, store }` as the first arg; the
+   *    public signature on `PlatformInstance<Def>` drops `ctx` and preserves
+   *    the declared return type.
+   *
+   * Names that collide with reserved instance keys (`user`, `space`,
+   * `messages`, plus any declared `events` key) are skipped at runtime with
+   * a warning and excluded at the type level.
    */
-  actions?: {
-    getMessage?: (_: {
-      space: _ResolvedSpace & SpaceRef;
-      messageId: string;
-      client: NoInferClient<_Client>;
-      config: z.infer<_ConfigSchema>;
-      store: Store;
-    }) => Promise<_MessageType | undefined>;
-  };
+  actions?: Partial<
+    PlatformWiseActions<
+      _ResolvedSpace,
+      _MessageType,
+      NoInferClient<_Client>,
+      z.infer<_ConfigSchema>
+    >
+  > &
+    _Actions;
 
   config: _ConfigSchema;
 
@@ -338,10 +415,7 @@ export interface PlatformDef<
 // ---------------------------------------------------------------------------
 
 export interface AnyPlatformDef {
-  actions?: {
-    // biome-ignore lint/suspicious/noExplicitAny: wildcard action
-    getMessage?: (_: any) => Promise<any>;
-  };
+  actions?: Record<string, InstanceActionFn>;
   config: z.ZodType<object>;
 
   // Optional escape hatches.
@@ -349,6 +423,7 @@ export interface AnyPlatformDef {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard event
     [key: string]: (ctx: any) => AsyncIterable<any>;
   };
+
   lifecycle: {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard lifecycle
     createClient: (ctx: any) => Promise<any>;
@@ -584,6 +659,60 @@ export type MessageActionMethods<Def extends AnyPlatformDef> = {
   ) => Promise<void>;
 };
 
+// Methods derived from `PlatformDef.actions`. The first parameter (`ctx`) is
+// the runtime context (`{ client, config, store }`) injected by
+// `createPlatformInstance`, so the public surface drops it. Unlike
+// `SpaceActionMethods` / `MessageActionMethods`, the declared **return type**
+// is preserved — instance actions return data, not `Promise<void>`.
+// The inner `A extends Record<string, AnyInstanceActionFn>` uses a maximally
+// permissive function shape so concrete actions (with typed `client`) flow
+// through without contravariance fights.
+type AnyInstanceActionFn = (
+  // biome-ignore lint/suspicious/noExplicitAny: structural shape only
+  ...args: any[]
+) => Promise<unknown>;
+type InstanceActionFns<Def extends AnyPlatformDef> = Def["actions"] extends
+  | infer A
+  | undefined
+  ? A extends Record<string, AnyInstanceActionFn>
+    ? A
+    : Record<string, never>
+  : Record<string, never>;
+
+// Reserved keys on `PlatformInstance` — same set the runtime guards. Includes
+// the base members (`user`, `space`, `messages`) plus every event name the
+// platform projects onto the instance, plus the platform-wise action keys
+// (`getMessage`) whose public signatures come from `PlatformWiseInstanceMethods`.
+type ReservedInstanceKeys<Def extends AnyPlatformDef> =
+  | "user"
+  | "space"
+  | "messages"
+  | PlatformWiseActionKey
+  | Extract<keyof CustomEventInstanceProperties<Def>, string>;
+
+// Methods derived from `PlatformDef.actions`, *excluding* platform-wise keys
+// (those are covered by `PlatformWiseInstanceMethods<Def>` so their signatures
+// stay typed even when the provider omits the override).
+export type InstanceActionMethods<Def extends AnyPlatformDef> = {
+  [K in Exclude<
+    keyof InstanceActionFns<Def>,
+    ReservedInstanceKeys<Def> | symbol | number
+  >]: (
+    ...args: TailArgs<Parameters<InstanceActionFns<Def>[K]>>
+  ) => ReturnType<InstanceActionFns<Def>[K]>;
+};
+
+// Methods derived from `PlatformWiseActions` — always present on the
+// platform instance regardless of whether the provider overrides them.
+// Signatures use the platform's resolved Space/Message types so they
+// type-check against `space.getMessage`-style sugar.
+export interface PlatformWiseInstanceMethods<Def extends AnyPlatformDef> {
+  getMessage: (
+    space: PlatformSpace<Def>,
+    messageId: string
+  ) => Promise<PlatformMessage<Def> | undefined>;
+}
+
 // Both `keyof Space` and `keyof SpaceActionMethods<Def>` are removed from the
 // schema shape before merging — at runtime `buildSpace` spreads
 // `platformActions` after `extras`/`spaceRef`, so an action with the same
@@ -622,7 +751,9 @@ export type PlatformInstance<Def extends AnyPlatformDef> = {
   readonly messages: AsyncIterable<[PlatformSpace<Def>, PlatformMessage<Def>]>;
   space(...args: SpaceArgs<Def>): Promise<PlatformSpace<Def>>;
   user(userID: string): Promise<PlatformUser<Def>>;
-} & CustomEventInstanceProperties<Def>;
+} & CustomEventInstanceProperties<Def> &
+  PlatformWiseInstanceMethods<Def> &
+  InstanceActionMethods<Def>;
 
 // Project the optional `events?` slot onto the platform instance as flat
 // async-iterable properties. When `events` is undefined (the 99% case), this

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -1,5 +1,7 @@
 import { createClient, MessageEffect } from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
+import { withSpan } from "@photon-ai/otel";
+import type { Attachment } from "../../content/attachment";
 import type { Avatar } from "../../content/avatar";
 import type { Edit } from "../../content/edit";
 import type { Rename } from "../../content/rename";
@@ -40,7 +42,13 @@ import {
   startTyping as remoteStartTyping,
   stopTyping as remoteStopTyping,
 } from "./remote/api";
-import { clientForPhone, isSharedMode, randomPhone } from "./remote/client";
+import { getRemoteAttachment } from "./remote/attachments";
+import {
+  availablePhones,
+  clientForPhone,
+  isSharedMode,
+  randomPhone,
+} from "./remote/client";
 import { dmChatGuid } from "./remote/ids";
 import {
   configSchema,
@@ -381,12 +389,58 @@ export const imessage = definePlatform("iMessage", {
   },
 
   actions: {
-    getMessage: async ({ space, messageId, client }) => {
+    getMessage: async ({ client }, space, messageId) => {
       if (isLocal(client)) {
         return localGetMessage(client, messageId);
       }
       const remote = clientForPhone(client, space.phone);
       return remoteGetMessage(remote, space.id, messageId, space.phone);
+    },
+    // Fetch an attachment by GUID. Returns a spectrum `Attachment` whose
+    // `.read()` / `.stream()` lazily download the bytes — calling both
+    // issues two independent gRPC downloads, so cache `.read()` if you
+    // need the bytes more than once. Returns `undefined` for unknown
+    // GUIDs. Local-mode iMessage is not supported.
+    getAttachment: async (
+      { client }: { client: IMessageClient },
+      guid: string,
+      phone?: string
+    ): Promise<Attachment | undefined> => {
+      if (isLocal(client)) {
+        throw UnsupportedError.action(
+          "getAttachment",
+          "iMessage (local mode)",
+          "fetching attachments by GUID requires remote iMessage"
+        );
+      }
+      if (client.length === 0) {
+        throw new Error("No iMessage clients configured");
+      }
+      const routedPhone = (() => {
+        if (isSharedMode(client)) {
+          return SHARED_PHONE;
+        }
+        if (phone) {
+          return phone;
+        }
+        if (client.length === 1) {
+          // biome-ignore lint/style/noNonNullAssertion: length checked above
+          return client[0]!.phone;
+        }
+        throw new Error(
+          `imessage.getAttachment requires a phone in multi-phone mode. Available: ${availablePhones(client).join(", ")}`
+        );
+      })();
+      const remote = clientForPhone(client, routedPhone);
+      return withSpan(
+        "spectrum.imessage.getAttachment",
+        {
+          "spectrum.provider": "iMessage",
+          "spectrum.imessage.attachment.guid": guid,
+          "spectrum.imessage.phone": routedPhone,
+        },
+        () => getRemoteAttachment(remote, guid)
+      );
     },
   },
 });

--- a/packages/spectrum-ts/src/providers/imessage/local/attachments.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local/attachments.ts
@@ -26,6 +26,7 @@ export const readLocalAttachment = async (
 const toAttachmentContent = (att: LocalAttachment): Content => {
   const { localPath } = att;
   return asAttachment({
+    id: att.id,
     name: att.fileName ?? DEFAULT_ATTACHMENT_NAME,
     mimeType: att.mimeType,
     size: att.sizeBytes,

--- a/packages/spectrum-ts/src/providers/imessage/remote/attachments.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/attachments.ts
@@ -1,0 +1,108 @@
+import {
+  type AdvancedIMessage,
+  NotFoundError,
+} from "@photon-ai/advanced-imessage";
+import { type Attachment, asAttachment } from "../../../content/attachment";
+
+/**
+ * Stream the primary file bytes of an attachment as a `ReadableStream`.
+ * Skips header and Live Photo companion frames; emits only `primaryChunk`
+ * payloads. Cleans up the underlying gRPC iterator on cancel and on error.
+ */
+export const downloadPrimaryAttachmentStream = (
+  client: AdvancedIMessage,
+  attachmentGuid: string
+): ReadableStream<Uint8Array> => {
+  const frames = client.attachments.downloadStream(attachmentGuid);
+  const iterator = frames[Symbol.asyncIterator]();
+  let closed = false;
+
+  const closeFrames = async (): Promise<void> => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    try {
+      await iterator.return?.();
+    } finally {
+      await frames.close();
+    }
+  };
+
+  return new ReadableStream<Uint8Array>({
+    async cancel() {
+      await closeFrames();
+    },
+    async pull(controller) {
+      try {
+        while (true) {
+          const result = await iterator.next();
+          if (result.done) {
+            controller.close();
+            await closeFrames();
+            return;
+          }
+          if (result.value.type === "primaryChunk") {
+            controller.enqueue(result.value.data);
+            return;
+          }
+        }
+      } catch (error) {
+        await closeFrames();
+        throw error;
+      }
+    },
+  });
+};
+
+/**
+ * Collect the primary file bytes of an attachment into a single `Buffer`.
+ * Skips header and Live Photo companion frames.
+ */
+export const downloadPrimaryAttachment = async (
+  client: AdvancedIMessage,
+  attachmentGuid: string
+): Promise<Buffer> => {
+  const chunks: Buffer[] = [];
+  const frames = client.attachments.downloadStream(attachmentGuid);
+  try {
+    for await (const frame of frames) {
+      if (frame.type === "primaryChunk") {
+        chunks.push(Buffer.from(frame.data));
+      }
+    }
+  } finally {
+    await frames.close();
+  }
+  return Buffer.concat(chunks);
+};
+
+/**
+ * Fetch an attachment by GUID and wrap it as a spectrum `Attachment`. The
+ * returned object is lazy: `.read()` triggers a Buffer download, `.stream()`
+ * opens a fresh byte stream. Calling both issues two independent gRPC
+ * downloads — cache `.read()` if you need the bytes more than once.
+ *
+ * Returns `undefined` when the GUID is unknown to the server.
+ */
+export const getRemoteAttachment = async (
+  client: AdvancedIMessage,
+  guid: string
+): Promise<Attachment | undefined> => {
+  let info: Awaited<ReturnType<AdvancedIMessage["attachments"]["get"]>>;
+  try {
+    info = await client.attachments.get(guid);
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      return;
+    }
+    throw err;
+  }
+  return asAttachment({
+    name: info.fileName,
+    mimeType: info.mimeType,
+    size: info.totalBytes,
+    read: () => downloadPrimaryAttachment(client, info.guid),
+    stream: async () => downloadPrimaryAttachmentStream(client, info.guid),
+  });
+};

--- a/packages/spectrum-ts/src/providers/imessage/remote/attachments.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/attachments.ts
@@ -99,6 +99,7 @@ export const getRemoteAttachment = async (
     throw err;
   }
   return asAttachment({
+    id: info.guid,
     name: info.fileName,
     mimeType: info.mimeType,
     size: info.totalBytes,

--- a/packages/spectrum-ts/src/providers/imessage/remote/inbound.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/inbound.ts
@@ -93,6 +93,7 @@ const toAttachmentContent = (
   info: AppleAttachment
 ): Content =>
   asAttachment({
+    id: info.guid,
     name: info.fileName,
     mimeType: info.mimeType,
     size: info.totalBytes,

--- a/packages/spectrum-ts/src/providers/imessage/remote/inbound.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/inbound.ts
@@ -14,6 +14,10 @@ import { fromVCard } from "../../../utils/vcard";
 import { getMessageCache, type MessageCache } from "../cache";
 import { isVCardAttachment } from "../shared/vcard";
 import type { IMessageMessage } from "../types";
+import {
+  downloadPrimaryAttachment,
+  downloadPrimaryAttachmentStream,
+} from "./attachments";
 import { formatChildId, parseChildId, toChatGuid, toMessageGuid } from "./ids";
 
 const URL_BALLOON_BUNDLE_ID = "com.apple.messages.URLBalloonProvider";
@@ -95,70 +99,6 @@ const toAttachmentContent = (
     read: async () => await downloadPrimaryAttachment(client, info.guid),
     stream: async () => downloadPrimaryAttachmentStream(client, info.guid),
   });
-
-const downloadPrimaryAttachmentStream = (
-  client: AdvancedIMessage,
-  attachmentGuid: string
-): ReadableStream<Uint8Array> => {
-  const frames = client.attachments.downloadStream(attachmentGuid);
-  const iterator = frames[Symbol.asyncIterator]();
-  let closed = false;
-
-  const closeFrames = async (): Promise<void> => {
-    if (closed) {
-      return;
-    }
-    closed = true;
-    try {
-      await iterator.return?.();
-    } finally {
-      await frames.close();
-    }
-  };
-
-  return new ReadableStream<Uint8Array>({
-    async cancel() {
-      await closeFrames();
-    },
-    async pull(controller) {
-      try {
-        while (true) {
-          const result = await iterator.next();
-          if (result.done) {
-            controller.close();
-            await closeFrames();
-            return;
-          }
-          if (result.value.type === "primaryChunk") {
-            controller.enqueue(result.value.data);
-            return;
-          }
-        }
-      } catch (error) {
-        await closeFrames();
-        throw error;
-      }
-    },
-  });
-};
-
-const downloadPrimaryAttachment = async (
-  client: AdvancedIMessage,
-  attachmentGuid: string
-): Promise<Buffer> => {
-  const chunks: Buffer[] = [];
-  const frames = client.attachments.downloadStream(attachmentGuid);
-  try {
-    for await (const frame of frames) {
-      if (frame.type === "primaryChunk") {
-        chunks.push(Buffer.from(frame.data));
-      }
-    }
-  } finally {
-    await frames.close();
-  }
-  return Buffer.concat(chunks);
-};
 
 const toVCardContent = async (
   client: AdvancedIMessage,

--- a/packages/spectrum-ts/src/providers/slack/messages.ts
+++ b/packages/spectrum-ts/src/providers/slack/messages.ts
@@ -72,6 +72,7 @@ const lazySlackFile = (
   file: SlackFile
 ): Content =>
   asAttachment({
+    id: file.id,
     name: file.name,
     mimeType: file.mimeType,
     size: file.size,

--- a/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/messages.ts
@@ -333,6 +333,7 @@ const lazyMedia = (
   media: { id: string; mimeType: string; filename?: string }
 ): Content =>
   asAttachment({
+    id: media.id,
     name: media.filename ?? `media-${media.id}`,
     mimeType: media.mimeType,
     read: async () =>


### PR DESCRIPTION
## Summary

- Splits `PlatformDef.actions` into two tiers — **platform-wise** (framework-known names every platform implicitly exposes) and **platform-specific** (free-form per-platform extensions) — and surfaces both as methods on `PlatformInstance<Def>` with declared return types preserved.
- Promotes `getMessage` to the first platform-wise action. It now lives on the platform instance (`im.getMessage(space, id)`) in addition to powering `space.getMessage(id)`. Platforms that don't override it get a default that throws `UnsupportedError`.
- Adds `imessage(spectrum).getAttachment(guid, phone?)` — fetch an attachment by GUID and get back a lazy spectrum `Attachment` whose `.read()` / `.stream()` issue independent gRPC downloads.
- Extracts the existing `downloadPrimaryAttachment` / `downloadPrimaryAttachmentStream` helpers out of `providers/imessage/remote/inbound.ts` into a new `providers/imessage/remote/attachments.ts` so both inbound parsing and the new `getAttachment` action share them.

## Behavior change

`space.getMessage(id)` previously **warned and returned `undefined`** when the provider didn't implement `getMessage`. It now **throws `UnsupportedError`**, matching the new platform-instance default and the project's other "action not supported" call sites. Callers that relied on silent-undefined should wrap in try/catch or check capability up front.

## Usage

```ts
import { Spectrum } from "spectrum-ts";
import { imessage } from "spectrum-ts/providers/imessage";

const app = await Spectrum({
  projectId: process.env.PROJECT_ID,
  projectSecret: process.env.PROJECT_SECRET,
  providers: [imessage.config()],
});

const im = imessage(app);

// Platform-wise action: same shape on every platform.
const msg = await im.getMessage(space, "some-message-id");

// Platform-specific action: fetch an attachment by GUID.
const att = await im.getAttachment("BAB...-GUID");
if (att) {
  const bytes = await att.read();       // Buffer
  // const stream = await att.stream(); // independent ReadableStream<Uint8Array>
}
```

In multi-phone mode, pass the phone explicitly: `im.getAttachment(guid, "+15551234567")`. Shared mode and single-phone mode route automatically. Local-mode iMessage throws `UnsupportedError` — GUID fetch requires the remote backend.

## Changes

| File | Change |
|---|---|
| `platform/types.ts` | Adds `InstanceActionFn`, `PlatformWiseActions<…>`, and `PlatformWiseActionKey`. `PlatformDef.actions` is now `Partial<PlatformWiseActions<…>> & _Actions` (free-form record). Adds `InstanceActionMethods<Def>` and `PlatformWiseInstanceMethods<Def>` and merges both into `PlatformInstance<Def>`. The platform-wise `getMessage` signature now takes `(ctx, space, messageId)` instead of a single struct. |
| `platform/define.ts` | New `buildInstanceActions` helper wires `def.actions` onto the instance: platform-wise keys get the override-or-default-throw treatment; platform-specific keys are surfaced only when declared and skipped (with warning) on reserved-name collisions. `definePlatform` gains a `_Actions` type param so platform-specific action signatures are inferred end-to-end. |
| `platform/build.ts` | Exports `PLATFORM_WISE_ACTION_KEYS` (kept in sync with the type via `satisfies`) and `warnReservedAction`. `scopeLabel` extracted to cover the new `"instance"` scope. `buildSpace.getMessageImpl` now calls the new positional-arg shape and throws `UnsupportedError` instead of warn-and-return when the action is missing. |
| `providers/imessage/index.ts` | `getMessage` updated to the new positional-arg shape. Adds the `getAttachment` action: routes to the right phone (shared / single / multi), wraps the call in a `spectrum.imessage.getAttachment` span, and delegates to `getRemoteAttachment`. Local mode and "no clients configured" surface as clear errors. |
| `providers/imessage/remote/attachments.ts` *(new)* | Exports `downloadPrimaryAttachment`, `downloadPrimaryAttachmentStream`, and `getRemoteAttachment`. `getRemoteAttachment` calls `client.attachments.get(guid)`, returns `undefined` on `NotFoundError`, and wraps the result as a lazy `Attachment`. |
| `providers/imessage/remote/inbound.ts` | Removes the two local download helpers (moved to `attachments.ts`) and imports them from there. No behavior change to inbound parsing. |
| `index.ts` | Re-exports `Attachment` and `AttachmentInput` types alongside the existing `attachment` builder. |

## Test plan

- [ ] `bun x ultracite check` is clean across the touched files.
- [ ] `bunx tsc --noEmit` is clean across the workspace.
- [ ] In a sample app with the iMessage provider: `im.getMessage(space, id)` returns the message; calling it on a provider that doesn't implement `getMessage` throws `UnsupportedError` (no longer silently `undefined`).
- [ ] `im.getAttachment(guid)` against a known GUID returns an `Attachment`; `.read()` returns a non-empty `Buffer`; `.stream()` yields the same bytes via the streaming path.
- [ ] `im.getAttachment("definitely-not-a-real-guid")` returns `undefined` (translated from `NotFoundError`).
- [ ] In multi-phone mode, calling `im.getAttachment(guid)` without `phone` throws with a clear "requires a phone" error listing the available phones; passing `phone` routes correctly.
- [ ] Local-mode iMessage: `im.getAttachment(guid)` throws `UnsupportedError` rather than dispatching.
- [ ] Inbound message handling (attachments arriving on `messages` stream) still produces working `Attachment` content — regression check on the helpers moved to `attachments.ts`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782552669&installation_id=127326493&pr_number=93&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F93&signature=5635f977bad35c3d2c8b56e32b555212ed632455b86dc3c4120048057a45a5e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iMessage: added attachment retrieval (download/stream) for remote attachments.
  * Platform: added per-instance actions support enabling instance-level provider actions.

* **Improvements**
  * Attachments across providers now include stable IDs and improved streaming/download behavior.
  * Provider errors are now surfaced explicitly when functionality is missing (fewer silent warnings).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->