### PR TITLE
fix(imessage): preserve captions on attachment messages

### DIFF
--- a/packages/spectrum-ts/src/providers/imessage/local/inbound.ts
+++ b/packages/spectrum-ts/src/providers/imessage/local/inbound.ts
@@ -3,17 +3,56 @@ import type {
   IMessageSDK,
   Message as LocalIMessage,
 } from "@photon-ai/imessage-kit";
+import { type Group, groupSchema } from "../../../content/group";
+import { asText } from "../../../content/text";
 import { type ManagedStream, stream } from "../../../utils/stream";
 import type { IMessageMessage } from "../types";
-import { localAttachmentContent } from "./attachments";
+import { type LocalAttachment, localAttachmentContent } from "./attachments";
 
 const ATTACHMENT_PLACEHOLDER = "\uFFFC";
 const ATTACHMENT_JOIN_RETRY_DELAY_MS = 250;
 const ATTACHMENT_JOIN_RETRY_LIMIT = 8;
 const ATTACHMENT_JOIN_FETCH_LIMIT = 10;
 
+type LocalMessageBase = Omit<IMessageMessage, "content" | "id">;
+type RawProviderMessage = Pick<IMessageMessage, "content" | "id">;
+
 const hasAttachmentPlaceholder = (message: LocalIMessage): boolean =>
   message.text?.includes(ATTACHMENT_PLACEHOLDER) ?? false;
+
+const textWithoutAttachmentPlaceholder = (
+  message: LocalIMessage
+): string | undefined => {
+  const text = message.text?.replaceAll(ATTACHMENT_PLACEHOLDER, "").trim();
+  return text ? text : undefined;
+};
+
+const asProviderGroup = (items: readonly RawProviderMessage[]): Group =>
+  groupSchema.parse({ type: "group", items });
+
+const textMessage = (
+  base: LocalMessageBase,
+  parentId: string,
+  text: string
+): IMessageMessage => ({
+  ...base,
+  id: `${parentId}:text`,
+  content: asText(text),
+  parentId,
+  partIndex: 0,
+});
+
+const attachmentMessage = async (
+  base: LocalMessageBase,
+  messageId: string,
+  attachment: LocalAttachment,
+  groupPart?: { parentId: string; partIndex: number }
+): Promise<IMessageMessage> => ({
+  ...base,
+  id: `${messageId}:${attachment.id}`,
+  content: await localAttachmentContent(attachment),
+  ...(groupPart ?? {}),
+});
 
 const isPendingAttachmentJoin = (message: LocalIMessage): boolean =>
   message.attachments.length === 0 &&
