### PR TITLE
feat(spectrum-ts): add streamText content type with streaming iMessage delivery

### DIFF
--- a/packages/spectrum-ts/src/content/stream-text.ts
+++ b/packages/spectrum-ts/src/content/stream-text.ts
@@ -1,0 +1,289 @@
+import z from "zod";
+import type { ContentBuilder } from "./types";
+
+/**
+ * Maps one chunk emitted by a stream to the incremental text it carries.
+ * Return a string to emit, or `null`/`undefined` to skip the chunk (e.g. for
+ * control events that carry no text).
+ */
+export type DeltaExtractor<T> = (chunk: T) => string | null | undefined;
+
+/**
+ * Anything `streamText()` accepts as a source. The builder normalizes all of
+ * these to an internal `AsyncIterable<string>` of text deltas:
+ *
+ * - the Vercel AI SDK `streamText()` result (its `.textStream` is picked up
+ *   automatically — pass either the whole result or `.textStream` directly),
+ * - a raw `AsyncIterable<T>` (e.g. an OpenAI / Anthropic streaming response),
+ * - a raw `ReadableStream<T>` of chunks.
+ */
+export type StreamTextSource<T = unknown> =
+  | { textStream: AsyncIterable<string> | ReadableStream<string> }
+  | AsyncIterable<T>
+  | ReadableStream<T>;
+
+export interface StreamTextOptions<T = unknown> {
+  /**
+   * Map each chunk to its incremental text. Omit to rely on built-in
+   * auto-detection of the common SDK shapes (OpenAI chat/responses, Anthropic
+   * messages, AI SDK text streams, and plain strings).
+   */
+  extract?: DeltaExtractor<T>;
+  /** Characters to buffer before sending the first message. Driver knob. */
+  firstChunkChars?: number;
+  /** Hard cap on the total number of edits applied. Driver knob. */
+  maxEdits?: number;
+  /** Minimum delay between in-place edits, in ms. Provider-driver knob. */
+  throttleMs?: number;
+}
+
+export const streamTextSchema = z.object({
+  type: z.literal("streamText"),
+  // A single-consumption producer of normalized text deltas. The builder
+  // closes over the normalized source; the platform driver calls it once.
+  // Kept opaque to Zod via `z.custom` (same approach as `attachment.read`).
+  stream: z.custom<() => AsyncIterable<string>>(
+    (v) => typeof v === "function",
+    {
+      message:
+        "streamText.stream must be a function returning AsyncIterable<string>",
+    }
+  ),
+  // `throttleMs: 0` is allowed and means "edit on every delta" (no throttle).
+  throttleMs: z.number().int().nonnegative().optional(),
+  firstChunkChars: z.number().int().positive().optional(),
+  maxEdits: z.number().int().positive().optional(),
+});
+
+export type StreamText = z.infer<typeof streamTextSchema>;
+
+// `string` = a text delta to emit, `null` = a recognized chunk that carries no
+// text (skip it), `undefined` = an unrecognized shape (try the next extractor).
+type ExtractResult = string | null | undefined;
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+// Anthropic / streaming control events that carry no text and should be skipped
+// rather than treated as an error.
+const SKIP_EVENT_TYPES: ReadonlySet<string> = new Set([
+  "message_start",
+  "message_delta",
+  "message_stop",
+  "content_block_start",
+  "content_block_stop",
+  "ping",
+]);
+
+// OpenAI `responses` streaming. The stream interleaves the text delta event
+// (`response.output_text.delta`) with many lifecycle events (`response.created`,
+// `response.output_text.done`, …) — recognize the whole `response.*` family so
+// the raw stream can be passed straight in, emitting only the text deltas.
+const fromOpenAIResponses = (obj: Record<string, unknown>): ExtractResult => {
+  const type = obj.type;
+  if (typeof type !== "string" || !type.startsWith("response.")) {
+    return;
+  }
+  if (type === "response.output_text.delta" && typeof obj.delta === "string") {
+    return obj.delta;
+  }
+  return null; // other response.* lifecycle events carry no plain text
+};
+
+// Anthropic raw event: `{ type: "content_block_delta", delta: { type, text } }`.
+const fromAnthropicDelta = (obj: Record<string, unknown>): ExtractResult => {
+  if (obj.type !== "content_block_delta") {
+    return;
+  }
+  const delta = asRecord(obj.delta);
+  if (delta?.type === "text_delta" && typeof delta.text === "string") {
+    return delta.text;
+  }
+  // A non-text content_block_delta (e.g. an input_json_delta) — skip.
+  return null;
+};
+
+// AI SDK `fullStream` text part: `{ type: "text-delta", textDelta | text }`.
+const fromAiSdkPart = (obj: Record<string, unknown>): ExtractResult => {
+  if (obj.type !== "text-delta") {
+    return;
+  }
+  if (typeof obj.textDelta === "string") {
+    return obj.textDelta;
+  }
+  return typeof obj.text === "string" ? obj.text : null;
+};
+
+// OpenAI `chat.completions` chunk: `choices[0].delta.content` (string | null).
+const fromOpenAIChat = (obj: Record<string, unknown>): ExtractResult => {
+  if (!Array.isArray(obj.choices)) {
+    return;
+  }
+  const delta = asRecord(asRecord(obj.choices[0])?.delta);
+  const content = delta?.content;
+  // Recognized chat chunk — emit the text, or skip role-only / finish chunks.
+  return typeof content === "string" ? content : null;
+};
+
+const fromControlEvent = (obj: Record<string, unknown>): ExtractResult =>
+  typeof obj.type === "string" && SKIP_EVENT_TYPES.has(obj.type)
+    ? null
+    : undefined;
+
+const OBJECT_EXTRACTORS: ReadonlyArray<
+  (obj: Record<string, unknown>) => ExtractResult
+> = [
+  fromOpenAIResponses,
+  fromAnthropicDelta,
+  fromAiSdkPart,
+  fromOpenAIChat,
+  fromControlEvent,
+];
+
+/**
+ * Auto-detect the text delta in a chunk from a popular LLM SDK. Pass a custom
+ * `extract` to `streamText()` for any shape this doesn't recognize.
+ */
+const defaultExtract: DeltaExtractor<unknown> = (chunk) => {
+  if (typeof chunk === "string") {
+    return chunk;
+  }
+  const record = asRecord(chunk);
+  if (!record) {
+    throw new Error(
+      `streamText: cannot extract a text delta from a ${typeof chunk} chunk. Pass { extract } to map your stream's chunks to text.`
+    );
+  }
+  for (const extractor of OBJECT_EXTRACTORS) {
+    const result = extractor(record);
+    if (result !== undefined) {
+      return result;
+    }
+  }
+  throw new Error(
+    `streamText: unrecognized chunk shape (type=${String(record.type)}). Pass an { extract } function to map your provider's chunk to a text delta.`
+  );
+};
+
+const isReadableStream = (value: unknown): value is ReadableStream<unknown> =>
+  typeof (value as ReadableStream<unknown>)?.getReader === "function";
+
+const isAsyncIterable = (value: unknown): value is AsyncIterable<unknown> =>
+  typeof (value as AsyncIterable<unknown>)?.[Symbol.asyncIterator] ===
+  "function";
+
+async function* readableToAsync<T>(
+  source: ReadableStream<T>
+): AsyncIterable<T> {
+  // Prefer native async iteration when the runtime supports it; otherwise fall
+  // back to a manual reader loop, releasing the lock when done.
+  if (isAsyncIterable(source)) {
+    yield* source as AsyncIterable<T>;
+    return;
+  }
+  // Older runtimes: the async-iterable guard above narrows `source` to `never`
+  // here (its lib type is already async-iterable), so reassert the stream type.
+  const reader = (source as ReadableStream<T>).getReader();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        return;
+      }
+      yield value;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+const resolveChunkIterable = <T>(
+  source: StreamTextSource<T>
+): AsyncIterable<unknown> => {
+  const textStream = (source as { textStream?: unknown }).textStream;
+  if (textStream != null) {
+    if (isReadableStream(textStream)) {
+      return readableToAsync(textStream);
+    }
+    if (isAsyncIterable(textStream)) {
+      return textStream;
+    }
+    throw new Error(
+      "streamText: `.textStream` must be an AsyncIterable or a ReadableStream."
+    );
+  }
+  if (isReadableStream(source)) {
+    return readableToAsync(source);
+  }
+  if (isAsyncIterable(source)) {
+    return source;
+  }
+  throw new Error(
+    "streamText: source must be an AsyncIterable, a ReadableStream, or an object with a `.textStream` (e.g. the AI SDK streamText() result)."
+  );
+};
+
+const normalize = <T>(
+  source: StreamTextSource<T>,
+  options?: StreamTextOptions<T>
+): (() => AsyncIterable<string>) => {
+  const extract: DeltaExtractor<unknown> = options?.extract
+    ? (options.extract as DeltaExtractor<unknown>)
+    : defaultExtract;
+  let consumed = false;
+  return async function* normalized() {
+    if (consumed) {
+      throw new Error(
+        "streamText: this source has already been consumed — a stream can only be sent once."
+      );
+    }
+    consumed = true;
+    for await (const chunk of resolveChunkIterable(source)) {
+      const delta = extract(chunk);
+      if (delta) {
+        yield delta;
+      }
+    }
+  };
+};
+
+export const asStreamText = (input: {
+  stream: () => AsyncIterable<string>;
+  throttleMs?: number;
+  firstChunkChars?: number;
+  maxEdits?: number;
+}): StreamText =>
+  streamTextSchema.parse({
+    type: "streamText",
+    stream: input.stream,
+    throttleMs: input.throttleMs,
+    firstChunkChars: input.firstChunkChars,
+    maxEdits: input.maxEdits,
+  });
+
+/**
+ * Wrap a streaming LLM text response so it can be sent like any other content.
+ *
+ * Delivery is platform-specific — iMessage (remote) sends the first chunk as a
+ * real message and then edits it in place as more text arrives. Platforms that
+ * can't stream reject it (the send is warn-and-skipped).
+ *
+ * Accepts whatever the popular SDKs return; pass `options.extract` for any
+ * chunk shape the built-in detection doesn't recognize.
+ */
+export function streamText<T = unknown>(
+  source: StreamTextSource<T>,
+  options?: StreamTextOptions<T>
+): ContentBuilder {
+  return {
+    build: async () =>
+      asStreamText({
+        stream: normalize(source, options),
+        throttleMs: options?.throttleMs,
+        firstChunkChars: options?.firstChunkChars,
+        maxEdits: options?.maxEdits,
+      }),
+  };
+}

