### PR TITLE
feat(spectrum-ts): project config fetch + iMessage contact-share on inbound

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "packages/spectrum-ts": {
       "name": "spectrum-ts",
-      "version": "1.15.0",
+      "version": "1.16.1",
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.10.0",
         "@photon-ai/imessage-kit": "^3.0.0",
@@ -28,6 +28,8 @@
         "@photon-ai/slack": "^0.2.0",
         "@photon-ai/whatsapp-business": "^0.1.1",
         "@repeaterjs/repeater": "^3.0.6",
+        "better-grpc": "^0.3.2",
+        "lru-cache": "^11.0.0",
         "mime-types": "^3.0.1",
         "nice-grpc": "^2.1.16",
         "nice-grpc-common": "^2.0.2",
@@ -144,6 +146,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
+
+    "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
@@ -293,9 +297,13 @@
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
+    "async-mutex": ["async-mutex@0.5.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA=="],
+
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "better-grpc": ["better-grpc@0.3.2", "", { "dependencies": { "@msgpack/msgpack": "^3.1.2", "async-mutex": "^0.5.0", "it-pushable": "^3.2.3", "nice-grpc": "^2.1.13", "zod": "^4.1.12" }, "peerDependencies": { "typescript": "^5" } }, "sha512-e+u6C4zHwjE5g7vOvDpFeMe7Nas7FU+xa6FktiheRTcOpEdD5nag+uoIw7L5bPXdxxg995feBAXLwIay/npEqw=="],
 
     "better-sqlite3": ["better-sqlite3@12.8.0", "", { "dependencies": { "bindings": "^1.5.0", "prebuild-install": "^7.1.1" } }, "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ=="],
 
@@ -423,6 +431,8 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "it-pushable": ["it-pushable@3.2.4", "", { "dependencies": { "p-defer": "^4.0.0" } }, "sha512-WSD7Ss4oCRfDZJT4ldLWr0Bom/muY90xxoJ5PQnU3uSKf0kxCOeehqZtiJX1ARqn+ymXGh1bxpDW9bDNHp2ivQ=="],
+
     "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
@@ -478,6 +488,8 @@
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "open-graph-scraper": ["open-graph-scraper@6.11.0", "", { "dependencies": { "chardet": "^2.1.1", "cheerio": "^1.1.2", "iconv-lite": "^0.7.0", "undici": "^7.16.0" } }, "sha512-KkO3qMMzJj9KYGtCl19dRtncb+RuBiG/P9BgukcAG4p2w9wSAWTE90vL6/xqth1K9ThkYF/+xfTGrVvU79TJtQ=="],
+
+    "p-defer": ["p-defer@4.0.1", "", {}, "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A=="],
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -570,6 +582,8 @@
     "ts-error": ["ts-error@1.0.6", "", {}, "sha512-tLJxacIQUM82IR7JO1UUkKlYuUTmoY9HBJAmNWFzheSlDS5SPMcNIepejHJa4BpPQLAcbRhRf3GDJzyj6rbKvA=="],
 
     "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsup": ["tsup@8.5.1", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.27.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "^0.7.6", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing=="],
 

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -77,6 +77,8 @@
     "@photon-ai/whatsapp-business": "^0.1.1",
     "@photon-ai/proto": "^0.2.4",
     "@repeaterjs/repeater": "^3.0.6",
+    "better-grpc": "^0.3.2",
+    "lru-cache": "^11.0.0",
     "mime-types": "^3.0.1",
     "nice-grpc": "^2.1.16",
     "nice-grpc-common": "^2.0.2",

--- a/packages/spectrum-ts/src/fusor/webhook.test.ts
+++ b/packages/spectrum-ts/src/fusor/webhook.test.ts
@@ -6,8 +6,18 @@ import type { Content } from "../content/types";
 import { defineFusorPlatform } from "../platform/define";
 import { Spectrum } from "../spectrum";
 import type { Message } from "../types/message";
+import { cloud } from "../utils/cloud";
 import { FusorCore } from "./core";
 import { fusor } from "./index";
+
+// Spectrum() fetches project metadata up-front when projectId/projectSecret are
+// supplied. These tests use placeholder credentials, so stub the cloud call to
+// avoid a real network request (and a VALIDATION_ERROR) during construction.
+spyOn(cloud, "getProject").mockResolvedValue({
+  id: "proj",
+  name: "Test Project",
+  profile: {},
+});
 
 // A minimal fusor-mode provider standing in for a real platform (Slack-ish).
 // Its verify() parses the inner HTTP body to a typed payload; messages() turns

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -76,6 +76,8 @@ export type {
   ImessageInfoData,
   PlatformStatus,
   PlatformsData,
+  ProjectData,
+  ProjectProfile,
   SharedTokenData,
   SlackTeamMeta,
   SlackTokenData,

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -191,7 +191,7 @@ type InferEventPayload<T> = T extends (ctx: never) => AsyncIterable<infer P>
 // Reserved names — event names that would collide with SpectrumInstance methods
 // ---------------------------------------------------------------------------
 
-type ReservedNames = "stop" | "send" | "__internal" | "__providers";
+type ReservedNames = "stop" | "send" | "config" | "__internal" | "__providers";
 
 // ---------------------------------------------------------------------------
 // PlatformDef — the full definition of a platform adapter

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -4,6 +4,7 @@ import type { Content } from "../content/types";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
 import type { User } from "../types/user";
+import type { ProjectData } from "../utils/cloud";
 import type { Store } from "../utils/store";
 import type { ManagedStream } from "../utils/stream";
 
@@ -132,6 +133,13 @@ export type EventProducer<
 > = (ctx: {
   client: NoInferClient<TClient>;
   config: TConfig;
+  /**
+   * Spectrum Cloud project metadata, fetched once at `Spectrum()` init.
+   * `undefined` when the instance was created without `projectId`/`projectSecret`
+   * (local-only setups). Providers read project-level toggles from
+   * `projectConfig.profile.<key>` — e.g. iMessage's `imessageSynced` flag.
+   */
+  projectConfig: ProjectData | undefined;
   store: Store;
 }) => AsyncIterable<TPayload>;
 

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -307,8 +307,10 @@ export const imessage = definePlatform("iMessage", {
     },
   },
 
-  messages: ({ client }) =>
-    isLocal(client) ? localMessages(client) : remoteMessages(client),
+  messages: ({ client, projectConfig }) =>
+    isLocal(client)
+      ? localMessages(client)
+      : remoteMessages(client, projectConfig),
 
   send: async ({ space, content, client }) => {
     if (content.type === "reply") {

--- a/packages/spectrum-ts/src/providers/imessage/remote/api.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/api.ts
@@ -3,6 +3,7 @@ import type { Avatar } from "../../../content/avatar";
 import type { Rename } from "../../../content/rename";
 import type { Content } from "../../../content/types";
 import type { ProviderMessageRecord } from "../../../platform/types";
+import type { ProjectData } from "../../../utils/cloud";
 import type { ManagedStream } from "../../../utils/stream";
 import type { Background } from "../content/background";
 import type { IMessageMessage, RemoteClient } from "../types";
@@ -24,8 +25,9 @@ import {
 } from "./typing";
 
 export const messages = (
-  clients: RemoteClient[]
-): ManagedStream<IMessageMessage> => remoteMessages(clients);
+  clients: RemoteClient[],
+  projectConfig: ProjectData | undefined
+): ManagedStream<IMessageMessage> => remoteMessages(clients, projectConfig);
 
 export const setBackground = async (
   remote: AdvancedIMessage,

--- a/packages/spectrum-ts/src/providers/imessage/remote/contact-share.test.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/contact-share.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import { ContactShareTracker, getContactShareTracker } from "./contact-share";
+
+const flush = (): Promise<void> =>
+  new Promise((resolve) => setImmediate(resolve));
+
+const makeClient = (
+  share: (chatGuid: string) => Promise<void>
+): AdvancedIMessage =>
+  ({
+    chats: { shareContactInfo: share },
+  }) as unknown as AdvancedIMessage;
+
+describe("ContactShareTracker", () => {
+  it("shares once per chat across repeated inbound messages", async () => {
+    const share = mock((_: string) => Promise.resolve());
+    const client = makeClient(share);
+    const tracker = new ContactShareTracker();
+
+    tracker.maybeShare(client, "chat-A");
+    tracker.maybeShare(client, "chat-A");
+    tracker.maybeShare(client, "chat-A");
+    await flush();
+
+    expect(share).toHaveBeenCalledTimes(1);
+    expect(share).toHaveBeenCalledWith("chat-A");
+  });
+
+  it("coalesces a burst of concurrent inbound messages to one API call", async () => {
+    let resolveShare!: () => void;
+    const sharePromise = new Promise<void>((r) => {
+      resolveShare = r;
+    });
+    const share = mock((_: string) => sharePromise);
+    const client = makeClient(share);
+    const tracker = new ContactShareTracker();
+
+    // Five concurrent inbound messages for the same chat — only the first
+    // should kick off the share; the rest should see the cached entry and
+    // skip even though the in-flight promise hasn't resolved yet.
+    for (let i = 0; i < 5; i++) {
+      tracker.maybeShare(client, "chat-burst");
+    }
+    expect(share).toHaveBeenCalledTimes(1);
+
+    resolveShare();
+    await flush();
+    expect(share).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares for distinct chats independently", async () => {
+    const share = mock((_: string) => Promise.resolve());
+    const client = makeClient(share);
+    const tracker = new ContactShareTracker();
+
+    tracker.maybeShare(client, "chat-A");
+    tracker.maybeShare(client, "chat-B");
+    tracker.maybeShare(client, "chat-A");
+    await flush();
+
+    expect(share).toHaveBeenCalledTimes(2);
+    expect(share.mock.calls.map((c) => c[0]).sort()).toEqual([
+      "chat-A",
+      "chat-B",
+    ]);
+  });
+
+  it("retries on the next inbound when a share fails", async () => {
+    let attempt = 0;
+    const share = mock((_: string) => {
+      attempt += 1;
+      return attempt === 1
+        ? Promise.reject(new Error("transient"))
+        : Promise.resolve();
+    });
+    const client = makeClient(share);
+    const tracker = new ContactShareTracker();
+
+    tracker.maybeShare(client, "chat-retry");
+    await flush();
+    expect(share).toHaveBeenCalledTimes(1);
+
+    // After failure the cache entry should be evicted, so the next inbound
+    // tries again rather than silently muting the chat.
+    tracker.maybeShare(client, "chat-retry");
+    await flush();
+    expect(share).toHaveBeenCalledTimes(2);
+
+    // The retry succeeded — subsequent inbounds within the window are deduped.
+    tracker.maybeShare(client, "chat-retry");
+    await flush();
+    expect(share).toHaveBeenCalledTimes(2);
+  });
+
+  it("never throws synchronously even when shareContactInfo rejects", async () => {
+    const share = mock((_: string) => Promise.reject(new Error("boom")));
+    const client = makeClient(share);
+    const tracker = new ContactShareTracker();
+
+    expect(() => tracker.maybeShare(client, "chat-throw")).not.toThrow();
+    await flush();
+    expect(share).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("getContactShareTracker", () => {
+  it("returns the same tracker for the same owner", () => {
+    const owner = {};
+    const a = getContactShareTracker(owner);
+    const b = getContactShareTracker(owner);
+    expect(a).toBe(b);
+  });
+
+  it("returns distinct trackers for distinct owners", () => {
+    const a = getContactShareTracker({});
+    const b = getContactShareTracker({});
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/spectrum-ts/src/providers/imessage/remote/contact-share.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/contact-share.ts
@@ -1,4 +1,5 @@
 import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import { sanitizeErrorMessage } from "@photon-ai/otel";
 import { LRUCache } from "lru-cache";
 
 const SHARE_TTL_MS = 24 * 60 * 60 * 1000;
@@ -32,17 +33,19 @@ export class ContactShareTracker {
       return;
     }
     this.cache.set(chatGuid, true);
+    // chatGuid embeds the peer's phone/email for DMs — scrub it before logging.
+    const safeChatGuid = sanitizeErrorMessage(chatGuid);
     client.chats
       .shareContactInfo(chatGuid)
       .then(() => {
         console.info(
-          `[spectrum-ts][imessage][contact-share] shared contact info to ${chatGuid}`
+          `[spectrum-ts][imessage][contact-share] shared contact info to ${safeChatGuid}`
         );
       })
       .catch((error: unknown) => {
         this.cache.delete(chatGuid);
         console.warn(
-          `[spectrum-ts][imessage][contact-share] failed to share contact info to ${chatGuid}`,
+          `[spectrum-ts][imessage][contact-share] failed to share contact info to ${safeChatGuid}`,
           error
         );
       });

--- a/packages/spectrum-ts/src/providers/imessage/remote/contact-share.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/contact-share.ts
@@ -1,0 +1,67 @@
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import { LRUCache } from "lru-cache";
+
+const SHARE_TTL_MS = 24 * 60 * 60 * 1000;
+const MAX_TRACKED_CHATS = 10_000;
+
+/**
+ * Tracks which chats this bot has already proactively pushed its contact card
+ * to, so `im.chats.shareContactInfo` is fired at most once per chat per 24h
+ * per iMessage provider instance.
+ *
+ * Backed by `lru-cache` for TTL + bounded memory. `ttlAutopurge: false`
+ * keeps eviction lazy (on access) — there is no background timer to leak
+ * across Spectrum lifecycles.
+ */
+export class ContactShareTracker {
+  private readonly cache = new LRUCache<string, true>({
+    max: MAX_TRACKED_CHATS,
+    ttl: SHARE_TTL_MS,
+    ttlAutopurge: false,
+  });
+
+  /**
+   * Best-effort share. The cache is set eagerly so that a burst of inbound
+   * messages for the same chat coalesces to a single API call. On failure the
+   * entry is evicted so the next inbound retries — transient errors don't
+   * permanently mute the feature for a chat. Never awaits and never throws:
+   * the receive stream must not crash on share failures.
+   */
+  maybeShare(client: AdvancedIMessage, chatGuid: string): void {
+    if (this.cache.has(chatGuid)) {
+      return;
+    }
+    this.cache.set(chatGuid, true);
+    client.chats
+      .shareContactInfo(chatGuid)
+      .then(() => {
+        console.info(
+          `[spectrum-ts][imessage][contact-share] shared contact info to ${chatGuid}`
+        );
+      })
+      .catch((error: unknown) => {
+        this.cache.delete(chatGuid);
+        console.warn(
+          `[spectrum-ts][imessage][contact-share] failed to share contact info to ${chatGuid}`,
+          error
+        );
+      });
+  }
+}
+
+const trackers = new WeakMap<object, ContactShareTracker>();
+
+/**
+ * Returns a per-owner tracker. Mirrors `getMessageCache`/`getPollCache` in
+ * ../cache.ts — keyed by an object (the `RemoteClient[]` array for remote
+ * mode), so each iMessage provider instance has its own tracker and multiple
+ * providers don't share state accidentally.
+ */
+export const getContactShareTracker = (owner: object): ContactShareTracker => {
+  let tracker = trackers.get(owner);
+  if (!tracker) {
+    tracker = new ContactShareTracker();
+    trackers.set(owner, tracker);
+  }
+  return tracker;
+};

--- a/packages/spectrum-ts/src/providers/imessage/remote/stream.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/stream.ts
@@ -8,6 +8,7 @@ import {
   type PollEvent,
   ValidationError,
 } from "@photon-ai/advanced-imessage";
+import type { ProjectData } from "../../../utils/cloud";
 import {
   type CloseableAsyncIterable,
   type ResumableStreamItem,
@@ -20,6 +21,7 @@ import {
   type RemoteClient,
   SHARED_PHONE,
 } from "../types";
+import { getContactShareTracker } from "./contact-share";
 import { toInboundMessages } from "./inbound";
 import { cachePollEvent, toPollDeltaMessages } from "./polls";
 import { toReactionMessages } from "./reactions";
@@ -47,15 +49,29 @@ const isEventFromCurrentAccount = (
     event.actor?.address !== undefined &&
     event.actor.address === phone);
 
+/**
+ * Side effect fired when a non-self `message.received` event is converted.
+ * Receives the `chatGuid` of the inbound message. Implementations must be
+ * synchronous and never throw — typical use is fire-and-forget cache lookup
+ * + background API call.
+ */
+type OnInboundMessage = (chatGuid: string) => void;
+
 const toMessageItem = async (
   client: AdvancedIMessage,
   event: MessageEvent,
   phone: string,
-  cursor: string
+  cursor: string,
+  onInbound?: OnInboundMessage
 ): Promise<ResumableStreamItem<IMessageMessage>> => {
   if (event.type === "message.received") {
     if (event.message.isFromMe) {
       return { cursor, id: event.message.guid, values: [] };
+    }
+
+    const inboundChatGuid = event.message.chatGuids?.[0];
+    if (inboundChatGuid) {
+      onInbound?.(inboundChatGuid);
     }
 
     const cache = getMessageCache(client);
@@ -189,17 +205,24 @@ const withClose = <T extends MessageEvent | PollEvent>(
 
 const messageStream = (
   client: AdvancedIMessage,
-  phone: string
+  phone: string,
+  onInbound?: OnInboundMessage
 ): ManagedStream<IMessageMessage> =>
   resumableOrderedStream<MessageEvent, MessageCatchUpEvent, IMessageMessage>({
     fetchMissed: (cursor) => catchUpEvents(client, cursor, isMessageEvent),
     isRetryableError: isRetryableIMessageStreamError,
     processLive: (event) =>
-      toMessageItem(client, event, phone, String(event.sequence)),
+      toMessageItem(client, event, phone, String(event.sequence), onInbound),
     processMissed: (event) =>
       event.type === "catchup.complete"
         ? Promise.resolve(toCatchUpCompleteItem(event))
-        : toMessageItem(client, event, phone, String(event.sequence)),
+        : toMessageItem(
+            client,
+            event,
+            phone,
+            String(event.sequence),
+            onInbound
+          ),
     subscribeLive: (cursor) =>
       withClose(client.messages.subscribeEvents(), cursor),
   });
@@ -225,18 +248,35 @@ const pollStream = (
 const clientStream = (
   client: AdvancedIMessage,
   pollCache: PollCache,
-  phone: string
+  phone: string,
+  onInbound?: OnInboundMessage
 ): ManagedStream<IMessageMessage> =>
   mergeStreams([
-    messageStream(client, phone),
+    messageStream(client, phone, onInbound),
     pollStream(client, pollCache, phone),
   ]);
 
 export const messages = (
-  clients: RemoteClient[]
+  clients: RemoteClient[],
+  projectConfig?: ProjectData | undefined
 ): ManagedStream<IMessageMessage> => {
   const pollCache = getPollCache(clients);
+  // When the project profile opts in to iMessage sync, push the bot's
+  // contact card to any chat we receive a new message in (24h dedupe per
+  // chat, fire-and-forget). The tracker is per `clients` array — same key
+  // shape as `getPollCache` — so multi-Spectrum setups don't cross-pollute.
+  const shareEnabled = projectConfig?.profile?.imessageSynced === true;
+  const tracker = shareEnabled ? getContactShareTracker(clients) : undefined;
   return mergeStreams(
-    clients.map((entry) => clientStream(entry.client, pollCache, entry.phone))
+    clients.map((entry) =>
+      clientStream(
+        entry.client,
+        pollCache,
+        entry.phone,
+        tracker
+          ? (chatGuid) => tracker.maybeShare(entry.client, chatGuid)
+          : undefined
+      )
+    )
   );
 };

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -35,6 +35,7 @@ import type {
 import type { Message } from "./types/message";
 import type { Space } from "./types/space";
 import type { AgentSender } from "./types/user";
+import { cloud, type ProjectData } from "./utils/cloud";
 import { createStore, type Store } from "./utils/store";
 import {
   type AsyncQueue,
@@ -185,6 +186,26 @@ function bootstrapTelemetry(opts: {
 
 export async function Spectrum<
   const Providers extends PlatformProviderConfig[],
+>(options: {
+  projectId: string;
+  projectSecret: string;
+  providers: [...Providers];
+  options?: SpectrumOptions;
+  telemetry?: boolean;
+  webhookSecret?: string;
+}): Promise<SpectrumInstance<Providers> & { readonly config: ProjectData }>;
+export async function Spectrum<
+  const Providers extends PlatformProviderConfig[],
+>(options: {
+  projectId?: never;
+  projectSecret?: never;
+  providers: [...Providers];
+  options?: SpectrumOptions;
+  telemetry?: boolean;
+  webhookSecret?: string;
+}): Promise<SpectrumInstance<Providers>>;
+export async function Spectrum<
+  const Providers extends PlatformProviderConfig[],
 >(
   options:
     | {
@@ -219,6 +240,14 @@ export async function Spectrum<
   const otelHandle = telemetry
     ? bootstrapTelemetry({ projectId, projectSecret })
     : undefined;
+
+  // Fetch project metadata up-front (before any provider createClient) so that
+  // bad credentials fail fast with no half-initialized providers to clean up,
+  // and so the resolved config can later be threaded into createClient ctx.
+  const projectConfig: ProjectData | undefined =
+    projectId !== undefined && projectSecret !== undefined
+      ? await cloud.getProject(projectId, projectSecret)
+      : undefined;
 
   const platformStates = new Map<string, PlatformRuntime>();
 
@@ -887,6 +916,7 @@ export async function Spectrum<
   const base = {
     __providers: providers,
     __internal: { platforms: platformStates },
+    config: projectConfig,
     messages,
     stop: stopOnce,
     webhook: handleWebhook as SpectrumInstance["webhook"],

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -243,7 +243,8 @@ export async function Spectrum<
 
   // Fetch project metadata up-front (before any provider createClient) so that
   // bad credentials fail fast with no half-initialized providers to clean up,
-  // and so the resolved config can later be threaded into createClient ctx.
+  // and so the resolved config is available to thread into platform `messages`
+  // and `events` ctx (e.g. iMessage reads `profile.imessageSynced` from here).
   const projectConfig: ProjectData | undefined =
     projectId !== undefined && projectSecret !== undefined
       ? await cloud.getProject(projectId, projectSecret)
@@ -365,6 +366,7 @@ export async function Spectrum<
       : (definition.messages({
           client,
           config,
+          projectConfig,
           store,
         }) as unknown as AsyncIterable<ProviderMessageRecord>);
 
@@ -552,6 +554,7 @@ export async function Spectrum<
           | ((ctx: {
               client: unknown;
               config: unknown;
+              projectConfig: ProjectData | undefined;
               store: Store;
             }) => AsyncIterable<unknown>)
           | undefined;
@@ -559,7 +562,12 @@ export async function Spectrum<
           continue;
         }
 
-        const providerEvents = producer({ client, config, store });
+        const providerEvents = producer({
+          client,
+          config,
+          projectConfig,
+          store,
+        });
         const annotatePlatform = async function* (): AsyncIterable<unknown> {
           for await (const value of providerEvents) {
             const annotated = await withSpan(

--- a/packages/spectrum-ts/src/utils/cloud.ts
+++ b/packages/spectrum-ts/src/utils/cloud.ts
@@ -63,6 +63,25 @@ export interface FusorTokenData {
   token: string;
 }
 
+/**
+ * Per-project profile bag — a flexible record of project-level settings
+ * defined in Spectrum Cloud. Concrete fields depend on the project; consumers
+ * read them as `app.config.profile.<key>`.
+ */
+export interface ProjectProfile {
+  [key: string]: unknown;
+}
+
+/**
+ * The project record returned by `GET /projects/{projectId}/`. Populated on
+ * `app.config` when `Spectrum()` is called with `projectId` + `projectSecret`.
+ */
+export interface ProjectData {
+  id: string;
+  name: string;
+  profile: ProjectProfile;
+}
+
 // ---------------------------------------------------------------------------
 // Error
 // ---------------------------------------------------------------------------
@@ -138,6 +157,14 @@ const basicAuth = (projectId: string, projectSecret: string): string =>
 // ---------------------------------------------------------------------------
 
 export const cloud = {
+  getProject: (
+    projectId: string,
+    projectSecret: string
+  ): Promise<ProjectData> =>
+    request(`/projects/${projectId}/`, {
+      headers: { Authorization: basicAuth(projectId, projectSecret) },
+    }),
+
   getSubscription: (projectId: string): Promise<SubscriptionData> =>
     request(`/projects/${projectId}/billing/subscription`),
 


### PR DESCRIPTION
## Summary

- Fetch Spectrum Cloud **project metadata** once at `Spectrum()` init and expose it on the instance as `app.config`, with the resolved config threaded into every platform's `messages` and `events` ctx as `projectConfig`.
- Add an opt-in **iMessage contact-share** feature: when a project profile sets `imessageSynced: true`, the bot proactively pushes its contact card to any chat it receives a new inbound message in, deduped per chat over a 24-hour window (fire-and-forget, never crashes the receive stream).
- Fetching project config up-front makes bad credentials **fail fast** before any provider client is created, so there are no half-initialized providers to clean up.

## Usage

```typescript
const app = await Spectrum({
  projectId: process.env.PROJECT_ID,
  projectSecret: process.env.PROJECT_SECRET,
  providers: [imessage.config()],
});

// Project metadata resolved at init (typed as ProjectData when credentials are supplied)
console.log(app.config.name);
console.log(app.config.profile.imessageSynced);
```

When the project's profile has `imessageSynced: true`, remote iMessage providers automatically share the bot's contact card on first inbound per chat — no extra wiring required.

## Changes

| File | Change |
|------|--------|
| `src/utils/cloud.ts` | Add `ProjectData` / `ProjectProfile` types and `cloud.getProject()` (`GET /projects/{id}/`). |
| `src/spectrum.ts` | Fetch project config up-front (fail-fast on bad creds); expose as `app.config`; thread `projectConfig` into `messages`/`events` ctx. Add typed overloads so `config` is `ProjectData` when credentials are passed. |
| `src/platform/types.ts` | Add `projectConfig` to `EventProducer` ctx; reserve `config` as an instance name. |
| `src/index.ts` | Export `ProjectData` and `ProjectProfile`. |
| `src/providers/imessage/remote/contact-share.ts` | New `ContactShareTracker` (LRU-backed, 24h TTL, bounded to 10k chats) + per-owner `getContactShareTracker`. Best-effort, coalesces inbound bursts, evicts on failure to retry. |
| `src/providers/imessage/remote/stream.ts` | Add `onInbound` side-effect hook fired on non-self `message.received`; wire contact-share when `profile.imessageSynced === true`. |
| `src/providers/imessage/remote/api.ts`, `index.ts` | Thread `projectConfig` through to the remote message stream. |
| `src/providers/imessage/remote/contact-share.test.ts` | New tests: once-per-chat dedupe, burst coalescing, per-chat independence, retry-on-failure, never-throws, per-owner tracker identity. |
| `src/fusor/webhook.test.ts` | Stub `cloud.getProject` so existing tests don't make a real network call during construction. |
| `package.json` / `bun.lock` | Add `lru-cache` and `better-grpc` dependencies. |

## Test plan

- [ ] `bun test` passes (incl. new `contact-share.test.ts` and updated `webhook.test.ts`)
- [ ] `bun x ultracite check` is clean
- [ ] `bun run build` succeeds
- [ ] Manual: with `imessageSynced: true`, inbound message triggers a single `shareContactInfo` per chat within 24h
- [ ] Manual: bad `projectId`/`projectSecret` fails fast at `Spectrum()` with no partially-initialized providers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782781745&installation_id=127326493&pr_number=98&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F98&signature=c2d020462c0588eb6cc884deb85576c4352d4c9813076a88fec2b4191d86ef8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic iMessage contact-card sharing when sync is enabled, with rate-limited dedupe per chat.
  * Project configuration metadata can be fetched/available during initialization when credentials are provided.

* **API**
  * New project-related types exported and configuration surfaced on initialized instances when credentials are supplied.

* **Chores**
  * Added runtime dependencies to support new functionality.

* **Tests**
  * Added tests covering contact-share behavior and webhook test stabilization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->