@@ -83,13 +122,33 @@ export const toMessages = async (
   };
 
   if (message.attachments.length > 0) {
-    return Promise.all(
-      message.attachments.map(async (att) => ({
-        ...base,
-        id: `${message.id}:${att.id}`,
-        content: await localAttachmentContent(att),
-      }))
+    const text = textWithoutAttachmentPlaceholder(message);
+    const textOffset = text ? 1 : 0;
+    const attachments = await Promise.all(
+      message.attachments.map((att, index) =>
+        attachmentMessage(
+          base,
+          message.id,
+          att,
+          message.attachments.length > 1 || text
+            ? { parentId: message.id, partIndex: index + textOffset }
+            : undefined
+        )
+      )
     );
+    if (!text && attachments.length === 1) {
+      return attachments;
+    }
+    const items = text
+      ? [textMessage(base, message.id, text), ...attachments]
+      : attachments;
+    return [
+      {
+        ...base,
+        id: message.id,
+        content: asProviderGroup(items),
+      },
+    ];
   }
 
   return [

--- a/packages/spectrum-ts/src/providers/imessage/remote/inbound.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/inbound.ts
@@ -26,6 +26,7 @@ import {
 } from "./ids";
 
 const URL_BALLOON_BUNDLE_ID = "com.apple.messages.URLBalloonProvider";
+const ATTACHMENT_PLACEHOLDER = "\uFFFC";
 
 export type ReceivedEvent = Extract<MessageEvent, { type: "message.received" }>;
 export type AppleMessage = ReceivedEvent["message"];
@@ -38,6 +39,15 @@ const getBalloonBundleId = (message: AppleMessage): string | undefined =>
 const messageAttachments = (
   message: AppleMessage
 ): readonly AppleAttachment[] => message.content.attachments;
+
+const textWithoutAttachmentPlaceholder = (
+  message: AppleMessage
+): string | undefined => {
+  const text = message.content.text
+    ?.replaceAll(ATTACHMENT_PLACEHOLDER, "")
+    .trim();
+  return text ? text : undefined;
+};
 
 const resolveChatGuid = (
   message: AppleMessage,
@@ -74,6 +84,20 @@ export const isIMessageMessage = (value: unknown): value is IMessageMessage => {
 
 const asProviderGroup = (items: readonly RawProviderMessage[]): Group =>
   groupSchema.parse({ type: "group", items });
+
+const buildTextMessage = (
+  base: RemoteMessageBase,
+  text: string,
+  id: string,
+  partIndex?: number,
+  parentId?: string
+): IMessageMessage => ({
+  ...base,
+  id,
+  content: asText(text),
+  ...(partIndex === undefined ? {} : { partIndex }),
+  ...(parentId === undefined ? {} : { parentId }),
+});
 
 export const buildMessageBase = (
   message: AppleMessage,
@@ -139,11 +163,68 @@ const buildAttachmentMessage = async (
   parentId?: string
 ): Promise<IMessageMessage> => {
   const content = await attachmentContent(client, info);
-  const msg: IMessageMessage = { ...base, id, content, partIndex };
-  if (parentId !== undefined) {
-    msg.parentId = parentId;
+  return {
+    ...base,
+    id,
+    content,
+    partIndex,
+    ...(parentId === undefined ? {} : { parentId }),
+  };
+};
+
+const buildAttachmentItems = async (
+  client: AdvancedIMessage,
+  base: RemoteMessageBase,
+  attachments: readonly AppleAttachment[],
+  parentId: string,
+  text: string | undefined
+): Promise<IMessageMessage[]> => {
+  const items: IMessageMessage[] = text
+    ? [buildTextMessage(base, text, formatChildId(0, parentId), 0, parentId)]
+    : [];
+  const attachmentPartOffset = items.length;
+
+  for (let i = 0; i < attachments.length; i++) {
+    const info = attachments[i];
+    if (!info) {
+      continue;
+    }
+    const partIndex = i + attachmentPartOffset;
+    items.push(
+      await buildAttachmentMessage(
+        client,
+        base,
+        info,
+        formatChildId(partIndex, parentId),
+        partIndex,
+        parentId
+      )
+    );
   }
-  return msg;
+
+  return items;
+};
+
+const buildAttachmentMessageOrGroup = async (
+  client: AdvancedIMessage,
+  base: RemoteMessageBase,
+  attachments: readonly AppleAttachment[],
+  messageId: string,
+  text: string | undefined
+): Promise<IMessageMessage> => {
+  const singleAttachment =
+    attachments.length === 1 ? attachments[0] : undefined;
+  if (singleAttachment && !text) {
+    return buildAttachmentMessage(client, base, singleAttachment, messageId, 0);
+  }
+
+  return {
+    ...base,
+    id: messageId,
+    content: asProviderGroup(
+      await buildAttachmentItems(client, base, attachments, messageId, text)
+    ),
+  };
 };
 
 const toRichlinkMessage = (
@@ -179,37 +260,14 @@ export const rebuildFromAppleMessage = async (
 
   const attachments = messageAttachments(message);
 
-  if (attachments.length === 1) {
-    const info = attachments[0];
-    if (!info) {
-      throw new Error("Unreachable: attachments.length === 1 but no element");
-    }
-    return buildAttachmentMessage(client, base, info, messageGuidStr, 0);
-  }
-
-  if (attachments.length > 1) {
-    const items: IMessageMessage[] = [];
-    for (let i = 0; i < attachments.length; i++) {
-      const info = attachments[i];
-      if (!info) {
-        continue;
-      }
-      items.push(
-        await buildAttachmentMessage(
-          client,
-          base,
-          info,
-          formatChildId(i, messageGuidStr),
-          i,
-          messageGuidStr
-        )
-      );
-    }
-    return {
-      ...base,
-      id: messageGuidStr,
-      content: asProviderGroup(items),
-    };
+  if (attachments.length > 0) {
+    return buildAttachmentMessageOrGroup(
+      client,
+      base,
+      attachments,
+      messageGuidStr,
+      textWithoutAttachmentPlaceholder(message)
+    );
   }
 
   if (getBalloonBundleId(message) === URL_BALLOON_BUNDLE_ID) {
@@ -260,47 +318,16 @@ export const toInboundMessages = async (
 
   const attachments = messageAttachments(event.message);
 
-  if (attachments.length === 1) {
-    const info = attachments[0];
-    if (!info) {
-      throw new Error("Unreachable: attachments.length === 1 but no element");
-    }
-    const msg = await buildAttachmentMessage(
+  if (attachments.length > 0) {
+    const msg = await buildAttachmentMessageOrGroup(
       client,
       base,
-      info,
+      attachments,
       messageGuidStr,
-      0
+      textWithoutAttachmentPlaceholder(event.message)
     );
     cacheMessage(cache, msg);
     return [msg];
-  }
-
-  if (attachments.length > 1) {
-    const items: IMessageMessage[] = [];
-    for (let i = 0; i < attachments.length; i++) {
-      const info = attachments[i];
-      if (!info) {
-        continue;
-      }
-      items.push(
-        await buildAttachmentMessage(
-          client,
-          base,
-          info,
-          formatChildId(i, messageGuidStr),
-          i,
-          messageGuidStr
-        )
-      );
-    }
-    const parent: IMessageMessage = {
-      ...base,
-      id: messageGuidStr,
-      content: asProviderGroup(items),
-    };
-    cacheMessage(cache, parent);
-    return [parent];
   }
 
   const text = event.message.content.text;

--- a/packages/spectrum-ts/test/providers/_imessage/local/inbound.test.ts
+++ b/packages/spectrum-ts/test/providers/_imessage/local/inbound.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "bun:test";
+import type { Message as LocalIMessage } from "@photon-ai/imessage-kit";
+import { toMessages } from "@/providers/imessage/local/inbound";
+import type { IMessageMessage } from "@/providers/imessage/types";
+
+const SENT_DATE = new Date(1_700_000_000_000);
+// Apple stores attachment placeholders in message text as U+FFFC.
+const ATTACHMENT_PLACEHOLDER = "\uFFFC";
+
+type LocalAttachment = LocalIMessage["attachments"][number];
+
+const attachment = (id: string, fileName: string): LocalAttachment =>
+  ({
+    id,
+    fileName,
+    localPath: `/tmp/${fileName}`,
+    mimeType: "image/jpeg",
+    sizeBytes: 123,
+  }) as LocalAttachment;
+
+const localMessage = (input: {
+  attachments?: LocalAttachment[];
+  id?: string;
+  text?: string | null;
+}): LocalIMessage => {
+  const attachments = input.attachments ?? [];
+  return {
+    id: input.id ?? "local-msg",
+    attachments,
+    chatId: "chat-1",
+    chatKind: "dm",
+    createdAt: SENT_DATE,
+    hasAttachments: attachments.length > 0,
+    kind: "text",
+    participant: "+15550100",
+    reaction: null,
+    retractedAt: null,
+    text: input.text ?? null,
+  } as unknown as LocalIMessage;
+};
+
+const groupItems = (message: IMessageMessage): IMessageMessage[] => {
+  if (message.content.type !== "group") {
+    throw new Error("expected group content");
+  }
+  return message.content.items as unknown as IMessageMessage[];
+};
+
+describe("iMessage local inbound", () => {
+  it("keeps a bare single attachment as attachment content", async () => {
+    const [message] = await toMessages(
+      localMessage({ attachments: [attachment("att-1", "photo.jpg")] })
+    );
+
+    expect(message).toMatchObject({
+      id: "local-msg:att-1",
+      content: {
+        type: "attachment",
+        id: "att-1",
+        name: "photo.jpg",
+      },
+    });
+    expect(message?.parentId).toBeUndefined();
+    expect(message?.partIndex).toBeUndefined();
+  });
+
+  it("groups caption text with attachments", async () => {
+    const [message] = await toMessages(
+      localMessage({
+        attachments: [attachment("att-1", "photo.jpg")],
+        text: `Look at this${ATTACHMENT_PLACEHOLDER}`,
+      })
+    );
+
+    if (!message) {
+      throw new Error("expected grouped message");
+    }
+    const items = groupItems(message);
+
+    expect(message.id).toBe("local-msg");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({
+      id: "local-msg:text",
+      parentId: "local-msg",
+      partIndex: 0,
+      content: { type: "text", text: "Look at this" },
+    });
+    expect(items[1]).toMatchObject({
+      id: "local-msg:att-1",
+      parentId: "local-msg",
+      partIndex: 1,
+      content: {
+        type: "attachment",
+        id: "att-1",
+        name: "photo.jpg",
+      },
+    });
+  });
+
+  it("groups multiple attachments from one local message", async () => {
+    const [message] = await toMessages(
+      localMessage({
+        attachments: [
+          attachment("att-1", "photo-1.jpg"),
+          attachment("att-2", "photo-2.jpg"),
+        ],
+      })
+    );
+
+    if (!message) {
+      throw new Error("expected grouped message");
+    }
+    const items = groupItems(message);
+
+    expect(message.id).toBe("local-msg");
+    expect(items.map((item) => item.id)).toEqual([
+      "local-msg:att-1",
+      "local-msg:att-2",
+    ]);
+    expect(items.map((item) => item.partIndex)).toEqual([0, 1]);
+  });
+});

--- a/packages/spectrum-ts/test/providers/_imessage/remote/inbound.test.ts
+++ b/packages/spectrum-ts/test/providers/_imessage/remote/inbound.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "bun:test";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import { MessageCache } from "@/providers/imessage/cache";
+import {
+  type AppleMessage,
+  type ReceivedEvent,
+  rebuildFromAppleMessage,
+  toInboundMessages,
+} from "@/providers/imessage/remote/inbound";
+import type { IMessageMessage } from "@/providers/imessage/types";
+
+const SENT_DATE = new Date(1_700_000_000_000);
+const CHAT_GUID = "any;-;+15550100";
+const PHONE = "+15550123";
+// Apple stores attachment placeholders in message text as U+FFFC.
+const ATTACHMENT_PLACEHOLDER = "\uFFFC";
+
+type AppleAttachment = AppleMessage["content"]["attachments"][number];
+
+const client = {} as AdvancedIMessage;
+
+const attachment = (
+  guid: string,
+  fileName: string,
+  mimeType = "image/jpeg"
+): AppleAttachment =>
+  ({
+    guid,
+    fileName,
+    mimeType,
+    totalBytes: 123,
+  }) as AppleAttachment;
+
+const appleMessage = (input: {
+  attachments?: AppleAttachment[];
+  guid?: string;
+  text?: string;
+}): AppleMessage =>
+  ({
+    guid: input.guid ?? "msg-guid",
+    dateCreated: SENT_DATE,
+    sender: { address: "+15550999" },
+    chatGuids: [CHAT_GUID],
+    content: {
+      attachments: input.attachments ?? [],
+      text: input.text,
+    },
+  }) as unknown as AppleMessage;
+
+const receivedEvent = (message: AppleMessage): ReceivedEvent =>
+  ({
+    type: "message.received",
+    chatGuid: CHAT_GUID,
+    message,
+    occurredAt: SENT_DATE,
+  }) as unknown as ReceivedEvent;
+
+const groupItems = (message: IMessageMessage): IMessageMessage[] => {
+  if (message.content.type !== "group") {
+    throw new Error("expected group content");
+  }
+  return message.content.items as unknown as IMessageMessage[];
+};
+
+describe("iMessage remote inbound", () => {
+  it("keeps a bare single attachment as attachment content", async () => {
+    const message = await rebuildFromAppleMessage(
+      client,
+      appleMessage({
+        attachments: [attachment("att-1", "photo.jpg")],
+        text: ATTACHMENT_PLACEHOLDER,
+      }),
+      PHONE
+    );
+
+    expect(message.id).toBe("msg-guid");
+    expect(message.partIndex).toBe(0);
+    expect(message.parentId).toBeUndefined();
+    expect(message.content).toMatchObject({
+      type: "attachment",
+      id: "att-1",
+      name: "photo.jpg",
+      mimeType: "image/jpeg",
+      size: 123,
+    });
+  });
+
+  it("groups caption text with a single attachment", async () => {
+    const message = await rebuildFromAppleMessage(
+      client,
+      appleMessage({
+        attachments: [attachment("att-1", "photo.jpg")],
+        text: `${ATTACHMENT_PLACEHOLDER}Look at this`,
+      }),
+      PHONE
+    );
+
+    const items = groupItems(message);
+    expect(message.id).toBe("msg-guid");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({
+      id: "p:0/msg-guid",
+      parentId: "msg-guid",
+      partIndex: 0,
+      content: { type: "text", text: "Look at this" },
+    });
+    expect(items[1]).toMatchObject({
+      id: "p:1/msg-guid",
+      parentId: "msg-guid",
+      partIndex: 1,
+      content: {
+        type: "attachment",
+        id: "att-1",
+        name: "photo.jpg",
+      },
+    });
+  });
+
+  it("preserves native part order for caption plus multiple attachments", async () => {
+    const message = await rebuildFromAppleMessage(
+      client,
+      appleMessage({
+        attachments: [
+          attachment("att-1", "photo-1.jpg"),
+          attachment("att-2", "photo-2.jpg"),
+        ],
+        text: `${ATTACHMENT_PLACEHOLDER}${ATTACHMENT_PLACEHOLDER}Two photos`,
+      }),
+      PHONE
+    );
+
+    const items = groupItems(message);
+    expect(items.map((item) => item.id)).toEqual([
+      "p:0/msg-guid",
+      "p:1/msg-guid",
+      "p:2/msg-guid",
+    ]);
+    expect(items.map((item) => item.partIndex)).toEqual([0, 1, 2]);
+    expect(items.map((item) => item.parentId)).toEqual([
+      "msg-guid",
+      "msg-guid",
+      "msg-guid",
+    ]);
+    expect(items[0]?.content).toEqual({ type: "text", text: "Two photos" });
+  });
+
+  it("does not create text items for attachment placeholders only", async () => {
+    const message = await rebuildFromAppleMessage(
+      client,
+      appleMessage({
+        attachments: [
+          attachment("att-1", "photo-1.jpg"),
+          attachment("att-2", "photo-2.jpg"),
+        ],
+        text: `${ATTACHMENT_PLACEHOLDER}${ATTACHMENT_PLACEHOLDER}`,
+      }),
+      PHONE
+    );
+
+    const items = groupItems(message);
+    expect(items).toHaveLength(2);
+    expect(items.map((item) => item.partIndex)).toEqual([0, 1]);
+    expect(items.map((item) => item.content.type)).toEqual([
+      "attachment",
+      "attachment",
+    ]);
+  });
+
+  it("caches grouped caption and attachment children from inbound events", async () => {
+    const cache = new MessageCache();
+    const [message] = await toInboundMessages(
+      client,
+      cache,
+      receivedEvent(
+        appleMessage({
+          attachments: [attachment("att-1", "photo.jpg")],
+          text: "Caption",
+        })
+      ),
+      PHONE
+    );
+
+    expect(message?.content.type).toBe("group");
+    expect(cache.get("msg-guid")?.content.type).toBe("group");
+    expect(cache.get("p:0/msg-guid")?.content).toEqual({
+      type: "text",
+      text: "Caption",
+    });
+    expect(cache.get("p:1/msg-guid")?.content).toMatchObject({
+      type: "attachment",
+      id: "att-1",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes iMessage inbound messages with attachments dropping or corrupting caption text.
- Models mixed text + attachment messages as Spectrum `group` content, matching the existing `group(...)` shape and Telegram caption/media precedent.
- Handles Apple’s `U+FFFC` attachment placeholder so attachment-only messages do not produce fake text items, and captions do not keep leading placeholder characters.
- Applies the fix to both remote iMessage and local iMessage inbound paths.
- Adds focused regression coverage for single attachments, captions, multiple attachments, placeholder-only text, and cache behavior.

## Root cause

iMessage attachment messages can carry their caption in `message.content.text`, but the remote inbound path handled attachments before reading that text. As a result, messages like “caption + image” were surfaced only as attachment content.

During live remote testing I also found Apple includes the object replacement character (`U+FFFC`) in message text as an attachment placeholder. Without stripping it, attachment-only messages looked like they had text, and caption text included leading placeholder characters.

Local iMessage had the same general shape issue: when attachments were present, text was not represented alongside them.

## The fix

1. **Remote iMessage inbound**
   - Normalize message text by removing Apple attachment placeholders.
   - Keep bare single-attachment messages as top-level `attachment`.
   - Convert caption + attachment messages into `group([text, attachment])`.
   - Convert caption + multiple attachments into `group([text, ...attachments])`.
   - Preserve native `partIndex` ordering so reactions/replies can still target group parts correctly.

2. **Local iMessage inbound**
   - Strip Apple attachment placeholders from local message text.
   - Preserve existing bare single-attachment behavior.
   - Represent caption + attachments and multi-attachment native messages as `group` content.

3. **Tests**
   - Add local and remote iMessage inbound regression tests covering attachment-only, captioned attachments, multi-attachment groups, placeholder-only text, and grouped child caching.

## Changes

| File | Change |
| --- | --- |
| `src/providers/imessage/remote/inbound.ts` | Preserve captions by grouping text + attachments; strip `U+FFFC`; keep child ids/part indexes stable |
| `src/providers/imessage/local/inbound.ts` | Mirror grouped caption/attachment behavior for local mode; preserve bare single-attachment behavior |
| `test/providers/_imessage/remote/inbound.test.ts` | Add remote inbound regression coverage |
| `test/providers/_imessage/local/inbound.test.ts` | Add local inbound regression coverage |

## Test plan

- [x] `bun run check`
- [x] `bun run typecheck`
- [x] `bun test` from `packages/spectrum-ts` — full suite passes
- [x] `bun run build` from `packages/spectrum-ts`
- [x] Live remote iMessage probe:
  - text only
  - single image only
  - text + single image
  - multiple images only
  - text + multiple images
  - text + PDF attachment

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783743934&installation_id=127326493&pr_number=118&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F118&signature=ec486805c467a20e0d4102cd732232d29fdfc9ee35c861347d72d31744523d7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of iMessage messages with attachments and captions to ensure consistent grouping and proper metadata assignment.

* **Tests**
  * Added comprehensive test coverage for iMessage message processing, including single/multiple attachments, captions, and grouped content scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->