--- a/packages/spectrum-ts/src/content/stream-text.ts
+++ b/packages/spectrum-ts/src/content/stream-text.ts
@@ -29,12 +29,6 @@ export interface StreamTextOptions<T = unknown> {
    * messages, AI SDK text streams, and plain strings).
    */
   extract?: DeltaExtractor<T>;
-  /** Characters to buffer before sending the first message. Driver knob. */
-  firstChunkChars?: number;
-  /** Hard cap on the total number of edits applied. Driver knob. */
-  maxEdits?: number;
-  /** Minimum delay between in-place edits, in ms. Provider-driver knob. */
-  throttleMs?: number;
 }
 
 export const streamTextSchema = z.object({
@@ -49,10 +43,6 @@ export const streamTextSchema = z.object({
         "streamText.stream must be a function returning AsyncIterable<string>",
     }
   ),
-  // `throttleMs: 0` is allowed and means "edit on every delta" (no throttle).
-  throttleMs: z.number().int().nonnegative().optional(),
-  firstChunkChars: z.number().int().positive().optional(),
-  maxEdits: z.number().int().positive().optional(),
 });
 
 export type StreamText = z.infer<typeof streamTextSchema>;
@@ -251,17 +241,8 @@ const normalize = <T>(
 
 export const asStreamText = (input: {
   stream: () => AsyncIterable<string>;
-  throttleMs?: number;
-  firstChunkChars?: number;
-  maxEdits?: number;
 }): StreamText =>
-  streamTextSchema.parse({
-    type: "streamText",
-    stream: input.stream,
-    throttleMs: input.throttleMs,
-    firstChunkChars: input.firstChunkChars,
-    maxEdits: input.maxEdits,
-  });
+  streamTextSchema.parse({ type: "streamText", stream: input.stream });
 
 /**
  * Wrap a streaming LLM text response so it can be sent like any other content.
@@ -278,12 +259,6 @@ export function streamText<T = unknown>(
   options?: StreamTextOptions<T>
 ): ContentBuilder {
   return {
-    build: async () =>
-      asStreamText({
-        stream: normalize(source, options),
-        throttleMs: options?.throttleMs,
-        firstChunkChars: options?.firstChunkChars,
-        maxEdits: options?.maxEdits,
-      }),
+    build: async () => asStreamText({ stream: normalize(source, options) }),
   };
 }

--- a/packages/spectrum-ts/src/content/types.ts
+++ b/packages/spectrum-ts/src/content/types.ts
@@ -11,6 +11,7 @@ import { reactionSchema } from "./reaction";
 import { renameSchema } from "./rename";
 import { replySchema } from "./reply";
 import { richlinkSchema } from "./richlink";
+import { streamTextSchema } from "./stream-text";
 import { textSchema } from "./text";
 import { typingSchema } from "./typing";
 import { voiceSchema } from "./voice";
@@ -22,6 +23,7 @@ import { voiceSchema } from "./voice";
 // in their reject-lists, so the looser typing here is also correct.
 const baseContentSchemas = [
   textSchema,
+  streamTextSchema,
   customSchema,
   attachmentSchema,
   contactSchema,

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -31,6 +31,13 @@ export { type Rename, rename } from "./content/rename";
 export { type Reply, reply } from "./content/reply";
 export { resolveContents } from "./content/resolve";
 export { type Richlink, richlink } from "./content/richlink";
+export {
+  type DeltaExtractor,
+  type StreamText,
+  type StreamTextOptions,
+  type StreamTextSource,
+  streamText,
+} from "./content/stream-text";
 export { text } from "./content/text";
 export type { Content, ContentBuilder, ContentInput } from "./content/types";
 export { type Typing, typing } from "./content/typing";

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -5,6 +5,7 @@ import type { Attachment } from "../../content/attachment";
 import type { Avatar } from "../../content/avatar";
 import type { Edit } from "../../content/edit";
 import type { Rename } from "../../content/rename";
+import type { StreamText } from "../../content/stream-text";
 import { definePlatform } from "../../platform/define";
 import type { ProviderMessageRecord } from "../../platform/types";
 import type { Message } from "../../types/message";
@@ -48,6 +49,7 @@ import {
   replyToMessage as remoteReplyToMessage,
   send as remoteSend,
   sendCustomizedMiniApp as remoteSendCustomizedMiniApp,
+  sendStreamText as remoteSendStreamText,
   setBackground as remoteSetBackground,
   setDisplayName as remoteSetDisplayName,
   setIcon as remoteSetIcon,
@@ -95,6 +97,22 @@ const handleEdit = async (
   }
   const remote = clientForPhone(client, space.phone);
   await remoteEditMessage(remote, space.id, content.target.id, content.content);
+};
+
+const handleStreamText = async (
+  client: IMessageClient,
+  space: { id: string; phone: string },
+  content: StreamText
+): Promise<ProviderMessageRecord> => {
+  if (isLocal(client)) {
+    throw UnsupportedError.action(
+      "streamText",
+      "iMessage (local mode)",
+      "streaming text responses require remote iMessage"
+    );
+  }
+  const remote = clientForPhone(client, space.phone);
+  return await remoteSendStreamText(remote, space.id, content);
 };
 
 const handleBackground = async (
@@ -390,6 +408,9 @@ export const imessage = definePlatform("iMessage", {
     if (content.type === "edit") {
       await handleEdit(client, space, content);
       return;
+    }
+    if (content.type === "streamText") {
+      return await handleStreamText(client, space, content);
     }
     if (content.type === "rename") {
       await handleRename(client, space, content);

--- a/packages/spectrum-ts/src/providers/imessage/remote/api.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/api.ts
@@ -1,6 +1,7 @@
 import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
 import type { Avatar } from "../../../content/avatar";
 import type { Rename } from "../../../content/rename";
+import type { StreamText } from "../../../content/stream-text";
 import type { Content } from "../../../content/types";
 import type { ProviderMessageRecord } from "../../../platform/types";
 import type { ProjectData } from "../../../utils/cloud";
@@ -21,6 +22,7 @@ import {
   send as sendRemoteMessage,
 } from "./send";
 import { messages as remoteMessages } from "./stream";
+import { sendStreamText as sendRemoteStreamText } from "./stream-text";
 import {
   startTyping as startRemoteTyping,
   stopTyping as stopRemoteTyping,
@@ -83,6 +85,13 @@ export const send = async (
   content: Content
 ): Promise<ProviderMessageRecord> =>
   sendRemoteMessage(remote, spaceId, content);
+
+export const sendStreamText = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  content: StreamText
+): Promise<ProviderMessageRecord> =>
+  sendRemoteStreamText(remote, spaceId, content);
 
 export const replyToMessage = async (
   remote: AdvancedIMessage,

--- a/packages/spectrum-ts/src/providers/imessage/remote/stream-text.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/stream-text.ts
@@ -1,0 +1,103 @@
+import type {
+  AdvancedIMessage,
+  Message as SDKMessage,
+} from "@photon-ai/advanced-imessage";
+import type { StreamText } from "../../../content/stream-text";
+import { asText } from "../../../content/text";
+import type { ProviderMessageRecord } from "../../../platform/types";
+import { unsupportedRemoteContent } from "../shared/errors";
+import { toChatGuid, toMessageGuid } from "./ids";
+
+// iMessage's native edit replaces the whole message body, so each update sends
+// the full accumulated text. Edits are throttled to keep the round-trip rate
+// sane; the default is a balance between feeling live and not flooding the
+// chat. Callers tune via `streamText(source, { throttleMs })`.
+const DEFAULT_THROTTLE_MS = 1500;
+
+// iMessage caps a message at ~5 edits — the backend silently drops further
+// edits, which would otherwise strand the message on an intermediate chunk and
+// never show the complete text. Default the budget to that cap so we always
+// have room for the final flush; one edit is reserved for it (see below).
+// Callers raise/lower it via `streamText(source, { maxEdits })`.
+const DEFAULT_MAX_EDITS = 5;
+
+/**
+ * Deliver a `streamText` content by sending the first chunk as a real message
+ * and editing it in place as more text arrives. The stream materializes into a
+ * normal text message: the returned record carries `asText(fullText)` with the
+ * first send's id and timestamp.
+ */
+export const sendStreamText = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  content: StreamText
+): Promise<ProviderMessageRecord> => {
+  const chat = toChatGuid(spaceId);
+  const throttleMs = content.throttleMs ?? DEFAULT_THROTTLE_MS;
+  const maxEdits = content.maxEdits ?? DEFAULT_MAX_EDITS;
+  const { firstChunkChars } = content;
+
+  let sent: SDKMessage | undefined; // the first (and only) message we created
+  let buffer = ""; // text accumulated before the first send
+  let full = ""; // everything seen so far
+  let lastSentText = ""; // last text actually pushed to iMessage
+  let lastEditAt = 0;
+  let editCount = 0;
+
+  const flushEdit = async (text: string): Promise<void> => {
+    if (!sent || text === lastSentText) {
+      return; // nothing to send, or already up to date
+    }
+    await remote.messages.edit(chat, toMessageGuid(sent.guid), text);
+    lastSentText = text;
+    lastEditAt = Date.now();
+    editCount += 1;
+  };
+
+  for await (const delta of content.stream()) {
+    full += delta;
+
+    if (!sent) {
+      buffer += delta;
+      const ready = firstChunkChars
+        ? buffer.length >= firstChunkChars
+        : buffer.length > 0;
+      if (ready) {
+        sent = await remote.messages.sendText(chat, buffer);
+        lastSentText = buffer;
+        lastEditAt = Date.now();
+        buffer = "";
+      }
+      continue;
+    }
+
+    // Reserve one edit from the budget for the guaranteed final flush, so
+    // whatever text is still pending always lands on the last edit.
+    const withinBudget = editCount < maxEdits - 1;
+    if (withinBudget && Date.now() - lastEditAt >= throttleMs) {
+      await flushEdit(full);
+    }
+  }
+
+  if (!sent) {
+    if (full.length === 0) {
+      throw unsupportedRemoteContent(
+        "streamText",
+        "stream produced no text — nothing to send"
+      );
+    }
+    // The stream ended before reaching `firstChunkChars`; send what we have.
+    sent = await remote.messages.sendText(chat, full);
+    lastSentText = full;
+  }
+
+  // Always finish on the complete text (no-op if the last edit already had it).
+  await flushEdit(full);
+
+  return {
+    id: sent.guid,
+    content: asText(full),
+    space: { id: spaceId },
+    timestamp: sent.dateCreated,
+  };
+};

