### PR TITLE
fix(fusor): dispatch webhook handler fire-and-forget after response

### DIFF
--- a/docs/fusor.md
+++ b/docs/fusor.md
@@ -84,8 +84,10 @@ through the stream; you don't handle them.
 Use this when Fusor **POSTs** events to your own HTTPS endpoint (serverless
 functions, an existing HTTP server, edge runtimes). `app.webhook()` is
 **stateless and request-scoped**: you call it inside your POST handler, it runs
-the same pipeline, invokes your handler once per resolved message, and returns
-the HTTP response Fusor relays back to the platform.
+the same pipeline, returns the HTTP response Fusor relays back to the platform
+(the platform's `respond()` reply), and dispatches your handler once per resolved
+message fire-and-forget — the handler runs after the response and never affects
+it.
 
 ### Enable it
 
@@ -122,8 +124,13 @@ type WebhookHandler = (space: Space, message: Message) => void | Promise<void>;
 ```
 
 The `handler` receives the same `(space, message)` you'd get from
-`app.messages` — `space.send(...)`, `message.reply(...)`, etc. all work. It is
-awaited before the HTTP response is returned.
+`app.messages` — `space.send(...)`, `message.reply(...)`, etc. all work. It runs
+**fire-and-forget**: the HTTP response (the platform's `respond()` reply) is
+computed and returned *first*, then the handler is dispatched without being
+awaited — so a slow handler can never delay the response, and a handler error
+can't change it (it's caught and logged, like an error in a `for await (… of
+app.messages)` loop body). See [Keeping handler work alive](#keeping-handler-work-alive)
+for the serverless caveat.
 
 > ⚠️ **Pass the raw body bytes.** The POST body is a protobuf envelope
 > (`application/x-protobuf`). Capture it as bytes (`request.arrayBuffer()`,
@@ -141,6 +148,10 @@ server.post("/webhooks/fusor", (c) =>
   })
 );
 ```
+
+The reply Hono sends is the platform ack, produced by the pipeline — not
+whatever your handler does. `space.send(...)` posts a *new* message back to the
+platform out-of-band; it is not the HTTP response.
 
 **Bun.serve / Next.js App Router / Cloudflare Workers** — native `Request` →
 `Response`:
@@ -175,24 +186,45 @@ app.post(
 ### What's automatic vs. your job
 
 - **Automatic:** decode the envelope, route by platform, verify the platform
-  signature, parse, and echo protocol replies (e.g. Slack `url_verification`) in
-  the HTTP response.
-- **Your job:** the `handler` — your application logic for each message.
+  signature, parse, build the HTTP response (the platform's `respond()` reply,
+  including protocol echoes like Slack `url_verification`), and dispatch your
+  handler.
+- **Your job:** the `handler` — your application logic for each message. It can't
+  affect the HTTP response; it runs after it.
 
 ### Status codes & retries
 
-`app.webhook()` returns the status Fusor relays. Fusor delivers
-**at-least-once** and retries non-2xx, so the mapping matters:
+`app.webhook()` returns the status Fusor relays — derived **entirely from the
+pipeline**, never from your handler. Fusor delivers **at-least-once** and retries
+non-2xx, so the mapping matters:
 
 | Situation | HTTP status | Fusor behavior |
 | --- | --- | --- |
 | Success (incl. a protocol reply) | reply status, or `200` | done |
 | Undecodable body / unknown platform / platform `verify()` failed | `400` (poison) | won't retry |
-| Your `handler` threw | `500` | retries |
+| Your `handler` threw | `200` (the pipeline ack — the throw is logged, not surfaced) | done, not retried |
 
-Because delivery is at-least-once, **your handler should be idempotent** — a
-retry re-runs it. Dedupe on the stable `message.id` if a side effect must happen
-exactly once.
+Because the handler runs fire-and-forget, **a handler failure does not trigger a
+Fusor retry** — if a side effect must survive failure, make it durable yourself
+(see below). Delivery is still at-least-once at the Fusor level, so **keep your
+handler idempotent** and dedupe on the stable `message.id` for exactly-once
+effects.
+
+### Keeping handler work alive
+
+Because the handler runs *after* the response, the runtime must stay alive long
+enough for it to finish:
+
+- **Long-running server** (Node `http`, `Bun.serve`, Express, a persistent
+  worker) — nothing to do; the event loop keeps the handler running. The examples
+  above are all this shape.
+- **Serverless / edge** (Vercel, Cloudflare Workers, AWS Lambda) — the function
+  can be frozen or torn down the moment you return the response, dropping
+  un-awaited handler work. Keeping it alive is **your** responsibility. The
+  robust, platform-agnostic pattern is **ack-then-enqueue**: in the handler, push
+  the message onto a durable queue (Vercel Queue, Upstash QStash, Inngest, SQS, a
+  DB outbox) and do the real work in a separate worker that has its own retries.
+  Spectrum intentionally does not manage function lifetime.
 
 ### Does not feed `app.messages`
 

--- a/packages/spectrum-ts/src/fusor/types.ts
+++ b/packages/spectrum-ts/src/fusor/types.ts
@@ -50,8 +50,17 @@ export interface FusorClient<TPayload = unknown> {
 /**
  * Request-scoped handler invoked once per inbound message that
  * `spectrum.webhook()` resolves. Receives the same fully-built `[space,
- * message]` pair that `spectrum.messages` yields; awaited before the HTTP
- * response is returned to fusor.
+ * message]` pair that `spectrum.messages` yields.
+ *
+ * Runs **fire-and-forget**: it is dispatched after the HTTP response (the
+ * platform's `respond()` reply) has already been computed, so its outcome never
+ * affects the response, and a throw is caught + logged rather than surfaced —
+ * mirroring the body of a `for await (… of spectrum.messages)` loop.
+ *
+ * On a long-running server the event loop keeps the handler alive. On
+ * serverless/edge runtimes the function may be frozen once the response is
+ * returned, so keeping background work alive is the caller's responsibility —
+ * the usual pattern is to enqueue the work and process it in a separate worker.
  */
 export type WebhookHandler = (
   space: Space,

--- a/packages/spectrum-ts/src/fusor/webhook.test.ts
+++ b/packages/spectrum-ts/src/fusor/webhook.test.ts
@@ -153,6 +153,7 @@ describe("spectrum.webhook", () => {
       providers: [makeSlack().config({})],
     });
     const received: [unknown, Message][] = [];
+    const { promise: finished, resolve: done } = Promise.withResolvers<void>();
 
     const result = await spectrum.webhook(
       {
@@ -164,8 +165,10 @@ describe("spectrum.webhook", () => {
       },
       (space, message) => {
         received.push([space, message]);
+        done();
       }
     );
+    await finished;
 
     expect(received).toHaveLength(1);
     const first = received.at(0);
@@ -188,6 +191,7 @@ describe("spectrum.webhook", () => {
       providers: [makeSlack().config({})],
     });
     const received: Message[] = [];
+    const { promise: finished, resolve: done } = Promise.withResolvers<void>();
 
     const result = await spectrum.webhook(
       {
@@ -196,8 +200,10 @@ describe("spectrum.webhook", () => {
       },
       (_space, message) => {
         received.push(message);
+        done();
       }
     );
+    await finished;
 
     expect(result.status).toBe(200);
     expect(received).toHaveLength(1);
@@ -312,11 +318,14 @@ describe("spectrum.webhook", () => {
     await spectrum.stop();
   });
 
-  it("returns 500 when the handler throws (fusor retries at-least-once)", async () => {
+  it("a handler throw does not change the response (200, runs async)", async () => {
     const spectrum = await Spectrum({
       ...baseConfig,
       providers: [makeSlack().config({})],
     });
+
+    let invoked = false;
+    const { promise: finished, resolve: done } = Promise.withResolvers<void>();
 
     const result = await spectrum.webhook(
       {
@@ -327,11 +336,16 @@ describe("spectrum.webhook", () => {
         ),
       },
       () => {
+        invoked = true;
+        done();
         throw new Error("downstream db down");
       }
     );
+    await finished;
 
-    expect(result.status).toBe(500);
+    // The throw is caught + logged asynchronously; the response is unaffected.
+    expect(result.status).toBe(200);
+    expect(invoked).toBe(true);
     await spectrum.stop();
   });
 
@@ -343,6 +357,7 @@ describe("spectrum.webhook", () => {
     });
 
     const received: Message[] = [];
+    const { promise: finished, resolve: done } = Promise.withResolvers<void>();
     await spectrum.webhook(
       {
         headers: {},
@@ -353,8 +368,12 @@ describe("spectrum.webhook", () => {
       },
       (_space, message) => {
         received.push(message);
+        if (received.length === 2) {
+          done();
+        }
       }
     );
+    await finished;
 
     expect(received.map((m) => m.content)).toEqual([
       { type: "text", text: "a" },
@@ -463,12 +482,15 @@ describe("spectrum.webhook", () => {
     );
 
     let delivered = 0;
+    const { promise: finished, resolve: done } = Promise.withResolvers<void>();
     const result = await spectrum.webhook(
       { headers: signEvent("1700000000", body), body },
       () => {
         delivered += 1;
+        done();
       }
     );
+    await finished;
 
     expect(result.status).toBe(200);
     expect(delivered).toBe(1);

--- a/packages/spectrum-ts/src/fusor/webhook.test.ts
+++ b/packages/spectrum-ts/src/fusor/webhook.test.ts
@@ -383,6 +383,42 @@ describe("spectrum.webhook", () => {
     await spectrum.stop();
   });
 
+  it("isolates a handler throw per message — the rest of the batch still delivers", async () => {
+    const spectrum = await Spectrum({
+      ...baseConfig,
+      providers: [makeSlack().config({})],
+      options: { flattenGroups: true },
+    });
+
+    const received: Message[] = [];
+    const { promise: finished, resolve: done } = Promise.withResolvers<void>();
+    await spectrum.webhook(
+      {
+        headers: {},
+        body: encodeEvent(
+          "slack",
+          JSON.stringify({ type: "group", texts: ["a", "b"] })
+        ),
+      },
+      (_space, message) => {
+        received.push(message);
+        // The first item throws; the second must still be delivered.
+        if (received.length === 1) {
+          throw new Error("first item failed");
+        }
+        done();
+      }
+    );
+    await finished;
+
+    expect(received.map((m) => m.content)).toEqual([
+      { type: "text", text: "a" },
+      { type: "text", text: "b" },
+    ]);
+
+    await spectrum.stop();
+  });
+
   it("throws when no fusor provider is configured", async () => {
     const spectrum = await Spectrum({ providers: [] });
 

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -78,9 +78,17 @@ export type SpectrumInstance<
     /**
      * Handle one inbound fusor webhook delivery. Call this from your HTTP
      * server's POST route — it verifies, decodes, routes to the matching
-     * provider's verify + message pipeline, invokes `handler` once per resolved
-     * message, and returns the HTTP response fusor relays back to the platform
-     * (including protocol echoes like Slack `url_verification`).
+     * provider's verify + message pipeline, and returns the HTTP response fusor
+     * relays back to the platform: the platform's `respond()` reply (including
+     * protocol echoes like Slack `url_verification`), computed synchronously and
+     * returned immediately.
+     *
+     * `handler` is invoked once per resolved message **fire-and-forget** — it is
+     * dispatched after the response is computed and is NOT awaited, so its
+     * outcome never changes the response (a throw is logged, not surfaced). On a
+     * long-running server the event loop keeps it alive; on serverless/edge,
+     * keeping the work alive past the response is the caller's job (e.g. enqueue
+     * and process in a separate worker).
      *
      * Stateless and request-scoped: it does NOT feed `spectrum.messages`, and it
      * never opens the gRPC stream. fusor delivers at-least-once, so `handler`
@@ -763,27 +771,6 @@ export async function Spectrum<
     }
   };
 
-  // Deliver to the request-scoped handler. Returns a 500 result on a handler
-  // throw (fusor retries, at-least-once), or null on success.
-  const runWebhookDelivery = async (
-    collected: ProviderMessageRecord[],
-    runtime: PlatformRuntime,
-    handler: WebhookHandler,
-    event: RawInboundEvent
-  ): Promise<WebhookRawResult | null> => {
-    try {
-      await deliverWebhookMessages(collected, runtime, handler);
-      return null;
-    } catch (error) {
-      lifecycleLog.error(`spectrum.webhook: handler threw, ${error}`, {
-        eventId: event.eventId,
-        platform: event.platform,
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return { status: 500, headers: {}, body: new Uint8Array(0) };
-    }
-  };
-
   // Run the shared fusor pipeline for a decoded event and map it to an HTTP
   // result. Records are collected for THIS request (webhook is stateless — they
   // do not feed spectrum.messages).
@@ -806,26 +793,36 @@ export async function Spectrum<
       };
     }
 
-    const runtime = platformStates.get(event.platform);
-    if (runtime) {
-      const failure = await runWebhookDelivery(
-        collected,
-        runtime,
-        handler,
-        event
-      );
-      if (failure) {
-        return failure;
-      }
-    }
-
-    // Success: status 0 → 200. Carries protocol echoes (e.g. Slack
-    // url_verification) produced by the platform's messages() respond().
-    return {
+    // The HTTP response is the platform's respond() reply (status 0 → 200,
+    // carrying protocol echoes like Slack url_verification). It is owned entirely
+    // by the pipeline — the handler dispatched below never affects it.
+    const result: WebhookRawResult = {
       status: reply.status === 0 ? 200 : reply.status,
       headers: reply.headers ?? {},
       body: reply.body ?? new Uint8Array(0),
     };
+
+    // Deliver to the request-scoped handler fire-and-forget: dispatched after
+    // the response is computed and NOT awaited, mirroring a
+    // `for await (… of spectrum.messages)` loop body. A throw is caught + logged,
+    // never surfaced as a 500 / fusor retry. On a long-running server the event
+    // loop keeps this alive; on serverless, keeping it alive past the response is
+    // the caller's responsibility (e.g. enqueue + process in a separate worker).
+    const runtime = platformStates.get(event.platform);
+    if (runtime && collected.length > 0) {
+      deliverWebhookMessages(collected, runtime, handler).catch((error) => {
+        lifecycleLog.error(
+          `spectrum.webhook: handler threw (async), ${error}`,
+          {
+            eventId: event.eventId,
+            platform: event.platform,
+            error: error instanceof Error ? error.message : String(error),
+          }
+        );
+      });
+    }
+
+    return result;
   };
 
   const handleWebhook = async (

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -728,15 +728,30 @@ export async function Spectrum<
   };
 
   // Resolve each collected record and hand it to the request-scoped handler.
+  // Each handler invocation is isolated: a throw on one message is logged with
+  // its own context and does NOT skip the remaining messages in the batch.
   const deliverWebhookMessages = async (
     collected: ProviderMessageRecord[],
     runtime: PlatformRuntime,
-    handler: WebhookHandler
+    handler: WebhookHandler,
+    event: RawInboundEvent
   ): Promise<void> => {
     for (const record of collected) {
       const tuples = await resolveRecordToMessages(record, runtime);
       for (const [space, message] of tuples) {
-        await handler(space, message);
+        try {
+          await handler(space, message);
+        } catch (error) {
+          lifecycleLog.error(
+            `spectrum.webhook: handler threw (async), ${error}`,
+            {
+              eventId: event.eventId,
+              platform: event.platform,
+              messageId: message.id,
+              error: error instanceof Error ? error.message : String(error),
+            }
+          );
+        }
       }
     }
   };
@@ -810,16 +825,21 @@ export async function Spectrum<
     // the caller's responsibility (e.g. enqueue + process in a separate worker).
     const runtime = platformStates.get(event.platform);
     if (runtime && collected.length > 0) {
-      deliverWebhookMessages(collected, runtime, handler).catch((error) => {
-        lifecycleLog.error(
-          `spectrum.webhook: handler threw (async), ${error}`,
-          {
-            eventId: event.eventId,
-            platform: event.platform,
-            error: error instanceof Error ? error.message : String(error),
-          }
-        );
-      });
+      // Per-message handler throws are isolated + logged inside
+      // deliverWebhookMessages; this safety net only fires on a message
+      // resolution or otherwise unexpected error.
+      deliverWebhookMessages(collected, runtime, handler, event).catch(
+        (error) => {
+          lifecycleLog.error(
+            `spectrum.webhook: delivery failed (async), ${error}`,
+            {
+              eventId: event.eventId,
+              platform: event.platform,
+              error: error instanceof Error ? error.message : String(error),
+            }
+          );
+        }
+      );
     }
 
     return result;


### PR DESCRIPTION
## Summary

- Makes `app.webhook()` return the HTTP response **before** running your handler, instead of awaiting the handler first.
- The HTTP response is now owned **entirely by the pipeline** — it's the platform's `respond()` reply (status `0 → 200`, carrying protocol echoes like Slack `url_verification`), computed synchronously and returned immediately.
- The `handler` is dispatched **fire-and-forget**: it runs after the response is computed and is *not* awaited, mirroring the body of a `for await (… of app.messages)` loop. A throw is caught + logged, never surfaced.
- Updates `docs/fusor.md`, the `WebhookHandler` / `spectrum.webhook` doc comments, and the webhook tests to match.

## Behavior change

| | Before | After |
| --- | --- | --- |
| Slow handler | delays the HTTP response | response returns first; handler can't delay it |
| Handler throws | `500` → Fusor **retries** (at-least-once) | `200` (pipeline ack); throw is logged, **no retry** |
| Response source | gated on handler completion | pipeline `respond()` reply only |

Because a handler failure no longer triggers a Fusor retry, callers that need a side effect to survive failure must make it durable themselves. Delivery is still at-least-once at the Fusor level, so handlers should stay **idempotent** (dedupe on the stable `message.id`).

### Serverless caveat

The handler now runs *after* the response, so the runtime must stay alive long enough to finish it. On a long-running server the event loop handles this automatically. On serverless/edge (Vercel, Cloudflare Workers, Lambda) the function can be frozen once the response returns — keeping background work alive is the caller's responsibility (the documented pattern is **ack-then-enqueue**: push the message to a durable queue and process it in a separate worker). Spectrum intentionally does not manage function lifetime.

## Changes

- **`packages/spectrum-ts/src/spectrum.ts`** — Remove `runWebhookDelivery` (the await-then-map-to-500 helper). Compute the `WebhookRawResult` from the pipeline reply first, then dispatch `deliverWebhookMessages(...)` fire-and-forget with a `.catch()` that logs the error (now tagged `handler threw (async)`). Only dispatches when `collected.length > 0`. Updates the `spectrum.webhook` doc comment.
- **`packages/spectrum-ts/src/fusor/types.ts`** — Rewrite the `WebhookHandler` doc comment to describe the fire-and-forget contract and the serverless lifetime caveat.
- **`packages/spectrum-ts/src/fusor/webhook.test.ts`** — Tests now await handler completion via `Promise.withResolvers()` (the handler is async). Rename + rework the "handler throws" test to assert the response is unaffected (`200`, handler still invoked) instead of `500`.
- **`docs/fusor.md`** — Document the fire-and-forget contract, the updated status-code/retry table, a "Keeping handler work alive" section (long-running vs serverless), and clarify that the Hono reply is the platform ack, not the handler's output.

## Test plan

- [ ] `bun test packages/spectrum-ts/src/fusor/webhook.test.ts`
- [ ] `bun x ultracite check`
- [ ] Confirm a slow/throwing handler no longer delays or changes the webhook HTTP response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782718364&installation_id=127326493&pr_number=97&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F97&signature=9f76b25223b51cf6bb19abddf86544aaeaecafee2533111b5d1687950805e0e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Webhook handlers now run fire-and-forget after the HTTP response is determined; handler failures are logged and no longer change the response status (pipeline acks are preserved).

* **Documentation**
  * Clarified webhook semantics, signature handling, status-mapping, and recommended ack-then-enqueue pattern for serverless/edge environments.

* **Tests**
  * Updated tests to deterministically await async handler completion and to reflect the new response behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/photon-hq/spectrum-ts/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->