### PR TITLE
feat(platform): fall back to plain text for platforms that can't stream

### DIFF
--- a/packages/spectrum-ts/src/content/stream-text.ts
+++ b/packages/spectrum-ts/src/content/stream-text.ts
@@ -245,11 +245,26 @@ export const asStreamText = (input: {
   streamTextSchema.parse({ type: "streamText", stream: input.stream });
 
 /**
+ * Consume a `streamText` content's stream to completion and return the full
+ * accumulated text. Used by the send pipeline's plain-text fallback for
+ * platforms that can't stream. Consumes the single-use stream — the content
+ * cannot be sent afterwards.
+ */
+export const drainStreamText = async (content: StreamText): Promise<string> => {
+  let full = "";
+  for await (const delta of content.stream()) {
+    full += delta;
+  }
+  return full;
+};
+
+/**
  * Wrap a streaming LLM text response so it can be sent like any other content.
  *
  * Delivery is platform-specific — iMessage (remote) sends the first chunk as a
  * real message and then edits it in place as more text arrives. Platforms that
- * can't stream reject it (the send is warn-and-skipped).
+ * can't stream wait for the stream to finish and deliver the accumulated text
+ * as one plain message.
  *
  * Accepts whatever the popular SDKs return; pass `options.extract` for any
  * chunk shape the built-in detection doesn't recognize.

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -8,6 +8,8 @@ import {
 import { rename as renameContent } from "../content/rename";
 import { reply as replyContent } from "../content/reply";
 import { resolveContents } from "../content/resolve";
+import { drainStreamText, type StreamText } from "../content/stream-text";
+import { asText } from "../content/text";
 import type { Content, ContentInput } from "../content/types";
 import { typing as typingContent } from "../content/typing";
 import { unsend as unsendContent } from "../content/unsend";
@@ -197,6 +199,77 @@ const unsupportedPlatformContentError = (
     `requires ${requiredPlatform}`
   );
 };
+
+// Locate the stream a send carries, if any. A stream appears either as the
+// top-level content or wrapped one level deep in `reply`/`edit` (the only
+// wrappers whose inner content can be a `streamText`).
+const findStreamText = (item: Content): StreamText | undefined => {
+  if (item.type === "streamText") {
+    return item;
+  }
+  if (
+    (item.type === "reply" || item.type === "edit") &&
+    item.content.type === "streamText"
+  ) {
+    return item.content;
+  }
+  return;
+};
+
+// Rewrite a stream-bearing content as plain text, preserving a `reply`/`edit`
+// wrapper so the fallback send keeps its target.
+const replaceStreamText = (item: Content, full: string): Content => {
+  const text = asText(full);
+  if (item.type === "reply" || item.type === "edit") {
+    return { ...item, content: text };
+  }
+  return text;
+};
+
+type ProviderSend = (
+  content: Content
+) => Promise<ProviderMessageRecord | undefined>;
+
+/**
+ * Dispatch `content` to the provider, falling back to plain text on platforms
+ * that can't stream. When the provider rejects a stream-bearing send with
+ * `UnsupportedError`, wait for the stream to finish and re-send the
+ * accumulated text as `text` content (preserving a `reply`/`edit` wrapper) —
+ * so `streamText` works everywhere, just without live updates. Rethrows the
+ * original error when no fallback applies (non-stream content, or a stream
+ * that produced no text); an `UnsupportedError` from the fallback send itself
+ * propagates too. Both land in the caller's warn-and-skip handling.
+ */
+async function sendWithStreamTextFallback(
+  send: ProviderSend,
+  item: Content,
+  platform: string
+): Promise<ProviderMessageRecord | undefined> {
+  try {
+    return await send(item);
+  } catch (err) {
+    if (!(err instanceof UnsupportedError)) {
+      throw err;
+    }
+    const source = findStreamText(item);
+    if (!source) {
+      throw err;
+    }
+    platformLog.info(
+      `${platform} does not support streaming text; waiting for the stream to finish to send the full text as one message.`,
+      {
+        "spectrum.provider": platform,
+        "spectrum.stream_text.fallback": true,
+      }
+    );
+    const full = await drainStreamText(source);
+    if (!full) {
+      // The stream ended without any text — nothing to send.
+      throw err;
+    }
+    return await send(replaceStreamText(item, full));
+  }
+}
 
 export type SpaceRef = {
   id: string;
@@ -405,19 +478,26 @@ export function buildSpace(params: BuildSpaceParams): Space {
         ...contentAttrs(item),
       },
       async () => {
+        const platformError = unsupportedPlatformContentError(
+          item,
+          definition.name
+        );
+        if (platformError) {
+          warnUnsupported(platformError, definition.name);
+          return;
+        }
+        const providerSend: ProviderSend = async (content) =>
+          (await definition.send({
+            ...actionCtx,
+            content,
+          })) as ProviderMessageRecord | undefined;
         let raw: ProviderMessageRecord | undefined;
         try {
-          const platformError = unsupportedPlatformContentError(
+          raw = await sendWithStreamTextFallback(
+            providerSend,
             item,
             definition.name
           );
-          if (platformError) {
-            throw platformError;
-          }
-          raw = (await definition.send({
-            ...actionCtx,
-            content: item,
-          })) as ProviderMessageRecord | undefined;
         } catch (err) {
           if (err instanceof UnsupportedError) {
             warnUnsupported(err, definition.name);

--- a/packages/spectrum-ts/test/core/send-stream-text-fallback.test.ts
+++ b/packages/spectrum-ts/test/core/send-stream-text-fallback.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "bun:test";
+import { stubCloud } from "@test/support/cloud";
+import { baseConfig, makeQueue, record } from "@test/support/platform";
+import z from "zod";
+import { streamText } from "@/content/stream-text";
+import type { Content } from "@/content/types";
+import { definePlatform } from "@/platform/define";
+import type { ProviderMessage, ProviderMessageRecord } from "@/platform/types";
+import { Spectrum } from "@/spectrum";
+import { UnsupportedError } from "@/utils/errors";
+
+stubCloud();
+
+const SENT_TIMESTAMP = new Date(123);
+
+type SendImpl = (
+  content: Content
+) => Promise<ProviderMessageRecord | undefined>;
+
+// One inbound text message, then a `send` whose behavior the test controls.
+// Mirrors makeUnsendProvider in send-unsend.test.ts.
+const makeProvider = (name: string, sendImpl: SendImpl) => {
+  const queue = makeQueue<ProviderMessage<{ id: string }, { id: string }>>();
+  queue.push(record("m1"));
+  queue.close();
+  return definePlatform(name, {
+    config: z.object({}),
+    lifecycle: {
+      createClient: () => Promise.resolve({}),
+    },
+    user: { resolve: ({ input }) => Promise.resolve({ id: input.userID }) },
+    space: {
+      create: ({ input }) =>
+        Promise.resolve({ id: input.users[0]?.id ?? "s1" }),
+    },
+    messages: () => queue.iter,
+    send: ({ content }) => sendImpl(content),
+  });
+};
+
+const firstMessage = async (app: Awaited<ReturnType<typeof Spectrum>>) => {
+  const iterator = app.messages[Symbol.asyncIterator]();
+  const first = await iterator.next();
+  if (first.done) {
+    throw new Error("expected an inbound message");
+  }
+  return first.value;
+};
+
+async function* chunks(...parts: string[]): AsyncIterable<string> {
+  for (const part of parts) {
+    yield part;
+  }
+}
+
+// A provider that can't stream: rejects any content carrying a `streamText`
+// (top-level or wrapped in reply/edit) but handles everything else, recording
+// each dispatch.
+const noStreamingSend = (platform: string) => {
+  const seen: Content[] = [];
+  const sendImpl: SendImpl = (content) => {
+    seen.push(content);
+    const inner =
+      content.type === "reply" || content.type === "edit"
+        ? content.content
+        : content;
+    if (inner.type === "streamText") {
+      return Promise.reject(UnsupportedError.content("streamText", platform));
+    }
+    if (content.type === "edit") {
+      // Edits are fire-and-forget; providers may return void.
+      return Promise.resolve(undefined);
+    }
+    return Promise.resolve({
+      id: `${content.type}-${seen.length}`,
+      content,
+      space: { id: "s1" },
+      timestamp: SENT_TIMESTAMP,
+    });
+  };
+  return { seen, sendImpl };
+};
+
+describe("streamText plain-text fallback", () => {
+  it("waits for the stream to finish and re-sends the full text", async () => {
+    const { seen, sendImpl } = noStreamingSend("stream-fallback-text");
+    const provider = makeProvider("stream-fallback-text", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const sent = await space.send(streamText(chunks("Hello, ", "world!")));
+
+      expect(seen.map((c) => c.type)).toEqual(["streamText", "text"]);
+      expect(seen.at(-1)).toEqual({ type: "text", text: "Hello, world!" });
+      // The fallback send produces a real Message handle.
+      expect(sent?.content).toEqual({ type: "text", text: "Hello, world!" });
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("preserves the reply wrapper (and its target) in the fallback send", async () => {
+    const { seen, sendImpl } = noStreamingSend("stream-fallback-reply");
+    const provider = makeProvider("stream-fallback-reply", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [, message] = await firstMessage(app);
+      const sent = await message.reply(streamText(chunks("a", "b", "c")));
+
+      expect(seen.map((c) => c.type)).toEqual(["reply", "reply"]);
+      const fallback = seen.at(-1);
+      if (fallback?.type !== "reply") {
+        throw new Error("expected a reply fallback dispatch");
+      }
+      expect(fallback.content).toEqual({ type: "text", text: "abc" });
+      expect(fallback.target).toBe(message);
+      expect(sent?.id).toBeDefined();
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("preserves the edit wrapper in the fallback send", async () => {
+    const { seen, sendImpl } = noStreamingSend("stream-fallback-edit");
+    const provider = makeProvider("stream-fallback-edit", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const sent = await space.send("hi");
+      if (!sent) {
+        throw new Error("expected the plain send to produce a message");
+      }
+      await sent.edit(streamText(chunks("re", "vised")));
+
+      expect(seen.map((c) => c.type)).toEqual(["text", "edit", "edit"]);
+      const fallback = seen.at(-1);
+      if (fallback?.type !== "edit") {
+        throw new Error("expected an edit fallback dispatch");
+      }
+      expect(fallback.content).toEqual({ type: "text", text: "revised" });
+      expect(fallback.target).toBe(sent);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("skips the fallback when the stream produces no text", async () => {
+    const { seen, sendImpl } = noStreamingSend("stream-fallback-empty");
+    const provider = makeProvider("stream-fallback-empty", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const sent = await space.send(streamText(chunks()));
+
+      // Nothing to send — warn-and-skip, no second dispatch.
+      expect(sent).toBeUndefined();
+      expect(seen.map((c) => c.type)).toEqual(["streamText"]);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("warn-and-skips when the fallback send is unsupported too", async () => {
+    const seen: Content[] = [];
+    const sendImpl: SendImpl = (content) => {
+      seen.push(content);
+      return Promise.reject(
+        UnsupportedError.content(content.type, "stream-fallback-none")
+      );
+    };
+    const provider = makeProvider("stream-fallback-none", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const sent = await space.send(streamText(chunks("lost")));
+
+      expect(sent).toBeUndefined();
+      expect(seen.map((c) => c.type)).toEqual(["streamText", "text"]);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("propagates stream errors instead of swallowing them", async () => {
+    const { sendImpl } = noStreamingSend("stream-fallback-error");
+    const provider = makeProvider("stream-fallback-error", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      async function* boom(): AsyncIterable<string> {
+        yield "partial";
+        throw new Error("stream blew up");
+      }
+      await expect(space.send(streamText(boom()))).rejects.toThrow(
+        "stream blew up"
+      );
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("does not interfere with platforms that stream natively", async () => {
+    const seen: Content[] = [];
+    const sendImpl: SendImpl = async (content) => {
+      seen.push(content);
+      if (content.type === "streamText") {
+        // A native driver consumes the stream itself and returns the
+        // materialized message (the iMessage remote shape).
+        let full = "";
+        for await (const delta of content.stream()) {
+          full += delta;
+        }
+        return {
+          id: "native-1",
+          content: { type: "text", text: full },
+          space: { id: "s1" },
+          timestamp: SENT_TIMESTAMP,
+        };
+      }
+      return {
+        id: `${content.type}-${seen.length}`,
+        content,
+        space: { id: "s1" },
+        timestamp: SENT_TIMESTAMP,
+      };
+    };
+    const provider = makeProvider("stream-native", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const sent = await space.send(streamText(chunks("live ", "stream")));
+
+      expect(seen.map((c) => c.type)).toEqual(["streamText"]);
+      expect(sent?.content).toEqual({ type: "text", text: "live stream" });
+    } finally {
+      await app.stop();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- When a platform's `send` throws `UnsupportedError` for a `streamText` content, the pipeline now drains the stream to completion and re-sends the accumulated text as a plain `text` message
- Preserves `reply` and `edit` wrappers in the fallback dispatch so the target message reference is kept intact
- If the stream produces no text, the original `UnsupportedError` propagates and the send is warn-and-skipped (same behavior as before)
- Platforms that handle `streamText` natively (e.g. iMessage remote) are unaffected — the fallback only triggers on `UnsupportedError`

## Changes

| File | What changed |
|------|-------------|
| `src/content/stream-text.ts` | Added `drainStreamText` — consumes a `StreamText` stream to a full string; updated JSDoc to reflect new fallback behavior |
| `src/platform/build.ts` | Added `findStreamText`, `replaceStreamText`, and `sendWithStreamTextFallback`; wired `sendWithStreamTextFallback` into the send pipeline in `buildSpace`; moved the `unsupportedPlatformContentError` check before the try/catch to keep non-streaming unsupported content on the fast path |
| `test/core/send-stream-text-fallback.test.ts` | New test suite (7 cases) covering: plain text fallback, reply wrapper preserved, edit wrapper preserved, empty stream skip, fallback-also-unsupported warn-and-skip, stream error propagation, native streaming platform unaffected |

## Test plan

- [ ] `bun test test/core/send-stream-text-fallback.test.ts` — all 7 new cases pass
- [ ] `bun test` — full suite green
- [ ] `bun x ultracite check` — no lint/format issues
- [ ] Send a `streamText` to a platform that rejects it (e.g. terminal provider) — confirm the full text arrives as a single message and the fallback log line appears
- [ ] Send a `streamText` to iMessage — confirm live streaming still works unchanged

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783678543&installation_id=127326493&pr_number=116&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F116&signature=c6b217fefa4cc8fc44516eca2455fae50f12b555c659cd3a56bf7f0967979320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic fallback support for platforms without streaming capabilities. Streaming text content now automatically converts to plain text and resends, preserving message context including replies and edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->