--- a/packages/spectrum-ts/src/providers/imessage/remote/stream-text.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/stream-text.ts
@@ -8,18 +8,21 @@ import type { ProviderMessageRecord } from "../../../platform/types";
 import { unsupportedRemoteContent } from "../shared/errors";
 import { toChatGuid, toMessageGuid } from "./ids";
 
-// iMessage's native edit replaces the whole message body, so each update sends
-// the full accumulated text. Edits are throttled to keep the round-trip rate
-// sane; the default is a balance between feeling live and not flooding the
-// chat. Callers tune via `streamText(source, { throttleMs })`.
-const DEFAULT_THROTTLE_MS = 1500;
+// Delivery pacing is fixed logic, not configurable. iMessage's native edit
+// replaces the whole message body, so each update sends the full accumulated
+// text. We can't know a stream's final length up front, so the gap between
+// edits grows exponentially: the first edit waits `INITIAL_THROTTLE_MS`, then
+// each subsequent one waits `BACKOFF_FACTOR`× longer. This spreads a fixed edit
+// budget across short and long streams alike — short streams update quickly,
+// long ones don't burn the budget in the opening seconds.
+const INITIAL_THROTTLE_MS = 1000;
+const BACKOFF_FACTOR = 2;
 
 // iMessage caps a message at ~5 edits — the backend silently drops further
 // edits, which would otherwise strand the message on an intermediate chunk and
