### PR TITLE
fix(spectrum-ts): add Node ESM require shim and smoke-import test

### DIFF
--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -63,11 +63,11 @@
     }
   },
   "scripts": {
-    "build": "bun scripts/prepare-package.ts && tsup && bun scripts/generate-manifest.ts",
+    "build": "bun scripts/prepare-package.ts && tsup && node scripts/smoke-import.mjs && bun scripts/generate-manifest.ts",
     "dev": "tsup --watch",
     "generate:emoji": "bun scripts/generate-emoji.ts",
     "generate:manifest": "bun scripts/generate-manifest.ts",
-    "prepack": "bun scripts/prepare-package.ts --publish && tsup && bun scripts/generate-manifest.ts && bun scripts/prepare-package.ts"
+    "prepack": "bun scripts/prepare-package.ts --publish && tsup && node scripts/smoke-import.mjs && bun scripts/generate-manifest.ts && bun scripts/prepare-package.ts"
   },
   "dependencies": {
     "@photon-ai/advanced-imessage": "^0.10.0",

--- a/packages/spectrum-ts/scripts/smoke-import.mjs
+++ b/packages/spectrum-ts/scripts/smoke-import.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Build smoke test: import the freshly built ESM bundle under Node — the exact
+ * environment a published consumer (and the sidecar) uses via the package's
+ * `default` export condition.
+ *
+ * This guards against the bundle throwing at import time, e.g. when esbuild
+ * inlines a CommonJS dependency and its rewritten `require(...)` hits the
+ * `Dynamic require of "x" is not supported` shim. Such a bundle imports fine
+ * under Bun (which resolves the `bun` condition to TS source) but is dead on
+ * Node — so it must run under Node here, after `tsup`, to be meaningful.
+ *
+ * Runs as part of `build`; exits non-zero on failure to fail the build.
+ */
+
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ENTRY = join(HERE, "..", "dist", "index.js");
+
+try {
+  const mod = await import(ENTRY);
+  const exportCount = Object.keys(mod).length;
+  if (exportCount === 0) {
+    throw new Error("bundle imported but exported nothing");
+  }
+  console.log(
+    `✓ smoke: dist/index.js imports under Node (${exportCount} exports)`
+  );
+} catch (error) {
+  console.error("✗ smoke: dist/index.js failed to import under Node");
+  console.error(error);
+  process.exit(1);
+}

--- a/packages/spectrum-ts/tsup.config.ts
+++ b/packages/spectrum-ts/tsup.config.ts
@@ -18,4 +18,13 @@ export default defineConfig({
   outDir: "dist",
   target: "esnext",
   external: ["ffmpeg-static"],
+  // esbuild bundles CommonJS dependencies (e.g. transitive `@grpc/grpc-js`) into
+  // this ESM output and rewrites their `require(...)` calls to a `__require` shim
+  // whose fallback throws `Dynamic require of "x" is not supported` — because
+  // `require` is undefined in a real ESM context. Injecting a `createRequire`
+  // banner into every emitted file restores a working `require`, so that shim
+  // delegates to it instead of throwing at import time under Node.
+  banner: {
+    js: 'import { createRequire as __spectrumCreateRequire } from "node:module"; const require = __spectrumCreateRequire(import.meta.url);',
+  },
 });


### PR DESCRIPTION
## Summary

- esbuild (via `tsup`) bundles CommonJS dependencies — e.g. transitive `@grpc/grpc-js` — into the ESM output and rewrites their `require(...)` calls to a `__require` shim. In a real ESM context `require` is undefined, so that shim's fallback throws `Dynamic require of "x" is not supported` **at import time** under Node.
- Bun hides the breakage: it resolves the `bun` export condition straight to TS source, so the bundled `dist/index.js` is never exercised the way a published consumer (or the Node sidecar) exercises it.
- This injects a `createRequire`-based `require` banner into every emitted file, so the `__require` shim delegates to a working `require` instead of throwing.
- Adds a Node smoke-import script that imports the freshly built `dist/index.js` under Node and runs after `tsup` in both `build` and `prepack`, so this class of failure is caught before publish.

## Changes

| File | Change |
|---|---|
| `packages/spectrum-ts/tsup.config.ts` | Adds a `banner.js` that imports `createRequire` from `node:module` and defines a module-scoped `require`, restoring a working `require` in the ESM bundle. |
| `packages/spectrum-ts/scripts/smoke-import.mjs` *(new)* | Imports the built `dist/index.js` under Node, asserts it exports something, and exits non-zero on failure so the build fails loudly. |
| `packages/spectrum-ts/package.json` | Inserts `node scripts/smoke-import.mjs` into the `build` and `prepack` scripts, right after `tsup`. |

## Test plan

- [x] `tsup` builds the ESM bundle successfully on top of current `main`.
- [x] `node scripts/smoke-import.mjs` passes: `✓ smoke: dist/index.js imports under Node (30 exports)`.
- [ ] CI `build` / `prepack` run the smoke step and stay green.

## Note for reviewers

This branch is cut fresh from `main` and contains **only** the ESM-shim fix. The earlier branch `ryan/fix-getmessage-and-fetch-attachment` was the source of #93 (platform action tiers + iMessage `getAttachment` + attachment stable IDs), which has already merged — so that work is intentionally **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782792950&installation_id=127326493&pr_number=100&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F100&signature=8e77549c662fd532df93b319e926bb96bdc249acffa01968ae93d245063baadf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build validation with automated module verification to ensure successful builds.
  * Improved ES module compatibility by adding support for CommonJS-style dependencies in the build output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->