### PR TITLE
refactor(telegram): rebuild the provider on the generated `@photon-ai/telegram-ts` client

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Visit **[docs.photon.codes](https://docs.photon.codes)** to view the full docume
 |----------|---------|
 | iMessage | `spectrum-ts/providers/imessage` |
 | WhatsApp | `spectrum-ts/providers/whatsapp` |
+| Telegram | `spectrum-ts/providers/telegram` |
 | Terminal | `spectrum-ts/providers/terminal` |
 | Custom   | `definePlatform` from `spectrum-ts` |
 

--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "@photon-ai/otel": "^0.1.1",
         "@photon-ai/proto": "^0.2.4",
         "@photon-ai/slack": "^0.2.0",
+        "@photon-ai/telegram-ts": "10.0.0",
         "@photon-ai/whatsapp-business": "^0.1.1",
         "@repeaterjs/repeater": "^3.0.6",
         "better-grpc": "^0.3.2",
@@ -39,7 +40,6 @@
         "zod": "^4.2.1",
       },
       "devDependencies": {
-        "@grammyjs/types": "^3.16.0",
         "@types/bun": "latest",
         "@types/mime-types": "^3.0.1",
         "@types/vcf": "^2.0.7",
@@ -134,8 +134,6 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
-    "@grammyjs/types": ["@grammyjs/types@3.27.3", "", {}, "sha512-yUKMLliGsGbnxu96YUJ7km7B0zy4PzeH/Jvti5705R/LeKDMqkDV4DckMSt+OrliWQpTwQljHE0QLol5zgxBkg=="],
-
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
@@ -191,6 +189,8 @@
     "@photon-ai/proto": ["@photon-ai/proto@0.2.4", "", { "dependencies": { "@bufbuild/protobuf": "^2.12.0", "nice-grpc-common": "^2.0.3" } }, "sha512-DQANEp0gHvtwqpMGEF0ufa0hs1nniRdsSuo0Q/TG6GoL1WjC5tp59tHFSLUeIm6fvnAuRjREsGzURz3+/69g7g=="],
 
     "@photon-ai/slack": ["@photon-ai/slack@0.2.0", "", { "dependencies": { "@bufbuild/protobuf": "^2.12.0", "@grpc/grpc-js": "^1.14.3", "nice-grpc": "^2.1.15", "nice-grpc-common": "^2.0.3" } }, "sha512-k3XzGKIVS1EsjrPz9pbWvrvScmiy/iqKdA2npS5xu1CtCoycBkdFsqJKyB6iIyDR02Q3/38kQh7MvKsCzUyo3Q=="],
+
+    "@photon-ai/telegram-ts": ["@photon-ai/telegram-ts@10.0.0", "", { "dependencies": { "zod": "^4.4.3" } }, "sha512-kYGj/ieKOCG+OxoD1R69xHoT7zHl9dboF52LMPUl4FnorbwA8b2pid0uFoDYF55WIfoeo+VSqwlmY84GgpSedg=="],
 
     "@photon-ai/whatsapp-business": ["@photon-ai/whatsapp-business@0.1.1", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "long": "^5.3.2", "nice-grpc": "^2.1.15", "nice-grpc-common": "^2.0.3", "protobufjs": "^8.0.1" } }, "sha512-JAf/gHh92+H6h/7AMOQ6l+WFYBWdeRH5fZ+tvOUYJJnX1C4aJPDFa23VTH4ndhKPgA5bK/h++cxUZx2lMubvYQ=="],
 

--- a/docs/fusor.md
+++ b/docs/fusor.md
@@ -45,12 +45,22 @@ parses the request. They are *not* something you call:
 
 - **`verify(req)`** turns the raw request into a typed `payload` (and rejects a
   bad signature).