-// never show the complete text. Default the budget to that cap so we always
-// have room for the final flush; one edit is reserved for it (see below).
-// Callers raise/lower it via `streamText(source, { maxEdits })`.
-const DEFAULT_MAX_EDITS = 5;
+// never show the complete text. We stay within that cap and reserve the last
+// edit for the final flush (see the budget check below).
+const MAX_EDITS = 5;
 
 /**
  * Deliver a `streamText` content by sending the first chunk as a real message
@@ -33,12 +36,8 @@ export const sendStreamText = async (
   content: StreamText
 ): Promise<ProviderMessageRecord> => {
   const chat = toChatGuid(spaceId);
-  const throttleMs = content.throttleMs ?? DEFAULT_THROTTLE_MS;
-  const maxEdits = content.maxEdits ?? DEFAULT_MAX_EDITS;
-  const { firstChunkChars } = content;
 
   let sent: SDKMessage | undefined; // the first (and only) message we created
-  let buffer = ""; // text accumulated before the first send
   let full = ""; // everything seen so far
   let lastSentText = ""; // last text actually pushed to iMessage
   let lastEditAt = 0;
@@ -58,37 +57,31 @@ export const sendStreamText = async (
     full += delta;
 
     if (!sent) {
-      buffer += delta;
-      const ready = firstChunkChars
-        ? buffer.length >= firstChunkChars
-        : buffer.length > 0;
-      if (ready) {
-        sent = await remote.messages.sendText(chat, buffer);
-        lastSentText = buffer;
-        lastEditAt = Date.now();
-        buffer = "";
-      }
+      // Send the first chunk straight away to get a message id to edit into.
+      sent = await remote.messages.sendText(chat, full);
+      lastSentText = full;
+      lastEditAt = Date.now();
       continue;
     }
 
-    // Reserve one edit from the budget for the guaranteed final flush, so
-    // whatever text is still pending always lands on the last edit.
-    const withinBudget = editCount < maxEdits - 1;
-    if (withinBudget && Date.now() - lastEditAt >= throttleMs) {
+    // Once only one edit of the budget remains, stop editing mid-stream and let
+    // the post-loop flush spend it — so the last edit always carries the full
+    // content (we wait for everything when it's our final chance).
+    const hasBudgetForInterimEdit = editCount < MAX_EDITS - 1;
+    // Exponential backoff: each edit waits longer than the previous one.
+    const requiredGap = INITIAL_THROTTLE_MS * BACKOFF_FACTOR ** editCount;
+    if (hasBudgetForInterimEdit && Date.now() - lastEditAt >= requiredGap) {
       await flushEdit(full);
     }
   }
 
   if (!sent) {
-    if (full.length === 0) {
-      throw unsupportedRemoteContent(
-        "streamText",
-        "stream produced no text — nothing to send"
-      );
-    }
-    // The stream ended before reaching `firstChunkChars`; send what we have.
-    sent = await remote.messages.sendText(chat, full);
-    lastSentText = full;
+    // Every non-empty delta sends immediately, so reaching here means the
+    // stream yielded no text at all.
+    throw unsupportedRemoteContent(
+      "streamText",
+      "stream produced no text — nothing to send"
+    );
   }
 
   // Always finish on the complete text (no-op if the last edit already had it).

--- a/packages/spectrum-ts/test/content/stream-text.test.ts
+++ b/packages/spectrum-ts/test/content/stream-text.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "bun:test";
+import {
+  type StreamText,
+  type StreamTextSource,
+  streamText,
+} from "@/content/stream-text";
+
+const UNRECOGNIZED_SHAPE = /unrecognized chunk shape/;
+const ALREADY_CONSUMED = /already been consumed/;
+
+async function* fromArray<T>(items: T[]): AsyncIterable<T> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+const readableOf = <T>(items: T[]): ReadableStream<T> =>
+  new ReadableStream<T>({
+    start(controller) {
+      for (const item of items) {
+        controller.enqueue(item);
+      }
+      controller.close();
+    },
+  });
+
+const drain = async (stream: AsyncIterable<string>): Promise<string[]> => {
+  const seen: string[] = [];
+  for await (const delta of stream) {
+    seen.push(delta);
+  }
+  return seen;
+};
+
+const collect = async (source: StreamTextSource): Promise<string[]> => {
+  const content = (await streamText(source).build()) as StreamText;
+  return drain(content.stream());
+};
+
+describe("streamText normalization", () => {
+  it("passes through a raw string async iterable", async () => {
+    expect(await collect(fromArray(["Hel", "lo"]))).toEqual(["Hel", "lo"]);
+  });
+
+  it("reads a ReadableStream of strings", async () => {
+    expect(await collect(readableOf(["a", "b", "c"]))).toEqual(["a", "b", "c"]);
+  });
+
+  it("picks up the AI SDK result's .textStream (async iterable)", async () => {
+    expect(await collect({ textStream: fromArray(["x", "y"]) })).toEqual([
+      "x",
+      "y",
+    ]);
+  });
+
+  it("picks up the AI SDK result's .textStream (ReadableStream)", async () => {
+    expect(await collect({ textStream: readableOf(["x", "y"]) })).toEqual([
+      "x",
+      "y",
+    ]);
+  });
+
+  it("extracts OpenAI chat.completions deltas and skips role/finish chunks", async () => {
+    const chunks = [
+      { choices: [{ delta: { role: "assistant" } }] },
+      { choices: [{ delta: { content: "Hel" } }] },
+      { choices: [{ delta: { content: "lo" } }] },
+      { choices: [{ delta: {}, finish_reason: "stop" }] },
+    ];
+    expect(await collect(fromArray(chunks))).toEqual(["Hel", "lo"]);
+  });
+
+  it("extracts OpenAI responses deltas and skips lifecycle events", async () => {
+    const events = [
+      { type: "response.created" },
+      { type: "response.output_text.delta", delta: "Hel" },
+      { type: "response.output_text.delta", delta: "lo" },
+      { type: "response.output_text.done" },
+      { type: "response.completed" },
+    ];
+    expect(await collect(fromArray(events))).toEqual(["Hel", "lo"]);
+  });
+
+  it("extracts Anthropic content_block_delta and skips control events", async () => {
+    const events = [
+      { type: "message_start" },
+      { type: "content_block_start" },
+      {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "Hel" },
+      },
+      { type: "ping" },
+      {
+        type: "content_block_delta",
+        delta: { type: "text_delta", text: "lo" },
+      },
+      { type: "content_block_stop" },
+      { type: "message_delta" },
+      { type: "message_stop" },
+    ];
+    expect(await collect(fromArray(events))).toEqual(["Hel", "lo"]);
+  });
+
+  it("uses a custom extract over the built-in detection", async () => {
+    const chunks = [{ piece: "Hel" }, { piece: "lo" }, { piece: null }];
+    const content = (await streamText(fromArray(chunks), {
+      extract: (chunk) => chunk.piece,
+    }).build()) as StreamText;
+    expect(await drain(content.stream())).toEqual(["Hel", "lo"]);
+  });
+
+  it("filters out empty-string deltas", async () => {
+    expect(await collect(fromArray(["a", "", "b"]))).toEqual(["a", "b"]);
+  });
+
+  it("throws a helpful error on an unrecognized chunk shape", async () => {
+    const content = (await streamText(
+      fromArray([{ mystery: 1 }])
+    ).build()) as StreamText;
+    await expect(drain(content.stream())).rejects.toThrow(UNRECOGNIZED_SHAPE);
+  });
+
+  it("throws when the source is consumed twice", async () => {
+    const content = (await streamText(
+      fromArray(["a", "b"])
+    ).build()) as StreamText;
+    await drain(content.stream());
+    await expect(drain(content.stream())).rejects.toThrow(ALREADY_CONSUMED);
+  });
+});

--- a/packages/spectrum-ts/test/providers/imessage/remote/stream-text.test.ts
+++ b/packages/spectrum-ts/test/providers/imessage/remote/stream-text.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, mock } from "bun:test";
+import type {
+  AdvancedIMessage,
+  Message as SDKMessage,
+} from "@photon-ai/advanced-imessage";
+import { IMessageSDK } from "@photon-ai/imessage-kit";
+import {
+  type StreamText,
+  type StreamTextOptions,
+  streamText,
+} from "@/content/stream-text";
+import { imessage } from "@/providers";
+import { sendStreamText } from "@/providers/imessage/remote/stream-text";
+import { UnsupportedError } from "@/utils/errors";
+
+const SENT_DATE = new Date(1_700_000_000_000);
+const BOOM = /boom/;
+const LOCAL_MODE = /local mode/;
+
+const makeRemote = () => {
+  const reply = {
+    guid: "msg-guid",
+    dateCreated: SENT_DATE,
+  } as unknown as SDKMessage;
+  const sendText = mock((_chat: string, _text: string) =>
+    Promise.resolve(reply)
+  );
+  const edit = mock((_chat: string, _guid: string, _text: string) =>
+    Promise.resolve(reply)
+  );
+  const remote = {
+    messages: { sendText, edit },
+  } as unknown as AdvancedIMessage;
+  return { remote, sendText, edit };
+};
+
+async function* fromArray(items: string[]): AsyncIterable<string> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+const content = async (
+  items: string[],
+  options?: StreamTextOptions
+): Promise<StreamText> =>
+  (await streamText(fromArray(items), options).build()) as StreamText;
+
+// `editArgs` → the new-text argument of each edit call, in order.
+const editArgs = (edit: ReturnType<typeof makeRemote>["edit"]): string[] =>
+  edit.mock.calls.map((call) => call[2]);
+
+describe("sendStreamText", () => {
+  it("sends the first delta then flushes the full text on completion", async () => {
+    const { remote, sendText, edit } = makeRemote();
+    const result = await sendStreamText(
+      remote,
+      "chat",
+      await content(["Hello", " ", "world"], { throttleMs: 10_000 })
+    );
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText.mock.calls[0]).toEqual(["chat", "Hello"]);
+    expect(edit).toHaveBeenCalledTimes(1);
+    expect(edit.mock.calls[0]).toEqual(["chat", "msg-guid", "Hello world"]);
+
+    expect(result.id).toBe("msg-guid");
+    expect(result.timestamp).toEqual(SENT_DATE);
+    expect(result.content).toEqual({ type: "text", text: "Hello world" });
+    expect(result.space).toEqual({ id: "chat" });
+  });
+
+  it("edits carry the cumulative full text (throttleMs: 0)", async () => {
+    const { remote, sendText, edit } = makeRemote();
+    await sendStreamText(
+      remote,
+      "chat",
+      await content(["a", "b", "c"], { throttleMs: 0 })
+    );
+
+    expect(sendText.mock.calls[0]).toEqual(["chat", "a"]);
+    expect(editArgs(edit)).toEqual(["ab", "abc"]);
+  });
+
+  it("buffers up to firstChunkChars before the first send", async () => {
+    const { remote, sendText, edit } = makeRemote();
+    await sendStreamText(
+      remote,
+      "chat",
+      await content(["a", "b", "c", "d"], {
+        firstChunkChars: 3,
+        throttleMs: 10_000,
+      })
+    );
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText.mock.calls[0]).toEqual(["chat", "abc"]);
+    expect(editArgs(edit)).toEqual(["abcd"]);
+  });
+
+  it("sends a single message and no edit when the stream ends below firstChunkChars", async () => {
+    const { remote, sendText, edit } = makeRemote();
+    const result = await sendStreamText(
+      remote,
+      "chat",
+      await content(["hi"], { firstChunkChars: 10 })
+    );
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText.mock.calls[0]).toEqual(["chat", "hi"]);
+    expect(edit).not.toHaveBeenCalled();
+    expect(result.content).toEqual({ type: "text", text: "hi" });
+  });
+
+  it("rejects with UnsupportedError when the stream is empty", async () => {
+    const { remote, sendText, edit } = makeRemote();
+    await expect(
+      sendStreamText(remote, "chat", await content([]))
+    ).rejects.toBeInstanceOf(UnsupportedError);
+    expect(sendText).not.toHaveBeenCalled();
+    expect(edit).not.toHaveBeenCalled();
+  });
+
+  it("propagates a mid-stream error after the first send", async () => {
+    async function* throwing(): AsyncIterable<string> {
+      yield "a";
+      throw new Error("boom");
+    }
+    const { remote, sendText, edit } = makeRemote();
+    const built = (await streamText(throwing()).build()) as StreamText;
+
+    await expect(sendStreamText(remote, "chat", built)).rejects.toThrow(BOOM);
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(edit).not.toHaveBeenCalled();
+  });
+
+  it("never exceeds maxEdits total edits", async () => {
+    const { remote, edit } = makeRemote();
+    await sendStreamText(
+      remote,
+      "chat",
+      await content(["a", "b", "c", "d", "e"], { throttleMs: 0, maxEdits: 3 })
+    );
+
+    expect(edit.mock.calls.length).toBeLessThanOrEqual(3);
+    // Final edit always carries the complete text regardless of the cap.
+    expect(editArgs(edit).at(-1)).toBe("abcde");
+  });
+
+  it("stays within the default edit budget and still lands the complete text", async () => {
+    const { remote, edit } = makeRemote();
+    const words = Array.from({ length: 20 }, (_, index) => `w${index} `);
+    await sendStreamText(
+      remote,
+      "chat",
+      // No maxEdits → the default cap applies; throttleMs 0 would otherwise
+      // try to edit on every delta and blow past iMessage's ~5-edit limit.
+      await content(words, { throttleMs: 0 })
+    );
+
+    expect(edit.mock.calls.length).toBeLessThanOrEqual(5);
+    expect(editArgs(edit).at(-1)).toBe(words.join(""));
+  });
+});
+
+describe("iMessage streamText local-mode rejection", () => {
+  it("throws UnsupportedError in local mode", async () => {
+    const localClient = Object.create(IMessageSDK.prototype) as IMessageSDK;
+    const send = imessage.config().__definition.send;
+
+    await expect(
+      send({
+        space: { id: "chat", phone: "p", type: "dm", __platform: "iMessage" },
+        content: await content(["hi"]),
+        client: localClient,
+      })
+    ).rejects.toThrow(LOCAL_MODE);
+  });
+});

--- a/packages/spectrum-ts/test/providers/imessage/remote/stream-text.test.ts
+++ b/packages/spectrum-ts/test/providers/imessage/remote/stream-text.test.ts
@@ -1,37 +1,42 @@
-import { describe, expect, it, mock } from "bun:test";
+import { afterEach, describe, expect, it, mock, setSystemTime } from "bun:test";
 import type {
   AdvancedIMessage,
   Message as SDKMessage,
 } from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
-import {
-  type StreamText,
-  type StreamTextOptions,
-  streamText,
-} from "@/content/stream-text";
-import { imessage } from "@/providers";
+import { type StreamText, streamText } from "@/content/stream-text";
+import { imessage } from "@/providers/imessage";
 import { sendStreamText } from "@/providers/imessage/remote/stream-text";
 import { UnsupportedError } from "@/utils/errors";
 
 const SENT_DATE = new Date(1_700_000_000_000);
-const BOOM = /boom/;
 const LOCAL_MODE = /local mode/;
+const BOOM = /boom/;
+
+// iMessage caps a message at ~5 edits; the driver stays within that budget.
+const MAX_EDITS = 5;
+
+afterEach(() => {
+  setSystemTime(); // restore the real clock after time-controlled tests
+});
 
 const makeRemote = () => {
   const reply = {
     guid: "msg-guid",
     dateCreated: SENT_DATE,
   } as unknown as SDKMessage;
+  const editTimes: number[] = [];
   const sendText = mock((_chat: string, _text: string) =>
     Promise.resolve(reply)
   );
-  const edit = mock((_chat: string, _guid: string, _text: string) =>
-    Promise.resolve(reply)
-  );
+  const edit = mock((_chat: string, _guid: string, _text: string) => {
+    editTimes.push(Date.now());
+    return Promise.resolve(reply);
+  });
   const remote = {
     messages: { sendText, edit },
   } as unknown as AdvancedIMessage;
-  return { remote, sendText, edit };
+  return { remote, sendText, edit, editTimes };
 };
 
 async function* fromArray(items: string[]): AsyncIterable<string> {
@@ -40,11 +45,22 @@ async function* fromArray(items: string[]): AsyncIterable<string> {
   }
 }
 
-const content = async (
-  items: string[],
-  options?: StreamTextOptions
-): Promise<StreamText> =>
-  (await streamText(fromArray(items), options).build()) as StreamText;
+// Advances the mocked system clock by `stepMs` before each delta, so the
+// driver's Date.now()-based backoff is fully deterministic.
+function timed(items: string[], stepMs: number): AsyncIterable<string> {
+  return (async function* timedGenerator() {
+    let now = 0;
+    setSystemTime(new Date(now));
+    for (const item of items) {
+      now += stepMs;
+      setSystemTime(new Date(now));
+      yield item;
+    }
+  })();
+}
+
+const build = async (source: AsyncIterable<string>): Promise<StreamText> =>
+  (await streamText(source).build()) as StreamText;
 
 // `editArgs` → the new-text argument of each edit call, in order.
 const editArgs = (edit: ReturnType<typeof makeRemote>["edit"]): string[] =>
@@ -52,11 +68,12 @@ const editArgs = (edit: ReturnType<typeof makeRemote>["edit"]): string[] =>
 
 describe("sendStreamText", () => {
   it("sends the first delta then flushes the full text on completion", async () => {
+    setSystemTime(new Date(0)); // freeze: no time passes, so no interim edits
     const { remote, sendText, edit } = makeRemote();
     const result = await sendStreamText(
       remote,
       "chat",
-      await content(["Hello", " ", "world"], { throttleMs: 10_000 })
+      await build(fromArray(["Hello", " ", "world"]))
     );
 
     expect(sendText).toHaveBeenCalledTimes(1);
@@ -70,40 +87,13 @@ describe("sendStreamText", () => {
     expect(result.space).toEqual({ id: "chat" });
   });
 
-  it("edits carry the cumulative full text (throttleMs: 0)", async () => {
-    const { remote, sendText, edit } = makeRemote();
-    await sendStreamText(
-      remote,
-      "chat",
-      await content(["a", "b", "c"], { throttleMs: 0 })
-    );
-
-    expect(sendText.mock.calls[0]).toEqual(["chat", "a"]);
-    expect(editArgs(edit)).toEqual(["ab", "abc"]);
-  });
-
-  it("buffers up to firstChunkChars before the first send", async () => {
-    const { remote, sendText, edit } = makeRemote();
-    await sendStreamText(
-      remote,
-      "chat",
-      await content(["a", "b", "c", "d"], {
-        firstChunkChars: 3,
-        throttleMs: 10_000,
-      })
-    );
-
-    expect(sendText).toHaveBeenCalledTimes(1);
-    expect(sendText.mock.calls[0]).toEqual(["chat", "abc"]);
-    expect(editArgs(edit)).toEqual(["abcd"]);
-  });
-
-  it("sends a single message and no edit when the stream ends below firstChunkChars", async () => {
+  it("sends a single message and no edit for a one-delta stream", async () => {
+    setSystemTime(new Date(0));
     const { remote, sendText, edit } = makeRemote();
     const result = await sendStreamText(
       remote,
       "chat",
-      await content(["hi"], { firstChunkChars: 10 })
+      await build(fromArray(["hi"]))
     );
 
     expect(sendText).toHaveBeenCalledTimes(1);
@@ -112,54 +102,59 @@ describe("sendStreamText", () => {
     expect(result.content).toEqual({ type: "text", text: "hi" });
   });
 
+  it("backs off, stays within the edit budget, and lands the complete text", async () => {
+    const { remote, sendText, edit, editTimes } = makeRemote();
+    // 40 tokens, one per simulated second. With backoff the interim edits land
+    // ~2s, 4s, 8s, 16s apart; everything after the budget is exhausted waits
+    // for the final flush.
+    const words = Array.from({ length: 40 }, (_, index) => `w${index} `);
+    await sendStreamText(remote, "chat", await build(timed(words, 1000)));
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+
+    // Stays within iMessage's edit cap.
+    expect(edit.mock.calls.length).toBeLessThanOrEqual(MAX_EDITS);
+
+    // Gaps between consecutive edits strictly grow (exponential backoff).
+    const gaps = editTimes
+      .slice(1)
+      .map((time, index) => time - (editTimes[index] as number));
+    for (let i = 1; i < gaps.length; i++) {
+      expect(gaps[i] as number).toBeGreaterThan(gaps[i - 1] as number);
+    }
+
+    // Each edit carries the cumulative text, and the last one is complete.
+    const texts = editArgs(edit);
+    for (let i = 1; i < texts.length; i++) {
+      expect((texts[i] as string).length).toBeGreaterThan(
+        (texts[i - 1] as string).length
+      );
+    }
+    expect(texts.at(-1)).toBe(words.join(""));
+  });
+
   it("rejects with UnsupportedError when the stream is empty", async () => {
     const { remote, sendText, edit } = makeRemote();
     await expect(
-      sendStreamText(remote, "chat", await content([]))
+      sendStreamText(remote, "chat", await build(fromArray([])))
     ).rejects.toBeInstanceOf(UnsupportedError);
     expect(sendText).not.toHaveBeenCalled();
     expect(edit).not.toHaveBeenCalled();
   });
 
   it("propagates a mid-stream error after the first send", async () => {
+    setSystemTime(new Date(0));
     async function* throwing(): AsyncIterable<string> {
       yield "a";
       throw new Error("boom");
     }
     const { remote, sendText, edit } = makeRemote();
-    const built = (await streamText(throwing()).build()) as StreamText;
 
-    await expect(sendStreamText(remote, "chat", built)).rejects.toThrow(BOOM);
+    await expect(
+      sendStreamText(remote, "chat", await build(throwing()))
+    ).rejects.toThrow(BOOM);
     expect(sendText).toHaveBeenCalledTimes(1);
     expect(edit).not.toHaveBeenCalled();
-  });
-
-  it("never exceeds maxEdits total edits", async () => {
-    const { remote, edit } = makeRemote();
-    await sendStreamText(
-      remote,
-      "chat",
-      await content(["a", "b", "c", "d", "e"], { throttleMs: 0, maxEdits: 3 })
-    );
-
-    expect(edit.mock.calls.length).toBeLessThanOrEqual(3);
-    // Final edit always carries the complete text regardless of the cap.
-    expect(editArgs(edit).at(-1)).toBe("abcde");
-  });
-
-  it("stays within the default edit budget and still lands the complete text", async () => {
-    const { remote, edit } = makeRemote();
-    const words = Array.from({ length: 20 }, (_, index) => `w${index} `);
-    await sendStreamText(
-      remote,
-      "chat",
-      // No maxEdits → the default cap applies; throttleMs 0 would otherwise
-      // try to edit on every delta and blow past iMessage's ~5-edit limit.
-      await content(words, { throttleMs: 0 })
-    );
-
-    expect(edit.mock.calls.length).toBeLessThanOrEqual(5);
-    expect(editArgs(edit).at(-1)).toBe(words.join(""));
   });
 });
 
@@ -171,7 +166,7 @@ describe("iMessage streamText local-mode rejection", () => {
     await expect(
       send({
         space: { id: "chat", phone: "p", type: "dm", __platform: "iMessage" },
-        content: await content(["hi"]),
+        content: await build(fromArray(["hi"])),
         client: localClient,
       })
     ).rejects.toThrow(LOCAL_MODE);


### PR DESCRIPTION
## Summary

- Adds a new `streamText()` content builder that wraps a streaming LLM response so it can be sent like any other Spectrum content.
- **Auto-detects text deltas** from the common SDK shapes out of the box — OpenAI `chat.completions`, OpenAI `responses`, Anthropic `messages`, the Vercel AI SDK (`.textStream` / `fullStream` `text-delta` parts), and plain strings. Lifecycle/control events that carry no text are skipped rather than erroring.
- **Normalizes any source** — an `AsyncIterable<T>`, a `ReadableStream<T>`, or an object with a `.textStream` — down to a single-consumption `AsyncIterable<string>` of deltas. A custom `{ extract }` function is the escape hatch for shapes the built-in detection doesn't recognize.
- **iMessage (remote) delivery**: sends the first chunk as a real message, then edits it in place as more text arrives. The result materializes into a normal text message (`asText(fullText)`) carrying the first send's id and timestamp.
- **Fixed exponential-backoff pacing** (no longer configurable): the gap between edits grows `INITIAL_THROTTLE_MS × BACKOFF_FACTOR^n`, staying within iMessage's ~5-edit cap and reserving the final edit for a full-text flush so the message always lands complete.
- Unsupported paths fail loudly/safely: iMessage **local mode** throws `UnsupportedError`, an empty stream throws `unsupportedRemoteContent`, and platforms that can't stream warn-and-skip.

## Usage

```typescript
import { streamText } from "spectrum-ts";

for await (const [space, message] of app.messages) {
  await space.responding(async () => {
    // Pass an AI SDK streamText() result, a raw OpenAI/Anthropic stream,
    // a ReadableStream, or any AsyncIterable<string>.
    await message.reply(streamText(llm.textStream));
  });
}

// Custom chunk shape? Map it yourself:
await space.send(
  streamText(myStream, { extract: (chunk) => chunk.piece })
);
```

## Changes

| File | Change |
|------|--------|
| `src/content/stream-text.ts` | **New.** `streamText()` builder, source normalization (AsyncIterable / ReadableStream / `.textStream`), and the default delta extractors for OpenAI/Anthropic/AI-SDK/string chunks. Enforces single consumption. |
| `src/content/types.ts` | Register `streamTextSchema` in the base content schema list. |
| `src/index.ts` | Export `streamText` and its `StreamText` / `StreamTextSource` / `StreamTextOptions` / `DeltaExtractor` types. |
| `src/providers/imessage/index.ts` | Route `streamText` content to the remote driver; throw `UnsupportedError` in local mode. |
| `src/providers/imessage/remote/api.ts` | Wire `sendStreamText` into the remote API surface. |
| `src/providers/imessage/remote/stream-text.ts` | **New.** Send-first-then-edit-in-place driver with fixed exponential-backoff pacing and the ~5-edit budget guard. |
| `test/content/stream-text.test.ts` | **New.** Normalization + auto-detection coverage (each SDK shape, custom `extract`, empty-delta filtering, unrecognized-shape error, double-consumption guard). |
| `test/providers/imessage/remote/stream-text.test.ts` | **New.** Driver coverage: first-send + final flush, single-delta no-op, backoff stays within budget and lands the full text, empty-stream rejection, mid-stream error propagation, local-mode rejection. |

## Test plan

- [x] `bun test test/content/stream-text.test.ts test/providers/imessage/remote/stream-text.test.ts` → **17 pass / 0 fail**
- [x] Edit pacing verified to stay within iMessage's ~5-edit cap with strictly growing gaps, and the last edit always carries the complete text
- [x] Empty stream and iMessage local mode both reject with the expected errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783574293&installation_id=127326493&pr_number=111&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F111&signature=6744895e35fa997220af9e56b9df64af613d1deea04ffd1e48c110c6f7ffb4b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced streaming text content support with automatic detection of multiple streaming input formats.
  * Integrated streaming text functionality into the iMessage provider for sending streamed messages with progressive updates.

* **Tests**
  * Added comprehensive test coverage for streaming text normalization and iMessage provider implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->