### PR TITLE
feat(telegram): add native streamText support via message drafts

### DIFF
--- a/packages/spectrum-ts/src/content/stream-text.ts
+++ b/packages/spectrum-ts/src/content/stream-text.ts
@@ -215,6 +215,20 @@ const resolveChunkIterable = <T>(
   );
 };
 
+/**
+ * Thrown when a single-use stream source is consumed a second time. The send
+ * pipeline's plain-text fallback matches on this to tell "the provider already
+ * consumed the stream" apart from a stream that errored mid-drain.
+ */
+export class StreamConsumedError extends Error {
+  constructor() {
+    super(
+      "streamText: this source has already been consumed — a stream can only be sent once."
+    );
+    this.name = "StreamConsumedError";
+  }
+}
+
 const normalize = <T>(
   source: StreamTextSource<T>,
   options?: StreamTextOptions<T>
@@ -225,9 +239,7 @@ const normalize = <T>(
   let consumed = false;
   return async function* normalized() {
     if (consumed) {
-      throw new Error(
-        "streamText: this source has already been consumed — a stream can only be sent once."
-      );
+      throw new StreamConsumedError();
     }
     consumed = true;
     for await (const chunk of resolveChunkIterable(source)) {
@@ -262,9 +274,10 @@ export const drainStreamText = async (content: StreamText): Promise<string> => {
  * Wrap a streaming LLM text response so it can be sent like any other content.
  *
  * Delivery is platform-specific — iMessage (remote) sends the first chunk as a
- * real message and then edits it in place as more text arrives. Platforms that
- * can't stream wait for the stream to finish and deliver the accumulated text
- * as one plain message.
+ * real message and then edits it in place as more text arrives; Telegram
+ * (private chats) animates a native draft preview and persists the final text
+ * as one message. Platforms that can't stream wait for the stream to finish
+ * and deliver the accumulated text as one plain message.
  *
  * Accepts whatever the popular SDKs return; pass `options.extract` for any
  * chunk shape the built-in detection doesn't recognize.

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -8,7 +8,11 @@ import {
 import { rename as renameContent } from "../content/rename";
 import { reply as replyContent } from "../content/reply";
 import { resolveContents } from "../content/resolve";
-import { drainStreamText, type StreamText } from "../content/stream-text";
+import {
+  drainStreamText,
+  StreamConsumedError,
+  type StreamText,
+} from "../content/stream-text";
 import { asText } from "../content/text";
 import type { Content, ContentInput } from "../content/types";
 import { typing as typingContent } from "../content/typing";
@@ -236,9 +240,11 @@ type ProviderSend = (
  * `UnsupportedError`, wait for the stream to finish and re-send the
  * accumulated text as `text` content (preserving a `reply`/`edit` wrapper) —
  * so `streamText` works everywhere, just without live updates. Rethrows the
- * original error when no fallback applies (non-stream content, or a stream
- * that produced no text); an `UnsupportedError` from the fallback send itself
- * propagates too. Both land in the caller's warn-and-skip handling.
+ * original error when no fallback applies (non-stream content, a stream that
+ * produced no text, or a stream the provider already consumed — e.g. a native
+ * driver that streamed and then failed); an `UnsupportedError` from the
+ * fallback send itself propagates too. Both land in the caller's warn-and-skip
+ * handling.
  */
 async function sendWithStreamTextFallback(
   send: ProviderSend,
@@ -262,7 +268,19 @@ async function sendWithStreamTextFallback(
         "spectrum.stream_text.fallback": true,
       }
     );
-    const full = await drainStreamText(source);
+    let full: string;
+    try {
+      full = await drainStreamText(source);
+    } catch (drainErr) {
+      if (drainErr instanceof StreamConsumedError) {
+        // The provider already consumed the stream (a native driver streamed
+        // it and then failed) — re-draining is impossible, so surface the
+        // original UnsupportedError rather than the consumed-stream error.
+        throw err;
+      }
+      // A genuine stream failure mid-drain propagates as-is.
+      throw drainErr;
+    }
     if (!full) {
       // The stream ended without any text — nothing to send.
       throw err;

--- a/packages/spectrum-ts/src/providers/telegram/outbound/send.ts
+++ b/packages/spectrum-ts/src/providers/telegram/outbound/send.ts
@@ -14,6 +14,7 @@ import { isAllowedReactionEmoji, normalizeReactionEmoji } from "../reactions";
 import type { TelegramSpace } from "../space";
 import type { ReactionTypeEmoji } from "../types";
 import { buildSend, parseMessageId } from "./message";
+import { sendStreamText } from "./stream-text";
 
 const MILLIS_PER_SECOND = 1000;
 
@@ -138,9 +139,10 @@ const sendEdit = async (
  * Outbound dispatcher. Fire-and-forget signals (typing, edit) return
  * `undefined`; message-producing content returns a record with the Telegram
  * message id. Reactions return a record with a synthetic id (Telegram assigns
- * none). A `group` fans out to one message per item. `poll`, `effect`,
- * `rename` and `avatar` are unsupported in v1 (use `custom` to reach any other
- * Bot API method directly).
+ * none). A `group` fans out to one message per item. `streamText` streams
+ * natively via message drafts in private chats (see `stream-text.ts`). `poll`,
+ * `effect`, `rename` and `avatar` are unsupported in v1 (use `custom` to reach
+ * any other Bot API method directly).
  */
 export const send = async ({
   space,
@@ -157,6 +159,8 @@ export const send = async ({
       return await sendEdit(client, space, content);
     case "group":
       return await sendGroup(client, space, content.items);
+    case "streamText":
+      return await sendStreamText(client, space, content);
     case "poll":
     case "poll_option":
     case "effect":

--- a/packages/spectrum-ts/src/providers/telegram/outbound/stream-text.ts
+++ b/packages/spectrum-ts/src/providers/telegram/outbound/stream-text.ts
@@ -1,0 +1,106 @@
+import { sendMessageDraft } from "@photon-ai/telegram-ts";
+import type { StreamText } from "../../../content/stream-text";
+import { asText } from "../../../content/text";
+import type { ProviderMessageRecord } from "../../../platform/types";
+import { UnsupportedError } from "../../../utils/errors";
+import { executeSpec, type TelegramClient } from "../client";
+import { TELEGRAM_PLATFORM } from "../config";
+import type { TelegramSpace } from "../space";
+
+const MILLIS_PER_SECOND = 1000;
+
+// Drafts are ephemeral previews replaced wholesale on every update and carry
+// no edit cap (unlike iMessage), so a fixed gap is enough pacing: frequent
+// enough to feel live, infrequent enough to stay clear of Bot API rate limits.
+const DRAFT_THROTTLE_MS = 500;
+
+// `draft_id` must be non-zero, and updates reusing an id animate in place. A
+// process-local counter gives each stream its own draft, so concurrent streams
+// into the same chat don't overwrite each other's preview.
+let nextDraftId = 1;
+
+/**
+ * Deliver a `streamText` content natively via Telegram message drafts
+ * (`sendMessageDraft`): an empty draft shows the client's "Thinking…"
+ * placeholder, throttled updates animate the accumulated text while the stream
+ * runs, and a final `sendMessage` persists the full text — drafts are
+ * ~30-second ephemeral previews, so only a real send lands in the chat.
+ * Drafts exist only in private chats; group/channel spaces (non-positive chat
+ * ids) throw `UnsupportedError` before the stream is consumed, letting the
+ * send pipeline's plain-text fallback deliver the accumulated text instead.
+ */
+export const sendStreamText = async (
+  client: TelegramClient,
+  space: TelegramSpace,
+  content: StreamText
+): Promise<ProviderMessageRecord> => {
+  const chatId = Number(space.id);
+  if (!(Number.isInteger(chatId) && chatId > 0)) {
+    throw UnsupportedError.content(
+      "streamText",
+      TELEGRAM_PLATFORM,
+      `message drafts work only in private chats (got chat id "${space.id}").`
+    );
+  }
+  const draftId = nextDraftId;
+  nextDraftId += 1;
+
+  let lastDraftText: string | undefined;
+  let lastDraftAt = 0;
+  let draftsAvailable = true;
+
+  const updateDraft = async (text: string): Promise<void> => {
+    if (!draftsAvailable || text === lastDraftText) {
+      return;
+    }
+    try {
+      await sendMessageDraft({
+        body: { chat_id: chatId, draft_id: draftId, text },
+        client,
+      });
+      lastDraftText = text;
+      lastDraftAt = Date.now();
+    } catch {
+      // The draft is only a preview — never let it sink the send. One failure
+      // disables further drafts (a Bot API server without `sendMessageDraft`
+      // would reject every call); the final `sendMessage` still delivers.
+      draftsAvailable = false;
+    }
+  };
+
+  // Telegram renders an empty draft as its native "Thinking…" placeholder,
+  // covering the gap until the first token arrives.
+  await updateDraft("");
+
+  let full = "";
+  for await (const delta of content.stream()) {
+    full += delta;
+    if (Date.now() - lastDraftAt >= DRAFT_THROTTLE_MS) {
+      await updateDraft(full);
+    }
+  }
+
+  if (!full) {
+    // The stream is already consumed, so the pipeline's plain-text fallback
+    // cannot apply — this lands in warn-and-skip. The lingering "Thinking…"
+    // draft expires on its own.
+    throw UnsupportedError.content(
+      "streamText",
+      TELEGRAM_PLATFORM,
+      "stream produced no text — nothing to send."
+    );
+  }
+
+  // Persist: only a real `sendMessage` lands the message in the chat (and
+  // replaces the draft client-side).
+  const sent = await executeSpec(client, {
+    method: "sendMessage",
+    params: { chat_id: space.id, text: full },
+  });
+  return {
+    id: String(sent.message_id),
+    content: asText(full),
+    space: { id: space.id },
+    timestamp: new Date(sent.date * MILLIS_PER_SECOND),
+  };
+};

--- a/packages/spectrum-ts/test/core/send-stream-text-fallback.test.ts
+++ b/packages/spectrum-ts/test/core/send-stream-text-fallback.test.ts
@@ -172,6 +172,48 @@ describe("streamText plain-text fallback", () => {
     }
   });
 
+  it("warn-and-skips when a native driver consumed the stream before failing", async () => {
+    const seen: Content[] = [];
+    const sendImpl: SendImpl = async (content) => {
+      seen.push(content);
+      if (content.type === "streamText") {
+        // A native driver drains the stream, finds nothing to send, and
+        // rejects — re-draining for the fallback is impossible by then.
+        let drained = "";
+        for await (const delta of content.stream()) {
+          drained += delta;
+        }
+        throw UnsupportedError.content(
+          "streamText",
+          "stream-consumed",
+          `stream produced no text (got "${drained}")`
+        );
+      }
+      return {
+        id: `${content.type}-${seen.length}`,
+        content,
+        space: { id: "s1" },
+        timestamp: SENT_TIMESTAMP,
+      };
+    };
+    const provider = makeProvider("stream-consumed", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const sent = await space.send(streamText(chunks()));
+
+      // The original UnsupportedError lands in warn-and-skip — the consumed
+      // stream must not surface as a hard "already consumed" error.
+      expect(sent).toBeUndefined();
+      expect(seen.map((c) => c.type)).toEqual(["streamText"]);
+    } finally {
+      await app.stop();
+    }
+  });
+
   it("warn-and-skips when the fallback send is unsupported too", async () => {
     const seen: Content[] = [];
     const sendImpl: SendImpl = (content) => {

--- a/packages/spectrum-ts/test/providers/telegram/outbound/stream-text.test.ts
+++ b/packages/spectrum-ts/test/providers/telegram/outbound/stream-text.test.ts
@@ -1,0 +1,205 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  setSystemTime,
+  spyOn,
+} from "bun:test";
+import { streamText } from "@/content/stream-text";
+import { configSchema } from "@/providers/telegram/config";
+import { send } from "@/providers/telegram/outbound/send";
+import { UnsupportedError } from "@/utils/errors";
+
+const TS_SEC = 1_700_000_000;
+const BOOM = /boom/;
+const config = configSchema.parse({ botToken: "1:abc" });
+const space = { id: "100" };
+
+interface Captured {
+  json: Record<string, unknown>;
+  method: string;
+}
+
+// `sendMessageDraft` goes through photon's typed function, which validates the
+// response against a Zod schema — its mock must echo `{ ok, result: true }`;
+// the final `sendMessage` accepts any result.
+const responseFor = (method: string): unknown =>
+  method === "sendMessageDraft"
+    ? { ok: true, result: true }
+    : { ok: true, result: { message_id: 555, date: TS_SEC } };
+
+let calls: Captured[];
+let failDrafts: boolean;
+
+beforeEach(() => {
+  calls = [];
+  failDrafts = false;
+  const impl = (input: Request): Promise<Response> => {
+    const url = input.url;
+    const method = url.slice(url.lastIndexOf("/") + 1);
+    const record = async (): Promise<Captured> => ({
+      json: (await input.clone().json()) as Record<string, unknown>,
+      method,
+    });
+    return record().then((captured) => {
+      calls.push(captured);
+      if (failDrafts && method === "sendMessageDraft") {
+        return Response.json(
+          { description: "draft rejected", ok: false },
+          { status: 400 }
+        );
+      }
+      return Response.json(responseFor(method));
+    });
+  };
+  spyOn(globalThis, "fetch").mockImplementation(
+    impl as unknown as typeof fetch
+  );
+});
+
+afterEach(() => {
+  mock.restore();
+  setSystemTime(); // restore the real clock after time-controlled tests
+});
+
+async function* fromArray(items: string[]): AsyncIterable<string> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+// bun's setSystemTime treats epoch 0 as "restore the real clock", so the
+// frozen timeline must start at a non-zero instant.
+const BASE_MS = 1_000_000;
+
+// Advances the mocked system clock by `stepMs` before each delta, so the
+// driver's Date.now()-based throttle is fully deterministic. The clock is
+// frozen eagerly (not on first pull): the driver stamps its throttle state
+// when it sends the "Thinking…" placeholder, before consuming the stream.
+function timed(items: string[], stepMs: number): AsyncIterable<string> {
+  setSystemTime(new Date(BASE_MS));
+  return (async function* timedGenerator() {
+    let now = BASE_MS;
+    for (const item of items) {
+      now += stepMs;
+      setSystemTime(new Date(now));
+      yield item;
+    }
+  })();
+}
+
+const drafts = (): Captured[] =>
+  calls.filter((c) => c.method === "sendMessageDraft");
+const finalSends = (): Captured[] =>
+  calls.filter((c) => c.method === "sendMessage");
+
+describe("telegram sendStreamText", () => {
+  it("streams drafts and persists the full text with sendMessage", async () => {
+    const result = await send({
+      space,
+      content: await streamText(timed(["Hello", " world", "!"], 1000)).build(),
+      config,
+    });
+
+    // "Thinking…" placeholder, then one animated update per (spaced) delta.
+    expect(drafts().map((c) => c.json.text)).toEqual([
+      "",
+      "Hello",
+      "Hello world",
+      "Hello world!",
+    ]);
+    // All updates target the same non-zero draft in the numeric chat id.
+    const draftIds = new Set(drafts().map((c) => c.json.draft_id));
+    expect(draftIds.size).toBe(1);
+    expect(draftIds.has(0)).toBe(false);
+    for (const draft of drafts()) {
+      expect(draft.json.chat_id).toBe(100);
+    }
+
+    // The draft is ephemeral — the message must be persisted for real.
+    expect(finalSends().map((c) => c.json)).toEqual([
+      { chat_id: "100", text: "Hello world!" },
+    ]);
+    expect(calls.at(-1)?.method).toBe("sendMessage");
+
+    expect(result?.id).toBe("555");
+    expect(result?.content).toEqual({ type: "text", text: "Hello world!" });
+    expect(result?.space.id).toBe("100");
+    expect(result?.timestamp).toEqual(new Date(TS_SEC * 1000));
+  });
+
+  it("throttles draft updates when deltas arrive faster than the gap", async () => {
+    setSystemTime(new Date(BASE_MS)); // freeze: no time passes, no interim drafts
+    await send({
+      space,
+      content: await streamText(fromArray(["a", "b", "c"])).build(),
+      config,
+    });
+
+    // Only the placeholder goes out; the text still lands via sendMessage.
+    expect(drafts().map((c) => c.json.text)).toEqual([""]);
+    expect(finalSends().map((c) => c.json.text)).toEqual(["abc"]);
+  });
+
+  it("rejects group chats before consuming the stream", async () => {
+    let pulled = false;
+    async function* tracking(): AsyncIterable<string> {
+      pulled = true;
+      yield "x";
+    }
+
+    await expect(
+      send({
+        space: { id: "-100123" },
+        content: await streamText(tracking()).build(),
+        config,
+      })
+    ).rejects.toBeInstanceOf(UnsupportedError);
+    expect(pulled).toBe(false);
+    expect(calls).toEqual([]);
+  });
+
+  it("rejects with UnsupportedError when the stream produces no text", async () => {
+    await expect(
+      send({
+        space,
+        content: await streamText(fromArray([])).build(),
+        config,
+      })
+    ).rejects.toBeInstanceOf(UnsupportedError);
+
+    // The placeholder went out (it expires on its own); nothing was persisted.
+    expect(drafts().map((c) => c.json.text)).toEqual([""]);
+    expect(finalSends()).toEqual([]);
+  });
+
+  it("disables drafts after a failure but still persists the message", async () => {
+    failDrafts = true;
+    const result = await send({
+      space,
+      content: await streamText(timed(["a", "b", "c"], 1000)).build(),
+      config,
+    });
+
+    // The placeholder attempt fails and no further drafts are tried.
+    expect(drafts()).toHaveLength(1);
+    expect(finalSends().map((c) => c.json.text)).toEqual(["abc"]);
+    expect(result?.id).toBe("555");
+  });
+
+  it("propagates a mid-stream error without sending the message", async () => {
+    setSystemTime(new Date(BASE_MS));
+    async function* throwing(): AsyncIterable<string> {
+      yield "a";
+      throw new Error("boom");
+    }
+
+    await expect(
+      send({ space, content: await streamText(throwing()).build(), config })
+    ).rejects.toThrow(BOOM);
+    expect(finalSends()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Telegram now handles `streamText` natively in private chats: an empty draft shows the client's "Thinking…" placeholder while the stream runs, throttled updates animate the accumulated text, and a final `sendMessage` persists the full result
- Group/channel chats (non-positive chat IDs) throw `UnsupportedError` before consuming the stream, so the pipeline's plain-text fallback delivers the accumulated text instead
- Draft updates are throttled to 500 ms intervals to stay clear of Bot API rate limits; a draft failure disables further previews but the final `sendMessage` still delivers
- Adds `StreamConsumedError` (a named subclass of `Error`) so the fallback pipeline can tell "provider already consumed the stream" apart from a stream that errored mid-drain — the original `UnsupportedError` is surfaced rather than a confusing "already consumed" error

## Usage

```ts
import { Spectrum } from "spectrum-ts";
import { telegram } from "spectrum-ts/providers/telegram";
import { streamText } from "spectrum-ts";

const app = await Spectrum({
  providers: [telegram.config({ botToken: process.env.BOT_TOKEN })],
});

for await (const [space, message] of app.messages) {
  await space.responding(async () => {
    // Private chats: streams natively via Telegram message drafts.
    // Group/channel chats: falls back to a single plain-text message.
    await space.send(streamText(myLLMStream));
  });
}
```

## Changes

| File | Change |
|---|---|
| `src/providers/telegram/outbound/stream-text.ts` | New `sendStreamText` — opens a draft, throttles live updates, persists with `sendMessage` |
| `src/providers/telegram/outbound/send.ts` | Wires `streamText` case to `sendStreamText`; updates dispatcher JSDoc |
| `src/content/stream-text.ts` | Extracts `StreamConsumedError` as a named class; updates JSDoc to mention Telegram |
| `src/platform/build.ts` | Matches on `StreamConsumedError` in the drain-fallback to rethrow the original `UnsupportedError` instead |
| `test/providers/telegram/outbound/stream-text.test.ts` | New suite (6 cases): full streaming, throttle, group-chat rejection, empty stream, draft-failure recovery, mid-stream error |
| `test/core/send-stream-text-fallback.test.ts` | New case: native driver consumes the stream before failing — confirms warn-and-skip (not a hard "already consumed" error) |

## Test plan

- [ ] `bun test test/providers/telegram/outbound/stream-text.test.ts` — all 6 new cases pass
- [ ] `bun test test/core/send-stream-text-fallback.test.ts` — all cases including the new "consumed stream" case pass
- [ ] `bun test` — full suite green
- [ ] `bun x ultracite check` — no lint/format issues
- [ ] Send a `streamText` to a Telegram private chat — confirm "Thinking…" placeholder appears, text animates, and the final message persists
- [ ] Send a `streamText` to a Telegram group — confirm the full accumulated text arrives as a single plain message (fallback path)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783723137&installation_id=127326493&pr_number=117&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F117&signature=bc78c835ca39274686b88fcecdf2c0f003f3c57368ca2c319842afada1399d4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Telegram streaming text responses now available via message drafts in private chats.

* **Improvements**
  * Enhanced fallback behavior when streaming is unavailable.
  * Improved stream consumption error handling and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->