### PR TITLE
feat(fusor): custom event channels via `fusorEvent` + fold `defineFusorPlatform` into `definePlatform`

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -16,7 +16,8 @@
     {
       "includes": [
         "packages/spectrum-ts/src/index.ts",
-        "packages/spectrum-ts/src/authoring.ts"
+        "packages/spectrum-ts/src/authoring.ts",
+        "packages/spectrum-ts/src/fusor/index.ts"
       ],
       "linter": {
         "rules": {

--- a/docs/fusor.md
+++ b/docs/fusor.md
@@ -15,10 +15,12 @@ parse the raw request, produce messages, and (optionally) reply. Only the
 transport differs. Pick whichever fits your deployment: a long-running worker
 (streaming) or a serverless / request-scoped HTTP handler (webhook).
 
-> Only **Fusor-backed providers** (those built with `defineFusorPlatform`, whose
-> `createClient` returns a `fusor(...)` client) use this. Providers with their
-> own transport — e.g. iMessage via `@photon-ai/advanced-imessage` — do **not**
-> go through the Fusor gRPC stream; see [When the gRPC stream
+> Only **Fusor-backed providers** use this: a provider is in *fusor mode* when
+> its `definePlatform` `lifecycle.createClient` returns a `fusor(...)` client
+> (rather than a long-lived SDK client). There is no separate
+> `defineFusorPlatform` — it's one overloaded `definePlatform`. Providers with
+> their own transport — e.g. iMessage via `@photon-ai/advanced-imessage` — do
+> **not** go through the Fusor gRPC stream; see [When the gRPC stream
 > opens](#when-the-grpc-stream-opens).
 
 ---
@@ -38,15 +40,17 @@ RawInboundEvent
 ```
 
 `verify()` and `messages()` here are **provider-authoring hooks** defined via
-`defineFusorPlatform` — the per-platform code that validates the signature and
+`definePlatform` — the per-platform code that validates the signature and
 parses the request. They are *not* something you call:
 
 - **`verify(req)`** turns the raw request into a typed `payload` (and rejects a
   bad signature).
 - **`messages({ payload, respond })`** returns the provider message record(s)
   Spectrum delivers, and may call `respond(...)` to set the synchronous reply.
-  ⚠️ This provider hook is distinct from **`app.messages`**, the stream *you*
-  consume — same word, different thing.
+  It can also return `fusorEvent(channel, data)` to route to a
+  [custom event channel](#custom-event-channels-fusorevent) instead of the
+  message stream. ⚠️ This provider hook is distinct from **`app.messages`**, the
+  stream *you* consume — same word, different thing.
 
 Internally this is `FusorCore.processEvent()`, driven either by the gRPC stream
 or by `app.webhook()`. You never call it directly.
@@ -224,6 +228,84 @@ expect a `for await (… of app.messages)` loop to observe webhook traffic.
 
 ---
 
+## Custom event channels (`fusorEvent`)
+
+Beyond the core message stream, a fusor provider can surface **custom event
+channels** — presence, read receipts, typing, reactions, anything that isn't a
+message. They appear as flat async-iterable properties on the app
+(`app.presence`, `app.readReceipt`, …), unified across every provider that
+declares the same channel.
+
+A regular (non-fusor) platform feeds a channel from a long-lived producer. A
+fusor platform has no client to stream from, so instead it **declares** each
+channel as a Zod schema and **emits** per webhook by returning
+`fusorEvent(channel, data)` from `messages`.
+
+### Authoring
+
+```typescript
+import { definePlatform, fusor, fusorEvent, type FusorMessages } from "spectrum-ts";
+import { z } from "zod";
+
+// 1. Declare each channel under `events` — the KEY is the channel name, the
+//    value is a Zod schema describing the payload (and typing `app.<channel>`).
+const presenceSchema = z.object({ user: z.string(), online: z.boolean() });
+
+// 2. `messages` MUST be a typed `FusorMessages<…>` reference (not an inline
+//    arrow) so overload resolution selects fusor mode — see the note below.
+const messages: FusorMessages<MyPayload> = ({ payload }) => {
+  if (payload.kind === "presence") {
+    return fusorEvent("presence", { user: payload.user, online: true });
+  }
+  // A bare record (or `fusorEvent("messages", record)`) goes to app.messages.
+  return { id: payload.id, content: payload.content, sender, space };
+};
+
+export const myProvider = definePlatform("myplatform", {
+  config: z.object({ /* … */ }),
+  lifecycle: { createClient: ({ config }) => Promise.resolve(fusor("myplatform", makeVerify(config))) },
+  user: { /* … */ },
+  space: { /* … */ },
+  events: { presence: presenceSchema }, // ← channel declaration
+  messages,
+  send,
+});
+```
+
+Three ways a `messages` handler can route its return value:
+
+| Return | Goes to |
+| --- | --- |
+| a bare `ProviderMessageRecord` (or array) | `app.messages` / the webhook handler |
+| `fusorEvent("messages", record)` | identical to the bare record above |
+| `fusorEvent("presence", data)` | the `presence` channel (`app.presence`) |
+
+The channel name in `fusorEvent(name, …)` is **not** type-checked against your
+declared `events` — a name that isn't a declared channel is logged with a
+warning and dropped (not silently lost). Keep it in sync with the `events` keys.
+
+### Consuming
+
+```typescript
+for await (const presence of app.presence) {
+  // presence: { user: string; online: boolean; platform: "myplatform" }
+}
+```
+
+Each event is the channel payload plus a `platform` tag identifying which
+provider emitted it. Custom events flow on **both** transports, but they go to
+the channel stream — **never** to the `app.webhook()` handler, which is
+messages-only.
+
+> **Authoring note — fusor mode selection.** `definePlatform` is overloaded; the
+> regular overload is tried first. A fusor provider is only matched when its
+> `messages` is a **typed `FusorMessages<…>` reference** (like the example
+> above) — an inline `messages: ({ payload }) => …` arrow is deferred during
+> overload resolution and mis-commits to the regular overload. Annotating
+> `createClient`'s return as `Promise<FusorClient<…>>` is also good practice.
+
+---
+
 ## When the gRPC stream opens
 
 The Fusor gRPC stream is opened **lazily** — only on the first time you consume
@@ -256,8 +338,10 @@ Consequences:
 
 - `app.webhook(request, handler)` — `src/spectrum.ts`
 - Shared pipeline — `FusorCore.processEvent()` in `src/fusor/core.ts`
-- Provider authoring — `defineFusorPlatform` / `fusor(platform, verify)` in
-  `src/platform/define.ts` and `src/fusor/index.ts`
+- Provider authoring — `definePlatform` (fusor overload) / `fusor(platform, verify)`
+  in `src/platform/define.ts` and `src/fusor/index.ts`
+- Custom events — `fusorEvent(channel, data)` in `src/fusor/event.ts`
 - Wire envelope — `RawInboundEvent` / `InboundReply` from
   `@photon-ai/proto/photon/fusor/v1/inbound`
-- Public types — `WebhookHandler`, `WebhookRawRequest`, `WebhookRawResult`
+- Public types — `WebhookHandler`, `WebhookRawRequest`, `WebhookRawResult`,
+  `FusorEvent`

--- a/packages/spectrum-ts/scripts/generate-manifest.ts
+++ b/packages/spectrum-ts/scripts/generate-manifest.ts
@@ -34,7 +34,7 @@ const DIST_PROVIDERS_DIR = join(PKG_ROOT, "dist", "providers");
 const OUT_PATH = join(PKG_ROOT, "dist", "manifest.json");
 
 const DEFINE_PLATFORM_RE =
-  /^export\s+const\s+(\w+)\s*=\s*define(?:Fusor)?Platform\(\s*(?:"([^"]+)"|(\w+))/m;
+  /^export\s+const\s+(\w+)\s*=\s*definePlatform\(\s*(?:"([^"]+)"|(\w+))/m;
 
 async function fileExists(path: string): Promise<boolean> {
   try {
@@ -45,7 +45,7 @@ async function fileExists(path: string): Promise<boolean> {
   }
 }
 
-// Fusor providers (`defineFusorPlatform`) pass their platform name as a shared
+// Fusor providers pass their platform name as a shared
 // const — the single source of truth for the routing key — rather than a string
 // literal. When the label isn't inline, resolve the const from the provider's
 // own source files.
@@ -86,7 +86,7 @@ async function buildManifest(): Promise<ManifestEntry[]> {
     const match = source.match(DEFINE_PLATFORM_RE);
     if (!match) {
       throw new Error(
-        `Provider "${key}" at ${sourcePath} does not match the expected \`export const <name> = definePlatform("<label>", ...)\` (or \`defineFusorPlatform(...)\`) pattern. If you intentionally renamed the call, update generate-manifest.ts.`
+        `Provider "${key}" at ${sourcePath} does not match the expected \`export const <name> = definePlatform("<label>", ...)\` pattern. If you intentionally renamed the call, update generate-manifest.ts.`
       );
     }
     const [, importName, literalLabel, labelConst] = match;

--- a/packages/spectrum-ts/src/fusor/core.ts
+++ b/packages/spectrum-ts/src/fusor/core.ts
@@ -8,13 +8,14 @@ import { type Channel, createChannel, createClient } from "nice-grpc";
 import { ClientError, Metadata, Status } from "nice-grpc-common";
 import type { ProviderMessageRecord } from "../platform/types";
 import { createFusorTokenProvider, type FusorTokenProvider } from "./auth";
+import { FUSOR_MESSAGES_CHANNEL, isFusorEvent } from "./event";
 import { type ParsedHttpRequest, parseHttpRequest } from "./parse";
 import {
   EventsServiceDefinition,
   type SubscribeRequest,
   type SubscribeResponse,
 } from "./service";
-import type { FusorReply, FusorVerify } from "./types";
+import type { FusorMessagesReturn, FusorReply, FusorVerify } from "./types";
 
 const DEFAULT_FUSOR_GRPC_URL = "fusor.spectrum.photon.codes:443";
 const RECONNECT_BASE_MS = 1000;
@@ -32,11 +33,10 @@ export interface RegisteredFusorHandler<TPayload = unknown> {
   messages: (ctx: {
     payload: TPayload;
     respond: (reply: FusorReply) => void;
-  }) =>
-    | ProviderMessageRecord
-    | ProviderMessageRecord[]
-    | undefined
-    | Promise<ProviderMessageRecord | ProviderMessageRecord[] | undefined>;
+  }) => FusorMessagesReturn | Promise<FusorMessagesReturn>;
+  // Route a `fusorEvent(channel, data)` to its custom event channel. Wired by
+  // the Spectrum bootstrap to the per-(platform, channel) queue.
+  pushEvent: (channel: string, data: unknown) => void;
   pushMessage: (record: ProviderMessageRecord) => void;
   verify: FusorVerify<TPayload>;
 }
@@ -166,6 +166,32 @@ function combineReplies(outcomes: HandlerOutcome[]): InboundReply {
   };
 }
 