-- **`messages({ payload, respond })`** returns the provider message record(s)
-  Spectrum delivers, and may call `respond(...)` to set the synchronous reply.
-  It can also return `fusorEvent(channel, data)` to route to a
+- **`messages({ payload, respond, config, store, projectConfig })`** returns the
+  provider message record(s) Spectrum delivers, and may call `respond(...)` to
+  set the synchronous reply. Besides `payload`/`respond`, the ctx carries the
+  same runtime context every other platform hook receives — the parsed `config`
+  (typed from your config schema), the per-platform `store`, and the Cloud
+  `projectConfig` — so you don't have to smuggle them through the payload. It can
+  also return `fusorEvent(channel, data)` to route to a
   [custom event channel](#custom-event-channels-fusorevent) instead of the
   message stream. ⚠️ This provider hook is distinct from **`app.messages`**, the
   stream *you* consume — same word, different thing.
+
+  > Note: in fusor mode the `client` returned by `createClient` is just the
+  > `fusor(...)` brand (platform + `verify`), **not** a usable API client, so it
+  > is intentionally absent from the ctx. A provider that needs a real client at
+  > message time threads it through the `payload` (as Telegram does for lazy
+  > media downloads).
 
 Internally this is `FusorCore.processEvent()`, driven either by the gRPC stream
 or by `app.webhook()`. You never call it directly.

--- a/docs/fusor.md
+++ b/docs/fusor.md
@@ -58,9 +58,10 @@ parses the request. They are *not* something you call:
 
   > Note: in fusor mode the `client` returned by `createClient` is just the
   > `fusor(...)` brand (platform + `verify`), **not** a usable API client, so it
-  > is intentionally absent from the ctx. A provider that needs a real client at
-  > message time threads it through the `payload` (as Telegram does for lazy
-  > media downloads).
+  > is intentionally absent from the ctx. A provider that needs a real API client
+  > at message time builds one inline from the ctx `config` (as Telegram does for
+  > lazy media downloads — its `createTelegramClient(...)` makes no network call,
+  > so there is nothing to cache or thread through the payload).
 
 Internally this is `FusorCore.processEvent()`, driven either by the gRPC stream
 or by `app.webhook()`. You never call it directly.

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -1,0 +1,179 @@
+# Telegram provider
+
+The Telegram provider connects a Telegram **bot** to Spectrum. Inbound updates
+arrive over [Fusor](./fusor.md) (webhook delivery); outbound sends go to the
+Telegram **Bot API**. Both directions run on
+[`@photon-ai/telegram-ts`](https://github.com/photon-hq/telegram-api) — the
+generated, type-safe Bot API client — so the provider holds **no** hand-written
+HTTP client of its own.
+
+```ts
+import { Spectrum } from "@photon-ai/spectrum-ts";
+import { telegram } from "@photon-ai/spectrum-ts/providers/telegram";
+
+const app = Spectrum({
+  providers: [telegram.config({ botToken: process.env.TELEGRAM_BOT_TOKEN! })],
+});
+```
+
+---
+
+## Design
+
+Telegram runs in **fusor mode**: `lifecycle.createClient` returns a `fusor(...)`
+client (platform + `verify`), not a long-lived SDK client. Two principles shape
+the implementation:
+
+1. **Receiving is pure parsing.** `verify` does not need a Bot API client — an
+   inbound webhook is just bytes to validate and parse. It checks the webhook
+   secret token and parses the `Update`; that's the whole payload.
+2. **A client is created inline, never cached.** `createTelegramClient(...)`
+   makes **no** network call, so building one costs nothing. `send` and the
+   inbound media-download path each construct one from `config` on demand. There
+   is no store-cached client and nothing to dispose.
+
+Because the Fusor `messages` handler receives the full hook ctx
+(`{ payload, respond, config, store, projectConfig }`), the inbound mapper reads
+`config` directly from its ctx — the client is **not** threaded through the
+payload.
+
+---
+
+## Inbound (`verify` → `messages`)
+
+```
+webhook bytes
+  → verify(config)      secret-token check + parse → Update         (no client)
+  → handleMessages(ctx) Update + config → ProviderMessageRecord | undefined
+  → media read()        getFile + authenticated fetch, lazily       (client built inline)
+```
+
+- **`verify(config)`** (`verify.ts`) — validates the
+  `X-Telegram-Bot-Api-Secret-Token` header (timing-safe; skipped when no
+  `webhookSecret` is set — Telegram does not HMAC-sign the body) and parses the
+  JSON body into an `Update`. A bad secret or malformed body throws, which Fusor
+  turns into a `400` (no retry). The payload is the bare `Update`.
+- **`handleMessages({ payload, config })`** (`inbound/messages.ts`) — maps the
+  `Update` to a `ProviderMessageRecord`. It reads `config` from the ctx to derive
+  the bot's own id (`botIdFromToken(config.botToken)`) and drop self-authored
+  updates, and to build lazy media readers.
+- **Lazy media** (`inbound/media.ts`) — each attachment's `read()` is
+  `() => downloadFile(config, fileId)`. Nothing is fetched on the webhook-ack
+  path; bytes download only when a consumer calls `read()` (and the content
+  builders memoize it, so a file downloads once).
+
+### What inbound surfaces (v1)
+
+| Update | Mapped to |
+| --- | --- |
+| `message` / `channel_post`, text | `text` content |
+| `message` / `channel_post`, media | `attachment` (or `voice`); caption + media → `group` |
+| `message_reaction` (emoji added) | `reaction` targeting the message |
+
+Media detection order: `voice → video_note → animation → video → audio →
+document → photo → sticker` (`animation` also sets `document`, so order matters).
+Voice notes become `voice`; everything else becomes an `attachment`.
+
+Ignored (returns `undefined`): edited messages, callback queries, polls,
+membership changes, and reaction **removals** (empty `new_reaction`).
+
+---
+
+## Outbound (`send`)
+
+`send({ space, content, config })` (`outbound/send.ts`) builds a photon client
+inline and dispatches by content type. Message-producing content is mapped to a
+small `TelegramSendSpec` by the pure `buildSend` (`outbound/message.ts`) and run
+through `executeSpec`; fire-and-forget signals call photon's typed functions
+directly.
+
+| Content | Bot API call |
+| --- | --- |
+| `text` | `sendMessage` |
+| `richlink` | `sendMessage` (Telegram auto-unfurls the URL) |
+| `attachment` (image) | `sendPhoto` |
+| `attachment` (video) | `sendVideo` |
+| `attachment` (other) | `sendDocument` |
+| `voice` | `sendVoice` |
+| `contact` | `sendDocument` (vCard `contact.vcf`) |
+| `reply` | wraps the inner send with `reply_parameters` |
+| `custom` | the named Bot API method, verbatim |
+| `group` | one message per item (returns the last) |
+| `reaction` | `setMessageReaction` (emoji pre-validated) → `undefined` |
+| `typing` | `sendChatAction` (`start` only; `stop` is a no-op) → `undefined` |
+| `edit` | `editMessageText` (text only) → `undefined` |
+
+Unsupported (throws `UnsupportedError`): `poll`, `poll_option`, `effect`,
+`rename`, `avatar`. Reach any other Bot API method through `custom`.
+
+---
+
+## The two photon gaps (the only non-typed-call glue)
+
+photon `10.0.0` covers every JSON Bot API method with typed functions
+(`sendMessage`, `setMessageReaction`, `sendChatAction`, `editMessageText`,
+`getFile`, …). Two things it cannot do directly, both bridged in `client.ts`:
+
+1. **Raw-byte uploads.** Typed `sendPhoto`/`sendDocument`/`sendVoice` accept only
+   a `string` file ref (file_id/URL), and photon doesn't export its form
+   serializer. So `executeSpec` uploads via photon's own low-level
+   `client.post(url, body, …)`: the file is wrapped in a `File` (so the multipart
+   part keeps its filename), a small inlined serializer turns the body into
+   `FormData`, and `headers: { "Content-Type": null }` drops the default JSON
+   header so fetch sets the multipart boundary. Still photon — just not the
+   generated wrapper.
+2. **File-byte download.** photon's `getFile` returns metadata only, and the file
+   endpoint (`/file/bot<token>/<path>`) is not a Bot API JSON method. So
+   `downloadFile` calls `getFile` (via photon) for the path, then does **one**
+   raw `fetch` for the bytes — the only line in the provider that reaches Telegram
+   outside photon. The token-bearing URL is never put into a thrown error.
+
+Errors from photon surface as `TelegramApiError` (token-free).
+
+---
+
+## Configuration
+
+| Field | Required | Notes |
+| --- | --- | --- |
+| `botToken` | yes | `<id>:<token>` from @BotFather. The `<id>` prefix is the bot's own id (self-echo drop). |
+| `webhookSecret` | no | The `secret_token` passed to `setWebhook`; verified against the inbound header. Omit to skip the check. |
+| `baseUrl` | no | Bot API origin; defaults to `https://api.telegram.org`. Override for a local Bot API server. |
+
+---
+
+## File map
+
+| File | Responsibility |
+| --- | --- |
+| `index.ts` | `definePlatform` wiring (fusor mode) |
+| `config.ts` | config schema, `TELEGRAM_PLATFORM`, `botIdFromToken` |
+| `verify.ts` | `verify(config)` — secret check + parse `Update` |
+| `client.ts` | `telegramClient`, `executeSpec`, `downloadFile` (all over photon) |
+| `types.ts` | photon type re-exports, `TelegramPayload = Update`, send DTOs |
+| `space.ts` | user/space resolution (`chat_id`) |
+| `reactions.ts` | allowed reaction-emoji set + normalization |
+| `inbound/messages.ts` | `handleMessages` — `Update` → record |
+| `inbound/media.ts` | media detection + lazy `read()` |
+| `outbound/message.ts` | `buildSend` — content → `TelegramSendSpec` (pure) |
+| `outbound/send.ts` | dispatcher; builds the client inline |
+
+---
+
+## Testing
+
+Tests live under `test/providers/telegram/`. The seam is `globalThis.fetch`:
+because `send` and the inbound `read()` build the photon client inline from
+`config` (which has no `fetch` field), there is no client to inject — a per-test
+`spyOn(globalThis, "fetch")` cleanly intercepts the real path and exercises
+photon's actual request serialization.
+
+- `verify.test.ts` — secret-token cases + `Update` parsing (pure).
+- `outbound/message.test.ts` — `buildSend` content→method/params/file mapping
+  (pure, no client).
+- `outbound/send.test.ts` — `send` end to end via a `fetch` spy: `chat_id`
+  injection, multipart uploads (filename preserved), reply threading, group
+  fan-out, reaction validation, typing/edit, unsupported.
+- `inbound/messages.test.ts` — record mapping for all media kinds, channel posts,
+  self-echo drop, reactions; the lazy-download test drives `getFile` + the file
+  fetch through the `fetch` spy.

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -41,7 +41,7 @@ payload.
 
 ## Inbound (`verify` → `messages`)
 
-```
+```text
 webhook bytes
   → verify(config)      secret-token check + parse → Update         (no client)
   → handleMessages(ctx) Update + config → ProviderMessageRecord | undefined

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -78,6 +78,7 @@
     "@photon-ai/imessage-kit": "^3.0.0",
     "@photon-ai/otel": "^0.1.1",
     "@photon-ai/slack": "^0.2.0",
+    "@photon-ai/telegram-ts": "10.0.0",
     "@photon-ai/whatsapp-business": "^0.1.1",
     "@photon-ai/proto": "^0.2.4",
     "@repeaterjs/repeater": "^3.0.6",
@@ -92,7 +93,6 @@
     "zod": "^4.2.1"
   },
   "devDependencies": {
-    "@grammyjs/types": "^3.16.0",
     "@types/bun": "latest",
     "@types/mime-types": "^3.0.1",
     "@types/vcf": "^2.0.7",

--- a/packages/spectrum-ts/src/fusor/core.ts
+++ b/packages/spectrum-ts/src/fusor/core.ts
@@ -346,7 +346,9 @@ export class FusorCore {
 
     sink.push({ init: { startSeq: 0 }, reply: undefined });
 
-    const metadata = Metadata().set("authorization", `Bearer ${token}`);
+    // Fusor's gRPC auth (fanout-grpc `authorize()`) reads the raw JWT from the
+    // `access_token` metadata key — not an `authorization: Bearer …` header.
+    const metadata = Metadata().set("access_token", token);
     const stream = client.subscribe(requestIterable, { metadata });
 
     try {

--- a/packages/spectrum-ts/src/fusor/types.ts
+++ b/packages/spectrum-ts/src/fusor/types.ts
@@ -1,6 +1,8 @@
 import type { ProviderMessageRecord } from "../platform/types";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
+import type { ProjectData } from "../utils/cloud";
+import type { Store } from "../utils/store";
 import type { FusorEvent } from "./event";
 
 export interface FusorVerifyRequest {
@@ -22,9 +24,19 @@ export interface FusorReply {
 
 export type FusorRespond = (reply: FusorReply) => void;
 
-export interface FusorMessagesCtx<TPayload> {
+export interface FusorMessagesCtx<TPayload, TConfig = unknown> {
+  /** Parsed provider config (`z.infer` of the platform's config schema). */
+  config: TConfig;
   payload: TPayload;
+  /**
+   * Spectrum Cloud project metadata, fetched once at `Spectrum()` init.
+   * `undefined` for local-only setups (no `projectId`/`projectSecret`). Read
+   * project-level toggles from `projectConfig.profile.<key>`.
+   */
+  projectConfig: ProjectData | undefined;
   respond: FusorRespond;
+  /** Per-platform in-memory key/value store, shared with the rest of the platform. */
+  store: Store;
 }
 
 export type FusorMessagesReturn =
@@ -33,8 +45,8 @@ export type FusorMessagesReturn =
   | (ProviderMessageRecord | FusorEvent)[]
   | undefined;
 
-export type FusorMessages<TPayload> = (
-  ctx: FusorMessagesCtx<TPayload>
+export type FusorMessages<TPayload, TConfig = unknown> = (
+  ctx: FusorMessagesCtx<TPayload, TConfig>
 ) => FusorMessagesReturn | Promise<FusorMessagesReturn>;
 
 export const FUSOR_BRAND: unique symbol = Symbol.for("spectrum.fusor.client");

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -1,4 +1,4 @@
-import { withSpan } from "@photon-ai/otel";
+import { createLogger, withSpan } from "@photon-ai/otel";
 import type z from "zod";
 import type { FusorClient, FusorMessages } from "../fusor/types";
 import type { Message } from "../types/message";
@@ -31,6 +31,8 @@ import type {
   SpaceActionFn,
   SpectrumLike,
 } from "./types";
+
+const platformLog = createLogger("spectrum.platform");
 
 function classifySpaceIdentifier(args: unknown[]): {
   kind: "phone" | "email" | "group" | "unknown";
@@ -554,18 +556,20 @@ export function definePlatform(name: string, rawDef: unknown): unknown {
 
   const narrowSpace = (input: Space) => {
     if (input.__platform !== name) {
-      throw new Error(
-        `Expected space from "${name}", got "${input.__platform}"`
-      );
+      platformLog.warn("space platform mismatch; narrowing skipped", {
+        expected: name,
+        actual: input.__platform,
+      });
     }
     return input as PlatformSpace<Def>;
   };
 
   const narrowMessage = (input: Message) => {
     if (input.platform !== name) {
-      throw new Error(
-        `Expected message from "${name}", got "${input.platform}"`
-      );
+      platformLog.warn("message platform mismatch; narrowing skipped", {
+        expected: name,
+        actual: input.platform,
+      });
     }
     return input as PlatformMessage<Def>;
   };

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -490,7 +490,7 @@ export function definePlatform<
         store: Store;
       }) => Promise<void>;
     };
-    messages: FusorMessages<_TPayload>;
+    messages: FusorMessages<_TPayload, z.infer<_ConfigSchema>>;
     static?: _Static;
   }
 ): Platform<

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -212,6 +212,13 @@ type ReservedNames = "stop" | "send" | "config" | "__internal" | "__providers";
 
 export interface CreateClientContext<_ConfigSchema extends z.ZodType<object>> {
   config: z.infer<_ConfigSchema>;
+  /**
+   * The resolved cloud project record (slug, profile, …) when `Spectrum()` runs
+   * with `projectId` + `projectSecret`; `undefined` in local/direct mode. Lets
+   * `createClient` self-register provider webhooks against the Fusor edge keyed
+   * by `projectConfig.slug` — see Telegram.
+   */
+  projectConfig: ProjectData | undefined;
   projectId: string | undefined;
   projectSecret: string | undefined;
   store: Store;

--- a/packages/spectrum-ts/src/providers/telegram/client.ts
+++ b/packages/spectrum-ts/src/providers/telegram/client.ts
@@ -18,8 +18,11 @@ export const telegramClient = (config: TelegramConfig): TelegramClient =>
 
 // photon's typed `send*` methods only accept a string file ref (file_id/URL) and
 // it does not export its form serializer, so raw-byte uploads go through the
-// low-level `client.post` with this serializer — a faithful copy of photon's
-// internal `formDataBodySerializer` (string/Blob verbatim, Date → ISO, else JSON).
+// low-level `client.post` with this serializer — modeled on photon's internal
+// `formDataBodySerializer` (string/Blob verbatim, Date → ISO, else JSON). Unlike
+// photon, an array/object is appended as a single JSON-encoded part: Telegram's
+// multipart fields (e.g. `caption_entities`, `media`) must be one JSON value, not
+// one part per element.
 const appendFormValue = (form: FormData, key: string, value: unknown): void => {
   if (typeof value === "string" || value instanceof Blob) {
     form.append(key, value);
@@ -36,13 +39,7 @@ const toFormData = (body: unknown): FormData => {
     if (value === undefined || value === null) {
       continue;
     }
-    if (Array.isArray(value)) {
-      for (const item of value) {
-        appendFormValue(form, key, item);
-      }
-    } else {
-      appendFormValue(form, key, value);
-    }
+    appendFormValue(form, key, value);
   }
   return form;
 };

--- a/packages/spectrum-ts/src/providers/telegram/client.ts
+++ b/packages/spectrum-ts/src/providers/telegram/client.ts
@@ -1,135 +1,118 @@
-import { botIdFromToken, type TelegramConfig } from "./config";
-import type { TelegramSendSpec } from "./types";
+import { createTelegramClient, getFile } from "@photon-ai/telegram-ts";
+import type { TelegramConfig } from "./config";
+import type { SentMessage, TelegramSendSpec } from "./types";
 
-const CLIENT_STORE_KEY = "telegram.client";
 const REQUEST_TIMEOUT_MS = 30_000;
 const TRAILING_SLASHES = /\/+$/;
 
-interface BotApiResponse<T> {
-  description?: string;
-  error_code?: number;
-  ok: boolean;
-  result?: T;
-}
-
 /**
- * The adapter's view of the Telegram Bot API. The Bot API is plain HTTP/JSON,
- * so this wraps the global `fetch` directly (no SDK): `call` executes any
- * method (JSON, or `multipart/form-data` when a file is attached) and unwraps
- * the `{ ok, result }` envelope; `download` resolves a `file_id` to bytes.
+ * A photon Bot API client (hey-api `Client`). Created per request — the
+ * constructor makes no network call, so there is nothing to cache. Sending and
+ * inbound media download each build one inline from `config`.
  */
-export interface TelegramClient {
-  /** The bot's own numeric id (token prefix), used to drop self-authored updates. */
-  readonly botId: string;
-  /** Execute one Bot API method and return its unwrapped `result`. */
-  call<T = unknown>(spec: TelegramSendSpec): Promise<T>;
-  /** Fetch a file's bytes by `file_id` (`getFile` → token URL → bytes). */
-  download(fileId: string): Promise<Buffer>;
-}
+export type TelegramClient = ReturnType<typeof createTelegramClient>;
 
-const toFormValue = (value: unknown): string =>
-  typeof value === "object" ? JSON.stringify(value) : String(value);
+/** Build a photon client bound to the bot token. Cheap: no network on construction. */
+export const telegramClient = (config: TelegramConfig): TelegramClient =>
+  createTelegramClient({ token: config.botToken, baseUrl: config.baseUrl });
 
-const buildBody = (
-  spec: TelegramSendSpec
-): { body: string | FormData; headers?: Record<string, string> } => {
-  if (!spec.file) {
-    return {
-      body: JSON.stringify(spec.params),
-      headers: { "content-type": "application/json" },
-    };
+// photon's typed `send*` methods only accept a string file ref (file_id/URL) and
+// it does not export its form serializer, so raw-byte uploads go through the
+// low-level `client.post` with this serializer — a faithful copy of photon's
+// internal `formDataBodySerializer` (string/Blob verbatim, Date → ISO, else JSON).
+const appendFormValue = (form: FormData, key: string, value: unknown): void => {
+  if (typeof value === "string" || value instanceof Blob) {
+    form.append(key, value);
+  } else if (value instanceof Date) {
+    form.append(key, value.toISOString());
+  } else {
+    form.append(key, JSON.stringify(value));
   }
+};
+
+const toFormData = (body: unknown): FormData => {
   const form = new FormData();
-  for (const [key, value] of Object.entries(spec.params)) {
+  for (const [key, value] of Object.entries(body as Record<string, unknown>)) {
     if (value === undefined || value === null) {
       continue;
     }
-    form.append(key, toFormValue(value));
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        appendFormValue(form, key, item);
+      }
+    } else {
+      appendFormValue(form, key, value);
+    }
   }
-  const blob = new Blob([new Uint8Array(spec.file.bytes)], {
-    type: spec.file.mimeType,
-  });
-  form.append(spec.file.field, blob, spec.file.filename);
-  return { body: form };
+  return form;
 };
 
-const makeTelegramClient = (config: TelegramConfig): TelegramClient => {
-  const base = config.baseUrl.replace(TRAILING_SLASHES, "");
-  const token = config.botToken;
-
-  const call = async <T = unknown>(spec: TelegramSendSpec): Promise<T> => {
-    const { body, headers } = buildBody(spec);
-    const res = await fetch(`${base}/bot${token}/${spec.method}`, {
-      method: "POST",
-      ...(headers ? { headers } : {}),
-      body,
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    });
-    // Read the body as text first: an upstream proxy (or a custom `baseUrl`
-    // test server) can return a non-JSON error page, and an unguarded
-    // `res.json()` would throw an opaque parse error that hides the method and
-    // status. Never include the URL (it carries the bot token) in errors.
-    const raw = await res.text();
-    let json: BotApiResponse<T> | undefined;
-    try {
-      json = raw ? (JSON.parse(raw) as BotApiResponse<T>) : undefined;
-    } catch {
-      throw new Error(
-        `Telegram ${spec.method} failed: ${res.status} ${res.statusText}`
-      );
-    }
-    if (!json?.ok) {
-      throw new Error(
-        `Telegram ${spec.method} failed: ${json?.error_code ?? res.status} ${json?.description ?? res.statusText}`
-      );
-    }
-    return json.result as T;
-  };
-
-  const download = async (fileId: string): Promise<Buffer> => {
-    const file = await call<{ file_path?: string }>({
-      method: "getFile",
-      params: { file_id: fileId },
-    });
-    if (!file.file_path) {
-      throw new Error(`Telegram getFile returned no file_path for ${fileId}`);
-    }
-    // The file URL embeds the bot token — keep it out of logs/errors.
-    const res = await fetch(`${base}/file/bot${token}/${file.file_path}`, {
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    });
-    if (!res.ok) {
-      throw new Error(
-        `Telegram media download failed: ${res.status} ${res.statusText}`
-      );
-    }
-    return Buffer.from(await res.arrayBuffer());
-  };
-
-  return { botId: botIdFromToken(token), call, download };
-};
-
-// Store is an SDK-internal KV reachable through lifecycle/send ctx. It isn't
-// exported from spectrum-ts, so we depend on its minimal structural shape.
-export interface StoreLike {
-  get(key: string): unknown;
-  set(key: string, value: unknown): void;
+/** The `{ ok, result }` envelope photon resolves to with `responseStyle: "data"`. */
+interface SendEnvelope {
+  result: SentMessage;
 }
 
-/** Build the client once (in `createClient`) and cache it on `store`. */
-export const initClient = (
-  store: StoreLike,
-  config: TelegramConfig
-): TelegramClient => {
-  const client = makeTelegramClient(config);
-  store.set(CLIENT_STORE_KEY, client);
-  return client;
+/**
+ * Execute one Bot API call through the photon client and return the sent
+ * message. JSON params go out as `application/json`; a `file` is uploaded as
+ * `multipart/form-data` — wrapped in a `File` so the part keeps its filename
+ * (`formDataBodySerializer` appends without an explicit name), with
+ * `Content-Type: null` dropping the default JSON header so fetch sets the
+ * multipart boundary. A failed call throws `TelegramApiError` (token-free).
+ */
+export const executeSpec = async (
+  client: TelegramClient,
+  spec: TelegramSendSpec
+): Promise<SentMessage> => {
+  const url = `/${spec.method}`;
+  if (spec.file) {
+    const file = new File(
+      [new Uint8Array(spec.file.bytes)],
+      spec.file.filename,
+      { type: spec.file.mimeType }
+    );
+    const res = await client.post({
+      body: { ...spec.params, [spec.file.field]: file },
+      bodySerializer: toFormData,
+      headers: { "Content-Type": null },
+      throwOnError: true,
+      url,
+    });
+    return (res.data as SendEnvelope).result;
+  }
+  const res = await client.post({ body: spec.params, throwOnError: true, url });
+  return (res.data as SendEnvelope).result;
 };
 
-/** Read the cached client in `send`/actions, rebuilding it if absent. */
-export const getClient = (
-  store: StoreLike,
-  config: TelegramConfig
-): TelegramClient =>
-  (store.get(CLIENT_STORE_KEY) as TelegramClient | undefined) ??
-  initClient(store, config);
+/**
+ * Resolve a `file_id` to its bytes. photon has no byte-download helper and the
+ * file endpoint is not a Bot API JSON method, so this is the one place that
+ * reaches Telegram outside photon: `getFile` (via photon) for the path, then a
+ * single authenticated `fetch`. The file URL embeds the bot token, so it is
+ * never interpolated into a thrown error.
+ */
+export const downloadFile = async (
+  config: TelegramConfig,
+  fileId: string
+): Promise<Buffer> => {
+  const client = telegramClient(config);
+  const meta = await getFile({
+    body: { file_id: fileId },
+    client,
+    throwOnError: true,
+  });
+  const filePath = meta.result?.file_path;
+  if (!filePath) {
+    throw new Error(`Telegram getFile returned no file_path for ${fileId}`);
+  }
+  const base = config.baseUrl.replace(TRAILING_SLASHES, "");
+  const res = await fetch(`${base}/file/bot${config.botToken}/${filePath}`, {
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Telegram media download failed: ${res.status} ${res.statusText}`
+    );
+  }
+  return Buffer.from(await res.arrayBuffer());
+};

--- a/packages/spectrum-ts/src/providers/telegram/inbound/media.ts
+++ b/packages/spectrum-ts/src/providers/telegram/inbound/media.ts
@@ -2,7 +2,8 @@ import { asAttachment } from "../../../content/attachment";
 import { asText } from "../../../content/text";
 import type { Content } from "../../../content/types";
 import { asVoice } from "../../../content/voice";
-import type { TelegramClient } from "../client";
+import { downloadFile } from "../client";
+import type { TelegramConfig } from "../config";
 import type { Message, PhotoSize } from "../types";
 
 const DEFAULT_VIDEO_MIME = "video/mp4";
@@ -30,12 +31,12 @@ interface TgFile {
   mime_type?: string;
 }
 
-const lazyRead = (client: TelegramClient, fileId: string) => () =>
-  client.download(fileId);
+const lazyRead = (config: TelegramConfig, fileId: string) => () =>
+  downloadFile(config, fileId);
 
 /** Build an attachment from any Telegram file, falling back when unnamed/untyped. */
 const fileAttachment = (
-  client: TelegramClient,
+  config: TelegramConfig,
   file: TgFile,
   fallbackExt: string,
   fallbackMime: string
@@ -45,11 +46,11 @@ const fileAttachment = (
     name: file.file_name ?? `${file.file_unique_id}.${fallbackExt}`,
     mimeType: file.mime_type ?? fallbackMime,
     size: file.file_size,
-    read: lazyRead(client, file.file_id),
+    read: lazyRead(config, file.file_id),
   });
 
 const stickerAttachment = (
-  client: TelegramClient,
+  config: TelegramConfig,
   sticker: NonNullable<Message["sticker"]>
 ): Content => {
   let ext = "webp";
@@ -66,7 +67,7 @@ const stickerAttachment = (
     name: `${sticker.file_unique_id}.${ext}`,
     mimeType,
     size: sticker.file_size,
-    read: lazyRead(client, sticker.file_id),
+    read: lazyRead(config, sticker.file_id),
   });
 };
 
@@ -83,41 +84,41 @@ const stickerAttachment = (
  */
 const mediaToContent = (
   msg: Message,
-  client: TelegramClient
+  config: TelegramConfig
 ): Content | undefined => {
   if (msg.voice) {
     return asVoice({
       mimeType: msg.voice.mime_type ?? DEFAULT_VOICE_MIME,
       duration: msg.voice.duration,
       size: msg.voice.file_size,
-      read: lazyRead(client, msg.voice.file_id),
+      read: lazyRead(config, msg.voice.file_id),
     });
   }
   if (msg.video_note) {
-    return fileAttachment(client, msg.video_note, "mp4", DEFAULT_VIDEO_MIME);
+    return fileAttachment(config, msg.video_note, "mp4", DEFAULT_VIDEO_MIME);
   }
   if (msg.animation) {
-    return fileAttachment(client, msg.animation, "mp4", DEFAULT_VIDEO_MIME);
+    return fileAttachment(config, msg.animation, "mp4", DEFAULT_VIDEO_MIME);
   }
   if (msg.video) {
-    return fileAttachment(client, msg.video, "mp4", DEFAULT_VIDEO_MIME);
+    return fileAttachment(config, msg.video, "mp4", DEFAULT_VIDEO_MIME);
   }
   if (msg.audio) {
-    return fileAttachment(client, msg.audio, "mp3", DEFAULT_AUDIO_MIME);
+    return fileAttachment(config, msg.audio, "mp3", DEFAULT_AUDIO_MIME);
   }
   if (msg.document) {
-    return fileAttachment(client, msg.document, "bin", DEFAULT_DOC_MIME);
+    return fileAttachment(config, msg.document, "bin", DEFAULT_DOC_MIME);
   }
   if (msg.photo && msg.photo.length > 0) {
     return fileAttachment(
-      client,
+      config,
       pickLargestPhoto(msg.photo),
       "jpg",
       "image/jpeg"
     );
   }
   if (msg.sticker) {
-    return stickerAttachment(client, msg.sticker);
+    return stickerAttachment(config, msg.sticker);
   }
   return;
 };
@@ -130,9 +131,9 @@ const mediaToContent = (
  */
 export const messageToContent = (
   msg: Message,
-  client: TelegramClient
+  config: TelegramConfig
 ): Content[] => {
-  const media = mediaToContent(msg, client);
+  const media = mediaToContent(msg, config);
   if (media) {
     const caption = msg.caption?.trim();
     return caption ? [asText(caption), media] : [media];

--- a/packages/spectrum-ts/src/providers/telegram/inbound/messages.ts
+++ b/packages/spectrum-ts/src/providers/telegram/inbound/messages.ts
@@ -2,9 +2,10 @@ import { asCustom } from "../../../content/custom";
 import { asGroup } from "../../../content/group";
 import { asReaction } from "../../../content/reaction";
 import type { Content } from "../../../content/types";
+import type { FusorMessagesCtx } from "../../../fusor/types";
 import type { ProviderMessageRecord } from "../../../platform/types";
 import type { Message as SpectrumMessage } from "../../../types/message";
-import type { TelegramClient } from "../client";
+import { botIdFromToken, type TelegramConfig } from "../config";
 import type {
   Message,
   ReactionType,
@@ -51,15 +52,15 @@ const toRecordContent = (
 
 const fromMessage = (
   msg: Message,
-  client: TelegramClient
+  config: TelegramConfig
 ): ProviderMessageRecord | undefined => {
   // Drop the bot's own messages so it never echoes itself. Telegram normally
   // doesn't deliver them, so this is belt-and-suspenders.
-  if (msg.from && String(msg.from.id) === client.botId) {
+  if (msg.from && String(msg.from.id) === botIdFromToken(config.botToken)) {
     return;
   }
   const content = toRecordContent(
-    messageToContent(msg, client),
+    messageToContent(msg, config),
     String(msg.message_id)
   );
   if (!content) {
@@ -116,14 +117,14 @@ const fromReaction = (
  * other update types are ignored (return `undefined`).
  */
 export const handleMessages = ({
-  payload,
-}: {
-  payload: TelegramPayload;
-}): ProviderMessageRecord | undefined => {
-  const { update, client } = payload;
+  payload: update,
+  config,
+}: FusorMessagesCtx<TelegramPayload, TelegramConfig>):
+  | ProviderMessageRecord
+  | undefined => {
   const message = update.message ?? update.channel_post;
   if (message) {
-    return fromMessage(message, client);
+    return fromMessage(message, config);
   }
   if (update.message_reaction) {
     return fromReaction(update.message_reaction);

--- a/packages/spectrum-ts/src/providers/telegram/index.ts
+++ b/packages/spectrum-ts/src/providers/telegram/index.ts
@@ -6,6 +6,7 @@ import { send } from "./outbound/send";
 import { resolveSpace, resolveUser, spaceParamsSchema } from "./space";
 import type { TelegramPayload } from "./types";
 import { verify } from "./verify";
+import { ensureWebhook } from "./webhook";
 
 export type { TelegramConfig } from "./config";
 
@@ -19,14 +20,26 @@ export type { TelegramConfig } from "./config";
  * Outbound (`send`) also builds a photon client inline. Both go through
  * `@photon-ai/telegram-ts`. Drop `telegram.config({...})` into
  * `Spectrum({ providers: [...] })`.
+ *
+ * In cloud mode (`projectConfig` present), `createClient` also self-registers
+ * the bot's webhook against the Fusor edge for the project slug — see
+ * `ensureWebhook`. Without a slug (local/direct mode) registration is skipped.
  */
 export const telegram = definePlatform(TELEGRAM_PLATFORM, {
   config: configSchema,
   lifecycle: {
     // Annotate the return so overload selection sees the `FusorClient` brand
     // without deferring this (context-sensitive) arrow — picks the fusor overload.
-    createClient: async ({ config }): Promise<FusorClient<TelegramPayload>> =>
-      fusor<TelegramPayload>(TELEGRAM_PLATFORM, verify(config)),
+    createClient: async ({
+      config,
+      projectConfig,
+    }): Promise<FusorClient<TelegramPayload>> => {
+      const slug = projectConfig?.slug;
+      if (slug) {
+        await ensureWebhook(config, slug);
+      }
+      return fusor<TelegramPayload>(TELEGRAM_PLATFORM, verify(config));
+    },
   },
   user: { resolve: resolveUser },
   space: { params: spaceParamsSchema, resolve: resolveSpace },

--- a/packages/spectrum-ts/src/providers/telegram/index.ts
+++ b/packages/spectrum-ts/src/providers/telegram/index.ts
@@ -1,23 +1,23 @@
 import { type FusorClient, fusor } from "../../fusor";
 import { definePlatform } from "../../platform/define";
-import { initClient } from "./client";
 import { configSchema, TELEGRAM_PLATFORM } from "./config";
 import { handleMessages } from "./inbound/messages";
 import { send } from "./outbound/send";
 import { resolveSpace, resolveUser, spaceParamsSchema } from "./space";
 import type { TelegramPayload } from "./types";
-import { makeVerify } from "./verify";
+import { verify } from "./verify";
 
 export type { TelegramConfig } from "./config";
 
 /**
  * Telegram provider for Spectrum.
  *
- * Inbound is delivered through Fusor: `createClient` builds the Bot API client
- * and returns a `fusor(...)` client whose `verify` checks the Telegram webhook
- * secret token and parses the `Update` (embedding the client so inbound media
- * can be downloaded lazily with the bot token). Outbound goes through the
- * Telegram Bot API over HTTP. Drop `telegram.config({...})` into
+ * Inbound is delivered through Fusor: `createClient` returns a `fusor(...)`
+ * client whose `verify` checks the Telegram webhook secret token and parses the
+ * `Update` (pure parsing — no client). The `messages` handler reads `config`
+ * from its ctx and builds a photon client inline only to download media bytes.
+ * Outbound (`send`) also builds a photon client inline. Both go through
+ * `@photon-ai/telegram-ts`. Drop `telegram.config({...})` into
  * `Spectrum({ providers: [...] })`.
  */
 export const telegram = definePlatform(TELEGRAM_PLATFORM, {
@@ -25,16 +25,8 @@ export const telegram = definePlatform(TELEGRAM_PLATFORM, {
   lifecycle: {
     // Annotate the return so overload selection sees the `FusorClient` brand
     // without deferring this (context-sensitive) arrow — picks the fusor overload.
-    createClient: async ({
-      config,
-      store,
-    }): Promise<FusorClient<TelegramPayload>> => {
-      const client = initClient(store, config);
-      return fusor<TelegramPayload>(
-        TELEGRAM_PLATFORM,
-        makeVerify(config, client)
-      );
-    },
+    createClient: async ({ config }): Promise<FusorClient<TelegramPayload>> =>
+      fusor<TelegramPayload>(TELEGRAM_PLATFORM, verify(config)),
   },
   user: { resolve: resolveUser },
   space: { params: spaceParamsSchema, resolve: resolveSpace },

--- a/packages/spectrum-ts/src/providers/telegram/outbound/send.ts
+++ b/packages/spectrum-ts/src/providers/telegram/outbound/send.ts
@@ -1,13 +1,18 @@
+import {
+  editMessageText,
+  sendChatAction,
+  setMessageReaction,
+} from "@photon-ai/telegram-ts";
 import type { Edit } from "../../../content/edit";
 import type { Reaction } from "../../../content/reaction";
 import type { Content } from "../../../content/types";
 import type { ProviderMessageRecord } from "../../../platform/types";
 import { UnsupportedError } from "../../../utils/errors";
-import { getClient, type StoreLike, type TelegramClient } from "../client";
+import { executeSpec, type TelegramClient, telegramClient } from "../client";
 import { TELEGRAM_PLATFORM, type TelegramConfig } from "../config";
 import { isAllowedReactionEmoji, normalizeReactionEmoji } from "../reactions";
 import type { TelegramSpace } from "../space";
-import type { SentMessage } from "../types";
+import type { ReactionTypeEmoji } from "../types";
 import { buildSend, parseMessageId } from "./message";
 
 const MILLIS_PER_SECOND = 1000;
@@ -16,7 +21,6 @@ interface SendArgs {
   config: TelegramConfig;
   content: Content;
   space: TelegramSpace;
-  store: StoreLike;
 }
 
 /** Build one content's spec, inject `chat_id`, execute it, return the record. */
@@ -26,7 +30,7 @@ const sendContent = async (
   content: Content
 ): Promise<ProviderMessageRecord> => {
   const spec = await buildSend(content);
-  const sent = await client.call<SentMessage>({
+  const sent = await executeSpec(client, {
     ...spec,
     params: { chat_id: space.id, ...spec.params },
   });
@@ -70,13 +74,14 @@ const sendReaction = async (
       `"${content.emoji}" is not an allowed Telegram reaction emoji.`
     );
   }
-  await client.call({
-    method: "setMessageReaction",
-    params: {
+  await setMessageReaction({
+    body: {
       chat_id: space.id,
       message_id: messageId,
-      reaction: [{ type: "emoji", emoji }],
+      // `emoji` is runtime-validated above; cast to photon's allowed-emoji union.
+      reaction: [{ emoji: emoji as ReactionTypeEmoji["emoji"], type: "emoji" }],
     },
+    client,
   });
   return;
 };
@@ -88,9 +93,9 @@ const sendTyping = async (
 ): Promise<undefined> => {
   // Telegram has no "stop typing" — the indicator auto-clears after ~5s.
   if (state === "start") {
-    await client.call({
-      method: "sendChatAction",
-      params: { chat_id: space.id, action: "typing" },
+    await sendChatAction({
+      body: { action: "typing", chat_id: space.id },
+      client,
     });
   }
   return;
@@ -108,13 +113,13 @@ const sendEdit = async (
       `only text content can be edited (got "${content.content.type}").`
     );
   }
-  await client.call({
-    method: "editMessageText",
-    params: {
+  await editMessageText({
+    body: {
       chat_id: space.id,
       message_id: parseMessageId(content.target.id),
       text: content.content.text,
     },
+    client,
   });
   return;
 };
@@ -130,9 +135,8 @@ export const send = async ({
   space,
   content,
   config,
-  store,
 }: SendArgs): Promise<ProviderMessageRecord | undefined> => {
-  const client = getClient(store, config);
+  const client = telegramClient(config);
   switch (content.type) {
     case "reaction":
       return await sendReaction(client, space, content);

--- a/packages/spectrum-ts/src/providers/telegram/types.ts
+++ b/packages/spectrum-ts/src/providers/telegram/types.ts
@@ -19,10 +19,11 @@ export type {
 
 /**
  * The payload `verify()` produces and `messages()` consumes. The raw `Update`
- * plus the `TelegramClient` — the `messages` hook receives only `{ payload,
- * respond }` (no store/config), so the client is threaded through here to build
- * the lazy media `read()` closures (inbound media is fetched with the bot
- * token, unlike presigned-URL platforms). The client never lands in a
+ * plus the `TelegramClient` — the `messages` hook ctx exposes config/store/
+ * projectConfig, but not a usable client (the fusor client is just the
+ * `verify` brand), so the real client is threaded through here to build the
+ * lazy media `read()` closures (inbound media is fetched with the bot token,
+ * unlike presigned-URL platforms). The client never lands in a
  * `ProviderMessageRecord`; only `() => client.download(fileId)` closures do.
  */
 export interface TelegramPayload {

--- a/packages/spectrum-ts/src/providers/telegram/types.ts
+++ b/packages/spectrum-ts/src/providers/telegram/types.ts
@@ -1,10 +1,13 @@
-import type { Message, MessageReactionUpdated, Update } from "@grammyjs/types";
-import type { TelegramClient } from "./client";
+import type {
+  Message,
+  MessageReactionUpdated,
+  Update,
+} from "@photon-ai/telegram-ts";
 
 // ---------------------------------------------------------------------------
-// Inbound — Telegram webhook payloads, typed from the official `@grammyjs/types`
-// package so the adapter stays in sync with the Bot API schema. These are
-// types-only imports and disappear at build time.
+// Inbound — Telegram webhook payloads, typed from `@photon-ai/telegram-ts` so
+// the adapter stays in sync with the Bot API schema. These are types-only
+// imports and disappear at build time.
 // ---------------------------------------------------------------------------
 
 export type {
@@ -15,29 +18,25 @@ export type {
   ReactionTypeEmoji,
   Update,
   User,
-} from "@grammyjs/types";
+} from "@photon-ai/telegram-ts";
 
 /**
- * The payload `verify()` produces and `messages()` consumes. The raw `Update`
- * plus the `TelegramClient` — the `messages` hook ctx exposes config/store/
- * projectConfig, but not a usable client (the fusor client is just the
- * `verify` brand), so the real client is threaded through here to build the
- * lazy media `read()` closures (inbound media is fetched with the bot token,
- * unlike presigned-URL platforms). The client never lands in a
- * `ProviderMessageRecord`; only `() => client.download(fileId)` closures do.
+ * The payload `verify()` produces and `messages()` consumes: just the parsed
+ * `Update`. Receiving is pure parsing — no client or config is bundled here.
+ * The inbound mapper reads `config` from its own ctx (the Fusor `messages`
+ * handler receives `{ config, payload, store, ... }`) and creates a client
+ * inline only when it needs to download media bytes.
  */
-export interface TelegramPayload {
-  client: TelegramClient;
-  update: Update;
-}
+export type TelegramPayload = Update;
 
 /** An inbound `message_reaction` update. */
 export type ReactionUpdate = MessageReactionUpdated;
 
 // ---------------------------------------------------------------------------
-// Outbound — the adapter's own DTOs at the `TelegramClient` boundary. Telegram
-// has no multi-part message: each content type is a distinct Bot API method, so
+// Outbound — the adapter's own DTOs at the Bot API boundary. Telegram has no
+// multi-part message: each content type is a distinct Bot API method, so
 // `buildSend` returns a *send spec* (one method call) rather than a parts list.
+// `executeSpec` runs it through the photon client.
 // ---------------------------------------------------------------------------
 
 /** A file to upload as `multipart/form-data` under `field` (e.g. `photo`). */

--- a/packages/spectrum-ts/src/providers/telegram/verify.ts
+++ b/packages/spectrum-ts/src/providers/telegram/verify.ts
@@ -1,6 +1,5 @@
 import { timingSafeEqual } from "node:crypto";
 import type { FusorVerify, FusorVerifyRequest } from "../../fusor/types";
-import type { TelegramClient } from "./client";
 import type { TelegramConfig } from "./config";
 import type { TelegramPayload, Update } from "./types";
 
@@ -53,22 +52,19 @@ const parseUpdate = (bodyText: string): Update => {
 };
 
 /**
- * Build the Fusor `verify` hook. Closes over `config` (to check the secret
- * token) and the already-built `client` (so the inbound mapper can attach
- * token-authenticated lazy media `read()` closures — the `messages` hook gets
- * only `{ payload, respond }`, with no access to the client otherwise). When no
- * `webhookSecret` is configured the token check is skipped and the body is
+ * Build the Fusor `verify` hook. Receiving is pure parsing: it closes over
+ * `config` only to check the webhook secret token, then parses the raw body
+ * into an `Update` and returns it as the payload — no client is involved. When
+ * no `webhookSecret` is configured the token check is skipped and the body is
  * parsed directly. Throwing rejects the event (Fusor returns 400 — no retry).
+ * The inbound mapper reads `config` from its own ctx and builds a client inline
+ * only if it needs to download media.
  */
-export const makeVerify =
-  (
-    config: TelegramConfig,
-    client: TelegramClient
-  ): FusorVerify<TelegramPayload> =>
+export const verify =
+  (config: TelegramConfig): FusorVerify<TelegramPayload> =>
   (req: FusorVerifyRequest): TelegramPayload => {
     if (config.webhookSecret) {
       verifySecret(req.headers, config.webhookSecret);
     }
-    const update = parseUpdate(new TextDecoder().decode(req.rawBody));
-    return { client, update };
+    return parseUpdate(new TextDecoder().decode(req.rawBody));
   };

--- a/packages/spectrum-ts/src/providers/telegram/webhook.ts
+++ b/packages/spectrum-ts/src/providers/telegram/webhook.ts
@@ -1,0 +1,63 @@
+import { getWebhookInfo, setWebhook } from "@photon-ai/telegram-ts";
+import { telegramClient } from "./client";
+import { TELEGRAM_PLATFORM, type TelegramConfig } from "./config";
+
+/**
+ * Base domain of the Fusor "super webhook" edge. Telegram delivers updates to
+ * `https://{slug}.{domain}/{platform}`, where Fusor forwards them on to
+ * Spectrum. Override per-environment (e.g. `staging.spctrm.dev`) via
+ * `SPECTRUM_SUPER_WEBHOOK`.
+ */
+const DEFAULT_SUPER_WEBHOOK_DOMAIN = "spctrm.dev";
+
+/**
+ * The Bot API webhook URL Telegram should POST updates to: the Fusor edge keyed
+ * by the project `slug`, on the Telegram platform path segment.
+ */
+export const webhookUrl = (slug: string): string => {
+  const domain =
+    process.env.SPECTRUM_SUPER_WEBHOOK ?? DEFAULT_SUPER_WEBHOOK_DOMAIN;
+  return `https://${slug}.${domain}/${TELEGRAM_PLATFORM}`;
+};
+
+/**
+ * Make Telegram deliver this bot's updates to the Fusor edge for `slug`.
+ *
+ * Idempotent: reads the current webhook via `getWebhookInfo` and only calls
+ * `setWebhook` when the URL differs, so a restart with an already-registered
+ * bot makes no write. `config.webhookSecret`, when set, is registered as the
+ * `secret_token` Telegram echoes back for inbound verification (see `verify`);
+ * when absent, the webhook is registered without one.
+ *
+ * Note: `getWebhookInfo` does not return the secret, so a secret-only change
+ * (same URL) is not re-applied — change the URL or clear the webhook to force it.
+ *
+ * Failures throw a token-free error (the bot token is never interpolated),
+ * failing `Spectrum()` startup fast: a bot that cannot register its webhook
+ * receives nothing.
+ */
+export const ensureWebhook = async (
+  config: TelegramConfig,
+  slug: string
+): Promise<void> => {
+  const client = telegramClient(config);
+  const url = webhookUrl(slug);
+  try {
+    const info = await getWebhookInfo({ client, throwOnError: true });
+    if (info.result?.url === url) {
+      return;
+    }
+    await setWebhook({
+      body: {
+        url,
+        ...(config.webhookSecret ? { secret_token: config.webhookSecret } : {}),
+      },
+      client,
+      throwOnError: true,
+    });
+  } catch (error) {
+    throw new Error(`Telegram webhook registration failed for ${url}`, {
+      cause: error,
+    });
+  }
+};

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -13,8 +13,6 @@ import { isFusorClient } from "./fusor/index";
 import type {
   FusorClient,
   FusorMessages,
-  FusorMessagesReturn,
-  FusorReply,
   WebhookHandler,
   WebhookRawRequest,
   WebhookRawResult,
@@ -548,10 +546,17 @@ export async function Spectrum<
 
       const handler: RegisteredFusorHandler = {
         verify: client.verify,
-        messages: async (ctx: {
-          payload: unknown;
-          respond: (reply: FusorReply) => void;
-        }): Promise<FusorMessagesReturn> => userMessages(ctx),
+        // Enrich the transport-level `{ payload, respond }` ctx with the same
+        // runtime context every other platform callback receives, so fusor
+        // handlers can read config/store/projectConfig directly instead of
+        // smuggling state through the payload.
+        messages: async (ctx) =>
+          userMessages({
+            ...ctx,
+            config: runtime.config,
+            store: runtime.store,
+            projectConfig: runtime.projectConfig,
+          }),
         pushMessage: (record) => queue.push(record),
         pushEvent: (channel, data) => {
           const eventQueue = eventQueues.get(channel);

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -476,6 +476,7 @@ export async function Spectrum<
               config: userConfig,
               projectId,
               projectSecret,
+              projectConfig,
               store,
             })
         );

--- a/packages/spectrum-ts/src/utils/cloud.ts
+++ b/packages/spectrum-ts/src/utils/cloud.ts
@@ -80,6 +80,12 @@ export interface ProjectData {
   id: string;
   name: string;
   profile: ProjectProfile;
+  /**
+   * URL-safe project identifier (e.g. `what-c62a6`). Used as the subdomain of
+   * the Fusor "super webhook" edge a platform registers its provider webhook
+   * against — see Telegram's `webhookUrl`.
+   */
+  slug: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/spectrum-ts/test/core/fusor/webhook.test.ts
+++ b/packages/spectrum-ts/test/core/fusor/webhook.test.ts
@@ -88,6 +88,7 @@ describe("spectrum.webhook", () => {
       id: "proj",
       name: "Test Project",
       profile: {},
+      slug: "test-project",
     });
 
     await spectrum.stop();

--- a/packages/spectrum-ts/test/core/fusor/webhook.test.ts
+++ b/packages/spectrum-ts/test/core/fusor/webhook.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, spyOn } from "bun:test";
 import { stubCloud } from "@test/support/cloud";
 import {
+  CTX_PROBE_PLATFORM,
+  type CtxProbeCapture,
   encodeEvent,
+  makeCtxProbe,
   makePresence,
   makeSlack,
   PRESENCE_PLATFORM,
@@ -51,6 +54,41 @@ describe("spectrum.webhook", () => {
     expect(message.direction).toBe("inbound");
     expect(message.content).toEqual({ type: "text", text: "hello" });
     expect(result.status).toBe(200);
+
+    await spectrum.stop();
+  });
+
+  it("threads config/store/projectConfig into the messages handler ctx", async () => {
+    const capture: CtxProbeCapture = {};
+    const spectrum = await Spectrum({
+      ...baseConfig,
+      providers: [makeCtxProbe(capture).config({ token: "tok-123" })],
+    });
+    const { promise: finished, resolve: done } = Promise.withResolvers<void>();
+
+    const result = await spectrum.webhook(
+      {
+        headers: {},
+        body: encodeEvent(
+          CTX_PROBE_PLATFORM,
+          JSON.stringify({ text: "hello ctx" })
+        ),
+      },
+      () => done()
+    );
+    await finished;
+
+    expect(result.status).toBe(200);
+    // Parsed provider config (from the platform's Zod schema), strongly typed.
+    expect(capture.config).toEqual({ token: "tok-123" });
+    // A live Store: the value written inside the handler reads back through it.
+    expect(capture.storeRoundTrip).toBe("hello ctx");
+    // Cloud project metadata (stubbed), matching the regular-mode contract.
+    expect(capture.projectConfig).toEqual({
+      id: "proj",
+      name: "Test Project",
+      profile: {},
+    });
 
     await spectrum.stop();
   });

--- a/packages/spectrum-ts/test/providers/telegram/inbound/messages.test.ts
+++ b/packages/spectrum-ts/test/providers/telegram/inbound/messages.test.ts
@@ -1,25 +1,21 @@
-import { describe, expect, it } from "bun:test";
-import type { TelegramClient } from "@/providers/telegram/client";
+import { describe, expect, it, spyOn } from "bun:test";
+import { configSchema } from "@/providers/telegram/config";
 import { handleMessages } from "@/providers/telegram/inbound/messages";
-import type { TelegramPayload, Update } from "@/providers/telegram/types";
+import type { Update } from "@/providers/telegram/types";
 
 const TS_SEC = 1_700_000_000;
 const DOWNLOAD = Buffer.from("file-bytes");
 
-const downloadCalls: string[] = [];
-const client: TelegramClient = {
-  botId: "999",
-  call: () => Promise.reject(new Error("unused")),
-  download: (fileId) => {
-    downloadCalls.push(fileId);
-    return Promise.resolve(DOWNLOAD);
-  },
-};
+// botToken prefix "999" is the bot's own id — drives the self-echo test.
+const config = configSchema.parse({ botToken: "999:abc" });
 
-const payload = (over: Record<string, unknown>): TelegramPayload => ({
-  client,
-  update: { update_id: 1, ...over } as unknown as Update,
-});
+const update = (over: Record<string, unknown>): Update =>
+  ({ update_id: 1, ...over }) as unknown as Update;
+
+// `handleMessages` is a Fusor handler; it only reads `payload` + `config`, so a
+// minimal ctx (cast to the full ctx type) is enough to exercise it.
+const ctx = (over: Record<string, unknown>) =>
+  ({ config, payload: update(over) }) as Parameters<typeof handleMessages>[0];
 
 const message = (over: Record<string, unknown>): Record<string, unknown> => ({
   message_id: 5,
@@ -30,7 +26,7 @@ const message = (over: Record<string, unknown>): Record<string, unknown> => ({
 });
 
 const handle = (over: Record<string, unknown>) =>
-  handleMessages({ payload: payload({ message: message(over) }) });
+  handleMessages(ctx({ message: message(over) }));
 
 describe("handleMessages — text", () => {
   it("maps a text message to text content", () => {
@@ -161,38 +157,65 @@ describe("handleMessages — media", () => {
     }
   });
 
-  it("downloads bytes lazily through the embedded client", async () => {
-    downloadCalls.length = 0;
-    const record = handle({
-      document: {
-        file_id: "doc-read",
-        file_unique_id: "u",
-        file_name: "f.bin",
-      },
-    });
-    expect(downloadCalls).toHaveLength(0); // not fetched yet
-    if (record?.content.type === "attachment") {
-      const bytes = await record.content.read();
-      expect(bytes).toEqual(DOWNLOAD);
-      expect(downloadCalls).toEqual(["doc-read"]);
-    } else {
-      throw new Error("expected attachment");
+  it("downloads bytes lazily through a client built inline", async () => {
+    const fetched: string[] = [];
+    const impl = (input: Request | string): Promise<Response> => {
+      const url = typeof input === "string" ? input : input.url;
+      fetched.push(url);
+      if (url.endsWith("/getFile")) {
+        return Promise.resolve(
+          Response.json({
+            ok: true,
+            result: {
+              file_id: "doc-read",
+              file_unique_id: "u",
+              file_path: "files/f.bin",
+            },
+          })
+        );
+      }
+      return Promise.resolve(new Response(DOWNLOAD));
+    };
+    const spy = spyOn(globalThis, "fetch").mockImplementation(
+      impl as unknown as typeof fetch
+    );
+    try {
+      const record = handle({
+        document: {
+          file_id: "doc-read",
+          file_unique_id: "u",
+          file_name: "f.bin",
+        },
+      });
+      expect(fetched).toHaveLength(0); // nothing fetched on the ack path
+      if (record?.content.type === "attachment") {
+        const bytes = await record.content.read();
+        expect(Buffer.from(bytes)).toEqual(DOWNLOAD);
+        expect(fetched.some((u) => u.endsWith("/getFile"))).toBe(true);
+        expect(
+          fetched.some((u) => u.includes("/file/bot999:abc/files/f.bin"))
+        ).toBe(true);
+      } else {
+        throw new Error("expected attachment");
+      }
+    } finally {
+      spy.mockRestore();
     }
   });
 });
 
 describe("handleMessages — channel posts & self-echo", () => {
   it("maps a senderless channel post", () => {
-    const record = handleMessages({
-      payload: payload({
+    const record = handleMessages(
+      ctx({
         channel_post: {
           message_id: 9,
           date: TS_SEC,
           chat: { id: -100, type: "channel" },
           text: "broadcast",
         },
-      }),
-    });
+      })
+    );
     expect(record?.content).toEqual({ type: "text", text: "broadcast" });
     expect(record?.sender).toBeUndefined();
     expect(record?.space.id).toBe("-100");
@@ -209,8 +232,8 @@ describe("handleMessages — channel posts & self-echo", () => {
 
 describe("handleMessages — reactions & ignored updates", () => {
   it("maps a message_reaction add to a reaction targeting the message", () => {
-    const record = handleMessages({
-      payload: payload({
+    const record = handleMessages(
+      ctx({
         message_reaction: {
           chat: { id: 100, type: "private" },
           message_id: 5,
@@ -219,8 +242,8 @@ describe("handleMessages — reactions & ignored updates", () => {
           old_reaction: [],
           new_reaction: [{ type: "emoji", emoji: "👍" }],
         },
-      }),
-    });
+      })
+    );
     expect(record?.content.type).toBe("reaction");
     if (record?.content.type === "reaction") {
       expect(record.content.emoji).toBe("👍");
@@ -230,8 +253,8 @@ describe("handleMessages — reactions & ignored updates", () => {
   });
 
   it("ignores a reaction removal (empty new_reaction)", () => {
-    const record = handleMessages({
-      payload: payload({
+    const record = handleMessages(
+      ctx({
         message_reaction: {
           chat: { id: 100, type: "private" },
           message_id: 5,
@@ -239,20 +262,18 @@ describe("handleMessages — reactions & ignored updates", () => {
           old_reaction: [{ type: "emoji", emoji: "👍" }],
           new_reaction: [],
         },
-      }),
-    });
+      })
+    );
     expect(record).toBeUndefined();
   });
 
   it("ignores update types outside v1 scope", () => {
     expect(
-      handleMessages({
-        payload: payload({ edited_message: message({ text: "x" }) }),
-      })
+      handleMessages(ctx({ edited_message: message({ text: "x" }) }))
     ).toBeUndefined();
     expect(
-      handleMessages({ payload: payload({ callback_query: { id: "cb" } }) })
+      handleMessages(ctx({ callback_query: { id: "cb" } }))
     ).toBeUndefined();
-    expect(handleMessages({ payload: payload({}) })).toBeUndefined();
+    expect(handleMessages(ctx({}))).toBeUndefined();
   });
 });

--- a/packages/spectrum-ts/test/providers/telegram/outbound/message.test.ts
+++ b/packages/spectrum-ts/test/providers/telegram/outbound/message.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "bun:test";
+import { attachment } from "@/content/attachment";
+import { contact } from "@/content/contact";
+import { poll } from "@/content/poll";
+import { reply } from "@/content/reply";
+import { richlink } from "@/content/richlink";
+import { text } from "@/content/text";
+import type { Content } from "@/content/types";
+import { voice } from "@/content/voice";
+import { buildSend } from "@/providers/telegram/outbound/message";
+import type { Message } from "@/types/message";
+
+const target = {
+  id: "42",
+  content: { type: "text", text: "x" },
+} as unknown as Message;
+
+// `buildSend` is the pure content → Bot API method/params mapping. It does NOT
+// inject `chat_id` (the caller does) or touch the network, so it is tested
+// directly with no client.
+describe("buildSend", () => {
+  it("maps text to sendMessage", async () => {
+    expect(await buildSend(await text("hi").build())).toEqual({
+      method: "sendMessage",
+      params: { text: "hi" },
+    });
+  });
+
+  it("maps a richlink to sendMessage with the url (Telegram auto-unfurls)", async () => {
+    expect(await buildSend(await richlink("https://x.test").build())).toEqual({
+      method: "sendMessage",
+      params: { text: "https://x.test" },
+    });
+  });
+
+  it("maps an image attachment to sendPhoto under the photo field", async () => {
+    const spec = await buildSend(
+      await attachment(Buffer.from("img"), {
+        mimeType: "image/png",
+        name: "p.png",
+      }).build()
+    );
+    expect(spec.method).toBe("sendPhoto");
+    expect(spec.file?.field).toBe("photo");
+    expect(spec.file?.filename).toBe("p.png");
+    expect(spec.file?.mimeType).toBe("image/png");
+  });
+
+  it("maps a non-image attachment to sendDocument", async () => {
+    const spec = await buildSend(
+      await attachment(Buffer.from("d"), {
+        mimeType: "application/pdf",
+        name: "d.pdf",
+      }).build()
+    );
+    expect(spec.method).toBe("sendDocument");
+    expect(spec.file?.field).toBe("document");
+  });
+
+  it("maps voice to sendVoice", async () => {
+    const spec = await buildSend(
+      await voice(Buffer.from("a"), {
+        mimeType: "audio/ogg",
+        name: "v.ogg",
+      }).build()
+    );
+    expect(spec.method).toBe("sendVoice");
+    expect(spec.file?.field).toBe("voice");
+    expect(spec.file?.filename).toBe("v.ogg");
+  });
+
+  it("maps a contact to a sendDocument vCard", async () => {
+    const spec = await buildSend(
+      await contact({ phones: [{ value: "+15551234567" }] }).build()
+    );
+    expect(spec.method).toBe("sendDocument");
+    expect(spec.file?.field).toBe("document");
+    expect(spec.file?.filename).toBe("contact.vcf");
+  });
+
+  it("threads a reply via reply_parameters around the inner spec", async () => {
+    const spec = await buildSend(await reply("hey", target).build());
+    expect(spec.method).toBe("sendMessage");
+    expect(spec.params).toEqual({
+      text: "hey",
+      reply_parameters: { message_id: 42 },
+    });
+  });
+
+  it("passes custom content straight to the named Bot API method", async () => {
+    const custom = {
+      type: "custom",
+      raw: { method: "sendDice", params: { emoji: "🎲" } },
+    } as unknown as Content;
+    expect(await buildSend(custom)).toEqual({
+      method: "sendDice",
+      params: { emoji: "🎲" },
+    });
+  });
+
+  it("throws UnsupportedError for content with no Bot API mapping", async () => {
+    await expect(
+      buildSend(await poll("Q?", "a", "b").build())
+    ).rejects.toThrow();
+  });
+});

--- a/packages/spectrum-ts/test/providers/telegram/outbound/send.test.ts
+++ b/packages/spectrum-ts/test/providers/telegram/outbound/send.test.ts
@@ -1,4 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
 import { attachment } from "@/content/attachment";
 import { poll } from "@/content/poll";
 import { reaction } from "@/content/reaction";
@@ -6,10 +14,8 @@ import { reply } from "@/content/reply";
 import { text } from "@/content/text";
 import type { Content } from "@/content/types";
 import { voice } from "@/content/voice";
-import type { TelegramClient } from "@/providers/telegram/client";
 import { configSchema } from "@/providers/telegram/config";
 import { send } from "@/providers/telegram/outbound/send";
-import type { SentMessage, TelegramSendSpec } from "@/providers/telegram/types";
 import type { Message } from "@/types/message";
 
 const TS_SEC = 1_700_000_000;
@@ -20,43 +26,78 @@ const target = {
   content: { type: "text", text: "x" },
 } as unknown as Message;
 
-const setup = () => {
-  const calls: TelegramSendSpec[] = [];
-  const client: TelegramClient = {
-    botId: "1",
-    call: <T = SentMessage>(spec: TelegramSendSpec): Promise<T> => {
-      calls.push(spec);
-      return Promise.resolve({ message_id: 555, date: TS_SEC } as unknown as T);
-    },
-    download: () => Promise.resolve(Buffer.alloc(0)),
+interface Captured {
+  contentType: string | null;
+  form?: FormData;
+  json?: Record<string, unknown>;
+  method: string;
+}
+
+// setMessageReaction/sendChatAction/editMessageText go through photon's typed
+// functions, which validate the response against a Zod schema — so the mock
+// must echo their `{ ok, result: true }` shape; message sends accept any result.
+const FIRE_AND_FORGET = new Set([
+  "setMessageReaction",
+  "sendChatAction",
+  "editMessageText",
+]);
+
+const responseFor = (method: string): unknown =>
+  FIRE_AND_FORGET.has(method)
+    ? { ok: true, result: true }
+    : { ok: true, result: { message_id: 555, date: TS_SEC } };
+
+let calls: Captured[];
+
+beforeEach(() => {
+  calls = [];
+  const impl = (input: Request): Promise<Response> => {
+    const url = input.url;
+    const method = url.slice(url.lastIndexOf("/") + 1);
+    const contentType = input.headers.get("content-type");
+    const record = async (): Promise<Captured> => {
+      if (contentType?.includes("application/json")) {
+        return {
+          contentType,
+          json: (await input.clone().json()) as Record<string, unknown>,
+          method,
+        };
+      }
+      return {
+        contentType,
+        form: (await input.clone().formData()) as unknown as FormData,
+        method,
+      };
+    };
+    return record().then((captured) => {
+      calls.push(captured);
+      return Response.json(responseFor(method));
+    });
   };
-  const map = new Map<string, unknown>([["telegram.client", client]]);
-  const store = {
-    get: (key: string) => map.get(key),
-    set: (key: string, value: unknown) => {
-      map.set(key, value);
-    },
-  };
-  return { calls, store };
-};
+  spyOn(globalThis, "fetch").mockImplementation(
+    impl as unknown as typeof fetch
+  );
+});
+
+afterEach(() => {
+  mock.restore();
+});
 
 describe("send — messages", () => {
-  it("sends text as sendMessage with the chat id", async () => {
-    const { calls, store } = setup();
+  it("sends text as sendMessage with the chat id and returns the record", async () => {
     const result = await send({
       space,
       content: await text("hi").build(),
       config,
-      store,
     });
     expect(result?.id).toBe("555");
     expect(result?.space.id).toBe("100");
+    expect(result?.timestamp).toEqual(new Date(TS_SEC * 1000));
     expect(calls[0]?.method).toBe("sendMessage");
-    expect(calls[0]?.params).toEqual({ chat_id: "100", text: "hi" });
+    expect(calls[0]?.json).toEqual({ chat_id: "100", text: "hi" });
   });
 
-  it("sends an image attachment via sendPhoto", async () => {
-    const { calls, store } = setup();
+  it("sends an image attachment via sendPhoto as multipart, preserving the filename", async () => {
     await send({
       space,
       content: await attachment(Buffer.from("img"), {
@@ -64,16 +105,14 @@ describe("send — messages", () => {
         name: "p.png",
       }).build(),
       config,
-      store,
     });
     expect(calls[0]?.method).toBe("sendPhoto");
-    expect(calls[0]?.file?.field).toBe("photo");
-    expect(calls[0]?.file?.filename).toBe("p.png");
-    expect(calls[0]?.params.chat_id).toBe("100");
+    expect(calls[0]?.contentType).not.toContain("application/json");
+    expect(calls[0]?.form?.get("chat_id")).toBe("100");
+    expect((calls[0]?.form?.get("photo") as File).name).toBe("p.png");
   });
 
   it("sends a non-image attachment via sendDocument", async () => {
-    const { calls, store } = setup();
     await send({
       space,
       content: await attachment(Buffer.from("d"), {
@@ -81,14 +120,12 @@ describe("send — messages", () => {
         name: "d.pdf",
       }).build(),
       config,
-      store,
     });
     expect(calls[0]?.method).toBe("sendDocument");
-    expect(calls[0]?.file?.field).toBe("document");
+    expect((calls[0]?.form?.get("document") as File).name).toBe("d.pdf");
   });
 
   it("sends voice via sendVoice", async () => {
-    const { calls, store } = setup();
     await send({
       space,
       content: await voice(Buffer.from("a"), {
@@ -96,22 +133,15 @@ describe("send — messages", () => {
         name: "v.ogg",
       }).build(),
       config,
-      store,
     });
     expect(calls[0]?.method).toBe("sendVoice");
-    expect(calls[0]?.file?.field).toBe("voice");
+    expect((calls[0]?.form?.get("voice") as File).name).toBe("v.ogg");
   });
 
   it("threads a reply via reply_parameters", async () => {
-    const { calls, store } = setup();
-    await send({
-      space,
-      content: await reply("hey", target).build(),
-      config,
-      store,
-    });
+    await send({ space, content: await reply("hey", target).build(), config });
     expect(calls[0]?.method).toBe("sendMessage");
-    expect(calls[0]?.params).toEqual({
+    expect(calls[0]?.json).toEqual({
       chat_id: "100",
       text: "hey",
       reply_parameters: { message_id: 42 },
@@ -119,7 +149,6 @@ describe("send — messages", () => {
   });
 
   it("fans a group out to one message per item, returning the last", async () => {
-    const { calls, store } = setup();
     const group = {
       type: "group",
       items: [
@@ -127,37 +156,34 @@ describe("send — messages", () => {
         { id: "b", content: await text("two").build() },
       ],
     } as unknown as Content;
-    const result = await send({ space, content: group, config, store });
+    const result = await send({ space, content: group, config });
     expect(calls).toHaveLength(2);
-    expect(calls[0]?.params).toMatchObject({ text: "one" });
-    expect(calls[1]?.params).toMatchObject({ text: "two" });
+    expect(calls[0]?.json).toMatchObject({ text: "one" });
+    expect(calls[1]?.json).toMatchObject({ text: "two" });
     expect(result?.id).toBe("555");
   });
 
   it("passes custom content straight to the named Bot API method", async () => {
-    const { calls, store } = setup();
     const custom = {
       type: "custom",
       raw: { method: "sendDice", params: { emoji: "🎲" } },
     } as unknown as Content;
-    await send({ space, content: custom, config, store });
+    await send({ space, content: custom, config });
     expect(calls[0]?.method).toBe("sendDice");
-    expect(calls[0]?.params).toEqual({ chat_id: "100", emoji: "🎲" });
+    expect(calls[0]?.json).toEqual({ chat_id: "100", emoji: "🎲" });
   });
 });
 
 describe("send — fire-and-forget", () => {
   it("sends a reaction via setMessageReaction and returns undefined", async () => {
-    const { calls, store } = setup();
     const result = await send({
       space,
       content: await reaction("👍", target).build(),
       config,
-      store,
     });
     expect(result).toBeUndefined();
     expect(calls[0]?.method).toBe("setMessageReaction");
-    expect(calls[0]?.params).toEqual({
+    expect(calls[0]?.json).toEqual({
       chat_id: "100",
       message_id: 42,
       reaction: [{ type: "emoji", emoji: "👍" }],
@@ -165,41 +191,32 @@ describe("send — fire-and-forget", () => {
   });
 
   it("rejects an invalid reaction emoji without calling the API", async () => {
-    const { calls, store } = setup();
     await expect(
-      send({
-        space,
-        content: await reaction("🚀", target).build(),
-        config,
-        store,
-      })
+      send({ space, content: await reaction("🚀", target).build(), config })
     ).rejects.toThrow("not an allowed");
     expect(calls).toHaveLength(0);
   });
 
-  it("starts a typing action; stop is a no-op", async () => {
-    const { calls, store } = setup();
+  it("starts a typing action via sendChatAction", async () => {
     await send({
       space,
       content: { type: "typing", state: "start" } as unknown as Content,
       config,
-      store,
     });
     expect(calls[0]?.method).toBe("sendChatAction");
-    expect(calls[0]?.params).toEqual({ chat_id: "100", action: "typing" });
+    expect(calls[0]?.json).toEqual({ action: "typing", chat_id: "100" });
+  });
 
-    const stop = setup();
+  it("treats typing stop as a no-op", async () => {
     await send({
       space,
       content: { type: "typing", state: "stop" } as unknown as Content,
       config,
-      store: stop.store,
     });
-    expect(stop.calls).toHaveLength(0);
+    expect(calls).toHaveLength(0);
   });
 
-  it("edits text via editMessageText and rejects non-text edits", async () => {
-    const { calls, store } = setup();
+  it("edits text via editMessageText", async () => {
     await send({
       space,
       content: {
@@ -208,15 +225,16 @@ describe("send — fire-and-forget", () => {
         target,
       } as unknown as Content,
       config,
-      store,
     });
     expect(calls[0]?.method).toBe("editMessageText");
-    expect(calls[0]?.params).toEqual({
+    expect(calls[0]?.json).toEqual({
       chat_id: "100",
       message_id: 42,
       text: "new",
     });
+  });
 
+  it("rejects a non-text edit without calling the API", async () => {
     await expect(
       send({
         space,
@@ -226,22 +244,16 @@ describe("send — fire-and-forget", () => {
           target,
         } as unknown as Content,
         config,
-        store,
       })
     ).rejects.toThrow();
+    expect(calls).toHaveLength(0);
   });
 });
 
 describe("send — unsupported", () => {
   it("throws UnsupportedError for polls", async () => {
-    const { store } = setup();
     await expect(
-      send({
-        space,
-        content: await poll("Q?", "a", "b").build(),
-        config,
-        store,
-      })
+      send({ space, content: await poll("Q?", "a", "b").build(), config })
     ).rejects.toThrow();
   });
 });

--- a/packages/spectrum-ts/test/providers/telegram/verify.test.ts
+++ b/packages/spectrum-ts/test/providers/telegram/verify.test.ts
@@ -1,16 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import type { TelegramClient } from "@/providers/telegram/client";
 import { configSchema } from "@/providers/telegram/config";
 import type { TelegramPayload } from "@/providers/telegram/types";
-import { makeVerify } from "@/providers/telegram/verify";
+import { verify } from "@/providers/telegram/verify";
 
 const SECRET = "s3cr3t_token-123";
-
-const fakeClient: TelegramClient = {
-  botId: "42",
-  call: () => Promise.reject(new Error("unused")),
-  download: () => Promise.reject(new Error("unused")),
-};
 
 const body = (updateId = 1): string =>
   JSON.stringify({
@@ -32,22 +25,20 @@ const request = (payload: string, headers: Record<string, string>) => ({
 });
 
 const verifyWith = (secret?: string) =>
-  makeVerify(
+  verify(
     configSchema.parse({
       botToken: "42:abc",
       ...(secret ? { webhookSecret: secret } : {}),
-    }),
-    fakeClient
+    })
   );
 
-describe("makeVerify", () => {
-  it("accepts when the secret token header matches", () => {
-    const result = verifyWith(SECRET)(
+describe("verify", () => {
+  it("accepts when the secret token header matches and returns the parsed update", () => {
+    const update = verifyWith(SECRET)(
       request(body(), { "x-telegram-bot-api-secret-token": SECRET })
     ) as TelegramPayload;
-    expect(result.update.update_id).toBe(1);
-    expect(result.update.message?.text).toBe("hi");
-    expect(result.client).toBe(fakeClient);
+    expect(update.update_id).toBe(1);
+    expect(update.message?.text).toBe("hi");
   });
 
   it("rejects a mismatched secret token", () => {
@@ -65,8 +56,8 @@ describe("makeVerify", () => {
   });
 
   it("skips verification when no secret is configured", () => {
-    const result = verifyWith()(request(body(), {})) as TelegramPayload;
-    expect(result.update.update_id).toBe(1);
+    const update = verifyWith()(request(body(), {})) as TelegramPayload;
+    expect(update.update_id).toBe(1);
   });
 
   it("rejects a body that is not valid JSON", () => {

--- a/packages/spectrum-ts/test/providers/telegram/webhook.test.ts
+++ b/packages/spectrum-ts/test/providers/telegram/webhook.test.ts
@@ -1,0 +1,148 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from "bun:test";
+import { configSchema } from "@/providers/telegram/config";
+import { ensureWebhook, webhookUrl } from "@/providers/telegram/webhook";
+
+const SLUG = "what-c62a6";
+const SECRET = "s3cr3t_token-123";
+const BOT_TOKEN = "42:supersecret";
+const EXPECTED_URL = `https://${SLUG}.spctrm.dev/telegram`;
+
+interface Captured {
+  json?: Record<string, unknown>;
+  method: string;
+}
+
+const config = (secret?: string) =>
+  configSchema.parse({
+    botToken: BOT_TOKEN,
+    ...(secret ? { webhookSecret: secret } : {}),
+  });
+
+let calls: Captured[];
+let currentUrl: string;
+let failMethod: string | null;
+let originalSuperWebhook: string | undefined;
+
+beforeEach(() => {
+  calls = [];
+  currentUrl = "";
+  failMethod = null;
+  originalSuperWebhook = process.env.SPECTRUM_SUPER_WEBHOOK;
+  // Truly unset so the default-domain test is deterministic.
+  delete process.env.SPECTRUM_SUPER_WEBHOOK;
+
+  const impl = (input: Request): Promise<Response> => {
+    const url = input.url;
+    const method = url.slice(url.lastIndexOf("/") + 1);
+    return (async (): Promise<Response> => {
+      const isJson = input.headers
+        .get("content-type")
+        ?.includes("application/json");
+      calls.push({
+        json: isJson
+          ? ((await input.clone().json()) as Record<string, unknown>)
+          : undefined,
+        method,
+      });
+      if (failMethod === method) {
+        return Response.json(
+          { description: "bad request", error_code: 400, ok: false },
+          { status: 400 }
+        );
+      }
+      if (method === "getWebhookInfo") {
+        return Response.json({
+          ok: true,
+          result: {
+            has_custom_certificate: false,
+            pending_update_count: 0,
+            url: currentUrl,
+          },
+        });
+      }
+      return Response.json({ ok: true, result: true });
+    })();
+  };
+  spyOn(globalThis, "fetch").mockImplementation(
+    impl as unknown as typeof fetch
+  );
+});
+
+afterEach(() => {
+  if (originalSuperWebhook === undefined) {
+    delete process.env.SPECTRUM_SUPER_WEBHOOK;
+  } else {
+    process.env.SPECTRUM_SUPER_WEBHOOK = originalSuperWebhook;
+  }
+  mock.restore();
+});
+
+describe("webhookUrl", () => {
+  it("builds the Fusor edge URL from the slug on the default domain", () => {
+    expect(webhookUrl(SLUG)).toBe(EXPECTED_URL);
+  });
+
+  it("honors the SPECTRUM_SUPER_WEBHOOK domain override", () => {
+    process.env.SPECTRUM_SUPER_WEBHOOK = "staging.spctrm.dev";
+    expect(webhookUrl(SLUG)).toBe(
+      `https://${SLUG}.staging.spctrm.dev/telegram`
+    );
+  });
+});
+
+describe("ensureWebhook", () => {
+  it("skips setWebhook when the webhook URL is already registered", async () => {
+    currentUrl = EXPECTED_URL;
+    await ensureWebhook(config(), SLUG);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("getWebhookInfo");
+  });
+
+  it("registers the webhook with secret_token when a webhookSecret is set", async () => {
+    await ensureWebhook(config(SECRET), SLUG);
+    expect(calls.map((c) => c.method)).toEqual([
+      "getWebhookInfo",
+      "setWebhook",
+    ]);
+    expect(calls[1]?.json).toEqual({
+      secret_token: SECRET,
+      url: EXPECTED_URL,
+    });
+  });
+
+  it("registers the webhook without secret_token when no webhookSecret is set", async () => {
+    await ensureWebhook(config(), SLUG);
+    expect(calls[1]?.method).toBe("setWebhook");
+    expect(calls[1]?.json).toEqual({ url: EXPECTED_URL });
+  });
+
+  it("registers when a different URL is already set", async () => {
+    currentUrl = "https://stale.example.com/telegram";
+    await ensureWebhook(config(), SLUG);
+    expect(calls[1]?.method).toBe("setWebhook");
+    expect(calls[1]?.json).toEqual({ url: EXPECTED_URL });
+  });
+
+  it("throws a token-free error when the Bot API call fails", async () => {
+    failMethod = "setWebhook";
+    let thrown: unknown;
+    try {
+      await ensureWebhook(config(SECRET), SLUG);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain(
+      "Telegram webhook registration failed"
+    );
+    expect((thrown as Error).message).not.toContain(BOT_TOKEN);
+  });
+});

--- a/packages/spectrum-ts/test/support/cloud.ts
+++ b/packages/spectrum-ts/test/support/cloud.ts
@@ -12,4 +12,5 @@ export const stubCloud = () =>
     id: "proj",
     name: "Test Project",
     profile: {},
+    slug: "test-project",
   });

--- a/packages/spectrum-ts/test/support/fusor.ts
+++ b/packages/spectrum-ts/test/support/fusor.ts
@@ -4,6 +4,7 @@ import type { Content } from "@/content/types";
 import { fusor, fusorEvent } from "@/fusor";
 import type { FusorMessages } from "@/fusor/types";
 import { definePlatform } from "@/platform/define";
+import type { ProjectData } from "@/utils/cloud";
 
 // A minimal fusor-mode provider standing in for a real platform (Slack-ish).
 // Its verify() parses the inner HTTP body to a typed payload; messages() turns
@@ -184,5 +185,65 @@ export const makePresence = () =>
     },
     events: { presence: presenceSchema },
     messages: presenceMessages,
+    send: () => Promise.resolve(undefined),
+  });
+
+// ---------------------------------------------------------------------------
+// Runtime-context probe — asserts the fusor `messages` ctx now carries
+// config/store/projectConfig (parity with the regular-mode handler contract).
+// ---------------------------------------------------------------------------
+
+export const CTX_PROBE_PLATFORM = "ctxprobe";
+
+const ctxProbeConfig = z.object({ token: z.string() });
+
+export interface CtxProbeCapture {
+  config?: z.infer<typeof ctxProbeConfig>;
+  projectConfig?: ProjectData | undefined;
+  storeRoundTrip?: string;
+}
+
+// Records the runtime ctx its `messages` handler is invoked with, so a test can
+// assert config/store/projectConfig were threaded in. A typed reference (not an
+// inline arrow) so overload resolution selects the fusor overload — and typed
+// `TConfig` so `config` lands as `{ token: string }`, not `unknown`.
+const ctxProbeMessages =
+  (
+    capture: CtxProbeCapture
+  ): FusorMessages<{ text: string }, z.infer<typeof ctxProbeConfig>> =>
+  ({ payload, config, store, projectConfig }) => {
+    capture.config = config;
+    capture.projectConfig = projectConfig;
+    // Prove `store` is a live Store, not a stub: a write reads back through it.
+    store.set("lastText", payload.text);
+    capture.storeRoundTrip = store.string("lastText");
+    return {
+      id: "c1",
+      content: { type: "text", text: payload.text } as Content,
+      sender: { id: "u1" },
+      space: { id: "s1" },
+    };
+  };
+
+export const makeCtxProbe = (capture: CtxProbeCapture) =>
+  definePlatform(CTX_PROBE_PLATFORM, {
+    config: ctxProbeConfig,
+    lifecycle: {
+      createClient: () =>
+        Promise.resolve(
+          fusor<{ text: string }>(CTX_PROBE_PLATFORM, (req) => {
+            const body = JSON.parse(new TextDecoder().decode(req.rawBody)) as {
+              text?: string;
+            };
+            return { text: body.text ?? "" };
+          })
+        ),
+    },
+    user: { resolve: ({ input }) => Promise.resolve({ id: input.userID }) },
+    space: {
+      resolve: ({ input }) =>
+        Promise.resolve({ id: input.users[0]?.id ?? "space" }),
+    },
+    messages: ctxProbeMessages(capture),
     send: () => Promise.resolve(undefined),
   });


### PR DESCRIPTION
## Summary

Rebuilds the Telegram provider on top of the generated, type-safe Bot API client (`@photon-ai/telegram-ts@10.0.0`), retiring the hand-written `fetch` wrapper and the `@grammyjs/types` dev dependency. To make that work cleanly, the Fusor `messages` hook is upgraded to receive the same runtime context every other platform callback gets — so the provider no longer smuggles a client through the payload — and the provider self-registers its webhook against the Fusor edge on startup.

- **Telegram now runs entirely on photon.** `client.ts` drops the bespoke `{ ok, result }` HTTP client; sending and inbound media-download build a photon client inline (the constructor makes no network call, so there is nothing to cache). The two things photon can't do directly — raw-byte multipart uploads and file-byte download — are the only glue left, both bridged through photon's own low-level `client.post` / `getFile`.
- **Fusor `messages` ctx enrichment.** `FusorMessagesCtx` now carries `config` (typed from the platform's Zod schema), `store`, and `projectConfig`, matching the regular-mode handler contract. The Telegram payload shrinks from `{ client, update }` to just the parsed `Update`; the inbound mapper reads `config` from its own ctx.
- **Webhook auto-registration.** New `webhook.ts`: in cloud mode (`projectConfig` present), `createClient` registers the bot's webhook against the Fusor "super webhook" edge (`https://{slug}.spctrm.dev/telegram`, overridable via `SPECTRUM_SUPER_WEBHOOK`). Idempotent — reads `getWebhookInfo` first and only writes when the URL differs.
- **Fusor gRPC auth fix.** The subscribe stream now sends the JWT under the `access_token` metadata key (what fanout-grpc's `authorize()` reads), not an `authorization: Bearer …` header.
- **Platform narrowing no longer throws.** `narrowSpace` / `narrowMessage` log a structured warning on a platform mismatch instead of throwing, so a cross-platform space/message degrades gracefully rather than crashing the pipeline.

## Usage

```ts
import { Spectrum } from "spectrum-ts";
import { telegram } from "spectrum-ts/providers/telegram";

const app = await Spectrum({
  projectId: process.env.PROJECT_ID,
  projectSecret: process.env.PROJECT_SECRET,
  providers: [telegram.config({ botToken: process.env.TELEGRAM_BOT_TOKEN! })],
});
```

On startup the bot's webhook is pointed at the project's Fusor edge automatically; inbound updates arrive over Fusor and outbound sends go to the Bot API — both through the generated client.

## Changes

| File | Change |
|------|--------|
| `providers/telegram/client.ts` | Replace the custom HTTP client with a photon-backed `executeSpec` + `downloadFile`; drop the store-cached client |
| `providers/telegram/webhook.ts` | **New** — `ensureWebhook` / `webhookUrl`, idempotent Fusor-edge registration |
| `providers/telegram/verify.ts` | `makeVerify(config, client)` → `verify(config)`; verify is now pure parsing (no client) |
| `providers/telegram/inbound/{messages,media}.ts` | Read `config` from ctx; lazy media `read()` builds a client inline |
| `providers/telegram/outbound/send.ts` | Use photon's typed `setMessageReaction`/`sendChatAction`/`editMessageText` and `executeSpec`; build client inline (no `store`) |
| `providers/telegram/types.ts` | Type imports from `@photon-ai/telegram-ts`; `TelegramPayload = Update` |
| `providers/telegram/index.ts` | `createClient` self-registers the webhook in cloud mode |
| `fusor/types.ts` | `FusorMessagesCtx<TPayload, TConfig>` gains `config` / `store` / `projectConfig` |
| `fusor/core.ts` | gRPC auth uses the `access_token` metadata key |
| `platform/define.ts` | `narrowSpace`/`narrowMessage` warn instead of throw |
| `platform/types.ts` | `CreateClientContext.projectConfig` |
| `spectrum.ts` | Thread `config`/`store`/`projectConfig` into the fusor `messages` handler |
| `utils/cloud.ts` | `ProjectData.slug` |
| `package.json` / `bun.lock` | Add `@photon-ai/telegram-ts@10.0.0`; remove `@grammyjs/types` |
| `docs/telegram.md` | **New** — full provider reference |
| `docs/fusor.md` | Document the enriched `messages` ctx |
| `README.md` | List Telegram in the Platforms table |
| `test/providers/telegram/**` | Re-seam tests on `globalThis.fetch`; add `webhook.test.ts` + `outbound/message.test.ts` |
| `test/core/fusor/webhook.test.ts`, `test/support/{cloud,fusor}.ts` | Add a ctx-probe asserting `config`/`store`/`projectConfig` are threaded in |

## Test plan

- [ ] `bun test` — Telegram inbound/outbound/verify/webhook suites and the Fusor ctx-threading test pass
- [ ] `bun x ultracite check` — lint/format clean
- [ ] Verify cloud-mode startup registers the webhook (and is a no-op when the URL is already current)
- [ ] Confirm the bot token never appears in thrown errors (download / webhook failure paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783577814&installation_id=127326493&pr_number=112&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F112&signature=35956b6302d3177067089d7077191575f5f4550bcc66b3c056bdde519f463506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Telegram provider added with webhook support and cloud-mode webhook registration
  * Message handlers receive enriched runtime context (config, project metadata, per-platform store)

* **Documentation**
  * Full Telegram provider docs added
  * Fusor message handler docs updated
  * Telegram listed in supported platforms table

* **Tests**
  * New/updated tests covering Telegram inbound/outbound, webhook, verify, and context wiring
<!-- end of auto-generated comment: release notes by coderabbit.ai -->