### PR TITLE
feat(space): replace callable space() with space.create(users) / space.get(id) namespace

### DIFF
--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -151,7 +151,7 @@ Errors from photon surface as `TelegramApiError` (token-free).
 | `verify.ts` | `verify(config)` — secret check + parse `Update` |
 | `client.ts` | `telegramClient`, `executeSpec`, `downloadFile` (all over photon) |
 | `types.ts` | photon type re-exports, `TelegramPayload = Update`, send DTOs |
-| `space.ts` | user/space resolution (`chat_id`) |
+| `space.ts` | user resolution + `space.create` (single-user private chats; existing chats go through `space.get(chatId)`) |
 | `reactions.ts` | allowed reaction-emoji set + normalization |
 | `inbound/messages.ts` | `handleMessages` — `Update` → record |
 | `inbound/media.ts` | media detection + lazy `read()` |

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -72,6 +72,7 @@ export type {
   PlatformUser,
   ProviderMessage,
   SchemaMessage,
+  SpaceNamespace,
 } from "./platform/types";
 export { Spectrum, type SpectrumInstance } from "./spectrum";
 export type { Message } from "./types/message";

--- a/packages/spectrum-ts/src/platform/define.ts
+++ b/packages/spectrum-ts/src/platform/define.ts
@@ -34,25 +34,6 @@ import type {
 
 const platformLog = createLogger("spectrum.platform");
 
-function classifySpaceIdentifier(args: unknown[]): {
-  kind: "phone" | "email" | "group" | "unknown";
-  identifier?: string;
-} {
-  const stringArgs = args.filter((a): a is string => typeof a === "string");
-  if (stringArgs.length > 1) {
-    return { kind: "group" };
-  }
-  const s = stringArgs[0];
-  if (!s) {
-    return { kind: "unknown" };
-  }
-  const { kind, identifier } = classifySingle(s);
-  if (kind === "unknown") {
-    return { kind: "unknown" };
-  }
-  return { kind, identifier };
-}
-
 type NoInferValue<T> = [T][T extends unknown ? 0 : never];
 
 type RawActionFactory = (
@@ -114,12 +95,6 @@ function createPlatformInstance<
   _Client,
   _ConfigSchema extends z.ZodType<object>,
 >(def: Def, runtime: PlatformRuntime): PlatformInstance<Def> {
-  const isPlatformUser = (value: unknown): value is PlatformUser<Def> =>
-    typeof value === "object" &&
-    value !== null &&
-    "__platform" in value &&
-    (value as { __platform?: unknown }).__platform === def.name;
-
   const resolveUserID = async (userID: string): Promise<PlatformUser<Def>> => {
     const resolved = await def.user.resolve({
       input: { userID },
@@ -133,116 +108,114 @@ function createPlatformInstance<
     } as PlatformUser<Def>;
   };
 
-  const resolveStringUsers = async (args: unknown[]): Promise<unknown[]> => {
-    const convertArg = async (arg: unknown): Promise<unknown> => {
-      if (typeof arg === "string") {
-        return await resolveUserID(arg);
-      }
-      if (Array.isArray(arg)) {
-        return await Promise.all(arg.map(convertArg));
-      }
-      return arg;
+  const providerCtx = () => ({
+    client: runtime.client as _Client,
+    config: runtime.config as z.infer<_ConfigSchema>,
+    store: runtime.store,
+  });
+
+  const parseSpaceParams = (params: unknown): unknown =>
+    params !== undefined && def.space.params
+      ? def.space.params.parse(params)
+      : params;
+
+  // Schema-validate a provider-resolved space and wrap it as a full
+  // PlatformSpace (spaceRef + universal sugar via buildSpace).
+  const finalizeSpace = (resolved: { id: string }): PlatformSpace<Def> => {
+    const parsedSpace = (
+      def.space.schema ? def.space.schema.parse(resolved) : resolved
+    ) as { id: string };
+    const spaceRef = {
+      ...(parsedSpace as Record<string, unknown>),
+      id: parsedSpace.id,
+      __platform: def.name,
     };
-    return await Promise.all(args.map(convertArg));
-  };
-
-  const normalizeSpaceArgs = (
-    args: unknown[]
-  ): { users: PlatformUser<Def>[]; params: unknown } => {
-    if (args.length === 0) {
-      return { users: [], params: undefined };
-    }
-
-    const [first, ...rest] = args;
-    if (Array.isArray(first)) {
-      return {
-        users: first as PlatformUser<Def>[],
-        params: rest[0],
-      };
-    }
-
-    if (!isPlatformUser(first)) {
-      return {
-        users: [],
-        params: first,
-      };
-    }
-
-    const last = args.at(-1);
-    if (last !== undefined && !isPlatformUser(last)) {
-      return {
-        users: args.slice(0, -1) as PlatformUser<Def>[],
-        params: last,
-      };
-    }
-
-    return {
-      users: args as PlatformUser<Def>[],
-      params: undefined,
+    const actionCtx = {
+      space: spaceRef,
+      ...providerCtx(),
     };
+    return buildSpace({
+      spaceRef,
+      extras: parsedSpace as Record<string, unknown>,
+      actionCtx,
+      definition: def as unknown as AnyPlatformDef,
+      client: runtime.client,
+      config: runtime.config,
+      store: runtime.store,
+    }) as PlatformSpace<Def>;
   };
 
   const base = {
     async user(userID: string) {
-      const resolved = await def.user.resolve({
-        input: { userID },
-        client: runtime.client as _Client,
-        config: runtime.config as z.infer<_ConfigSchema>,
-        store: runtime.store,
-      });
-      return {
-        ...resolved,
-        __platform: def.name,
-      } as PlatformUser<Def>;
+      return await resolveUserID(userID);
     },
 
-    async space(...args: unknown[]) {
-      const { kind, identifier } = classifySpaceIdentifier(args);
-      return withSpan(
-        "spectrum.space.resolve",
-        {
-          "spectrum.provider": def.name,
-          "spectrum.space.identifier_kind": kind,
-          "spectrum.space.identifier": identifier,
-        },
-        async () => {
-          const convertedArgs = await resolveStringUsers(args);
-          const { users, params } = normalizeSpaceArgs(convertedArgs);
-          let parsedParams = params;
-          if (params !== undefined && def.space.params) {
-            parsedParams = def.space.params.parse(params);
+    space: {
+      create: async (
+        users: PlatformUser<Def> | string | (PlatformUser<Def> | string)[],
+        params?: unknown
+      ): Promise<PlatformSpace<Def>> => {
+        const userList = Array.isArray(users) ? users : [users];
+        const first = userList.length === 1 ? userList[0] : undefined;
+        const single =
+          typeof first === "string" ? classifySingle(first) : undefined;
+        const kind =
+          userList.length > 1 ? "group" : (single?.kind ?? "unknown");
+        return await withSpan(
+          "spectrum.space.create",
+          {
+            "spectrum.provider": def.name,
+            "spectrum.space.user_count": userList.length,
+            "spectrum.space.identifier_kind": kind,
+            "spectrum.space.identifier":
+              kind === "unknown" ? undefined : single?.identifier,
+          },
+          async () => {
+            const resolvedUsers = await Promise.all(
+              userList.map((u) =>
+                typeof u === "string" ? resolveUserID(u) : u
+              )
+            );
+            const resolved = await def.space.create({
+              input: { users: resolvedUsers, params: parseSpaceParams(params) },
+              ...providerCtx(),
+            });
+            return finalizeSpace(resolved);
           }
-          const resolved = await def.space.resolve({
-            input: { users, params: parsedParams },
-            client: runtime.client as _Client,
-            config: runtime.config as z.infer<_ConfigSchema>,
-            store: runtime.store,
-          });
-          const parsedSpace = def.space.schema
-            ? def.space.schema.parse(resolved)
-            : resolved;
-          const spaceRef = {
-            ...(parsedSpace as Record<string, unknown>),
-            id: parsedSpace.id,
-            __platform: def.name,
-          };
-          const actionCtx = {
-            space: spaceRef,
-            client: runtime.client as _Client,
-            config: runtime.config as z.infer<_ConfigSchema>,
-            store: runtime.store,
-          };
-          return buildSpace({
-            spaceRef,
-            extras: parsedSpace as Record<string, unknown>,
-            actionCtx,
-            definition: def as unknown as AnyPlatformDef,
-            client: runtime.client,
-            config: runtime.config,
-            store: runtime.store,
-          }) as PlatformSpace<Def>;
-        }
-      );
+        );
+      },
+
+      get: async (id: string, params?: unknown): Promise<PlatformSpace<Def>> =>
+        await withSpan(
+          "spectrum.space.get",
+          {
+            "spectrum.provider": def.name,
+            "spectrum.space.id": id,
+          },
+          async () => {
+            const parsedParams = parseSpaceParams(params);
+            if (def.space.get) {
+              const resolved = await def.space.get({
+                input: { id, params: parsedParams },
+                ...providerCtx(),
+              });
+              return finalizeSpace(resolved);
+            }
+            // Framework default: the id alone is the space. Providers whose
+            // schema needs more fields must implement `space.get`.
+            const candidate = { id };
+            if (def.space.schema) {
+              const parsed = def.space.schema.safeParse(candidate);
+              if (!parsed.success) {
+                throw new Error(
+                  `Platform "${def.name}" cannot construct a space from an id alone — its space schema requires more fields. Implement \`space.get\` in the "${def.name}" provider definition.`,
+                  { cause: parsed.error }
+                );
+              }
+            }
+            return finalizeSpace(candidate);
+          }
+        ),
     },
   };
 
@@ -317,11 +290,13 @@ function createPlatformInstance<
   // Spread order: actions first, events last — an event stream cannot be
   // silently shadowed by an action of the same name (the reserved-key check
   // above already skips such actions, so this is belt-and-braces).
+  // Two-step cast: `messages` is wired via defineProperty above, so `base`
+  // doesn't structurally satisfy PlatformInstance at the type level.
   return Object.assign(
     base,
     instanceActions,
     eventProperties
-  ) as PlatformInstance<Def>;
+  ) as unknown as PlatformInstance<Def>;
 }
 
 // `definePlatform` has two call shapes, expressed as overloads:

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -398,9 +398,26 @@ export interface PlatformDef<
   space: {
     schema?: _SpaceSchema;
     params?: _SpaceParamsSchema;
-    resolve: (_: {
+    create: (_: {
       input: {
         users: (_ResolvedUser & { __platform: _Name })[];
+        params?: _SpaceParamsSchema extends z.ZodType<object>
+          ? z.infer<_SpaceParamsSchema>
+          : undefined;
+      };
+      client: NoInferClient<_Client>;
+      config: z.infer<_ConfigSchema>;
+      store: Store;
+    }) => Promise<_ResolvedSpace>;
+    /**
+     * Optional: hydrate a space from a known platform space id. When absent,
+     * the framework builds the candidate `{ id }` and validates it against
+     * `space.schema` — providers whose schema requires more fields must
+     * implement this.
+     */
+    get?: (_: {
+      input: {
+        id: string;
         params?: _SpaceParamsSchema extends z.ZodType<object>
           ? z.infer<_SpaceParamsSchema>
           : undefined;
@@ -479,7 +496,9 @@ export interface AnyPlatformDef {
     schema?: z.ZodType<object>;
     params?: z.ZodType<object>;
     // biome-ignore lint/suspicious/noExplicitAny: wildcard resolver
-    resolve: (_: any) => Promise<any>;
+    create: (_: any) => Promise<any>;
+    // biome-ignore lint/suspicious/noExplicitAny: wildcard resolver
+    get?: (_: any) => Promise<any>;
     actions?: Record<string, SpaceActionFn>;
   };
   user: {
@@ -603,7 +622,7 @@ export type CustomEventStreams<Providers extends PlatformProviderConfig[]> = {
 // ---------------------------------------------------------------------------
 
 type ResolvedSpaceOf<Def extends AnyPlatformDef> = AwaitedReturn<
-  Def["space"]["resolve"]
+  Def["space"]["create"]
 >;
 type SchemaSpaceOf<Def extends AnyPlatformDef> = InferOptionalSchema<
   Def["space"]["schema"]
@@ -619,30 +638,47 @@ type SpaceShapeOf<Def extends AnyPlatformDef> = [SchemaSpaceOf<Def>] extends [
   ? ResolvedSpaceOf<Def>
   : SchemaSpaceOf<Def>;
 
-type SpaceParamsInputOf<Def extends AnyPlatformDef> = InputSchema<
-  Def["space"]["params"]
->;
+// When a provider declares no `space.params`, `definePlatform`'s
+// `_SpaceParamsSchema` has no inference candidate and falls back to its
+// constraint — the broad `z.ZodType<object>`. A declared schema is always a
+// strict subtype (e.g. `ZodObject<…>`), so "is the broad type assignable
+// here?" cleanly separates absent (→ never, no params argument) from declared.
+type SpaceParamsInputOf<Def extends AnyPlatformDef> =
+  z.ZodType<object> extends Def["space"]["params"]
+    ? never
+    : InputSchema<Def["space"]["params"]>;
 
 type SpaceUserLike<Def extends AnyPlatformDef> = PlatformUser<Def> | string;
 
-type SpaceArrayArgs<Def extends AnyPlatformDef> = [
+// Params tuple for `space.create` / `space.get`:
+// - no params schema on the provider           → no params argument at all
+// - schema with only optional fields           → optional trailing params
+// - schema with required fields (slack teamId) → required trailing params
+type SpaceParamsArgs<Def extends AnyPlatformDef> = [
   SpaceParamsInputOf<Def>,
 ] extends [never]
-  ? [users: SpaceUserLike<Def>[]]
-  :
-      | [users: SpaceUserLike<Def>[]]
-      | [users: SpaceUserLike<Def>[], params: SpaceParamsInputOf<Def>]
-      | [params: SpaceParamsInputOf<Def>];
+  ? []
+  : Record<string, never> extends SpaceParamsInputOf<Def>
+    ? [params?: SpaceParamsInputOf<Def>]
+    : [params: SpaceParamsInputOf<Def>];
 
-type SpaceVarargArgs<Def extends AnyPlatformDef> = [
-  SpaceParamsInputOf<Def>,
-] extends [never]
-  ? SpaceUserLike<Def>[]
-  : SpaceUserLike<Def>[] | [...SpaceUserLike<Def>[], SpaceParamsInputOf<Def>];
-
-type SpaceArgs<Def extends AnyPlatformDef> =
-  | SpaceArrayArgs<Def>
-  | SpaceVarargArgs<Def>;
+export interface SpaceNamespace<Def extends AnyPlatformDef> {
+  /**
+   * Resolve or create a space from its participants — a single user (1:1
+   * conversation) or several (group, where the platform supports it). Users
+   * may be raw id strings or previously resolved `PlatformUser`s.
+   */
+  create(
+    users: SpaceUserLike<Def> | SpaceUserLike<Def>[],
+    ...params: SpaceParamsArgs<Def>
+  ): Promise<PlatformSpace<Def>>;
+  /**
+   * Construct a space from a known platform space id — e.g. one persisted
+   * from an earlier event. Providers may hydrate platform-specific fields
+   * (or verify existence) via their `space.get` hook.
+   */
+  get(id: string, ...params: SpaceParamsArgs<Def>): Promise<PlatformSpace<Def>>;
+}
 
 // Methods derived from `PlatformDef.space.actions`. The first parameter
 // (`space`) is bound to the built `PlatformSpace<Def>` at construction time,
@@ -783,7 +819,7 @@ export type PlatformUser<Def extends AnyPlatformDef> = Omit<
 
 export type PlatformInstance<Def extends AnyPlatformDef> = {
   readonly messages: AsyncIterable<[PlatformSpace<Def>, PlatformMessage<Def>]>;
-  space(...args: SpaceArgs<Def>): Promise<PlatformSpace<Def>>;
+  readonly space: SpaceNamespace<Def>;
   user(userID: string): Promise<PlatformUser<Def>>;
 } & CustomEventInstanceProperties<Def> &
   PlatformWiseInstanceMethods<Def> &

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -63,7 +63,7 @@ import {
   isSharedMode,
   randomPhone,
 } from "./remote/client";
-import { dmChatGuid } from "./remote/ids";
+import { chatTypeFromGuid, dmChatGuid } from "./remote/ids";
 import {
   configSchema,
   type IMessageClient,
@@ -287,10 +287,10 @@ export const imessage = definePlatform("iMessage", {
   space: {
     schema: spaceSchema,
     params: spaceParamsSchema,
-    resolve: async ({ input, client }) => {
+    create: async ({ input, client }) => {
       if (isLocal(client)) {
         throw UnsupportedError.action(
-          "createSpace",
+          "space.create",
           "iMessage (local mode)",
           "local mode only supports replying to existing messages"
         );
@@ -303,24 +303,68 @@ export const imessage = definePlatform("iMessage", {
       if (client.length === 0) {
         throw new Error("No iMessage clients configured");
       }
-      // Shared mode: ignore any user-supplied phone — there is only one
-      // identity, tagged at the SHARED_PHONE sentinel.
-      const phone = isSharedMode(client)
-        ? SHARED_PHONE
-        : (input.params?.phone ?? randomPhone(client));
-      const remote = clientForPhone(client, phone);
+
       const addresses = input.users.map((u) => u.id);
 
-      if (input.users.length === 1) {
+      // Shared mode: one identity at the SHARED_PHONE sentinel. DM guids are
+      // deterministic (`any;-;{address}`), so no server call is needed — but
+      // the shared gateway cannot create group chats.
+      if (isSharedMode(client)) {
+        if (addresses.length > 1) {
+          throw UnsupportedError.action(
+            "space.create",
+            "iMessage (shared mode)",
+            "shared mode cannot create group chats — use a dedicated number, or space.get(chatGuid) for an existing group"
+          );
+        }
         return {
           id: dmChatGuid(addresses[0] ?? ""),
           type: "dm" as const,
-          phone,
+          phone: SHARED_PHONE,
         };
       }
 
+      // Dedicated mode: DMs and groups both go through the create API so the
+      // server-issued guid is authoritative.
+      const phone = input.params?.phone ?? randomPhone(client);
+      const remote = clientForPhone(client, phone);
       const { chat } = await remote.chats.create(addresses);
-      return { id: chat.guid as string, type: "group" as const, phone };
+      return {
+        id: chat.guid,
+        type: chat.isGroup ? ("group" as const) : ("dm" as const),
+        phone,
+      };
+    },
+    get: async ({ input, client }) => {
+      if (isLocal(client)) {
+        throw UnsupportedError.action(
+          "space.get",
+          "iMessage (local mode)",
+          "local mode only supports replying to existing messages"
+        );
+      }
+
+      if (client.length === 0) {
+        throw new Error("No iMessage clients configured");
+      }
+      // No server call: the guid itself encodes the chat type, and sends
+      // route by `phone`. Shared mode has a single identity, one configured
+      // client is unambiguous, anything else needs an explicit phone.
+      const phone = isSharedMode(client)
+        ? SHARED_PHONE
+        : (input.params?.phone ??
+          (client.length === 1 ? client[0]?.phone : undefined));
+      if (!phone) {
+        throw new Error(
+          "iMessage space.get requires params.phone when multiple clients " +
+            `are configured. Available: ${availablePhones(client).join(", ")}`
+        );
+      }
+      return {
+        id: input.id,
+        type: chatTypeFromGuid(input.id),
+        phone,
+      };
     },
     actions: {
       // Sugar: `space.background(input, opts?)` →

--- a/packages/spectrum-ts/src/providers/imessage/remote/ids.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/ids.ts
@@ -6,6 +6,11 @@ export type MessageGuid = string;
 
 export const dmChatGuid = (address: string): ChatGuid => `any;-;${address}`;
 
+// Chat guids encode their kind in the separator: groups use `;+;`
+// (e.g. `iMessage;+;chat123…`), DMs use `;-;` (e.g. `any;-;+1555…`).
+export const chatTypeFromGuid = (guid: ChatGuid): "dm" | "group" =>
+  guid.includes(";+;") ? "group" : "dm";
+
 export const toChatGuid = (value: string): ChatGuid => value;
 
 export const toMessageGuid = (value: string): MessageGuid => value;

--- a/packages/spectrum-ts/src/providers/imessage/remote/inbound.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/inbound.ts
@@ -18,7 +18,12 @@ import {
   downloadPrimaryAttachment,
   downloadPrimaryAttachmentStream,
 } from "./attachments";
-import { formatChildId, parseChildId, toMessageGuid } from "./ids";
+import {
+  chatTypeFromGuid,
+  formatChildId,
+  parseChildId,
+  toMessageGuid,
+} from "./ids";
 
 const URL_BALLOON_BUNDLE_ID = "com.apple.messages.URLBalloonProvider";
 
@@ -81,7 +86,7 @@ export const buildMessageBase = (
     sender: { id: resolveSenderId(message) },
     space: {
       id: chat,
-      type: chat.includes(";+;") ? "group" : "dm",
+      type: chatTypeFromGuid(chat),
       phone,
     },
     timestamp,

--- a/packages/spectrum-ts/src/providers/imessage/remote/polls.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/polls.ts
@@ -8,6 +8,7 @@ import type {
 import { asPoll, asPollOption, type PollChoice } from "../../../content/poll";
 import type { CachedPoll, PollCache } from "../cache";
 import type { IMessageMessage } from "../types";
+import { chatTypeFromGuid } from "./ids";
 
 type VotedPollEvent = PollEvent & {
   delta: Extract<PollChangeDelta, { type: "voted" }>;
@@ -128,7 +129,7 @@ const buildPollOptionMessage = (
     sender: { id: input.senderAddress },
     space: {
       id: input.chatGuid,
-      type: input.chatGuid.includes(";+;") ? "group" : "dm",
+      type: chatTypeFromGuid(input.chatGuid),
       phone: input.phone,
     },
     timestamp: input.event.occurredAt,

--- a/packages/spectrum-ts/src/providers/imessage/remote/reactions.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/reactions.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../content/reaction";
 import type { MessageCache } from "../cache";
 import type { IMessageMessage } from "../types";
-import { toChatGuid, toMessageGuid } from "./ids";
+import { chatTypeFromGuid, toChatGuid, toMessageGuid } from "./ids";
 import {
   cacheMessage,
   isIMessageMessage,
@@ -118,7 +118,7 @@ export const toReactionMessages = async (
       sender: { id: senderAddress },
       space: {
         id: event.chatGuid,
-        type: event.chatGuid.includes(";+;") ? "group" : "dm",
+        type: chatTypeFromGuid(event.chatGuid),
         phone,
       },
       timestamp: event.occurredAt,

--- a/packages/spectrum-ts/src/providers/slack/index.ts
+++ b/packages/spectrum-ts/src/providers/slack/index.ts
@@ -61,29 +61,19 @@ export const slack = definePlatform("Slack", {
   space: {
     schema: spaceSchema,
     params: spaceParamsSchema,
-    resolve: async ({ input }) => {
+    create: async ({ input }) => {
       const teamId = input.params?.teamId;
       if (!teamId) {
         throw new Error(
           "Slack space creation requires a teamId param. " +
-            "Pass it via slack.space({ channel, teamId }) or " +
-            "slack.space([user], { teamId })."
-        );
-      }
-      const channel = input.params?.channel;
-      if (channel) {
-        return { id: channel, teamId };
-      }
-      if (input.users.length === 0) {
-        throw new Error(
-          "Slack space creation requires either a channel param or at least one user"
+            "Pass it via space.create(user, { teamId })."
         );
       }
       if (input.users.length > 1) {
         throw UnsupportedError.action(
-          "createSpace",
+          "space.create",
           "Slack",
-          "group DMs require an explicit channel id (Slack's conversations.open is not exposed); pass `channel` in params"
+          "group DMs require an explicit channel id (Slack's conversations.open is not exposed); use space.get(channelId, { teamId })"
         );
       }
       const user = input.users[0];
@@ -93,6 +83,16 @@ export const slack = definePlatform("Slack", {
       // Slack accepts a user id (`U...`) as a `channel` for DMs. Skip
       // `conversations.open` — the runtime resolves the IM channel on send.
       return { id: user.id, teamId };
+    },
+    get: async ({ input }) => {
+      const teamId = input.params?.teamId;
+      if (!teamId) {
+        throw new Error(
+          "Slack spaces require a teamId param. " +
+            "Pass it via space.get(channelId, { teamId })."
+        );
+      }
+      return { id: input.id, teamId };
     },
   },
 

--- a/packages/spectrum-ts/src/providers/slack/types.ts
+++ b/packages/spectrum-ts/src/providers/slack/types.ts
@@ -38,7 +38,6 @@ export const spaceSchema = z.object({
 });
 
 export const spaceParamsSchema = z.object({
-  channel: z.string().optional(),
   teamId: z.string(),
 });
 

--- a/packages/spectrum-ts/src/providers/telegram/index.ts
+++ b/packages/spectrum-ts/src/providers/telegram/index.ts
@@ -3,7 +3,7 @@ import { definePlatform } from "../../platform/define";
 import { configSchema, TELEGRAM_PLATFORM } from "./config";
 import { handleMessages } from "./inbound/messages";
 import { send } from "./outbound/send";
-import { resolveSpace, resolveUser, spaceParamsSchema } from "./space";
+import { createSpace, resolveUser } from "./space";
 import type { TelegramPayload } from "./types";
 import { verify } from "./verify";
 import { ensureWebhook } from "./webhook";
@@ -42,7 +42,7 @@ export const telegram = definePlatform(TELEGRAM_PLATFORM, {
     },
   },
   user: { resolve: resolveUser },
-  space: { params: spaceParamsSchema, resolve: resolveSpace },
+  space: { create: createSpace },
   messages: handleMessages,
   send,
 });

--- a/packages/spectrum-ts/src/providers/telegram/space.ts
+++ b/packages/spectrum-ts/src/providers/telegram/space.ts
@@ -1,19 +1,6 @@
-import z from "zod";
-
 export interface TelegramSpace {
   id: string;
 }
-
-export const spaceParamsSchema = z.object({
-  /**
-   * Target a chat directly by id. Telegram chat ids are numbers in the wire
-   * format (negative for groups/supergroups); accept either form and store as
-   * a string. For a private chat the id equals the user's id.
-   */
-  chatId: z.union([z.string().min(1), z.number()]).optional(),
-});
-
-export type TelegramSpaceParams = z.infer<typeof spaceParamsSchema>;
 
 export const resolveUser = ({
   input,
@@ -22,30 +9,26 @@ export const resolveUser = ({
 }): Promise<{ id: string }> => Promise.resolve({ id: input.userID });
 
 /**
- * Resolve a space to a Telegram `chat_id`. A bot cannot initiate a conversation
- * or create a group, so a space is always an existing chat: either passed
- * explicitly via `params.chatId`, or — for a private chat — the single
- * recipient's user id (which equals the chat id). Anything else is unsupported.
+ * Create a space for a Telegram `chat_id`. A bot cannot initiate a
+ * conversation or create a group, so creation only works for a private chat:
+ * the single recipient's user id equals the chat id. Existing chats (groups,
+ * supergroups, channels) are addressed by id via `space.get(chatId)` —
+ * Telegram chat ids are numbers in the wire format (negative for
+ * groups/supergroups); stringify them with `String(chatId)`.
  */
-export const resolveSpace = ({
+export const createSpace = ({
   input,
 }: {
-  input: { users: { id: string }[]; params?: TelegramSpaceParams };
+  input: { users: { id: string }[] };
 }): Promise<TelegramSpace> => {
-  const chatId = input.params?.chatId;
-  if (chatId !== undefined) {
-    return Promise.resolve({ id: String(chatId) });
-  }
   const [first, ...rest] = input.users;
   if (first && rest.length === 0) {
     return Promise.resolve({ id: first.id });
   }
   if (!first) {
-    throw new Error(
-      "Telegram space creation requires params.chatId or a single recipient user."
-    );
+    throw new Error("Telegram space creation requires a recipient user.");
   }
   throw new Error(
-    "Telegram bots cannot create group chats — pass params.chatId for an existing chat, or resolve a single user (their private chat)."
+    "Telegram bots cannot create group chats — use space.get(chatId) for an existing chat, or create a space with a single user (their private chat)."
   );
 };

--- a/packages/spectrum-ts/src/providers/terminal/index.ts
+++ b/packages/spectrum-ts/src/providers/terminal/index.ts
@@ -602,12 +602,18 @@ export const terminal = definePlatform("Terminal", {
   },
 
   space: {
-    params: z.object({ id: z.string().optional() }),
-    resolve: async ({ client, input }) => {
-      const id = input.params?.id ?? generateChatId(client);
+    create: async ({ client }) => {
+      const id = generateChatId(client);
       client.knownChats.add(id);
       await client.session.request("ensureSpace", { id });
       return { id };
+    },
+    // Explicit (not the framework default) so targeting a known id still
+    // materializes the chat in the TUI via `ensureSpace`.
+    get: async ({ client, input }) => {
+      client.knownChats.add(input.id);
+      await client.session.request("ensureSpace", { id: input.id });
+      return { id: input.id };
     },
   },
 

--- a/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
+++ b/packages/spectrum-ts/src/providers/whatsapp-business/index.ts
@@ -52,13 +52,13 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
 
   space: {
     schema: spaceSchema,
-    resolve: async ({ input }) => {
+    create: async ({ input }) => {
       if (input.users.length === 0) {
         throw new Error("WhatsApp space creation requires at least one user");
       }
       if (input.users.length > 1) {
         throw UnsupportedError.action(
-          "createSpace",
+          "space.create",
           "WhatsApp Business",
           "only 1:1 conversations are supported"
         );

--- a/packages/spectrum-ts/test/core/space.test.ts
+++ b/packages/spectrum-ts/test/core/space.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "bun:test";
+import { stubCloud } from "@test/support/cloud";
+import {
+  baseConfig,
+  makeManagedProvider,
+  makeSchemaProvider,
+} from "@test/support/platform";
+import { Spectrum } from "@/spectrum";
+
+stubCloud();
+
+const NEEDS_HOOK_ERROR =
+  /space-get-needs-hook.*cannot construct a space from an id alone[\s\S]*space\.get/;
+
+describe("space.create", () => {
+  it("resolves a single string user through user.resolve and builds a full space", async () => {
+    const provider = makeManagedProvider("space-create-single");
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const instance = provider(app);
+      const space = await instance.space.create("u42");
+      expect(space.id).toBe("u42");
+      expect(space.__platform).toBe("space-create-single");
+      expect(typeof space.send).toBe("function");
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("accepts mixed string/PlatformUser arrays and resolves every entry", async () => {
+    const provider = makeSchemaProvider("space-create-mixed");
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const instance = provider(app);
+      const resolved = await instance.user("b");
+      const space = await instance.space.create(["a", resolved], {
+        extra: "custom",
+      });
+      expect(space.id).toBe("a+b");
+      expect(space.extra).toBe("custom");
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("validates params against the provider params schema", async () => {
+    const provider = makeSchemaProvider("space-create-params");
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const instance = provider(app);
+      const badParams = { extra: 123 } as unknown as { extra: string };
+      await expect(instance.space.create(["a"], badParams)).rejects.toThrow();
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("validates the created space against the space schema", async () => {
+    const provider = makeSchemaProvider("space-create-schema");
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const instance = provider(app);
+      const space = await instance.space.create(["a"], { extra: "kept" });
+      // Schema fields are surfaced as typed extras on the built space.
+      expect(space.extra).toBe("kept");
+    } finally {
+      await app.stop();
+    }
+  });
+});
+
+describe("space.get", () => {
+  it("defaults to { id } when the provider has no get hook and no schema", async () => {
+    const provider = makeManagedProvider("space-get-default");
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const instance = provider(app);
+      const space = await instance.space.get("s9");
+      expect(space.id).toBe("s9");
+      expect(space.__platform).toBe("space-get-default");
+      expect(typeof space.send).toBe("function");
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("hydrates platform fields through the provider get hook", async () => {
+    const provider = makeSchemaProvider("space-get-hook", { withGet: true });
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const instance = provider(app);
+      const space = await instance.space.get("g1", { extra: "hydrated-x" });
+      expect(space.id).toBe("g1");
+      expect(space.extra).toBe("hydrated-x");
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("fails loudly when the schema needs fields the default { id } cannot supply", async () => {
+    const provider = makeSchemaProvider("space-get-needs-hook");
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const instance = provider(app);
+      await expect(
+        instance.space.get("g1", { extra: "ignored" })
+      ).rejects.toThrow(NEEDS_HOOK_ERROR);
+    } finally {
+      await app.stop();
+    }
+  });
+});

--- a/packages/spectrum-ts/test/providers/imessage/space.test.ts
+++ b/packages/spectrum-ts/test/providers/imessage/space.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "bun:test";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import { IMessageSDK } from "@photon-ai/imessage-kit";
+import { imessage } from "@/providers/imessage";
+import type { RemoteClient } from "@/providers/imessage/types";
+import { SHARED_PHONE } from "@/providers/imessage/types";
+
+const SHARED_GROUP_ERROR = /shared mode cannot create group chats/;
+const MULTI_CLIENT_ERROR = /params\.phone.*\+15550100, \+15550111/;
+const LOCAL_MODE_ERROR = /local mode/;
+
+const def = imessage.config({}).__definition;
+
+const ctx = {
+  config: {} as never,
+  store: undefined as never,
+};
+
+// Fake remote whose chats.create issues server guids; throws when a path is
+// not supposed to reach the API at all.
+const fakeRemote = (
+  onCreate?: (addresses: string[]) => { guid: string; isGroup: boolean }
+) =>
+  ({
+    chats: {
+      create: (addresses: string[]) => {
+        if (!onCreate) {
+          return Promise.reject(
+            new Error("chats.create should not have been called")
+          );
+        }
+        return Promise.resolve({ chat: onCreate(addresses) });
+      },
+    },
+  }) as unknown as AdvancedIMessage;
+
+const clients = (
+  entries: [
+    phone: string,
+    onCreate?: (addresses: string[]) => { guid: string; isGroup: boolean },
+  ][]
+): RemoteClient[] =>
+  entries.map(([phone, onCreate]) => ({ phone, client: fakeRemote(onCreate) }));
+
+describe("imessage space.create", () => {
+  it("shared mode: builds the deterministic DM guid without an API call", async () => {
+    const client = clients([[SHARED_PHONE]]);
+    await expect(
+      def.space.create({
+        ...ctx,
+        client,
+        input: { users: [{ id: "+15550123" }] },
+      })
+    ).resolves.toEqual({
+      id: "any;-;+15550123",
+      type: "dm",
+      phone: SHARED_PHONE,
+    });
+  });
+
+  it("shared mode: cannot create group chats", async () => {
+    const client = clients([[SHARED_PHONE]]);
+    await expect(
+      def.space.create({
+        ...ctx,
+        client,
+        input: { users: [{ id: "a@x.com" }, { id: "b@x.com" }] },
+      })
+    ).rejects.toThrow(SHARED_GROUP_ERROR);
+  });
+
+  it("dedicated mode: creates a DM through the API and uses the server guid", async () => {
+    const client = clients([
+      [
+        "+15550100",
+        (addresses) => ({ guid: `any;-;${addresses[0]}`, isGroup: false }),
+      ],
+    ]);
+    await expect(
+      def.space.create({
+        ...ctx,
+        client,
+        input: { users: [{ id: "+15550123" }] },
+      })
+    ).resolves.toEqual({
+      id: "any;-;+15550123",
+      type: "dm",
+      phone: "+15550100",
+    });
+  });
+
+  it("dedicated mode: creates a group through the API and uses the server guid", async () => {
+    const client = clients([
+      ["+15550100", () => ({ guid: "iMessage;+;chat42", isGroup: true })],
+    ]);
+    await expect(
+      def.space.create({
+        ...ctx,
+        client,
+        input: { users: [{ id: "a@x.com" }, { id: "b@x.com" }] },
+      })
+    ).resolves.toEqual({
+      id: "iMessage;+;chat42",
+      type: "group",
+      phone: "+15550100",
+    });
+  });
+
+  it("dedicated mode: routes creation to the client owning params.phone", async () => {
+    const client = clients([
+      ["+15550100"],
+      ["+15550111", () => ({ guid: "iMessage;+;chat7", isGroup: true })],
+    ]);
+    await expect(
+      def.space.create({
+        ...ctx,
+        client,
+        input: {
+          users: [{ id: "a@x.com" }, { id: "b@x.com" }],
+          params: { phone: "+15550111" },
+        },
+      })
+    ).resolves.toEqual({
+      id: "iMessage;+;chat7",
+      type: "group",
+      phone: "+15550111",
+    });
+  });
+});
+
+describe("imessage space.get", () => {
+  it("constructs the space offline, deriving dm type from the guid shape", async () => {
+    const client = clients([[SHARED_PHONE]]);
+    await expect(
+      def.space.get?.({ ...ctx, client, input: { id: "any;-;+15550123" } })
+    ).resolves.toEqual({
+      id: "any;-;+15550123",
+      type: "dm",
+      phone: SHARED_PHONE,
+    });
+  });
+
+  it("derives group type from the `;+;` guid separator", async () => {
+    const client = clients([["+15550100"]]);
+    await expect(
+      def.space.get?.({ ...ctx, client, input: { id: "iMessage;+;chat42" } })
+    ).resolves.toEqual({
+      id: "iMessage;+;chat42",
+      type: "group",
+      phone: "+15550100",
+    });
+  });
+
+  it("tags the space with params.phone when provided", async () => {
+    const client = clients([["+15550100"], ["+15550111"]]);
+    await expect(
+      def.space.get?.({
+        ...ctx,
+        client,
+        input: { id: "any;-;a@x.com", params: { phone: "+15550111" } },
+      })
+    ).resolves.toEqual({
+      id: "any;-;a@x.com",
+      type: "dm",
+      phone: "+15550111",
+    });
+  });
+
+  it("requires params.phone when multiple clients are configured", async () => {
+    const client = clients([["+15550100"], ["+15550111"]]);
+    await expect(
+      def.space.get?.({ ...ctx, client, input: { id: "any;-;x" } })
+    ).rejects.toThrow(MULTI_CLIENT_ERROR);
+  });
+
+  it("is unsupported in local mode", async () => {
+    const localClient = Object.create(IMessageSDK.prototype) as IMessageSDK;
+    await expect(
+      def.space.get?.({ ...ctx, client: localClient, input: { id: "any;-;x" } })
+    ).rejects.toThrow(LOCAL_MODE_ERROR);
+  });
+});

--- a/packages/spectrum-ts/test/providers/slack/space.test.ts
+++ b/packages/spectrum-ts/test/providers/slack/space.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { slack } from "@/providers/slack";
+
+// Reach the inline def through the provider-config seam — the hooks only
+// touch `input`, so the rest of the ctx can be stubbed.
+const def = slack.config({ tokens: { T012ABCDE: "jwt" } }).__definition;
+
+const ctx = {
+  client: undefined as never,
+  config: {} as never,
+  store: undefined as never,
+};
+
+const TEAM_ID_ERROR = /teamId/;
+const MULTI_USER_ERROR = /space\.get/;
+
+describe("slack space.create", () => {
+  it("uses the user id as the DM channel", async () => {
+    await expect(
+      def.space.create({
+        ...ctx,
+        input: { users: [{ id: "U1" }], params: { teamId: "T1" } },
+      })
+    ).resolves.toEqual({ id: "U1", teamId: "T1" });
+  });
+
+  it("requires a teamId param", async () => {
+    await expect(
+      def.space.create({ ...ctx, input: { users: [{ id: "U1" }] } })
+    ).rejects.toThrow(TEAM_ID_ERROR);
+  });
+
+  it("rejects group DMs and points to space.get", async () => {
+    await expect(
+      def.space.create({
+        ...ctx,
+        input: {
+          users: [{ id: "U1" }, { id: "U2" }],
+          params: { teamId: "T1" },
+        },
+      })
+    ).rejects.toThrow(MULTI_USER_ERROR);
+  });
+});
+
+describe("slack space.get", () => {
+  it("returns the channel id with the teamId", async () => {
+    await expect(
+      def.space.get?.({
+        ...ctx,
+        input: { id: "C123", params: { teamId: "T1" } },
+      })
+    ).resolves.toEqual({ id: "C123", teamId: "T1" });
+  });
+
+  it("requires a teamId param", async () => {
+    await expect(
+      def.space.get?.({ ...ctx, input: { id: "C123" } })
+    ).rejects.toThrow(TEAM_ID_ERROR);
+  });
+});

--- a/packages/spectrum-ts/test/providers/telegram/space.test.ts
+++ b/packages/spectrum-ts/test/providers/telegram/space.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { createSpace } from "@/providers/telegram/space";
+
+const ZERO_USERS_ERROR = /requires a recipient user/;
+const MULTI_USER_ERROR = /space\.get\(chatId\)/;
+
+describe("telegram createSpace", () => {
+  it("maps a single user to their private chat id", async () => {
+    await expect(
+      createSpace({ input: { users: [{ id: "42" }] } })
+    ).resolves.toEqual({ id: "42" });
+  });
+
+  it("rejects zero users", () => {
+    expect(() => createSpace({ input: { users: [] } })).toThrow(
+      ZERO_USERS_ERROR
+    );
+  });
+
+  it("rejects multi-user creation and points to space.get", () => {
+    expect(() =>
+      createSpace({ input: { users: [{ id: "1" }, { id: "2" }] } })
+    ).toThrow(MULTI_USER_ERROR);
+  });
+});

--- a/packages/spectrum-ts/test/support/fusor.ts
+++ b/packages/spectrum-ts/test/support/fusor.ts
@@ -87,7 +87,7 @@ export const makeSlack = (opts: { verifyThrows?: boolean } = {}) =>
     },
     user: { resolve: ({ input }) => Promise.resolve({ id: input.userID }) },
     space: {
-      resolve: ({ input }) =>
+      create: ({ input }: { input: { users: { id: string }[] } }) =>
         Promise.resolve({ id: input.users[0]?.id ?? "space" }),
     },
     messages: slackMessages,
@@ -180,7 +180,7 @@ export const makePresence = () =>
     },
     user: { resolve: ({ input }) => Promise.resolve({ id: input.userID }) },
     space: {
-      resolve: ({ input }) =>
+      create: ({ input }: { input: { users: { id: string }[] } }) =>
         Promise.resolve({ id: input.users[0]?.id ?? "space" }),
     },
     events: { presence: presenceSchema },
@@ -241,7 +241,7 @@ export const makeCtxProbe = (capture: CtxProbeCapture) =>
     },
     user: { resolve: ({ input }) => Promise.resolve({ id: input.userID }) },
     space: {
-      resolve: ({ input }) =>
+      create: ({ input }: { input: { users: { id: string }[] } }) =>
         Promise.resolve({ id: input.users[0]?.id ?? "space" }),
     },
     messages: ctxProbeMessages(capture),

--- a/packages/spectrum-ts/test/support/platform.ts
+++ b/packages/spectrum-ts/test/support/platform.ts
@@ -94,7 +94,7 @@ export const makeManagedProvider = (
     },
     user: { resolve: ({ input }) => Promise.resolve({ id: input.userID }) },
     space: {
-      resolve: ({ input }) =>
+      create: ({ input }) =>
         Promise.resolve({ id: input.users[0]?.id ?? "s1" }),
     },
     messages(): ManagedStream<FakeInboundMessage> {
@@ -122,6 +122,51 @@ export const makeManagedProvider = (
   });
 };
 
+// Provider with a space schema + params schema (the slack/imessage shape) for
+// exercising space.create/space.get validation paths. `withGet` toggles a
+// provider-implemented `space.get` hook; without it the framework default
+// applies — and fails, because the schema requires `extra`.
+export const makeSchemaProvider = (
+  name: string,
+  opts: { withGet?: boolean } = {}
+) => {
+  // Closed-out queue: an immediately-done inbound stream — these fakes only
+  // exercise space resolution, never inbound messages.
+  const queue = makeQueue<never>();
+  queue.close();
+  return definePlatform(name, {
+    config: z.object({}),
+    lifecycle: {
+      createClient: () => Promise.resolve({}),
+    },
+    user: { resolve: ({ input }) => Promise.resolve({ id: input.userID }) },
+    space: {
+      schema: z.object({ extra: z.string(), id: z.string() }),
+      params: z.object({ extra: z.string() }),
+      create: ({ input }) =>
+        Promise.resolve({
+          extra: input.params?.extra ?? "default",
+          id: input.users.map((u) => u.id).join("+"),
+        }),
+      ...(opts.withGet
+        ? {
+            get: ({
+              input,
+            }: {
+              input: { id: string; params?: { extra: string } };
+            }) =>
+              Promise.resolve({
+                extra: input.params?.extra ?? "hydrated",
+                id: input.id,
+              }),
+          }
+        : {}),
+    },
+    messages: () => queue.iter,
+    send: () => Promise.resolve(undefined),
+  });
+};
+
 // Provider whose `messages` is a NATIVE async generator blocking on a queue that
 // only closes in destroyClient (the terminal-BEFORE-fix shape). Its stream can't
 // be cancelled by return(); it relies on the bounded safety net + destroyClient.
@@ -139,7 +184,7 @@ export const makeNativeProvider = (name: string) => {
     },
     user: { resolve: ({ input }) => Promise.resolve({ id: input.userID }) },
     space: {
-      resolve: ({ input }) =>
+      create: ({ input }) =>
         Promise.resolve({ id: input.users[0]?.id ?? "s1" }),
     },
     async *messages() {

--- a/packages/spectrum-ts/tsconfig.json
+++ b/packages/spectrum-ts/tsconfig.json
@@ -3,7 +3,6 @@
   "include": ["src", "test"],
   "compilerOptions": {
     "strictNullChecks": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
       "@test/*": ["./test/*"]


### PR DESCRIPTION
## Summary

- Replaces the overloaded `space(...args)` callable with an explicit `space` namespace containing two methods: `space.create(users, params?)` and `space.get(id, params?)`
- Renames the `space.resolve` hook in `PlatformDef` to `space.create`, and adds an optional `space.get` hook for hydrating a space from a known id
- Adds a framework-level default for `space.get` — providers with no schema (or a schema whose fields are all satisfiable from `{ id }`) get it for free; providers whose schema requires additional fields must implement the hook and get a clear error if they don't
- Exports `SpaceNamespace<Def>` from the public API
- Updates all built-in providers (iMessage, Slack, Telegram, Terminal, WhatsApp Business) to the new shape
- Removes the `channel` param shortcut from Slack's space params schema — channel access now goes through `space.get(channelId, { teamId })`
- Extracts `chatTypeFromGuid` helper in iMessage and consolidates the three in-line `guid.includes(";+;")` checks
- Adds comprehensive test coverage: `test/core/space.test.ts`, `test/providers/imessage/space.test.ts`, `test/providers/slack/space.test.ts`, `test/providers/telegram/space.test.ts`
- Removes `baseUrl` from `tsconfig.json` (tsgo/TS7 compatibility)

## Usage

```typescript
// Before
const space = await imessageInstance.space(user, { phone: "+15550100" });
const space = await slackInstance.space({ channel: "C123", teamId: "T1" });
const space = await telegramInstance.space({ chatId: -100123 });

// After
const space = await imessageInstance.space.create(user, { phone: "+15550100" });
const space = await slackInstance.space.get("C123", { teamId: "T1" });
const space = await telegramInstance.space.get("-100123");
```

## Changes

| File | Change |
|---|---|
| `src/platform/types.ts` | `space.resolve` → `space.create`; add `space.get?` hook; new `SpaceNamespace<Def>` interface; tighten `SpaceParamsInputOf` logic |
| `src/platform/define.ts` | Implement `space.create` / `space.get` on the platform instance; extract `finalizeSpace` / `providerCtx` helpers; remove old vararg normalisation logic |
| `src/index.ts` | Export `SpaceNamespace` |
| `src/providers/imessage/index.ts` | `resolve` → `create`; add `space.get` hook (offline, guid-derived type); fix shared-mode group-chat error; dedicate mode always calls the API for DMs too |
| `src/providers/imessage/remote/ids.ts` | Extract `chatTypeFromGuid` |
| `src/providers/imessage/remote/{inbound,polls,reactions}.ts` | Use `chatTypeFromGuid` |
| `src/providers/slack/index.ts` | `resolve` → `create`; add `space.get`; remove `channel` param shortcut |
| `src/providers/slack/types.ts` | Remove `channel` from `spaceParamsSchema` |
| `src/providers/telegram/{index,space}.ts` | `resolveSpace` → `createSpace`; remove `chatId` param (existing chats use `space.get`) |
| `src/providers/terminal/index.ts` | `resolve` → `create`; add `space.get` (materialises chat via `ensureSpace`) |
| `src/providers/whatsapp-business/index.ts` | `resolve` → `create` |
| `test/core/space.test.ts` | New: framework-level `space.create` / `space.get` tests |
| `test/providers/imessage/space.test.ts` | New: iMessage create + get tests (shared/dedicated/local modes) |
| `test/providers/slack/space.test.ts` | New: Slack create + get tests |
| `test/providers/telegram/space.test.ts` | New: Telegram createSpace tests |
| `test/support/fusor.ts` | Update stub providers |
| `test/support/platform.ts` | Update stub providers; add `makeSchemaProvider` |
| `docs/telegram.md` | Update `space.ts` module description |
| `tsconfig.json` | Remove `baseUrl` |

## Test plan

- [ ] `bun test` passes across all new and existing test files
- [ ] `bun x ultracite check` reports no issues
- [ ] `space.create` with a string user resolves through `user.resolve` before calling the provider hook
- [ ] `space.get` with no provider hook and no schema returns `{ id }` wrapped as a full `PlatformSpace`
- [ ] `space.get` on a provider with a schema that needs extra fields throws a descriptive error pointing to `space.get`
- [ ] iMessage shared-mode `space.create` with multiple users throws the shared-group error
- [ ] iMessage `space.get` with multiple clients and no `params.phone` throws listing available phones
- [ ] Slack `space.get` requires `params.teamId`
- [ ] Telegram `space.get(chatId)` round-trips as `{ id: chatId }`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783663412&installation_id=127326493&pr_number=114&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F114&signature=d8f709d4246dd08ba17c8ea2be789211e52eb14bc58edf3796dc79328ae20327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Platform space operations now feature separate `create` and `get` methods, improving API clarity and separation of concerns.

* **Refactor**
  * Consolidated space handling across iMessage, Slack, Telegram, Terminal, and WhatsApp Business providers.
  * Enhanced chat type detection for iMessage to better distinguish direct messages and group conversations.
  * Optimized platform configuration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->