+// Route a handler's return value. A bare record (or `fusorEvent("messages", …)`)
+// goes to the message sink (`deliver`, which the webhook path overrides);
+// `fusorEvent(channel, …)` goes to its per-channel queue via `pushEvent` —
+// always, on both transports, since the webhook handler is messages-only.
+function routeHandlerResult(
+  result: FusorMessagesReturn,
+  handler: RegisteredFusorHandler,
+  deliver: (record: ProviderMessageRecord) => void
+): void {
+  if (result === undefined) {
+    return;
+  }
+  const items = Array.isArray(result) ? result : [result];
+  for (const item of items) {
+    if (!isFusorEvent(item)) {
+      deliver(item);
+      continue;
+    }
+    if (item.name === FUSOR_MESSAGES_CHANNEL) {
+      deliver(item.data as ProviderMessageRecord);
+    } else {
+      handler.pushEvent(item.name, item.data);
+    }
+  }
+}
+
 function runHandlerOnce<TPayload>(
   handler: RegisteredFusorHandler<TPayload>,
   parsedRequest: ParsedHttpRequest,
@@ -191,12 +217,7 @@ function runHandlerOnce<TPayload>(
       const result = await handler.messages({ payload, respond });
       returned = true;
 
-      if (result !== undefined) {
-        const records = Array.isArray(result) ? result : [result];
-        for (const record of records) {
-          deliver(record);
-        }
-      }
+      routeHandlerResult(result, handler as RegisteredFusorHandler, deliver);
       return { ok: true, reply };
     } catch (error) {
       const errorReason =

--- a/packages/spectrum-ts/src/fusor/event.ts
+++ b/packages/spectrum-ts/src/fusor/event.ts
@@ -1,0 +1,42 @@
+// ---------------------------------------------------------------------------
+// fusorEvent — emit a custom event channel from a fusor `messages` handler
+// ---------------------------------------------------------------------------
+//
+// A fusor platform has no long-lived client to stream custom events from, so
+// instead of a producer it *declares* each channel as a Zod schema under
+// `events` (the key is the channel name) and *emits* per-webhook by returning
+// `fusorEvent(channel, data)` from `messages`. The fusor core inspects each
+// returned item: a `FusorEvent` whose `name` is a declared channel routes
+// `data` to `spectrum.<channel>`; the reserved `name` "messages" (and any bare
+// `ProviderMessageRecord`) routes to the core `spectrum.messages` stream.
+//
+// Emit is intentionally untyped (a free function, not checked against the
+// declared channels) — a pragmatic bridge until the platform model is fully
+// fusor-based. A typo in the channel name is caught at runtime by the core,
+// which warns instead of silently dropping.
+
+const FUSOR_EVENT_BRAND: unique symbol = Symbol.for("spectrum.fusor.event");
+
+/** The reserved channel name that routes back to `spectrum.messages`. */
+export const FUSOR_MESSAGES_CHANNEL = "messages";
+
+export interface FusorEvent<TName extends string = string, TData = unknown> {
+  readonly data: TData;
+  readonly name: TName;
+  readonly [FUSOR_EVENT_BRAND]: true;
+}
+
+export function fusorEvent<TName extends string, TData>(
+  name: TName,
+  data: TData
+): FusorEvent<TName, TData> {
+  return { [FUSOR_EVENT_BRAND]: true, name, data };
+}
+
+export function isFusorEvent(value: unknown): value is FusorEvent {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { [FUSOR_EVENT_BRAND]?: unknown })[FUSOR_EVENT_BRAND] === true
+  );
+}

--- a/packages/spectrum-ts/src/fusor/index.ts
+++ b/packages/spectrum-ts/src/fusor/index.ts
@@ -1,5 +1,6 @@
 import { FUSOR_BRAND, type FusorClient, type FusorVerify } from "./types";
 
