### PR TITLE
feat: telegram

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "zod": "^4.2.1",
       },
       "devDependencies": {
+        "@grammyjs/types": "^3.16.0",
         "@types/bun": "latest",
         "@types/mime-types": "^3.0.1",
         "@types/vcf": "^2.0.7",
@@ -132,6 +133,8 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+
+    "@grammyjs/types": ["@grammyjs/types@3.27.3", "", {}, "sha512-yUKMLliGsGbnxu96YUJ7km7B0zy4PzeH/Jvti5705R/LeKDMqkDV4DckMSt+OrliWQpTwQljHE0QLol5zgxBkg=="],
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
 

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -88,6 +88,7 @@
     "zod": "^4.2.1"
   },
   "devDependencies": {
+    "@grammyjs/types": "^3.16.0",
     "@types/bun": "latest",
     "@types/mime-types": "^3.0.1",
     "@types/vcf": "^2.0.7",

--- a/packages/spectrum-ts/scripts/generate-manifest.ts
+++ b/packages/spectrum-ts/scripts/generate-manifest.ts
@@ -34,7 +34,7 @@ const DIST_PROVIDERS_DIR = join(PKG_ROOT, "dist", "providers");
 const OUT_PATH = join(PKG_ROOT, "dist", "manifest.json");
 
 const DEFINE_PLATFORM_RE =
-  /^export\s+const\s+(\w+)\s*=\s*definePlatform\(\s*"([^"]+)"/m;
+  /^export\s+const\s+(\w+)\s*=\s*define(?:Fusor)?Platform\(\s*(?:"([^"]+)"|(\w+))/m;
 
 async function fileExists(path: string): Promise<boolean> {
   try {
@@ -43,6 +43,33 @@ async function fileExists(path: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+// Fusor providers (`defineFusorPlatform`) pass their platform name as a shared
+// const — the single source of truth for the routing key — rather than a string
+// literal. When the label isn't inline, resolve the const from the provider's
+// own source files.
+async function resolvePlatformLabel(
+  key: string,
+  constName: string
+): Promise<string> {
+  const dir = join(PROVIDERS_DIR, key);
+  const constRe = new RegExp(
+    `(?:export\\s+)?const\\s+${constName}\\s*=\\s*"([^"]+)"`
+  );
+  const files = await readdir(dir, { withFileTypes: true });
+  for (const file of files) {
+    if (!(file.isFile() && file.name.endsWith(".ts"))) {
+      continue;
+    }
+    const match = (await readFile(join(dir, file.name), "utf8")).match(constRe);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  throw new Error(
+    `Provider "${key}" references platform-name constant "${constName}" but no \`const ${constName} = "..."\` was found in its source.`
+  );
 }
 
 async function buildManifest(): Promise<ManifestEntry[]> {
@@ -59,12 +86,18 @@ async function buildManifest(): Promise<ManifestEntry[]> {
     const match = source.match(DEFINE_PLATFORM_RE);
     if (!match) {
       throw new Error(
-        `Provider "${key}" at ${sourcePath} does not match the expected \`export const <name> = definePlatform("<label>", ...)\` pattern. If you intentionally renamed the call, update generate-manifest.ts.`
+        `Provider "${key}" at ${sourcePath} does not match the expected \`export const <name> = definePlatform("<label>", ...)\` (or \`defineFusorPlatform(...)\`) pattern. If you intentionally renamed the call, update generate-manifest.ts.`
       );
     }
-    const [, importName, label] = match;
-    if (!(importName && label)) {
+    const [, importName, literalLabel, labelConst] = match;
+    if (!importName) {
       throw new Error(`Failed to parse provider "${key}"`);
+    }
+    const label =
+      literalLabel ??
+      (labelConst ? await resolvePlatformLabel(key, labelConst) : undefined);
+    if (!label) {
+      throw new Error(`Failed to parse label for provider "${key}"`);
     }
 
     // Guard against the manifest declaring a provider that tsup didn't

--- a/packages/spectrum-ts/src/providers/index.ts
+++ b/packages/spectrum-ts/src/providers/index.ts
@@ -1,5 +1,6 @@
 // biome-ignore lint/performance/noBarrelFile: provider aggregate entrypoint
 export { imessage } from "./imessage";
 export { slack } from "./slack";
+export { telegram } from "./telegram";
 export { terminal } from "./terminal";
 export { whatsappBusiness } from "./whatsapp-business";

--- a/packages/spectrum-ts/src/providers/telegram/client.ts
+++ b/packages/spectrum-ts/src/providers/telegram/client.ts
@@ -1,5 +1,5 @@
 import { botIdFromToken, type TelegramConfig } from "./config";
-import type { SentMessage, TelegramSendSpec } from "./types";
+import type { TelegramSendSpec } from "./types";
 
 const CLIENT_STORE_KEY = "telegram.client";
 const REQUEST_TIMEOUT_MS = 30_000;
@@ -22,7 +22,7 @@ export interface TelegramClient {
   /** The bot's own numeric id (token prefix), used to drop self-authored updates. */
   readonly botId: string;
   /** Execute one Bot API method and return its unwrapped `result`. */
-  call<T = SentMessage>(spec: TelegramSendSpec): Promise<T>;
+  call<T = unknown>(spec: TelegramSendSpec): Promise<T>;
   /** Fetch a file's bytes by `file_id` (`getFile` → token URL → bytes). */
   download(fileId: string): Promise<Buffer>;
 }
@@ -57,7 +57,7 @@ const makeTelegramClient = (config: TelegramConfig): TelegramClient => {
   const base = config.baseUrl.replace(TRAILING_SLASHES, "");
   const token = config.botToken;
 
-  const call = async <T = SentMessage>(spec: TelegramSendSpec): Promise<T> => {
+  const call = async <T = unknown>(spec: TelegramSendSpec): Promise<T> => {
     const { body, headers } = buildBody(spec);
     const res = await fetch(`${base}/bot${token}/${spec.method}`, {
       method: "POST",
@@ -65,11 +65,22 @@ const makeTelegramClient = (config: TelegramConfig): TelegramClient => {
       body,
       signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     });
-    const json = (await res.json()) as BotApiResponse<T>;
-    if (!json.ok) {
-      // Never include the URL (it carries the bot token) in errors.
+    // Read the body as text first: an upstream proxy (or a custom `baseUrl`
+    // test server) can return a non-JSON error page, and an unguarded
+    // `res.json()` would throw an opaque parse error that hides the method and
+    // status. Never include the URL (it carries the bot token) in errors.
+    const raw = await res.text();
+    let json: BotApiResponse<T> | undefined;
+    try {
+      json = raw ? (JSON.parse(raw) as BotApiResponse<T>) : undefined;
+    } catch {
       throw new Error(
-        `Telegram ${spec.method} failed: ${json.error_code ?? res.status} ${json.description ?? res.statusText}`
+        `Telegram ${spec.method} failed: ${res.status} ${res.statusText}`
+      );
+    }
+    if (!json?.ok) {
+      throw new Error(
+        `Telegram ${spec.method} failed: ${json?.error_code ?? res.status} ${json?.description ?? res.statusText}`
       );
     }
     return json.result as T;

--- a/packages/spectrum-ts/src/providers/telegram/client.ts
+++ b/packages/spectrum-ts/src/providers/telegram/client.ts
@@ -1,0 +1,124 @@
+import { botIdFromToken, type TelegramConfig } from "./config";
+import type { SentMessage, TelegramSendSpec } from "./types";
+
+const CLIENT_STORE_KEY = "telegram.client";
+const REQUEST_TIMEOUT_MS = 30_000;
+const TRAILING_SLASHES = /\/+$/;
+
+interface BotApiResponse<T> {
+  description?: string;
+  error_code?: number;
+  ok: boolean;
+  result?: T;
+}
+
+/**
+ * The adapter's view of the Telegram Bot API. The Bot API is plain HTTP/JSON,
+ * so this wraps the global `fetch` directly (no SDK): `call` executes any
+ * method (JSON, or `multipart/form-data` when a file is attached) and unwraps
+ * the `{ ok, result }` envelope; `download` resolves a `file_id` to bytes.
+ */
+export interface TelegramClient {
+  /** The bot's own numeric id (token prefix), used to drop self-authored updates. */
+  readonly botId: string;
+  /** Execute one Bot API method and return its unwrapped `result`. */
+  call<T = SentMessage>(spec: TelegramSendSpec): Promise<T>;
+  /** Fetch a file's bytes by `file_id` (`getFile` → token URL → bytes). */
+  download(fileId: string): Promise<Buffer>;
+}
+
+const toFormValue = (value: unknown): string =>
+  typeof value === "object" ? JSON.stringify(value) : String(value);
+
+const buildBody = (
+  spec: TelegramSendSpec
+): { body: string | FormData; headers?: Record<string, string> } => {
+  if (!spec.file) {
+    return {
+      body: JSON.stringify(spec.params),
+      headers: { "content-type": "application/json" },
+    };
+  }
+  const form = new FormData();
+  for (const [key, value] of Object.entries(spec.params)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+    form.append(key, toFormValue(value));
+  }
+  const blob = new Blob([new Uint8Array(spec.file.bytes)], {
+    type: spec.file.mimeType,
+  });
+  form.append(spec.file.field, blob, spec.file.filename);
+  return { body: form };
+};
+
+const makeTelegramClient = (config: TelegramConfig): TelegramClient => {
+  const base = config.baseUrl.replace(TRAILING_SLASHES, "");
+  const token = config.botToken;
+
+  const call = async <T = SentMessage>(spec: TelegramSendSpec): Promise<T> => {
+    const { body, headers } = buildBody(spec);
+    const res = await fetch(`${base}/bot${token}/${spec.method}`, {
+      method: "POST",
+      ...(headers ? { headers } : {}),
+      body,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    const json = (await res.json()) as BotApiResponse<T>;
+    if (!json.ok) {
+      // Never include the URL (it carries the bot token) in errors.
+      throw new Error(
+        `Telegram ${spec.method} failed: ${json.error_code ?? res.status} ${json.description ?? res.statusText}`
+      );
+    }
+    return json.result as T;
+  };
+
+  const download = async (fileId: string): Promise<Buffer> => {
+    const file = await call<{ file_path?: string }>({
+      method: "getFile",
+      params: { file_id: fileId },
+    });
+    if (!file.file_path) {
+      throw new Error(`Telegram getFile returned no file_path for ${fileId}`);
+    }
+    // The file URL embeds the bot token — keep it out of logs/errors.
+    const res = await fetch(`${base}/file/bot${token}/${file.file_path}`, {
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      throw new Error(
+        `Telegram media download failed: ${res.status} ${res.statusText}`
+      );
+    }
+    return Buffer.from(await res.arrayBuffer());
+  };
+
+  return { botId: botIdFromToken(token), call, download };
+};
+
+// Store is an SDK-internal KV reachable through lifecycle/send ctx. It isn't
+// exported from spectrum-ts, so we depend on its minimal structural shape.
+export interface StoreLike {
+  get(key: string): unknown;
+  set(key: string, value: unknown): void;
+}
+
+/** Build the client once (in `createClient`) and cache it on `store`. */
+export const initClient = (
+  store: StoreLike,
+  config: TelegramConfig
+): TelegramClient => {
+  const client = makeTelegramClient(config);
+  store.set(CLIENT_STORE_KEY, client);
+  return client;
+};
+
+/** Read the cached client in `send`/actions, rebuilding it if absent. */
+export const getClient = (
+  store: StoreLike,
+  config: TelegramConfig
+): TelegramClient =>
+  (store.get(CLIENT_STORE_KEY) as TelegramClient | undefined) ??
+  initClient(store, config);

--- a/packages/spectrum-ts/src/providers/telegram/config.ts
+++ b/packages/spectrum-ts/src/providers/telegram/config.ts
@@ -1,0 +1,50 @@
+import z from "zod";
+
+/**
+ * The platform identifier — used for ALL THREE of:
+ *
+ * - the `defineFusorPlatform` name (so `message.platform` / `__platform` and
+ *   the `platformStates` key are this value),
+ * - the `fusor(...)` routing key the handler is registered under, and
+ * - the value Fusor tags inbound Telegram events with (`event.platform`).
+ *
+ * Spectrum's webhook delivery looks the runtime up by `event.platform` against
+ * the platform name (`platformStates.get(event.platform)`), while routing is by
+ * the fusor key — so these MUST be the same string. It must also match Fusor's
+ * configured platform identifier for Telegram (the `<platform>` path segment
+ * the webhook is delivered under).
+ */
+export const TELEGRAM_PLATFORM = "telegram";
+
+/** Default Bot API origin; override via `config.baseUrl` for a local test server. */
+export const DEFAULT_BASE_URL = "https://api.telegram.org";
+
+/**
+ * Telegram's webhook secret token is echoed verbatim in a header, so it is
+ * constrained to the header-safe character set documented for `setWebhook`.
+ */
+const SECRET_TOKEN_PATTERN = /^[A-Za-z0-9_-]{1,256}$/;
+
+export const configSchema = z.object({
+  /** Bot token from @BotFather (outbound API calls + media downloads). */
+  botToken: z.string().min(1),
+  /**
+   * The `secret_token` passed to `setWebhook`. When present, inbound webhooks
+   * are verified against the `X-Telegram-Bot-Api-Secret-Token` header; when
+   * omitted, the check is skipped. Telegram does not HMAC-sign the body, so
+   * this shared token is the only inbound authentication.
+   */
+  webhookSecret: z.string().regex(SECRET_TOKEN_PATTERN).optional(),
+  /** Override the Bot API base URL. Defaults to `https://api.telegram.org`. */
+  baseUrl: z.url().default(DEFAULT_BASE_URL),
+});
+
+export type TelegramConfig = z.infer<typeof configSchema>;
+
+/**
+ * The bot's own numeric id is the prefix of the token (`<id>:<hash>`). Used to
+ * drop inbound updates the bot itself produced, so a bot never echoes its own
+ * sends.
+ */
+export const botIdFromToken = (botToken: string): string =>
+  botToken.split(":")[0] ?? "";

--- a/packages/spectrum-ts/src/providers/telegram/config.ts
+++ b/packages/spectrum-ts/src/providers/telegram/config.ts
@@ -25,9 +25,18 @@ export const DEFAULT_BASE_URL = "https://api.telegram.org";
  */
 const SECRET_TOKEN_PATTERN = /^[A-Za-z0-9_-]{1,256}$/;
 
+/**
+ * Bot tokens are `<numeric_id>:<auth_token>`. Validating the shape fails fast on
+ * a malformed token instead of silently deriving a bad `botId` (token prefix)
+ * and Bot API URLs from it.
+ */
+const BOT_TOKEN_PATTERN = /^\d+:[A-Za-z0-9_-]+$/;
+
 export const configSchema = z.object({
   /** Bot token from @BotFather (outbound API calls + media downloads). */
-  botToken: z.string().min(1),
+  botToken: z
+    .string()
+    .regex(BOT_TOKEN_PATTERN, "botToken must be in the form '<id>:<token>'"),
   /**
    * The `secret_token` passed to `setWebhook`. When present, inbound webhooks
    * are verified against the `X-Telegram-Bot-Api-Secret-Token` header; when

--- a/packages/spectrum-ts/src/providers/telegram/inbound/media.ts
+++ b/packages/spectrum-ts/src/providers/telegram/inbound/media.ts
@@ -1,0 +1,145 @@
+import { asAttachment } from "../../../content/attachment";
+import { asText } from "../../../content/text";
+import type { Content } from "../../../content/types";
+import { asVoice } from "../../../content/voice";
+import type { TelegramClient } from "../client";
+import type { Message, PhotoSize } from "../types";
+
+const DEFAULT_VIDEO_MIME = "video/mp4";
+const DEFAULT_AUDIO_MIME = "audio/mpeg";
+const DEFAULT_VOICE_MIME = "audio/ogg";
+const DEFAULT_DOC_MIME = "application/octet-stream";
+
+const pixelArea = (photo: PhotoSize): number =>
+  photo.file_size ?? photo.width * photo.height;
+
+/** Telegram sends several `PhotoSize`s; pick the largest (best quality). */
+const pickLargestPhoto = (photos: PhotoSize[]): PhotoSize =>
+  photos.reduce((best, next) =>
+    pixelArea(next) > pixelArea(best) ? next : best
+  );
+
+// The fields every Telegram file object shares (Document/Video/Audio/Animation/
+// PhotoSize/...). `file_name`/`mime_type` are absent on some kinds, so callers
+// pass a fallback extension + MIME type.
+interface TgFile {
+  file_id: string;
+  file_name?: string;
+  file_size?: number;
+  file_unique_id: string;
+  mime_type?: string;
+}
+
+const lazyRead = (client: TelegramClient, fileId: string) => () =>
+  client.download(fileId);
+
+/** Build an attachment from any Telegram file, falling back when unnamed/untyped. */
+const fileAttachment = (
+  client: TelegramClient,
+  file: TgFile,
+  fallbackExt: string,
+  fallbackMime: string
+): Content =>
+  asAttachment({
+    id: file.file_id,
+    name: file.file_name ?? `${file.file_unique_id}.${fallbackExt}`,
+    mimeType: file.mime_type ?? fallbackMime,
+    size: file.file_size,
+    read: lazyRead(client, file.file_id),
+  });
+
+const stickerAttachment = (
+  client: TelegramClient,
+  sticker: NonNullable<Message["sticker"]>
+): Content => {
+  let ext = "webp";
+  let mimeType = "image/webp";
+  if (sticker.is_animated) {
+    ext = "tgs";
+    mimeType = "application/x-tgsticker";
+  } else if (sticker.is_video) {
+    ext = "webm";
+    mimeType = "video/webm";
+  }
+  return asAttachment({
+    id: sticker.file_id,
+    name: `${sticker.file_unique_id}.${ext}`,
+    mimeType,
+    size: sticker.file_size,
+    read: lazyRead(client, sticker.file_id),
+  });
+};
+
+/**
+ * Map a Telegram `Message` to its media `Content`, or `undefined` if it carries
+ * no media. A message holds at most one media kind, but `animation` also
+ * populates `document` (and stickers have sub-types), so detection runs in a
+ * fixed first-match order: voice → video_note → animation → video → audio →
+ * document → photo → sticker.
+ *
+ * Bytes are read lazily: each `read()` runs `getFile` + an authenticated
+ * download only when the consumer calls it, keeping the webhook ack path free
+ * of network I/O. The `as*` builders memoize `read`, so a file downloads once.
+ */
+const mediaToContent = (
+  msg: Message,
+  client: TelegramClient
+): Content | undefined => {
+  if (msg.voice) {
+    return asVoice({
+      mimeType: msg.voice.mime_type ?? DEFAULT_VOICE_MIME,
+      duration: msg.voice.duration,
+      size: msg.voice.file_size,
+      read: lazyRead(client, msg.voice.file_id),
+    });
+  }
+  if (msg.video_note) {
+    return fileAttachment(client, msg.video_note, "mp4", DEFAULT_VIDEO_MIME);
+  }
+  if (msg.animation) {
+    return fileAttachment(client, msg.animation, "mp4", DEFAULT_VIDEO_MIME);
+  }
+  if (msg.video) {
+    return fileAttachment(client, msg.video, "mp4", DEFAULT_VIDEO_MIME);
+  }
+  if (msg.audio) {
+    return fileAttachment(client, msg.audio, "mp3", DEFAULT_AUDIO_MIME);
+  }
+  if (msg.document) {
+    return fileAttachment(client, msg.document, "bin", DEFAULT_DOC_MIME);
+  }
+  if (msg.photo && msg.photo.length > 0) {
+    return fileAttachment(
+      client,
+      pickLargestPhoto(msg.photo),
+      "jpg",
+      "image/jpeg"
+    );
+  }
+  if (msg.sticker) {
+    return stickerAttachment(client, msg.sticker);
+  }
+  return;
+};
+
+/**
+ * Map an inbound `Message` to its Spectrum `Content` parts: the media (if any)
+ * plus its `caption` as a leading text part, or a bare `text` message. Returns
+ * `[]` when nothing is representable (service messages, etc.) so the caller can
+ * drop it.
+ */
+export const messageToContent = (
+  msg: Message,
+  client: TelegramClient
+): Content[] => {
+  const media = mediaToContent(msg, client);
+  if (media) {
+    const caption = msg.caption?.trim();
+    return caption ? [asText(caption), media] : [media];
+  }
+  const text = msg.text;
+  if (text !== undefined && text.length > 0) {
+    return [asText(text)];
+  }
+  return [];
+};

--- a/packages/spectrum-ts/src/providers/telegram/inbound/messages.test.ts
+++ b/packages/spectrum-ts/src/providers/telegram/inbound/messages.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "bun:test";
+import type { TelegramClient } from "../client";
+import type { TelegramPayload, Update } from "../types";
+import { handleMessages } from "./messages";
+
+const TS_SEC = 1_700_000_000;
+const DOWNLOAD = Buffer.from("file-bytes");
+
+const downloadCalls: string[] = [];
+const client: TelegramClient = {
+  botId: "999",
+  call: () => Promise.reject(new Error("unused")),
+  download: (fileId) => {
+    downloadCalls.push(fileId);
+    return Promise.resolve(DOWNLOAD);
+  },
+};
+
+const payload = (over: Record<string, unknown>): TelegramPayload => ({
+  client,
+  update: { update_id: 1, ...over } as unknown as Update,
+});
+
+const message = (over: Record<string, unknown>): Record<string, unknown> => ({
+  message_id: 5,
+  date: TS_SEC,
+  chat: { id: 100, type: "private" },
+  from: { id: 7, is_bot: false, first_name: "Alice", username: "alice" },
+  ...over,
+});
+
+const handle = (over: Record<string, unknown>) =>
+  handleMessages({ payload: payload({ message: message(over) }) });
+
+describe("handleMessages — text", () => {
+  it("maps a text message to text content", () => {
+    const record = handle({ text: "hello" });
+    expect(record?.id).toBe("5");
+    expect(record?.content).toEqual({ type: "text", text: "hello" });
+    expect(record?.sender?.id).toBe("7");
+    expect(record?.sender?.handle).toBe("alice");
+    expect(record?.space.id).toBe("100");
+    expect(record?.timestamp).toEqual(new Date(TS_SEC * 1000));
+  });
+});
+
+describe("handleMessages — media", () => {
+  it("picks the largest photo size", () => {
+    const record = handle({
+      photo: [
+        {
+          file_id: "small",
+          file_unique_id: "u1",
+          width: 90,
+          height: 90,
+          file_size: 1000,
+        },
+        {
+          file_id: "big",
+          file_unique_id: "u2",
+          width: 1280,
+          height: 1280,
+          file_size: 50_000,
+        },
+      ],
+    });
+    expect(record?.content.type).toBe("attachment");
+    if (record?.content.type === "attachment") {
+      expect(record.content.id).toBe("big");
+      expect(record.content.mimeType).toBe("image/jpeg");
+    }
+  });
+
+  it("maps a document with its real name and mime type", () => {
+    const record = handle({
+      document: {
+        file_id: "doc1",
+        file_unique_id: "u",
+        file_name: "report.pdf",
+        mime_type: "application/pdf",
+        file_size: 2048,
+      },
+    });
+    if (record?.content.type === "attachment") {
+      expect(record.content.name).toBe("report.pdf");
+      expect(record.content.mimeType).toBe("application/pdf");
+      expect(record.content.size).toBe(2048);
+    } else {
+      throw new Error("expected attachment");
+    }
+  });
+
+  it("maps a voice note to voice content", () => {
+    const record = handle({
+      voice: {
+        file_id: "v1",
+        file_unique_id: "u",
+        duration: 3,
+        mime_type: "audio/ogg",
+        file_size: 999,
+      },
+    });
+    expect(record?.content.type).toBe("voice");
+    if (record?.content.type === "voice") {
+      expect(record.content.mimeType).toBe("audio/ogg");
+      expect(record.content.duration).toBe(3);
+    }
+  });
+
+  it("maps an audio (music) file to an attachment, not voice", () => {
+    const record = handle({
+      audio: {
+        file_id: "a1",
+        file_unique_id: "u",
+        duration: 200,
+        mime_type: "audio/mpeg",
+        file_size: 5000,
+      },
+    });
+    expect(record?.content.type).toBe("attachment");
+  });
+
+  it("bundles caption + media into a group", () => {
+    const record = handle({
+      caption: "see this",
+      photo: [
+        {
+          file_id: "p",
+          file_unique_id: "u",
+          width: 100,
+          height: 100,
+          file_size: 10,
+        },
+      ],
+    });
+    expect(record?.content.type).toBe("group");
+    if (record?.content.type === "group") {
+      expect(record.content.items).toHaveLength(2);
+      expect(record.content.items[0]?.content.type).toBe("text");
+      expect(record.content.items[1]?.content.type).toBe("attachment");
+    }
+  });
+
+  it("maps an animation once even though Telegram also sets document", () => {
+    const record = handle({
+      animation: {
+        file_id: "anim",
+        file_unique_id: "ua",
+        width: 1,
+        height: 1,
+        duration: 1,
+        file_name: "g.mp4",
+        mime_type: "video/mp4",
+      },
+      document: { file_id: "dup", file_unique_id: "ud" },
+    });
+    if (record?.content.type === "attachment") {
+      expect(record.content.id).toBe("anim");
+    } else {
+      throw new Error("expected attachment");
+    }
+  });
+
+  it("downloads bytes lazily through the embedded client", async () => {
+    downloadCalls.length = 0;
+    const record = handle({
+      document: {
+        file_id: "doc-read",
+        file_unique_id: "u",
+        file_name: "f.bin",
+      },
+    });
+    expect(downloadCalls).toHaveLength(0); // not fetched yet
+    if (record?.content.type === "attachment") {
+      const bytes = await record.content.read();
+      expect(bytes).toEqual(DOWNLOAD);
+      expect(downloadCalls).toEqual(["doc-read"]);
+    } else {
+      throw new Error("expected attachment");
+    }
+  });
+});
+
+describe("handleMessages — channel posts & self-echo", () => {
+  it("maps a senderless channel post", () => {
+    const record = handleMessages({
+      payload: payload({
+        channel_post: {
+          message_id: 9,
+          date: TS_SEC,
+          chat: { id: -100, type: "channel" },
+          text: "broadcast",
+        },
+      }),
+    });
+    expect(record?.content).toEqual({ type: "text", text: "broadcast" });
+    expect(record?.sender).toBeUndefined();
+    expect(record?.space.id).toBe("-100");
+  });
+
+  it("ignores the bot's own messages", () => {
+    const record = handle({
+      from: { id: 999, is_bot: true, first_name: "Bot" },
+      text: "my own echo",
+    });
+    expect(record).toBeUndefined();
+  });
+});
+
+describe("handleMessages — reactions & ignored updates", () => {
+  it("maps a message_reaction add to a reaction targeting the message", () => {
+    const record = handleMessages({
+      payload: payload({
+        message_reaction: {
+          chat: { id: 100, type: "private" },
+          message_id: 5,
+          user: { id: 7, is_bot: false, first_name: "Alice" },
+          date: TS_SEC,
+          old_reaction: [],
+          new_reaction: [{ type: "emoji", emoji: "👍" }],
+        },
+      }),
+    });
+    expect(record?.content.type).toBe("reaction");
+    if (record?.content.type === "reaction") {
+      expect(record.content.emoji).toBe("👍");
+      expect(record.content.target.id).toBe("5");
+    }
+    expect(record?.space.id).toBe("100");
+  });
+
+  it("ignores a reaction removal (empty new_reaction)", () => {
+    const record = handleMessages({
+      payload: payload({
+        message_reaction: {
+          chat: { id: 100, type: "private" },
+          message_id: 5,
+          date: TS_SEC,
+          old_reaction: [{ type: "emoji", emoji: "👍" }],
+          new_reaction: [],
+        },
+      }),
+    });
+    expect(record).toBeUndefined();
+  });
+
+  it("ignores update types outside v1 scope", () => {
+    expect(
+      handleMessages({
+        payload: payload({ edited_message: message({ text: "x" }) }),
+      })
+    ).toBeUndefined();
+    expect(
+      handleMessages({ payload: payload({ callback_query: { id: "cb" } }) })
+    ).toBeUndefined();
+    expect(handleMessages({ payload: payload({}) })).toBeUndefined();
+  });
+});

--- a/packages/spectrum-ts/src/providers/telegram/inbound/messages.ts
+++ b/packages/spectrum-ts/src/providers/telegram/inbound/messages.ts
@@ -1,0 +1,129 @@
+import { asCustom } from "../../../content/custom";
+import { asGroup } from "../../../content/group";
+import { asReaction } from "../../../content/reaction";
+import type { Content } from "../../../content/types";
+import type { ProviderMessageRecord } from "../../../platform/types";
+import type { Message as SpectrumMessage } from "../../../types/message";
+import type { TelegramClient } from "../client";
+import type {
+  Message,
+  ReactionType,
+  ReactionTypeEmoji,
+  ReactionUpdate,
+  TelegramPayload,
+  User,
+} from "../types";
+import { messageToContent } from "./media";
+
+const MILLIS_PER_SECOND = 1000;
+
+// Inbound items are not full Messages yet — core's wrapProviderMessage inflates
+// them. A minimal `{ id, content }` shape satisfies the `isMessage` guard used
+// for group items and reaction targets.
+const stubMessage = (id: string, content: Content): SpectrumMessage =>
+  ({ id, content }) as unknown as SpectrumMessage;
+
+const senderRef = (user: User) => ({
+  id: String(user.id),
+  ...(user.username ? { handle: user.username } : {}),
+  isMe: false,
+});
+
+// One Telegram message maps to a single content (text or media), or — when a
+// media message also has a caption — a `group` of [caption, media] that
+// `flattenGroups` can split back into one message per part downstream.
+const toRecordContent = (
+  contents: Content[],
+  messageId: string
+): Content | undefined => {
+  if (contents.length === 0) {
+    return;
+  }
+  if (contents.length === 1) {
+    return contents[0];
+  }
+  return asGroup({
+    items: contents.map((content, index) =>
+      stubMessage(`${messageId}:${index}`, content)
+    ),
+  });
+};
+
+const fromMessage = (
+  msg: Message,
+  client: TelegramClient
+): ProviderMessageRecord | undefined => {
+  // Drop the bot's own messages so it never echoes itself. Telegram normally
+  // doesn't deliver them, so this is belt-and-suspenders.
+  if (msg.from && String(msg.from.id) === client.botId) {
+    return;
+  }
+  const content = toRecordContent(
+    messageToContent(msg, client),
+    String(msg.message_id)
+  );
+  if (!content) {
+    return;
+  }
+  return {
+    id: String(msg.message_id),
+    content,
+    ...(msg.from ? { sender: senderRef(msg.from) } : {}),
+    space: { id: String(msg.chat.id) },
+    timestamp: new Date(msg.date * MILLIS_PER_SECOND),
+  };
+};
+
+const emojiReactions = (reactions: ReactionType[]): string[] =>
+  reactions
+    .filter((r): r is ReactionTypeEmoji => r.type === "emoji")
+    .map((r) => r.emoji);
+
+const fromReaction = (
+  reaction: ReactionUpdate
+): ProviderMessageRecord | undefined => {
+  const added = emojiReactions(reaction.new_reaction);
+  if (added.length === 0) {
+    return; // Reaction removed — nothing to surface (cf. LinQ ignoring removals).
+  }
+  const previous = new Set(emojiReactions(reaction.old_reaction));
+  const emoji = added.find((e) => !previous.has(e)) ?? added[0];
+  if (!emoji) {
+    return;
+  }
+  const target = stubMessage(
+    String(reaction.message_id),
+    asCustom({ telegram: "reaction-target" })
+  );
+  // Telegram has no event id for reactions, so synthesize a stable one.
+  return {
+    id: `reaction:${reaction.chat.id}:${reaction.message_id}:${reaction.date}`,
+    content: asReaction({ emoji, target }),
+    ...(reaction.user ? { sender: senderRef(reaction.user) } : {}),
+    space: { id: String(reaction.chat.id) },
+    timestamp: new Date(reaction.date * MILLIS_PER_SECOND),
+  };
+};
+
+/**
+ * Map a verified Telegram `Update` to the Spectrum message it represents. v1
+ * surfaces new messages and channel posts (text + media, with captions) and
+ * emoji reactions (`message_reaction`, which requires the operator to list it
+ * in `allowed_updates`). Edits, callback queries, polls, membership changes and
+ * other update types are ignored (return `undefined`).
+ */
+export const handleMessages = ({
+  payload,
+}: {
+  payload: TelegramPayload;
+}): ProviderMessageRecord | undefined => {
+  const { update, client } = payload;
+  const message = update.message ?? update.channel_post;
+  if (message) {
+    return fromMessage(message, client);
+  }
+  if (update.message_reaction) {
+    return fromReaction(update.message_reaction);
+  }
+  return;
+};

--- a/packages/spectrum-ts/src/providers/telegram/inbound/messages.ts
+++ b/packages/spectrum-ts/src/providers/telegram/inbound/messages.ts
@@ -95,9 +95,12 @@ const fromReaction = (
     String(reaction.message_id),
     asCustom({ telegram: "reaction-target" })
   );
-  // Telegram has no event id for reactions, so synthesize a stable one.
+  // Telegram has no event id for reactions, so synthesize a stable one. Include
+  // the actor and emoji so distinct users (or emoji) reacting to the same
+  // message within the same second don't collide on a shared id.
+  const actorId = reaction.user ? String(reaction.user.id) : "anonymous";
   return {
-    id: `reaction:${reaction.chat.id}:${reaction.message_id}:${reaction.date}`,
+    id: `reaction:${reaction.chat.id}:${reaction.message_id}:${reaction.date}:${actorId}:${emoji}`,
     content: asReaction({ emoji, target }),
     ...(reaction.user ? { sender: senderRef(reaction.user) } : {}),
     space: { id: String(reaction.chat.id) },

--- a/packages/spectrum-ts/src/providers/telegram/index.ts
+++ b/packages/spectrum-ts/src/providers/telegram/index.ts
@@ -1,0 +1,37 @@
+import { fusor } from "../../fusor";
+import { defineFusorPlatform } from "../../platform/define";
+import { initClient } from "./client";
+import { configSchema, TELEGRAM_PLATFORM } from "./config";
+import { handleMessages } from "./inbound/messages";
+import { send } from "./outbound/send";
+import { resolveSpace, resolveUser, spaceParamsSchema } from "./space";
+import type { TelegramPayload } from "./types";
+import { makeVerify } from "./verify";
+
+export type { TelegramConfig } from "./config";
+
+/**
+ * Telegram provider for Spectrum.
+ *
+ * Inbound is delivered through Fusor: `createClient` builds the Bot API client
+ * and returns a `fusor(...)` client whose `verify` checks the Telegram webhook
+ * secret token and parses the `Update` (embedding the client so inbound media
+ * can be downloaded lazily with the bot token). Outbound goes through the
+ * Telegram Bot API over HTTP. Drop `telegram.config({...})` into
+ * `Spectrum({ providers: [...] })`.
+ */
+export const telegram = defineFusorPlatform(TELEGRAM_PLATFORM, {
+  config: configSchema,
+  lifecycle: {
+    createClient: ({ config, store }) => {
+      const client = initClient(store, config);
+      return Promise.resolve(
+        fusor<TelegramPayload>(TELEGRAM_PLATFORM, makeVerify(config, client))
+      );
+    },
+  },
+  user: { resolve: resolveUser },
+  space: { params: spaceParamsSchema, resolve: resolveSpace },
+  messages: handleMessages,
+  send,
+});

--- a/packages/spectrum-ts/src/providers/telegram/outbound/message.ts
+++ b/packages/spectrum-ts/src/providers/telegram/outbound/message.ts
@@ -1,0 +1,115 @@
+import type { Content } from "../../../content/types";
+import { UnsupportedError } from "../../../utils/errors";
+import { toVCard } from "../../../utils/vcard";
+import { TELEGRAM_PLATFORM } from "../config";
+import type { TelegramSendSpec } from "../types";
+
+const VCARD_FILENAME = "contact.vcf";
+const VCARD_MIME = "text/vcard";
+const DEFAULT_VOICE_FILENAME = "voice.ogg";
+
+const customToSpec = (raw: unknown): TelegramSendSpec => {
+  if (
+    typeof raw === "object" &&
+    raw !== null &&
+    typeof (raw as { method?: unknown }).method === "string"
+  ) {
+    const value = raw as { method: string; params?: Record<string, unknown> };
+    return { method: value.method, params: value.params ?? {} };
+  }
+  throw new Error(
+    "Telegram custom content `raw` must be a `{ method, params }` Bot API call."
+  );
+};
+
+const attachmentSpec = async (content: {
+  name: string;
+  mimeType: string;
+  read: () => Promise<Buffer>;
+}): Promise<TelegramSendSpec> => {
+  const bytes = await content.read();
+  const file = {
+    field: "document",
+    filename: content.name,
+    mimeType: content.mimeType,
+    bytes,
+  };
+  if (content.mimeType.startsWith("image/")) {
+    return {
+      method: "sendPhoto",
+      params: {},
+      file: { ...file, field: "photo" },
+    };
+  }
+  if (content.mimeType.startsWith("video/")) {
+    return {
+      method: "sendVideo",
+      params: {},
+      file: { ...file, field: "video" },
+    };
+  }
+  return { method: "sendDocument", params: {}, file };
+};
+
+/**
+ * Turn one message-producing `Content` into a single Bot API call. Telegram has
+ * no multi-part message — each content type is its own method/endpoint — so
+ * this returns a `TelegramSendSpec` (the caller injects `chat_id` and executes
+ * it). `reply` recurses and threads `reply_parameters`; `group` is NOT handled
+ * here (it becomes N separate sends in `send.ts`). Fire-and-forget content
+ * (reaction, typing, edit) and unsupported types never reach this function.
+ */
+export const buildSend = async (
+  content: Content
+): Promise<TelegramSendSpec> => {
+  switch (content.type) {
+    case "text":
+      return { method: "sendMessage", params: { text: content.text } };
+    case "richlink":
+      // Telegram auto-unfurls a bare URL in the message text.
+      return { method: "sendMessage", params: { text: content.url } };
+    case "attachment":
+      return await attachmentSpec(content);
+    case "voice": {
+      const bytes = await content.read();
+      return {
+        method: "sendVoice",
+        params:
+          content.duration === undefined ? {} : { duration: content.duration },
+        file: {
+          field: "voice",
+          filename: content.name ?? DEFAULT_VOICE_FILENAME,
+          mimeType: content.mimeType,
+          bytes,
+        },
+      };
+    }
+    case "contact": {
+      const vcf = await toVCard(content);
+      return {
+        method: "sendDocument",
+        params: {},
+        file: {
+          field: "document",
+          filename: VCARD_FILENAME,
+          mimeType: VCARD_MIME,
+          bytes: Buffer.from(vcf, "utf8"),
+        },
+      };
+    }
+    case "reply": {
+      const inner = await buildSend(content.content);
+      return {
+        ...inner,
+        params: {
+          ...inner.params,
+          reply_parameters: { message_id: Number(content.target.id) },
+        },
+      };
+    }
+    case "custom":
+      return customToSpec(content.raw);
+    default:
+      throw UnsupportedError.content(content.type, TELEGRAM_PLATFORM);
+  }
+};

--- a/packages/spectrum-ts/src/providers/telegram/outbound/message.ts
+++ b/packages/spectrum-ts/src/providers/telegram/outbound/message.ts
@@ -8,14 +8,41 @@ const VCARD_FILENAME = "contact.vcf";
 const VCARD_MIME = "text/vcard";
 const DEFAULT_VOICE_FILENAME = "voice.ogg";
 
+/**
+ * Telegram message ids are positive integers. Reject anything else up front so a
+ * malformed `target.id` surfaces a clear error here instead of being coerced to
+ * `NaN` and sent on to the Bot API as a confusing 400.
+ */
+export const parseMessageId = (id: string): number => {
+  const messageId = Number(id);
+  if (!Number.isInteger(messageId) || messageId <= 0) {
+    throw new Error(
+      `Telegram message id must be a positive integer (got "${id}").`
+    );
+  }
+  return messageId;
+};
+
 const customToSpec = (raw: unknown): TelegramSendSpec => {
   if (
     typeof raw === "object" &&
     raw !== null &&
     typeof (raw as { method?: unknown }).method === "string"
   ) {
-    const value = raw as { method: string; params?: Record<string, unknown> };
-    return { method: value.method, params: value.params ?? {} };
+    const value = raw as { method: string; params?: unknown };
+    const { params } = value;
+    if (
+      params !== undefined &&
+      (typeof params !== "object" || params === null || Array.isArray(params))
+    ) {
+      throw new Error(
+        "Telegram custom content `raw.params` must be an object when provided."
+      );
+    }
+    return {
+      method: value.method,
+      params: (params ?? {}) as Record<string, unknown>,
+    };
   }
   throw new Error(
     "Telegram custom content `raw` must be a `{ method, params }` Bot API call."
@@ -103,7 +130,7 @@ export const buildSend = async (
         ...inner,
         params: {
           ...inner.params,
-          reply_parameters: { message_id: Number(content.target.id) },
+          reply_parameters: { message_id: parseMessageId(content.target.id) },
         },
       };
     }

--- a/packages/spectrum-ts/src/providers/telegram/outbound/send.test.ts
+++ b/packages/spectrum-ts/src/providers/telegram/outbound/send.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from "bun:test";
+import { attachment } from "../../../content/attachment";
+import { poll } from "../../../content/poll";
+import { reaction } from "../../../content/reaction";
+import { reply } from "../../../content/reply";
+import { text } from "../../../content/text";
+import type { Content } from "../../../content/types";
+import { voice } from "../../../content/voice";
+import type { Message } from "../../../types/message";
+import type { TelegramClient } from "../client";
+import { configSchema } from "../config";
+import type { SentMessage, TelegramSendSpec } from "../types";
+import { send } from "./send";
+
+const TS_SEC = 1_700_000_000;
+const config = configSchema.parse({ botToken: "1:abc" });
+const space = { id: "100" };
+const target = {
+  id: "42",
+  content: { type: "text", text: "x" },
+} as unknown as Message;
+
+const setup = (opts?: { callThrows?: boolean }) => {
+  const calls: TelegramSendSpec[] = [];
+  const client: TelegramClient = {
+    botId: "1",
+    call: <T = SentMessage>(spec: TelegramSendSpec): Promise<T> => {
+      calls.push(spec);
+      if (opts?.callThrows) {
+        return Promise.reject(
+          new Error("Telegram setMessageReaction failed: 400 REACTION_INVALID")
+        );
+      }
+      return Promise.resolve({ message_id: 555, date: TS_SEC } as unknown as T);
+    },
+    download: () => Promise.resolve(Buffer.alloc(0)),
+  };
+  const map = new Map<string, unknown>([["telegram.client", client]]);
+  const store = {
+    get: (key: string) => map.get(key),
+    set: (key: string, value: unknown) => {
+      map.set(key, value);
+    },
+  };
+  return { calls, store };
+};
+
+describe("send — messages", () => {
+  it("sends text as sendMessage with the chat id", async () => {
+    const { calls, store } = setup();
+    const result = await send({
+      space,
+      content: await text("hi").build(),
+      config,
+      store,
+    });
+    expect(result?.id).toBe("555");
+    expect(result?.space.id).toBe("100");
+    expect(calls[0]?.method).toBe("sendMessage");
+    expect(calls[0]?.params).toEqual({ chat_id: "100", text: "hi" });
+  });
+
+  it("sends an image attachment via sendPhoto", async () => {
+    const { calls, store } = setup();
+    await send({
+      space,
+      content: await attachment(Buffer.from("img"), {
+        mimeType: "image/png",
+        name: "p.png",
+      }).build(),
+      config,
+      store,
+    });
+    expect(calls[0]?.method).toBe("sendPhoto");
+    expect(calls[0]?.file?.field).toBe("photo");
+    expect(calls[0]?.file?.filename).toBe("p.png");
+    expect(calls[0]?.params.chat_id).toBe("100");
+  });
+
+  it("sends a non-image attachment via sendDocument", async () => {
+    const { calls, store } = setup();
+    await send({
+      space,
+      content: await attachment(Buffer.from("d"), {
+        mimeType: "application/pdf",
+        name: "d.pdf",
+      }).build(),
+      config,
+      store,
+    });
+    expect(calls[0]?.method).toBe("sendDocument");
+    expect(calls[0]?.file?.field).toBe("document");
+  });
+
+  it("sends voice via sendVoice", async () => {
+    const { calls, store } = setup();
+    await send({
+      space,
+      content: await voice(Buffer.from("a"), {
+        mimeType: "audio/ogg",
+        name: "v.ogg",
+      }).build(),
+      config,
+      store,
+    });
+    expect(calls[0]?.method).toBe("sendVoice");
+    expect(calls[0]?.file?.field).toBe("voice");
+  });
+
+  it("threads a reply via reply_parameters", async () => {
+    const { calls, store } = setup();
+    await send({
+      space,
+      content: await reply("hey", target).build(),
+      config,
+      store,
+    });
+    expect(calls[0]?.method).toBe("sendMessage");
+    expect(calls[0]?.params).toEqual({
+      chat_id: "100",
+      text: "hey",
+      reply_parameters: { message_id: 42 },
+    });
+  });
+
+  it("fans a group out to one message per item, returning the last", async () => {
+    const { calls, store } = setup();
+    const group = {
+      type: "group",
+      items: [
+        { id: "a", content: await text("one").build() },
+        { id: "b", content: await text("two").build() },
+      ],
+    } as unknown as Content;
+    const result = await send({ space, content: group, config, store });
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.params).toMatchObject({ text: "one" });
+    expect(calls[1]?.params).toMatchObject({ text: "two" });
+    expect(result?.id).toBe("555");
+  });
+
+  it("passes custom content straight to the named Bot API method", async () => {
+    const { calls, store } = setup();
+    const custom = {
+      type: "custom",
+      raw: { method: "sendDice", params: { emoji: "🎲" } },
+    } as unknown as Content;
+    await send({ space, content: custom, config, store });
+    expect(calls[0]?.method).toBe("sendDice");
+    expect(calls[0]?.params).toEqual({ chat_id: "100", emoji: "🎲" });
+  });
+});
+
+describe("send — fire-and-forget", () => {
+  it("sends a reaction via setMessageReaction and returns undefined", async () => {
+    const { calls, store } = setup();
+    const result = await send({
+      space,
+      content: await reaction("👍", target).build(),
+      config,
+      store,
+    });
+    expect(result).toBeUndefined();
+    expect(calls[0]?.method).toBe("setMessageReaction");
+    expect(calls[0]?.params).toEqual({
+      chat_id: "100",
+      message_id: 42,
+      reaction: [{ type: "emoji", emoji: "👍" }],
+    });
+  });
+
+  it("rewraps an invalid reaction emoji as an UnsupportedError", async () => {
+    const { store } = setup({ callThrows: true });
+    await expect(
+      send({
+        space,
+        content: await reaction("🚀", target).build(),
+        config,
+        store,
+      })
+    ).rejects.toThrow("not an allowed");
+  });
+
+  it("starts a typing action; stop is a no-op", async () => {
+    const { calls, store } = setup();
+    await send({
+      space,
+      content: { type: "typing", state: "start" } as unknown as Content,
+      config,
+      store,
+    });
+    expect(calls[0]?.method).toBe("sendChatAction");
+    expect(calls[0]?.params).toEqual({ chat_id: "100", action: "typing" });
+
+    const stop = setup();
+    await send({
+      space,
+      content: { type: "typing", state: "stop" } as unknown as Content,
+      config,
+      store: stop.store,
+    });
+    expect(stop.calls).toHaveLength(0);
+  });
+
+  it("edits text via editMessageText and rejects non-text edits", async () => {
+    const { calls, store } = setup();
+    await send({
+      space,
+      content: {
+        type: "edit",
+        content: { type: "text", text: "new" },
+        target,
+      } as unknown as Content,
+      config,
+      store,
+    });
+    expect(calls[0]?.method).toBe("editMessageText");
+    expect(calls[0]?.params).toEqual({
+      chat_id: "100",
+      message_id: 42,
+      text: "new",
+    });
+
+    await expect(
+      send({
+        space,
+        content: {
+          type: "edit",
+          content: { type: "richlink", url: "https://x.test" },
+          target,
+        } as unknown as Content,
+        config,
+        store,
+      })
+    ).rejects.toThrow();
+  });
+});
+
+describe("send — unsupported", () => {
+  it("throws UnsupportedError for polls", async () => {
+    const { store } = setup();
+    await expect(
+      send({
+        space,
+        content: await poll("Q?", "a", "b").build(),
+        config,
+        store,
+      })
+    ).rejects.toThrow();
+  });
+});

--- a/packages/spectrum-ts/src/providers/telegram/outbound/send.test.ts
+++ b/packages/spectrum-ts/src/providers/telegram/outbound/send.test.ts
@@ -20,17 +20,12 @@ const target = {
   content: { type: "text", text: "x" },
 } as unknown as Message;
 
-const setup = (opts?: { callThrows?: boolean }) => {
+const setup = () => {
   const calls: TelegramSendSpec[] = [];
   const client: TelegramClient = {
     botId: "1",
     call: <T = SentMessage>(spec: TelegramSendSpec): Promise<T> => {
       calls.push(spec);
-      if (opts?.callThrows) {
-        return Promise.reject(
-          new Error("Telegram setMessageReaction failed: 400 REACTION_INVALID")
-        );
-      }
       return Promise.resolve({ message_id: 555, date: TS_SEC } as unknown as T);
     },
     download: () => Promise.resolve(Buffer.alloc(0)),
@@ -169,8 +164,8 @@ describe("send — fire-and-forget", () => {
     });
   });
 
-  it("rewraps an invalid reaction emoji as an UnsupportedError", async () => {
-    const { store } = setup({ callThrows: true });
+  it("rejects an invalid reaction emoji without calling the API", async () => {
+    const { calls, store } = setup();
     await expect(
       send({
         space,
@@ -179,6 +174,7 @@ describe("send — fire-and-forget", () => {
         store,
       })
     ).rejects.toThrow("not an allowed");
+    expect(calls).toHaveLength(0);
   });
 
   it("starts a typing action; stop is a no-op", async () => {

--- a/packages/spectrum-ts/src/providers/telegram/outbound/send.ts
+++ b/packages/spectrum-ts/src/providers/telegram/outbound/send.ts
@@ -8,7 +8,7 @@ import { TELEGRAM_PLATFORM, type TelegramConfig } from "../config";
 import { isAllowedReactionEmoji, normalizeReactionEmoji } from "../reactions";
 import type { TelegramSpace } from "../space";
 import type { SentMessage } from "../types";
-import { buildSend } from "./message";
+import { buildSend, parseMessageId } from "./message";
 
 const MILLIS_PER_SECOND = 1000;
 
@@ -58,27 +58,26 @@ const sendReaction = async (
   space: TelegramSpace,
   content: Reaction
 ): Promise<undefined> => {
-  try {
-    await client.call({
-      method: "setMessageReaction",
-      params: {
-        chat_id: space.id,
-        message_id: Number(content.target.id),
-        reaction: [
-          { type: "emoji", emoji: normalizeReactionEmoji(content.emoji) },
-        ],
-      },
-    });
-  } catch (err) {
-    if (!isAllowedReactionEmoji(content.emoji)) {
-      throw UnsupportedError.content(
-        "reaction",
-        TELEGRAM_PLATFORM,
-        `"${content.emoji}" is not an allowed Telegram reaction emoji.`
-      );
-    }
-    throw err;
+  const messageId = parseMessageId(content.target.id);
+  const emoji = normalizeReactionEmoji(content.emoji);
+  // Validate before calling: setMessageReaction only accepts a fixed emoji set
+  // in non-premium chats. Checking up front gives a clear error and avoids
+  // mis-attributing an unrelated API failure (network, rate limit) to the emoji.
+  if (!isAllowedReactionEmoji(emoji)) {
+    throw UnsupportedError.content(
+      "reaction",
+      TELEGRAM_PLATFORM,
+      `"${content.emoji}" is not an allowed Telegram reaction emoji.`
+    );
   }
+  await client.call({
+    method: "setMessageReaction",
+    params: {
+      chat_id: space.id,
+      message_id: messageId,
+      reaction: [{ type: "emoji", emoji }],
+    },
+  });
   return;
 };
 
@@ -113,7 +112,7 @@ const sendEdit = async (
     method: "editMessageText",
     params: {
       chat_id: space.id,
-      message_id: Number(content.target.id),
+      message_id: parseMessageId(content.target.id),
       text: content.content.text,
     },
   });

--- a/packages/spectrum-ts/src/providers/telegram/outbound/send.ts
+++ b/packages/spectrum-ts/src/providers/telegram/outbound/send.ts
@@ -1,0 +1,155 @@
+import type { Edit } from "../../../content/edit";
+import type { Reaction } from "../../../content/reaction";
+import type { Content } from "../../../content/types";
+import type { ProviderMessageRecord } from "../../../platform/types";
+import { UnsupportedError } from "../../../utils/errors";
+import { getClient, type StoreLike, type TelegramClient } from "../client";
+import { TELEGRAM_PLATFORM, type TelegramConfig } from "../config";
+import { isAllowedReactionEmoji, normalizeReactionEmoji } from "../reactions";
+import type { TelegramSpace } from "../space";
+import type { SentMessage } from "../types";
+import { buildSend } from "./message";
+
+const MILLIS_PER_SECOND = 1000;
+
+interface SendArgs {
+  config: TelegramConfig;
+  content: Content;
+  space: TelegramSpace;
+  store: StoreLike;
+}
+
+/** Build one content's spec, inject `chat_id`, execute it, return the record. */
+const sendContent = async (
+  client: TelegramClient,
+  space: TelegramSpace,
+  content: Content
+): Promise<ProviderMessageRecord> => {
+  const spec = await buildSend(content);
+  const sent = await client.call<SentMessage>({
+    ...spec,
+    params: { chat_id: space.id, ...spec.params },
+  });
+  return {
+    id: String(sent.message_id),
+    content,
+    space: { id: space.id },
+    timestamp: new Date(sent.date * MILLIS_PER_SECOND),
+  };
+};
+
+// A Spectrum `group` has no single-message equivalent on Telegram, so each item
+// is sent as its own message. The last sent message is returned as "the"
+// record (most-recent id is the natural threading target).
+const sendGroup = async (
+  client: TelegramClient,
+  space: TelegramSpace,
+  items: { content: Content }[]
+): Promise<ProviderMessageRecord | undefined> => {
+  let last: ProviderMessageRecord | undefined;
+  for (const item of items) {
+    last = await sendContent(client, space, item.content);
+  }
+  return last;
+};
+
+const sendReaction = async (
+  client: TelegramClient,
+  space: TelegramSpace,
+  content: Reaction
+): Promise<undefined> => {
+  try {
+    await client.call({
+      method: "setMessageReaction",
+      params: {
+        chat_id: space.id,
+        message_id: Number(content.target.id),
+        reaction: [
+          { type: "emoji", emoji: normalizeReactionEmoji(content.emoji) },
+        ],
+      },
+    });
+  } catch (err) {
+    if (!isAllowedReactionEmoji(content.emoji)) {
+      throw UnsupportedError.content(
+        "reaction",
+        TELEGRAM_PLATFORM,
+        `"${content.emoji}" is not an allowed Telegram reaction emoji.`
+      );
+    }
+    throw err;
+  }
+  return;
+};
+
+const sendTyping = async (
+  client: TelegramClient,
+  space: TelegramSpace,
+  state: "start" | "stop"
+): Promise<undefined> => {
+  // Telegram has no "stop typing" — the indicator auto-clears after ~5s.
+  if (state === "start") {
+    await client.call({
+      method: "sendChatAction",
+      params: { chat_id: space.id, action: "typing" },
+    });
+  }
+  return;
+};
+
+const sendEdit = async (
+  client: TelegramClient,
+  space: TelegramSpace,
+  content: Edit
+): Promise<undefined> => {
+  if (content.content.type !== "text") {
+    throw UnsupportedError.content(
+      "edit",
+      TELEGRAM_PLATFORM,
+      `only text content can be edited (got "${content.content.type}").`
+    );
+  }
+  await client.call({
+    method: "editMessageText",
+    params: {
+      chat_id: space.id,
+      message_id: Number(content.target.id),
+      text: content.content.text,
+    },
+  });
+  return;
+};
+
+/**
+ * Outbound dispatcher. Fire-and-forget signals (reaction, typing, edit) return
+ * `undefined`; message-producing content returns a record with the Telegram
+ * message id. A `group` fans out to one message per item. `poll`, `effect`,
+ * `rename` and `avatar` are unsupported in v1 (use `custom` to reach any other
+ * Bot API method directly).
+ */
+export const send = async ({
+  space,
+  content,
+  config,
+  store,
+}: SendArgs): Promise<ProviderMessageRecord | undefined> => {
+  const client = getClient(store, config);
+  switch (content.type) {
+    case "reaction":
+      return await sendReaction(client, space, content);
+    case "typing":
+      return await sendTyping(client, space, content.state);
+    case "edit":
+      return await sendEdit(client, space, content);
+    case "group":
+      return await sendGroup(client, space, content.items);
+    case "poll":
+    case "poll_option":
+    case "effect":
+    case "rename":
+    case "avatar":
+      throw UnsupportedError.content(content.type, TELEGRAM_PLATFORM);
+    default:
+      return await sendContent(client, space, content);
+  }
+};

--- a/packages/spectrum-ts/src/providers/telegram/reactions.ts
+++ b/packages/spectrum-ts/src/providers/telegram/reactions.ts
@@ -1,0 +1,108 @@
+/**
+ * Telegram reactions ARE emoji (unlike LinQ's tapback enum), so inbound and
+ * outbound need no translation — the emoji string maps straight to/from
+ * Spectrum. The catch: `setMessageReaction` only accepts a fixed set of
+ * standard emoji in non-premium chats; anything else fails with
+ * `REACTION_INVALID`. This set is exported so callers can pre-check, and the
+ * send path uses it to turn that API error into a clearer message.
+ *
+ * Source: the default `available_reactions` documented for the Bot API. The set
+ * is stable but Telegram can extend it; treat membership as a best-effort hint,
+ * not a hard guarantee.
+ */
+export const ALLOWED_REACTION_EMOJI: ReadonlySet<string> = new Set([
+  "👍",
+  "👎",
+  "❤",
+  "🔥",
+  "🥰",
+  "👏",
+  "😁",
+  "🤔",
+  "🤯",
+  "😱",
+  "🤬",
+  "😢",
+  "🎉",
+  "🤩",
+  "🤮",
+  "💩",
+  "🙏",
+  "👌",
+  "🕊",
+  "🤡",
+  "🥱",
+  "🥴",
+  "😍",
+  "🐳",
+  "❤‍🔥",
+  "🌚",
+  "🌭",
+  "💯",
+  "🤣",
+  "⚡",
+  "🍌",
+  "🏆",
+  "💔",
+  "🤨",
+  "😐",
+  "🍓",
+  "🍾",
+  "💋",
+  "🖕",
+  "😈",
+  "😴",
+  "😭",
+  "🤓",
+  "👻",
+  "👨‍💻",
+  "👀",
+  "🎃",
+  "🙈",
+  "😇",
+  "😨",
+  "🤝",
+  "✍",
+  "🤗",
+  "🫡",
+  "🎅",
+  "🎄",
+  "☃",
+  "💅",
+  "🤪",
+  "🗿",
+  "🆒",
+  "💘",
+  "🙉",
+  "🦄",
+  "😘",
+  "💊",
+  "🙊",
+  "😎",
+  "👾",
+  "🤷‍♂",
+  "🤷",
+  "🤷‍♀",
+  "😡",
+]);
+
+const VARIATION_SELECTOR_16 = /️/g;
+
+const stripVariationSelector = (emoji: string): string =>
+  emoji.replace(VARIATION_SELECTOR_16, "");
+
+/**
+ * Telegram's reaction set uses bare codepoints (no U+FE0F variation selector),
+ * while clients/Spectrum often carry the emoji-presentation form (e.g. `❤️`).
+ * Strip the selector before comparing so both forms validate.
+ */
+export const isAllowedReactionEmoji = (emoji: string): boolean =>
+  ALLOWED_REACTION_EMOJI.has(stripVariationSelector(emoji));
+
+/**
+ * The form to send to `setMessageReaction`. Known reactions are normalized to
+ * the bare codepoint Telegram expects; unknown emoji pass through unchanged so
+ * the API's own validation (and our clearer error) can take over.
+ */
+export const normalizeReactionEmoji = (emoji: string): string =>
+  isAllowedReactionEmoji(emoji) ? stripVariationSelector(emoji) : emoji;

--- a/packages/spectrum-ts/src/providers/telegram/space.ts
+++ b/packages/spectrum-ts/src/providers/telegram/space.ts
@@ -1,0 +1,51 @@
+import z from "zod";
+
+export interface TelegramSpace {
+  id: string;
+}
+
+export const spaceParamsSchema = z.object({
+  /**
+   * Target a chat directly by id. Telegram chat ids are numbers in the wire
+   * format (negative for groups/supergroups); accept either form and store as
+   * a string. For a private chat the id equals the user's id.
+   */
+  chatId: z.union([z.string().min(1), z.number()]).optional(),
+});
+
+export type TelegramSpaceParams = z.infer<typeof spaceParamsSchema>;
+
+export const resolveUser = ({
+  input,
+}: {
+  input: { userID: string };
+}): Promise<{ id: string }> => Promise.resolve({ id: input.userID });
+
+/**
+ * Resolve a space to a Telegram `chat_id`. A bot cannot initiate a conversation
+ * or create a group, so a space is always an existing chat: either passed
+ * explicitly via `params.chatId`, or — for a private chat — the single
+ * recipient's user id (which equals the chat id). Anything else is unsupported.
+ */
+export const resolveSpace = ({
+  input,
+}: {
+  input: { users: { id: string }[]; params?: TelegramSpaceParams };
+}): Promise<TelegramSpace> => {
+  const chatId = input.params?.chatId;
+  if (chatId !== undefined) {
+    return Promise.resolve({ id: String(chatId) });
+  }
+  const [first, ...rest] = input.users;
+  if (first && rest.length === 0) {
+    return Promise.resolve({ id: first.id });
+  }
+  if (!first) {
+    throw new Error(
+      "Telegram space creation requires params.chatId or a single recipient user."
+    );
+  }
+  throw new Error(
+    "Telegram bots cannot create group chats — pass params.chatId for an existing chat, or resolve a single user (their private chat)."
+  );
+};

--- a/packages/spectrum-ts/src/providers/telegram/types.ts
+++ b/packages/spectrum-ts/src/providers/telegram/types.ts
@@ -1,0 +1,58 @@
+import type { Message, MessageReactionUpdated, Update } from "@grammyjs/types";
+import type { TelegramClient } from "./client";
+
+// ---------------------------------------------------------------------------
+// Inbound — Telegram webhook payloads, typed from the official `@grammyjs/types`
+// package so the adapter stays in sync with the Bot API schema. These are
+// types-only imports and disappear at build time.
+// ---------------------------------------------------------------------------
+
+export type {
+  Message,
+  MessageReactionUpdated,
+  PhotoSize,
+  ReactionType,
+  ReactionTypeEmoji,
+  Update,
+  User,
+} from "@grammyjs/types";
+
+/**
+ * The payload `verify()` produces and `messages()` consumes. The raw `Update`
+ * plus the `TelegramClient` — the `messages` hook receives only `{ payload,
+ * respond }` (no store/config), so the client is threaded through here to build
+ * the lazy media `read()` closures (inbound media is fetched with the bot
+ * token, unlike presigned-URL platforms). The client never lands in a
+ * `ProviderMessageRecord`; only `() => client.download(fileId)` closures do.
+ */
+export interface TelegramPayload {
+  client: TelegramClient;
+  update: Update;
+}
+
+/** An inbound `message_reaction` update. */
+export type ReactionUpdate = MessageReactionUpdated;
+
+// ---------------------------------------------------------------------------
+// Outbound — the adapter's own DTOs at the `TelegramClient` boundary. Telegram
+// has no multi-part message: each content type is a distinct Bot API method, so
+// `buildSend` returns a *send spec* (one method call) rather than a parts list.
+// ---------------------------------------------------------------------------
+
+/** A file to upload as `multipart/form-data` under `field` (e.g. `photo`). */
+export interface TelegramSendFile {
+  bytes: Buffer;
+  field: string;
+  filename: string;
+  mimeType: string;
+}
+
+/** One Bot API call: a method, its JSON params, and an optional uploaded file. */
+export interface TelegramSendSpec {
+  file?: TelegramSendFile;
+  method: string;
+  params: Record<string, unknown>;
+}
+
+/** The subset of a sent `Message` the adapter reads back after a successful send. */
+export type SentMessage = Pick<Message, "message_id" | "date">;

--- a/packages/spectrum-ts/src/providers/telegram/verify.test.ts
+++ b/packages/spectrum-ts/src/providers/telegram/verify.test.ts
@@ -80,4 +80,10 @@ describe("makeVerify", () => {
       verifyWith()(request(JSON.stringify({ message: {} }), {}))
     ).toThrow("update_id");
   });
+
+  it("rejects a payload with a non-numeric update_id", () => {
+    expect(() =>
+      verifyWith()(request(JSON.stringify({ update_id: "1" }), {}))
+    ).toThrow("update_id");
+  });
 });

--- a/packages/spectrum-ts/src/providers/telegram/verify.test.ts
+++ b/packages/spectrum-ts/src/providers/telegram/verify.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import type { TelegramClient } from "./client";
+import { configSchema } from "./config";
+import type { TelegramPayload } from "./types";
+import { makeVerify } from "./verify";
+
+const SECRET = "s3cr3t_token-123";
+
+const fakeClient: TelegramClient = {
+  botId: "42",
+  call: () => Promise.reject(new Error("unused")),
+  download: () => Promise.reject(new Error("unused")),
+};
+
+const body = (updateId = 1): string =>
+  JSON.stringify({
+    update_id: updateId,
+    message: {
+      message_id: 5,
+      date: 1_700_000_000,
+      chat: { id: 100, type: "private" },
+      from: { id: 7, is_bot: false, first_name: "Alice" },
+      text: "hi",
+    },
+  });
+
+const request = (payload: string, headers: Record<string, string>) => ({
+  headers,
+  method: "POST",
+  path: "/telegram",
+  rawBody: new TextEncoder().encode(payload),
+});
+
+const verifyWith = (secret?: string) =>
+  makeVerify(
+    configSchema.parse({
+      botToken: "42:abc",
+      ...(secret ? { webhookSecret: secret } : {}),
+    }),
+    fakeClient
+  );
+
+describe("makeVerify", () => {
+  it("accepts when the secret token header matches", () => {
+    const result = verifyWith(SECRET)(
+      request(body(), { "x-telegram-bot-api-secret-token": SECRET })
+    ) as TelegramPayload;
+    expect(result.update.update_id).toBe(1);
+    expect(result.update.message?.text).toBe("hi");
+    expect(result.client).toBe(fakeClient);
+  });
+
+  it("rejects a mismatched secret token", () => {
+    expect(() =>
+      verifyWith(SECRET)(
+        request(body(), { "x-telegram-bot-api-secret-token": "wrong" })
+      )
+    ).toThrow("mismatch");
+  });
+
+  it("rejects a missing secret token header when a secret is configured", () => {
+    expect(() => verifyWith(SECRET)(request(body(), {}))).toThrow(
+      "missing the secret token"
+    );
+  });
+
+  it("skips verification when no secret is configured", () => {
+    const result = verifyWith()(request(body(), {})) as TelegramPayload;
+    expect(result.update.update_id).toBe(1);
+  });
+
+  it("rejects a body that is not valid JSON", () => {
+    expect(() => verifyWith()(request("not json", {}))).toThrow(
+      "not valid JSON"
+    );
+  });
+
+  it("rejects a payload missing update_id", () => {
+    expect(() =>
+      verifyWith()(request(JSON.stringify({ message: {} }), {}))
+    ).toThrow("update_id");
+  });
+});

--- a/packages/spectrum-ts/src/providers/telegram/verify.ts
+++ b/packages/spectrum-ts/src/providers/telegram/verify.ts
@@ -1,0 +1,74 @@
+import { timingSafeEqual } from "node:crypto";
+import type { FusorVerify, FusorVerifyRequest } from "../../fusor/types";
+import type { TelegramClient } from "./client";
+import type { TelegramConfig } from "./config";
+import type { TelegramPayload, Update } from "./types";
+
+/**
+ * Telegram echoes the `secret_token` configured in `setWebhook` back in this
+ * header (lowercased by Spectrum/Fusor). It is the ONLY inbound authentication
+ * — Telegram does not HMAC-sign the request body.
+ */
+const SECRET_TOKEN_HEADER = "x-telegram-bot-api-secret-token";
+
+const safeEqual = (a: string, b: string): boolean => {
+  const left = Buffer.from(a, "utf8");
+  const right = Buffer.from(b, "utf8");
+  if (left.length === 0 || left.length !== right.length) {
+    return false;
+  }
+  return timingSafeEqual(left, right);
+};
+
+const verifySecret = (
+  headers: Record<string, string>,
+  secret: string
+): void => {
+  const provided = headers[SECRET_TOKEN_HEADER];
+  if (!provided) {
+    throw new Error("Telegram webhook is missing the secret token header");
+  }
+  if (!safeEqual(provided, secret)) {
+    throw new Error("Telegram webhook secret token mismatch");
+  }
+};
+
+const isUpdate = (value: unknown): value is Update =>
+  typeof value === "object" &&
+  value !== null &&
+  "update_id" in value &&
+  typeof (value as { update_id: unknown }).update_id === "number";
+
+const parseUpdate = (bodyText: string): Update => {
+  let json: unknown;
+  try {
+    json = JSON.parse(bodyText);
+  } catch {
+    throw new Error("Telegram webhook body is not valid JSON");
+  }
+  if (!isUpdate(json)) {
+    throw new Error("Telegram webhook payload is missing a numeric update_id");
+  }
+  return json;
+};
+
+/**
+ * Build the Fusor `verify` hook. Closes over `config` (to check the secret
+ * token) and the already-built `client` (so the inbound mapper can attach
+ * token-authenticated lazy media `read()` closures — the `messages` hook gets
+ * only `{ payload, respond }`, with no access to the client otherwise). When no
+ * `webhookSecret` is configured the token check is skipped and the body is
+ * parsed directly. Throwing rejects the event (Fusor returns 400 — no retry).
+ */
+export const makeVerify =
+  (
+    config: TelegramConfig,
+    client: TelegramClient
+  ): FusorVerify<TelegramPayload> =>
+  (req: FusorVerifyRequest): TelegramPayload => {
+    if (config.webhookSecret) {
+      verifySecret(req.headers, config.webhookSecret);
+    }
+    const update = parseUpdate(new TextDecoder().decode(req.rawBody));
+    return { client, update };
+  };

--- a/packages/spectrum-ts/tsup.config.ts
+++ b/packages/spectrum-ts/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     "providers/index": "src/providers/index.ts",
     "providers/imessage/index": "src/providers/imessage/index.ts",
     "providers/slack/index": "src/providers/slack/index.ts",
+    "providers/telegram/index": "src/providers/telegram/index.ts",
     "providers/terminal/index": "src/providers/terminal/index.ts",
     "providers/whatsapp-business/index":
       "src/providers/whatsapp-business/index.ts",


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783390887&installation_id=127326493&pr_number=105&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F105&signature=9131838ef31e7a353dd1307477f5049d6f03042c294b8e386f5cc4280a9a3dc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Telegram bot provider for sending/receiving messages, including message reactions, typing indicators, and message editing
  * Media handling for photos, videos, audio, documents, voice notes, stickers, and lazy downloads
  * Secure webhook verification and provider configuration/validation

* **Tests**
  * Added comprehensive tests for inbound mapping, outbound sending, and webhook verification

* **Chores**
  * Updated build configuration and added a dev dependency for Telegram types
<!-- end of auto-generated comment: release notes by coderabbit.ai -->