+export { type FusorEvent, fusorEvent, isFusorEvent } from "./event";
 export type {
   FusorClient,
   FusorMessages,

--- a/packages/spectrum-ts/src/fusor/types.ts
+++ b/packages/spectrum-ts/src/fusor/types.ts
@@ -1,6 +1,7 @@
 import type { ProviderMessageRecord } from "../platform/types";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
+import type { FusorEvent } from "./event";
 
 export interface FusorVerifyRequest {
   headers: Record<string, string>;
@@ -28,7 +29,8 @@ export interface FusorMessagesCtx<TPayload> {
 
 export type FusorMessagesReturn =
   | ProviderMessageRecord
-  | ProviderMessageRecord[]
+  | FusorEvent
+  | (ProviderMessageRecord | FusorEvent)[]
   | undefined;
 
 export type FusorMessages<TPayload> = (

--- a/packages/spectrum-ts/src/fusor/webhook.test.ts
+++ b/packages/spectrum-ts/src/fusor/webhook.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, it, spyOn } from "bun:test";
 import { RawInboundEvent } from "@photon-ai/proto/photon/fusor/v1/inbound";
 import z from "zod";
 import type { Content } from "../content/types";
-import { defineFusorPlatform } from "../platform/define";
+import { definePlatform } from "../platform/define";
 import { Spectrum } from "../spectrum";
 import type { Message } from "../types/message";
 import { cloud } from "../utils/cloud";
 import { FusorCore } from "./core";
-import { fusor } from "./index";
+import { fusor, fusorEvent } from "./index";
+import type { FusorMessages } from "./types";
 
 // Spectrum() fetches project metadata up-front when projectId/projectSecret are
 // supplied. These tests use placeholder credentials, so stub the cloud call to
@@ -27,8 +28,49 @@ type SlackPayload =
   | { kind: "group"; texts: string[] }
   | { kind: "typing" };
 
+// A typed `FusorMessages` reference (not an inline arrow). Overload resolution
+// keys on this: a typed reference is non-context-sensitive, so it's checked in
+// pass 1, rejects the regular overload, and selects the fusor one. An inline
+// `messages: ({ payload }) => …` would be deferred and mis-commit to regular.
+const slackMessages: FusorMessages<SlackPayload> = ({ payload, respond }) => {
+  if (payload.kind === "verify") {
+    respond({ status: 200, body: payload.challenge });
+    return;
+  }
+  if (payload.kind === "typing") {
+    // A senderless inbound signal (no `sender` field): typing carries no
+    // attributable author. Core must resolve this without throwing.
+    return {
+      id: "t1",
+      content: { type: "typing", state: "start" } as unknown as Content,
+      space: { id: "s1" },
+    };
+  }
+  if (payload.kind === "group") {
+    const items = payload.texts.map((text, i) => ({
+      id: `g${i}`,
+      content: { type: "text", text } as Content,
+      sender: { id: "u1" },
+      space: { id: "s1" },
+    }));
+    return {
+      id: "grp",
+      content: { type: "group", items } as unknown as Content,
+      sender: { id: "u1" },
+      space: { id: "s1" },
+    };
+  }
+  return {
+    id: "m1",
+    content: { type: "text", text: payload.text } as Content,
+    sender: { id: "u1" },
+    space: { id: "s1" },
+    timestamp: new Date(0),
+  };
+};
+
 const makeSlack = (opts: { verifyThrows?: boolean } = {}) =>
-  defineFusorPlatform("slack", {
+  definePlatform("slack", {
     config: z.object({}),
     lifecycle: {
       createClient: () =>
@@ -61,42 +103,7 @@ const makeSlack = (opts: { verifyThrows?: boolean } = {}) =>
       resolve: ({ input }) =>
         Promise.resolve({ id: input.users[0]?.id ?? "space" }),
     },
-    messages: ({ payload, respond }) => {
-      if (payload.kind === "verify") {
-        respond({ status: 200, body: payload.challenge });
-        return;
-      }
-      if (payload.kind === "typing") {
-        // A senderless inbound signal (no `sender` field): typing carries no
-        // attributable author. Core must resolve this without throwing.
-        return {
-          id: "t1",
-          content: { type: "typing", state: "start" } as unknown as Content,
-          space: { id: "s1" },
-        };
-      }
-      if (payload.kind === "group") {
-        const items = payload.texts.map((text, i) => ({
-          id: `g${i}`,
-          content: { type: "text", text } as Content,
-          sender: { id: "u1" },
-          space: { id: "s1" },
-        }));
-        return {
-          id: "grp",
-          content: { type: "group", items } as unknown as Content,
-          sender: { id: "u1" },
-          space: { id: "s1" },
-        };
-      }
-      return {
-        id: "m1",
-        content: { type: "text", text: payload.text } as Content,
-        sender: { id: "u1" },
-        space: { id: "s1" },
-        timestamp: new Date(0),
-      };
-    },
+    messages: slackMessages,
     send: () => Promise.resolve(undefined),
   });
 
@@ -500,5 +507,181 @@ describe("spectrum.webhook", () => {
     } finally {
       startSpy.mockRestore();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fusor custom event channels (`events` schema + `fusorEvent`)
+// ---------------------------------------------------------------------------
+
+type PresencePayload =
+  | { kind: "message"; text: string }
+  | { kind: "presence"; user: string }
+  | { kind: "viaMessagesChannel"; text: string }
+  | { kind: "undeclared" };
+
+const presenceSchema = z.object({ user: z.string(), online: z.boolean() });
+
+// A typed `FusorMessages` reference (not inline) so overload resolution picks
+// the fusor overload. Demonstrates the three routes a fusor handler can take.
+const presenceMessages: FusorMessages<PresencePayload> = ({ payload }) => {
+  if (payload.kind === "presence") {
+    return fusorEvent("presence", { user: payload.user, online: true });
+  }
+  if (payload.kind === "viaMessagesChannel") {
+    // `fusorEvent("messages", record)` must behave exactly like returning the
+    // record bare — i.e. route to the core `spectrum.messages` stream.
+    return fusorEvent("messages", {
+      id: "viaev",
+      content: { type: "text", text: payload.text } as Content,
+      sender: { id: "u1" },
+      space: { id: "s1" },
+    });
+  }
+  if (payload.kind === "undeclared") {
+    return fusorEvent("ghost", { dropped: true });
+  }
+  return {
+    id: "pm1",
+    content: { type: "text", text: payload.text } as Content,
+    sender: { id: "u1" },
+    space: { id: "s1" },
+  };
+};
+
+const PRESENCE_PLATFORM = "pres";
+
+const makePresence = () =>
+  definePlatform(PRESENCE_PLATFORM, {
+    config: z.object({}),
+    lifecycle: {
+      createClient: () =>
+        Promise.resolve(
+          fusor<PresencePayload>(PRESENCE_PLATFORM, (req) => {
+            const body = JSON.parse(new TextDecoder().decode(req.rawBody)) as {
+              type: string;
+              text?: string;
+              user?: string;
+            };
+            if (body.type === "presence") {
+              return { kind: "presence", user: body.user ?? "" };
+            }
+            if (body.type === "via-messages") {
+              return { kind: "viaMessagesChannel", text: body.text ?? "" };
+            }
+            if (body.type === "undeclared") {
+              return { kind: "undeclared" };
+            }
+            return { kind: "message", text: body.text ?? "" };
+          })
+        ),
+    },
+    user: { resolve: ({ input }) => Promise.resolve({ id: input.userID }) },
+    space: {
+      resolve: ({ input }) =>
+        Promise.resolve({ id: input.users[0]?.id ?? "space" }),
+    },
+    events: { presence: presenceSchema },
+    messages: presenceMessages,
+    send: () => Promise.resolve(undefined),
+  });
+
+describe("fusor events", () => {
+  it("routes fusorEvent(channel) to spectrum.<channel>, not the message handler", async () => {
+    const spectrum = await Spectrum({
+      ...baseConfig,
+      providers: [makePresence().config({})],
+    });
+    // Attach to the presence stream before firing so the broadcaster is wired.
+    const presence = (
+      spectrum as unknown as { presence: AsyncIterable<unknown> }
+    ).presence[Symbol.asyncIterator]();
+    const firstPresence = presence.next();
+
+    let handlerCalls = 0;
+    const result = await spectrum.webhook(
+      {
+        headers: {},
+        body: encodeEvent(
+          PRESENCE_PLATFORM,
+          JSON.stringify({ type: "presence", user: "alice" })
+        ),
+      },
+      () => {
+        handlerCalls += 1;
+      }
+    );
+    expect(result.status).toBe(200);
+
+    const event = await firstPresence;
+    expect(event.done).toBe(false);
+    expect(event.value).toEqual({
+      user: "alice",
+      online: true,
+      platform: PRESENCE_PLATFORM,
+    });
+    // The event went to the channel, NOT the (messages-only) webhook handler.
+    expect(handlerCalls).toBe(0);
+
+    await presence.return?.();
+    await spectrum.stop();
+  });
+
+  it("treats fusorEvent('messages', record) like a bare record", async () => {
+    const spectrum = await Spectrum({
+      ...baseConfig,
+      providers: [makePresence().config({})],
+    });
+    const received: Message[] = [];
+    const { promise: finished, resolve: done } = Promise.withResolvers<void>();
+
+    const result = await spectrum.webhook(
+      {
+        headers: {},
+        body: encodeEvent(
+          PRESENCE_PLATFORM,
+          JSON.stringify({ type: "via-messages", text: "hi" })
+        ),
+      },
+      (_space, message) => {
+        received.push(message);
+        done();
+      }
+    );
+    await finished;
+
+    expect(result.status).toBe(200);
+    expect(received).toHaveLength(1);
+    expect(received.at(0)?.content).toEqual({ type: "text", text: "hi" });
+
+    await spectrum.stop();
+  });
+
+  it("drops an undeclared event channel without delivering to the handler", async () => {
+    const spectrum = await Spectrum({
+      ...baseConfig,
+      providers: [makePresence().config({})],
+    });
+    let handlerCalls = 0;
+    const result = await spectrum.webhook(
+      {
+        headers: {},
+        body: encodeEvent(
+          PRESENCE_PLATFORM,
+          JSON.stringify({ type: "undeclared" })
+        ),
+      },
+      () => {
+        handlerCalls += 1;
+      }
+    );
+    // Graceful: a 200 reply and nothing delivered to the message handler.
+    expect(result.status).toBe(200);
+    await new Promise((resolve) => {
+      setTimeout(resolve, NO_MESSAGE_WAIT_MS);
+    });
+    expect(handlerCalls).toBe(0);
+
+    await spectrum.stop();
   });
 });

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -38,6 +38,7 @@ export { type Voice, voice } from "./content/voice";
 export { Emoji, type EmojiKey } from "./emoji";
 export type {
   FusorClient,
+  FusorEvent,
   FusorMessages,
   FusorMessagesCtx,
   FusorMessagesReturn,
@@ -49,8 +50,8 @@ export type {
   WebhookRawRequest,
   WebhookRawResult,
 } from "./fusor";
-export { fusor, isFusorClient } from "./fusor";
-export { defineFusorPlatform, definePlatform } from "./platform/define";
+export { fusor, fusorEvent, isFusorClient, isFusorEvent } from "./fusor";
+export { definePlatform } from "./platform/define";
 export type {
   AnyPlatformDef,
   EventProducer,

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -1,6 +1,5 @@
 import { withSpan } from "@photon-ai/otel";
 import type z from "zod";
-import type { Content } from "../content/types";
 import type { FusorClient, FusorMessages } from "../fusor/types";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
@@ -28,7 +27,6 @@ import type {
   PlatformUser,
   PlatformWiseActionKey,
   ProviderMessage,
-  ProviderMessageRecord,
   SpaceActionFn,
   SpectrumLike,
 } from "./types";
@@ -252,19 +250,27 @@ function createPlatformInstance<
   const eventProperties: Record<string, AsyncIterable<unknown>> = {};
   const customEvents = def.events ?? {};
   for (const eventName of Object.keys(customEvents)) {
-    const producer = customEvents[eventName] as
-      | ((ctx: {
-          client: unknown;
-          config: unknown;
-          store: Store;
-        }) => AsyncIterable<unknown>)
-      | undefined;
-    if (producer) {
+    const declared = customEvents[eventName];
+    if (typeof declared === "function") {
+      // Regular platform: a producer driven by the long-lived client.
+      const producer = declared as (ctx: {
+        client: unknown;
+        config: unknown;
+        store: Store;
+      }) => AsyncIterable<unknown>;
       eventProperties[eventName] = producer({
         client: runtime.client,
         config: runtime.config,
         store: runtime.store,
       });
+      continue;
+    }
+    // Fusor platform: the channel is a Zod schema; its data arrives via the
+    // `messages` handler returning `fusorEvent(eventName, data)`, buffered on a
+    // per-channel queue that the runtime exposes as a fanout subscription.
+    const fusorEvents = runtime.subscribeEvent?.(eventName);
+    if (fusorEvents) {
+      eventProperties[eventName] = fusorEvents;
     }
   }
 
@@ -311,6 +317,30 @@ function createPlatformInstance<
   ) as PlatformInstance<Def>;
 }
 
+// `definePlatform` has two call shapes, expressed as overloads:
+//
+// 1. **Fusor mode** — `lifecycle.createClient` returns `fusor(name, verify)`
+//    (a branded `FusorClient<TPayload>`). There is no long-lived SDK client;
+//    `messages` runs once per inbound webhook against an already-verified
+//    payload, returning the message(s) to emit on `spectrum.messages` (and
+//    optionally calling `respond(reply)` to shape the HTTP reply to fusor).
+// 2. **Regular mode** — `createClient` returns a normal SDK client and
+//    `messages` is a long-lived `EventProducer` (async-iterable) stream.
+//
+// Overloads (not one conditional signature): switching `messages`'s shape on
+// the resolved `_Client` via a conditional type breaks TS contextual typing of
+// `({ client, config })` for regular providers — the conditional collapses to
+// `unknown` before `_Client` resolves. Two concrete signatures sidestep that.
+//
+// The REGULAR overload is listed first. Overload resolution defers
+// context-sensitive (unannotated-param) arrows during applicability, so a def
+// whose `createClient` and `messages` are both inline arrows — every regular
+// provider — matches the first applicable overload (regular). A fusor provider
+// opts in by giving `messages` a typed `FusorMessages` reference (e.g.
+// telegram's `handleMessages`): that's non-context-sensitive, checked in pass 1,
+// so it rejects the regular overload and selects the fusor one. The fusor input
+// reuses `PlatformDef` with `_Client = FusorClient<_TPayload>` (which fixes
+// every client position), overriding only `lifecycle`/`messages`.
 export function definePlatform<
   _Name extends string,
   _ConfigSchema extends z.ZodType<object>,
@@ -396,25 +426,105 @@ export function definePlatform<
     _Actions
   >
 > &
-  Readonly<_Static> {
-  type Def = PlatformDef<
+  Readonly<_Static>;
+
+export function definePlatform<
+  _Name extends string,
+  _ConfigSchema extends z.ZodType<object>,
+  _UserSchema extends z.ZodType<object> | undefined,
+  _SpaceSchema extends z.ZodType<object> | undefined,
+  _SpaceParamsSchema extends z.ZodType<object> | undefined,
+  _TPayload,
+  _ResolvedUser extends { id: string },
+  _ResolvedSpace extends { id: string },
+  _MessageSchema extends z.ZodType<object> | undefined = undefined,
+  // Fusor custom event channels: each value is a Zod schema; the key is the
+  // channel name. Surfaced as `spectrum.<channel>` and emitted from `messages`
+  // via `fusorEvent(channel, data)`. (`messages` is reserved — the core stream.)
+  _FusorEvents extends
+    | (Record<string, z.ZodType> & { messages?: never })
+    | undefined = undefined,
+  _Static extends Record<string, unknown> = Record<never, never>,
+  _SpaceActions extends Record<string, SpaceActionFn> = Record<never, never>,
+  _MessageActions extends Record<string, MessageActionFn> = Record<
+    never,
+    never
+  >,
+>(
+  name: _Name,
+  def: Omit<
+    PlatformDef<
+      _Name,
+      _ConfigSchema,
+      _UserSchema,
+      _SpaceSchema,
+      _SpaceParamsSchema,
+      FusorClient<_TPayload>,
+      _ResolvedUser,
+      _ResolvedSpace,
+      _MessageSchema,
+      ProviderMessage<
+        _ResolvedUser,
+        _ResolvedSpace,
+        _MessageSchema extends z.ZodType<object>
+          ? z.infer<_MessageSchema>
+          : Record<never, never>
+      >,
+      _FusorEvents,
+      _SpaceActions,
+      _MessageActions
+    >,
+    "lifecycle" | "name" | "messages"
+  > & {
+    lifecycle: {
+      createClient: (
+        ctx: CreateClientContext<_ConfigSchema>
+      ) => Promise<FusorClient<_TPayload>>;
+      destroyClient?: (ctx: {
+        client: FusorClient<_TPayload>;
+        store: Store;
+      }) => Promise<void>;
+    };
+    messages: FusorMessages<_TPayload>;
+    static?: _Static;
+  }
+): Platform<
+  PlatformDef<
     _Name,
     _ConfigSchema,
     _UserSchema,
     _SpaceSchema,
     _SpaceParamsSchema,
-    _Client,
+    FusorClient<_TPayload>,
     _ResolvedUser,
     _ResolvedSpace,
     _MessageSchema,
-    _MessageType,
-    _Events,
+    ProviderMessage<
+      _ResolvedUser,
+      _ResolvedSpace,
+      _MessageSchema extends z.ZodType<object>
+        ? z.infer<_MessageSchema>
+        : Record<never, never>
+    >,
+    _FusorEvents,
     _SpaceActions,
-    _MessageActions,
-    _Actions
-  >;
+    _MessageActions
+  >
+> &
+  Readonly<_Static>;
 
-  const fullDef = { name, ...def };
+// Implementation signature — intentionally loose so both overloads above are
+// assignable to it. Callers only ever see the overloads; the body erases to
+// `AnyPlatformDef` and the overload return types restore precision at the call
+// site. The runtime is identical for both modes: fusor's `messages`/`events`
+// are read off `__definition` by FusorCore, never invoked here.
+export function definePlatform(name: string, rawDef: unknown): unknown {
+  const def = rawDef as AnyPlatformDef & {
+    static?: Record<string, unknown>;
+  };
+  type Def = AnyPlatformDef;
+
+  const fullDef = { ...def, name };
 
   const platformCache = new WeakMap<SpectrumLike, PlatformInstance<Def>>();
 
@@ -429,7 +539,7 @@ export function definePlatform<
       throw new Error(`Platform "${name}" is not registered`);
     }
 
-    const instance = createPlatformInstance<Def, _Client, _ConfigSchema>(
+    const instance = createPlatformInstance<Def, unknown, z.ZodType<object>>(
       fullDef as Def & AnyPlatformDef,
       runtime
     );
@@ -468,7 +578,7 @@ export function definePlatform<
     throw new Error("Invalid input to platform narrowing function");
   }) as Platform<Def>;
 
-  narrower.config = (config?: z.input<_ConfigSchema>) => {
+  narrower.config = (config?: unknown) => {
     const resolvedConfig = config ?? {};
     return {
       __tag: "PlatformProviderConfig" as const,
@@ -496,158 +606,5 @@ export function definePlatform<
     Object.assign(narrower, def.static);
   }
 
-  return narrower as Platform<Def> & Readonly<_Static>;
-}
-
-// ---------------------------------------------------------------------------
-// defineFusorPlatform — fusor-mode entrypoint
-// ---------------------------------------------------------------------------
-//
-// Sibling to `definePlatform` for webhook-driven platforms whose
-// `lifecycle.createClient` returns `fusor(platform, verify)`. In fusor mode
-// there is no long-lived SDK client to talk to, and the `messages` callback
-// runs once per inbound webhook against an already-verified payload — its
-// return value becomes the message(s) emitted on `spectrum.messages`, and an
-// optional `respond(reply)` call customises the HTTP-shaped response sent
-// back to fusor.
-//
-// Why a separate function (instead of overloading `definePlatform`):
-// switching `messages`'s shape based on the resolved type of `_Client` via a
-// conditional type breaks TS contextual typing of the `({ client, config })`
-// parameter for non-fusor providers (Slack/iMessage `_Client` is a union or
-// branded type; the conditional collapses to `unknown` before `_Client`
-// resolves). Keeping the two entrypoints separate sidesteps the inference
-// race and gives each call site clean parameter types.
-export function defineFusorPlatform<
-  _Name extends string,
-  _ConfigSchema extends z.ZodType<object>,
-  _UserSchema extends z.ZodType<object> | undefined,
-  _SpaceSchema extends z.ZodType<object> | undefined,
-  _SpaceParamsSchema extends z.ZodType<object> | undefined,
-  _TPayload,
-  _ResolvedUser extends { id: string },
-  _ResolvedSpace extends { id: string },
-  _MessageSchema extends z.ZodType<object> | undefined = undefined,
-  _Static extends Record<string, unknown> = Record<never, never>,
-  _SpaceActions extends Record<string, SpaceActionFn> = Record<never, never>,
-  _MessageActions extends Record<string, MessageActionFn> = Record<
-    never,
-    never
-  >,
->(
-  name: _Name,
-  def: {
-    config: _ConfigSchema;
-    lifecycle: {
-      createClient: (
-        ctx: CreateClientContext<_ConfigSchema>
-      ) => Promise<FusorClient<_TPayload>>;
-      destroyClient?: (ctx: {
-        client: FusorClient<_TPayload>;
-        store: Store;
-      }) => Promise<void>;
-    };
-    user: {
-      schema?: _UserSchema;
-      resolve: (_: {
-        input: { userID: string };
-        client: FusorClient<_TPayload>;
-        config: z.infer<_ConfigSchema>;
-        store: Store;
-      }) => Promise<_ResolvedUser>;
-    };
-    space: {
-      schema?: _SpaceSchema;
-      params?: _SpaceParamsSchema;
-      resolve: (_: {
-        input: {
-          users: (_ResolvedUser & { __platform: _Name })[];
-          params?: _SpaceParamsSchema extends z.ZodType<object>
-            ? z.infer<_SpaceParamsSchema>
-            : undefined;
-        };
-        client: FusorClient<_TPayload>;
-        config: z.infer<_ConfigSchema>;
-        store: Store;
-      }) => Promise<_ResolvedSpace>;
-      actions?: _SpaceActions;
-    };
-    message?: {
-      schema?: _MessageSchema;
-      actions?: _MessageActions;
-    };
-    messages: FusorMessages<_TPayload>;
-    send: (_: {
-      space: _ResolvedSpace & { id: string; __platform: _Name };
-      content: Content;
-      client: FusorClient<_TPayload>;
-      config: z.infer<_ConfigSchema>;
-      store: Store;
-    }) => Promise<ProviderMessageRecord | undefined>;
-    actions?: {
-      getMessage?: (_: {
-        space: _ResolvedSpace & { id: string; __platform: _Name };
-        messageId: string;
-        client: FusorClient<_TPayload>;
-        config: z.infer<_ConfigSchema>;
-        store: Store;
-      }) => Promise<unknown>;
-    };
-    static?: _Static;
-  }
-): Platform<
-  PlatformDef<
-    _Name,
-    _ConfigSchema,
-    _UserSchema,
-    _SpaceSchema,
-    _SpaceParamsSchema,
-    FusorClient<_TPayload>,
-    _ResolvedUser,
-    _ResolvedSpace,
-    _MessageSchema,
-    ProviderMessage<
-      _ResolvedUser,
-      _ResolvedSpace,
-      _MessageSchema extends z.ZodType<object>
-        ? z.infer<_MessageSchema>
-        : Record<never, never>
-    >,
-    undefined,
-    _SpaceActions,
-    _MessageActions
-  >
-> &
-  Readonly<_Static> {
-  // `messages` is typed as `FusorMessages<TPayload>` at the call-site, but the
-  // stored PlatformDef shape uses the unified `EventProducer<...>` type.
-  // FusorCore reads `messages` directly off `__definition` at runtime and
-  // invokes it with `{ payload, respond }`, so the cast is safe.
-  return definePlatform(
-    name,
-    def as unknown as Parameters<typeof definePlatform>[1]
-  ) as unknown as Platform<
-    PlatformDef<
-      _Name,
-      _ConfigSchema,
-      _UserSchema,
-      _SpaceSchema,
-      _SpaceParamsSchema,
-      FusorClient<_TPayload>,
-      _ResolvedUser,
-      _ResolvedSpace,
-      _MessageSchema,
-      ProviderMessage<
-        _ResolvedUser,
-        _ResolvedSpace,
-        _MessageSchema extends z.ZodType<object>
-          ? z.infer<_MessageSchema>
-          : Record<never, never>
-      >,
-      undefined,
-      _SpaceActions,
-      _MessageActions
-    >
-  > &
-    Readonly<_Static>;
+  return narrower as Platform<Def> & Record<string, unknown>;
 }

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -3,6 +3,7 @@ import type z from "zod";
 import type { FusorClient, FusorMessages } from "../fusor/types";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
+import type { ProjectData } from "../utils/cloud";
 import { UnsupportedError } from "../utils/errors";
 import { classifyIdentifier as classifySingle } from "../utils/identifier";
 import type { Store } from "../utils/store";
@@ -252,15 +253,19 @@ function createPlatformInstance<
   for (const eventName of Object.keys(customEvents)) {
     const declared = customEvents[eventName];
     if (typeof declared === "function") {
-      // Regular platform: a producer driven by the long-lived client.
+      // Regular platform: a producer driven by the long-lived client. Pass the
+      // full EventProducer context (incl. projectConfig) so an instance-level
+      // `platform.<event>` matches the top-level `spectrum.<event>` stream.
       const producer = declared as (ctx: {
         client: unknown;
         config: unknown;
+        projectConfig: ProjectData | undefined;
         store: Store;
       }) => AsyncIterable<unknown>;
       eventProperties[eventName] = producer({
         client: runtime.client,
         config: runtime.config,
+        projectConfig: runtime.projectConfig,
         store: runtime.store,
       });
       continue;
@@ -442,7 +447,7 @@ export function definePlatform<
   // channel name. Surfaced as `spectrum.<channel>` and emitted from `messages`
   // via `fusorEvent(channel, data)`. (`messages` is reserved — the core stream.)
   _FusorEvents extends
-    | (Record<string, z.ZodType> & { messages?: never })
+    | (Record<string, z.ZodType<object>> & { messages?: never })
     | undefined = undefined,
   _Static extends Record<string, unknown> = Record<never, never>,
   _SpaceActions extends Record<string, SpaceActionFn> = Record<never, never>,

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -191,9 +191,14 @@ export type SchemaMessage<
   MergeSchema<TSpaceSchema, ResolvedSpace>
 >;
 
-type InferEventPayload<T> = T extends (ctx: never) => AsyncIterable<infer P>
-  ? P
-  : never;
+// A custom event channel is declared either as a long-lived producer (regular
+// platforms) or — for fusor platforms — as a Zod schema whose inferred type is
+// the channel payload. Check the schema form first (a ZodType is not callable).
+type InferEventPayload<T> = T extends z.ZodType
+  ? z.infer<T>
+  : T extends (ctx: never) => AsyncIterable<infer P>
+    ? P
+    : never;
 
 // ---------------------------------------------------------------------------
 // Reserved names — event names that would collide with SpectrumInstance methods
@@ -250,7 +255,9 @@ export interface PlatformDef<
   _Events extends
     | (Record<
         string,
-        EventProducer<unknown, _Client, z.infer<_ConfigSchema>>
+        // Regular platforms supply a producer; fusor platforms declare a Zod
+        // schema (the channel payload type) and emit via `fusorEvent(...)`.
+        EventProducer<unknown, _Client, z.infer<_ConfigSchema>> | z.ZodType
       > & { messages?: never })
     | undefined = undefined,
   _SpaceActions extends Record<string, SpaceActionFn> = Record<never, never>,
@@ -433,10 +440,11 @@ export interface AnyPlatformDef {
   actions?: Record<string, InstanceActionFn>;
   config: z.ZodType<object>;
 
-  // Optional escape hatches.
+  // Optional escape hatches. A channel is either a producer (regular platforms)
+  // or a Zod schema declaring the payload of a fusor `fusorEvent(...)` channel.
   events?: {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard event
-    [key: string]: (ctx: any) => AsyncIterable<any>;
+    [key: string]: ((ctx: any) => AsyncIterable<any>) | z.ZodType;
   };
 
   lifecycle: {
@@ -794,6 +802,11 @@ export interface PlatformRuntime {
   config: unknown;
   definition: AnyPlatformDef;
   store: Store;
+  // Fanout subscription to a fusor custom event channel (declared as a schema
+  // under `events`). Returns `undefined` when the platform has no such channel
+  // (e.g. every regular, producer-based platform). Fed by the `messages`
+  // handler returning `fusorEvent(channel, data)`.
+  subscribeEvent?: (channel: string) => AsyncIterable<unknown> | undefined;
   subscribeMessages: () => ManagedStream<[Space, Message]>;
 }
 

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -256,8 +256,11 @@ export interface PlatformDef<
     | (Record<
         string,
         // Regular platforms supply a producer; fusor platforms declare a Zod
-        // schema (the channel payload type) and emit via `fusorEvent(...)`.
-        EventProducer<unknown, _Client, z.infer<_ConfigSchema>> | z.ZodType
+        // schema (the channel payload type) and emit via `fusorEvent(...)`. The
+        // schema must produce an object — event payloads are spread with a
+        // `platform` tag, so non-object outputs (e.g. `z.string()`) are invalid.
+        | EventProducer<unknown, _Client, z.infer<_ConfigSchema>>
+        | z.ZodType<object>
       > & { messages?: never })
     | undefined = undefined,
   _SpaceActions extends Record<string, SpaceActionFn> = Record<never, never>,
@@ -441,10 +444,11 @@ export interface AnyPlatformDef {
   config: z.ZodType<object>;
 
   // Optional escape hatches. A channel is either a producer (regular platforms)
-  // or a Zod schema declaring the payload of a fusor `fusorEvent(...)` channel.
+  // or an object-output Zod schema declaring the payload of a fusor
+  // `fusorEvent(...)` channel.
   events?: {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard event
-    [key: string]: ((ctx: any) => AsyncIterable<any>) | z.ZodType;
+    [key: string]: ((ctx: any) => AsyncIterable<any>) | z.ZodType<object>;
   };
 
   lifecycle: {
@@ -801,6 +805,10 @@ export interface PlatformRuntime {
   client: unknown;
   config: unknown;
   definition: AnyPlatformDef;
+  // Spectrum Cloud project metadata, so instance-level event producers receive
+  // the same `{ client, config, projectConfig, store }` context as the
+  // top-level `spectrum.<event>` streams (the `EventProducer` contract).
+  projectConfig: ProjectData | undefined;
   store: Store;
   // Fanout subscription to a fusor custom event channel (declared as a schema
   // under `events`). Returns `undefined` when the platform has no such channel

--- a/packages/spectrum-ts/src/providers/telegram/config.ts
+++ b/packages/spectrum-ts/src/providers/telegram/config.ts
@@ -3,7 +3,7 @@ import z from "zod";
 /**
  * The platform identifier — used for ALL THREE of:
  *
- * - the `defineFusorPlatform` name (so `message.platform` / `__platform` and
+ * - the `definePlatform` name (so `message.platform` / `__platform` and
  *   the `platformStates` key are this value),
  * - the `fusor(...)` routing key the handler is registered under, and
  * - the value Fusor tags inbound Telegram events with (`event.platform`).

--- a/packages/spectrum-ts/src/providers/telegram/index.ts
+++ b/packages/spectrum-ts/src/providers/telegram/index.ts
@@ -30,7 +30,10 @@ export const telegram = definePlatform(TELEGRAM_PLATFORM, {
       store,
     }): Promise<FusorClient<TelegramPayload>> => {
       const client = initClient(store, config);
-      return fusor<TelegramPayload>(TELEGRAM_PLATFORM, makeVerify(config, client));
+      return fusor<TelegramPayload>(
+        TELEGRAM_PLATFORM,
+        makeVerify(config, client)
+      );
     },
   },
   user: { resolve: resolveUser },

--- a/packages/spectrum-ts/src/providers/telegram/index.ts
+++ b/packages/spectrum-ts/src/providers/telegram/index.ts
@@ -1,5 +1,5 @@
-import { fusor } from "../../fusor";
-import { defineFusorPlatform } from "../../platform/define";
+import { type FusorClient, fusor } from "../../fusor";
+import { definePlatform } from "../../platform/define";
 import { initClient } from "./client";
 import { configSchema, TELEGRAM_PLATFORM } from "./config";
 import { handleMessages } from "./inbound/messages";
@@ -20,14 +20,17 @@ export type { TelegramConfig } from "./config";
  * Telegram Bot API over HTTP. Drop `telegram.config({...})` into
  * `Spectrum({ providers: [...] })`.
  */
-export const telegram = defineFusorPlatform(TELEGRAM_PLATFORM, {
+export const telegram = definePlatform(TELEGRAM_PLATFORM, {
   config: configSchema,
   lifecycle: {
-    createClient: ({ config, store }) => {
+    // Annotate the return so overload selection sees the `FusorClient` brand
+    // without deferring this (context-sensitive) arrow — picks the fusor overload.
+    createClient: async ({
+      config,
+      store,
+    }): Promise<FusorClient<TelegramPayload>> => {
       const client = initClient(store, config);
-      return Promise.resolve(
-        fusor<TelegramPayload>(TELEGRAM_PLATFORM, makeVerify(config, client))
-      );
+      return fusor<TelegramPayload>(TELEGRAM_PLATFORM, makeVerify(config, client));
     },
   },
   user: { resolve: resolveUser },

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -255,6 +255,14 @@ export async function Spectrum<
   // Per-platform message broadcasters (lazy: created on first subscribe).
   const messageBroadcasters = new Map<string, Broadcaster<[Space, Message]>>();
 
+  // Per-(platform, channel) fusor event queues (populated for fusor platforms
+  // that declare `events`). Fed by a `messages` handler returning
+  // `fusorEvent(channel, data)`; drained as `spectrum.<channel>`.
+  const fusorEventSources = new Map<string, Map<string, AsyncQueue<unknown>>>();
+
+  // Per-(platform, channel) event broadcasters (lazy: created on first subscribe).
+  const eventBroadcasters = new Map<string, Broadcaster<unknown>>();
+
   // Custom event streams keyed by event name
   const customEventStreams = new Map<string, ManagedStream<unknown>>();
 
@@ -399,6 +407,33 @@ export async function Spectrum<
     return broadcaster;
   };
 
+  // Broadcast a fusor platform's per-channel event queue so both the
+  // spectrum-level `spectrum.<channel>` stream and the instance-level
+  // `platform.<channel>` property can consume it independently. Returns
+  // undefined when the platform declared no such channel (every regular
+  // platform), so callers fall back to the producer path.
+  const getOrCreateEventBroadcast = (
+    platform: string,
+    channel: string
+  ): Broadcaster<unknown> | undefined => {
+    const queue = fusorEventSources.get(platform)?.get(channel);
+    if (!queue) {
+      return;
+    }
+    if (stopped) {
+      throw new Error(
+        `Spectrum instance has been stopped; cannot subscribe to "${platform}" event "${channel}"`
+      );
+    }
+    const key = `${platform} ${channel}`;
+    let broadcaster = eventBroadcasters.get(key);
+    if (!broadcaster) {
+      broadcaster = broadcast(adaptIterable(queue.iterable));
+      eventBroadcasters.set(key, broadcaster);
+    }
+    return broadcaster;
+  };
+
   // Initialize all provider clients eagerly. Each runtime exposes
   // `subscribeMessages()` that returns a fresh fanout consumer of the
   // platform's single upstream message stream.
@@ -440,6 +475,12 @@ export async function Spectrum<
           ...state,
           subscribeMessages: () =>
             getOrCreateMessageBroadcast(state).subscribe(),
+          // Fanout subscription to a fusor event channel. Returns undefined for
+          // regular platforms (no per-channel queue) — callers fall back to the
+          // producer path. Resolved lazily, after the fusor bootstrap below has
+          // created the per-(platform, channel) queues.
+          subscribeEvent: (channel: string) =>
+            getOrCreateEventBroadcast(def.name, channel)?.subscribe(),
         });
       }
     }
@@ -472,6 +513,20 @@ export async function Spectrum<
       const userMessages = runtime.definition
         .messages as unknown as FusorMessages<unknown>;
 
+      // One queue per declared event channel (schema-valued `events` keys).
+      // `pushEvent` routes a `fusorEvent(channel, data)` here; an undeclared
+      // channel (a typo in the handler) is warned and dropped rather than
+      // silently lost.
+      const declaredEvents = (runtime.definition.events ?? {}) as Record<
+        string,
+        unknown
+      >;
+      const eventQueues = new Map<string, AsyncQueue<unknown>>();
+      for (const channel of Object.keys(declaredEvents)) {
+        eventQueues.set(channel, createAsyncQueue<unknown>());
+      }
+      fusorEventSources.set(name, eventQueues);
+
       const handler: RegisteredFusorHandler = {
         verify: client.verify,
         messages: async (ctx: {
@@ -479,6 +534,17 @@ export async function Spectrum<
           respond: (reply: FusorReply) => void;
         }): Promise<FusorMessagesReturn> => userMessages(ctx),
         pushMessage: (record) => queue.push(record),
+        pushEvent: (channel, data) => {
+          const eventQueue = eventQueues.get(channel);
+          if (!eventQueue) {
+            lifecycleLog.warn(
+              `spectrum: fusorEvent("${channel}", …) names a channel not declared in "${name}".events; dropping`,
+              { platform: name, channel }
+            );
+            return;
+          }
+          eventQueue.push(data);
+        },
       };
       fusorCore.register(client.platform, handler);
     }
@@ -542,24 +608,28 @@ export async function Spectrum<
       const providerStreams: ManagedStream<unknown>[] = [];
       for (const state of platformStates.values()) {
         const { client, config, definition, store } = state;
-        const producer = definition.events?.[eventName] as
-          | ((ctx: {
+
+        // Resolve this platform's raw source for `eventName`: a fusor platform's
+        // per-channel fanout (declared as a schema, fed by `fusorEvent(...)`) or
+        // a regular platform's producer. Skip platforms that have neither.
+        let source: AsyncIterable<unknown> | undefined =
+          state.subscribeEvent?.(eventName);
+        if (!source) {
+          const producer = definition.events?.[eventName];
+          if (typeof producer !== "function") {
+            continue;
+          }
+          source = (
+            producer as (ctx: {
               client: unknown;
               config: unknown;
               projectConfig: ProjectData | undefined;
               store: Store;
-            }) => AsyncIterable<unknown>)
-          | undefined;
-        if (!producer) {
-          continue;
+            }) => AsyncIterable<unknown>
+          )({ client, config, projectConfig, store });
         }
 
-        const providerEvents = producer({
-          client,
-          config,
-          projectConfig,
-          store,
-        });
+        const providerEvents = source;
         const annotatePlatform = async function* (): AsyncIterable<unknown> {
           for await (const value of providerEvents) {
             const annotated = await withSpan(
@@ -598,6 +668,22 @@ export async function Spectrum<
 
   const messagesStream = createMessagesStream();
 
+  // Close + drop every fusor queue (per-platform message queues and
+  // per-(platform, channel) event queues). Extracted from stopOnce to keep its
+  // cognitive complexity in check.
+  const closeFusorSources = () => {
+    for (const queue of fusorMessageSources.values()) {
+      queue.close();
+    }
+    fusorMessageSources.clear();
+    for (const queues of fusorEventSources.values()) {
+      for (const queue of queues.values()) {
+        queue.close();
+      }
+    }
+    fusorEventSources.clear();
+  };
+
   const stopOnce = async () => {
     if (stopped) {
       return;
@@ -610,6 +696,9 @@ export async function Spectrum<
         eventStream.close()
       ),
       ...Array.from(messageBroadcasters.values(), (broadcaster) =>
+        broadcaster.close()
+      ),
+      ...Array.from(eventBroadcasters.values(), (broadcaster) =>
         broadcaster.close()
       ),
     ];
@@ -635,10 +724,7 @@ export async function Spectrum<
         lifecycleLog.warn("fusor core close failed", { error });
       });
       fusorCloseMs = Math.round(performance.now() - fusorCloseStart);
-      for (const queue of fusorMessageSources.values()) {
-        queue.close();
-      }
-      fusorMessageSources.clear();
+      closeFusorSources();
     }
 
     // Phase 3: destroy clients
@@ -668,6 +754,7 @@ export async function Spectrum<
 
     customEventStreams.clear();
     messageBroadcasters.clear();
+    eventBroadcasters.clear();
     platformStates.clear();
     lifecycleLog.info("Spectrum stopped", {
       providers: providerNames,

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -473,6 +473,7 @@ export async function Spectrum<
 
         platformStates.set(def.name, {
           ...state,
+          projectConfig,
           subscribeMessages: () =>
             getOrCreateMessageBroadcast(state).subscribe(),
           // Fanout subscription to a fusor event channel. Returns undefined for


### PR DESCRIPTION
## Summary

- **Custom event channels for fusor providers (`fusorEvent`).** A fusor provider has no long-lived client to stream non-message signals (presence, read receipts, typing, reactions) from. It can now **declare** each channel as a Zod schema under `events` and **emit** per webhook by returning `fusorEvent(channel, data)` from its `messages` handler. Channels surface as flat async-iterables on the app (`app.presence`, `app.readReceipt`, …), unified across every provider that declares the same channel, and flow on **both** transports (gRPC stream + `app.webhook()`).
- **`defineFusorPlatform` is gone — merged into `definePlatform`.** There is now a single overloaded `definePlatform`: the regular overload is tried first, and a provider opts into *fusor mode* by giving `messages` a typed `FusorMessages<…>` reference (which is non-context-sensitive, so overload resolution selects the fusor overload). This removes a parallel ~140-line entrypoint that duplicated the whole `PlatformDef` shape.
- **Routing is centralized.** `FusorCore` now routes each handler return value: a bare `ProviderMessageRecord` (or `fusorEvent("messages", record)`) goes to `app.messages` / the webhook handler; `fusorEvent("<channel>", data)` goes to its per-channel queue. An undeclared channel name is **logged and dropped**, never silently lost.

## Usage

Authoring — declare channels under `events`, emit from `messages`:

```typescript
import { definePlatform, fusor, fusorEvent, type FusorMessages, type FusorClient } from "spectrum-ts";
import { z } from "zod";

const presenceSchema = z.object({ user: z.string(), online: z.boolean() });

// MUST be a typed `FusorMessages<…>` reference (not an inline arrow) so overload
// resolution selects fusor mode.
const messages: FusorMessages<MyPayload> = ({ payload }) => {
  if (payload.kind === "presence") {
    return fusorEvent("presence", { user: payload.user, online: true });
  }
  return { id: payload.id, content: payload.content, sender, space }; // → app.messages
};

export const myProvider = definePlatform("myplatform", {
  config: z.object({ /* … */ }),
  lifecycle: {
    createClient: ({ config }): Promise<FusorClient<MyPayload>> =>
      Promise.resolve(fusor("myplatform", makeVerify(config))),
  },
  user: { /* … */ },
  space: { /* … */ },
  events: { presence: presenceSchema }, // ← channel declaration
  messages,
  send,
});
```

Consuming — each event is the channel payload plus a `platform` tag:

```typescript
for await (const presence of app.presence) {
  // { user: string; online: boolean; platform: "myplatform" }
}
```

Routing table for a `messages` return value:

| Return | Goes to |
| --- | --- |
| bare `ProviderMessageRecord` (or array) | `app.messages` / webhook handler |
| `fusorEvent("messages", record)` | identical to the bare record |
| `fusorEvent("presence", data)` | the `presence` channel (`app.presence`) |
| `fusorEvent("<undeclared>", data)` | logged with a warning, dropped |

> Custom events go to the channel stream **only** — never to the `app.webhook()` handler, which is messages-only.

## Changes

| File | Change |
| --- | --- |
| `src/fusor/event.ts` | **New.** `fusorEvent(name, data)` factory, `FusorEvent` branded type, `isFusorEvent` guard, and the reserved `FUSOR_MESSAGES_CHANNEL` (`"messages"`). |
| `src/fusor/core.ts` | New `routeHandlerResult()` splits handler output between the message sink and per-channel `pushEvent`; `RegisteredFusorHandler` gains `pushEvent(channel, data)`. |
| `src/fusor/types.ts` | `FusorMessagesReturn` widened to accept `FusorEvent` (and mixed arrays). |
| `src/fusor/index.ts` | Re-export `fusorEvent` / `FusorEvent` / `isFusorEvent`. |
| `src/platform/define.ts` | Remove `defineFusorPlatform`; add the fusor overload of `definePlatform`; loose implementation signature; schema-valued event channels feed `runtime.subscribeEvent`. |
| `src/platform/types.ts` | `events` values may be a `z.ZodType` (fusor) or a producer (regular); `InferEventPayload` checks the schema form first; `PlatformRuntime.subscribeEvent?`. |
| `src/spectrum.ts` | Per-(platform, channel) `AsyncQueue` + lazy `Broadcaster`; bootstrap wires `pushEvent`; `getOrCreateEventBroadcast`; `closeFusorSources()` extracted for teardown. |
| `src/index.ts` | Public exports: `fusorEvent`, `isFusorEvent`, `FusorEvent`; drop `defineFusorPlatform`. |
| `src/providers/telegram/{index,config}.ts` | Migrate Telegram from `defineFusorPlatform` to `definePlatform` (annotated `createClient` return picks the fusor overload). |
| `scripts/generate-manifest.ts` | Manifest regex matches `definePlatform` only (no more `defineFusorPlatform`). |
| `biome.jsonc` | Allow `fusor/index.ts` as a re-export barrel. |
| `docs/fusor.md` | New "Custom event channels (`fusorEvent`)" section; references updated from `defineFusorPlatform` to the `definePlatform` fusor overload. |
| `src/fusor/webhook.test.ts` | Migrate existing Slack fixture to `definePlatform` + typed `FusorMessages`; add a `fusor events` suite covering channel routing, `fusorEvent("messages", …)` parity, and undeclared-channel drop. |

## Test plan

- [ ] `bun test packages/spectrum-ts/src/fusor/webhook.test.ts` — new `fusor events` suite passes (channel routing, messages-channel parity, undeclared-channel drop) alongside the migrated Slack suite.
- [ ] `bun x ultracite check` — clean (includes the `telegram/index.ts` line-wrap fix).
- [ ] `bun run build` / typecheck — both `definePlatform` overloads resolve; Telegram selects the fusor overload via its annotated `createClient` return.
- [ ] Manifest generation still resolves the Telegram routing key from `definePlatform`.

> ⚠️ The `style(telegram): …` commit is **unsigned** — the local 1Password SSH signing agent failed (`failed to fill whole buffer`). Re-sign/amend if branch protection requires signed commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783456670&installation_id=127326493&pr_number=106&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F106&signature=76b1b5ff614a95692f1a6e7ccb11ea5d5a51b89b954228319d6267f04b798aa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom Fusor event channels with typed routing and a branded event construct; events can be routed to messages or to channel-specific handlers.

* **Documentation**
  * Updated Fusor docs to consolidate provider authoring via a single platform API and to document custom event channels and typing rules.

* **Tests**
  * Added tests covering fusor event routing, typed payloads, messages routing, and undeclared-channel behavior.

* **Chores**
  * Updated configuration and export surface to include new Fusor event support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->