### PR TITLE
feat(ENG-1564): native markdown for iMessage + text/markdown API overloads

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "@repeaterjs/repeater": "^3.0.6",
         "better-grpc": "^0.3.2",
         "lru-cache": "^11.0.0",
+        "marked": "^18.0.5",
         "mime-types": "^3.0.1",
         "nice-grpc": "^2.1.16",
         "nice-grpc-common": "^2.0.2",
@@ -453,6 +454,8 @@
     "lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -114,15 +114,16 @@ Unsupported (throws `UnsupportedError`): `poll`, `poll_option`, `effect`,
 Markdown rendering escapes all text — including raw HTML in the source — so
 the output can never fail Bot API parsing. On platforms without markdown
 support, the core send pipeline downgrades `markdown` to readable plain text
-(the same mechanism as the `streamText` fallback).
+(the same mechanism as the text-stream fallback).
 
-`markdown(streamText(source))` — or equivalently
-`streamText(source, { format: "markdown" })` — streams markdown natively:
-every draft update re-renders the accumulated markdown through the same HTML
-pipeline (unclosed markers stay literal, so partial renders are always valid),
-and the final persist sends the rendered HTML with `parse_mode: "HTML"`. On
-platforms without native markdown streaming, the drained text re-enters the
-send pipeline as `markdown` content and downgrades to plain text at worst.
+`markdown(source)` with a stream source (an AI SDK result, an OpenAI /
+Anthropic streaming response, or any AsyncIterable / ReadableStream) streams
+markdown natively: every draft update re-renders the accumulated markdown
+through the same HTML pipeline (unclosed markers stay literal, so partial
+renders are always valid), and the final persist sends the rendered HTML with
+`parse_mode: "HTML"`. On platforms without native markdown streaming, the
+drained text re-enters the send pipeline as `markdown` content and downgrades
+to plain text at worst.
 
 ---
 

--- a/docs/telegram.md
+++ b/docs/telegram.md
@@ -77,6 +77,10 @@ Voice notes become `voice`; everything else becomes an `attachment`.
 Ignored (returns `undefined`): edited messages, callback queries, polls,
 membership changes, and reaction **removals** (empty `new_reaction`).
 
+Inbound formatting entities are **not** mapped to `markdown` — inbound text
+always surfaces as `text`. `markdown` is an outbound-only content type by
+design (a decision, not a gap).
+
 ---
 
 ## Outbound (`send`)
@@ -90,6 +94,7 @@ typed functions directly.
 | Content | Bot API call |
 | --- | --- |
 | `text` | `sendMessage` |
+| `markdown` | `sendMessage` with `parse_mode: "HTML"` (standard markdown → Telegram HTML via `outbound/markdown.ts`) |
 | `richlink` | `sendMessage` (Telegram auto-unfurls the URL) |
 | `attachment` (image) | `sendPhoto` |
 | `attachment` (video) | `sendVideo` |
@@ -101,10 +106,23 @@ typed functions directly.
 | `group` | one message per item (returns the last) |
 | `reaction` | `setMessageReaction` (emoji pre-validated) → synthetic record (Telegram assigns no reaction id) |
 | `typing` | `sendChatAction` (`start` only; `stop` is a no-op) → `undefined` |
-| `edit` | `editMessageText` (text only) → `undefined` |
+| `edit` | `editMessageText` (text or markdown) → `undefined` |
 
 Unsupported (throws `UnsupportedError`): `poll`, `poll_option`, `effect`,
 `rename`, `avatar`. Reach any other Bot API method through `custom`.
+
+Markdown rendering escapes all text — including raw HTML in the source — so
+the output can never fail Bot API parsing. On platforms without markdown
+support, the core send pipeline downgrades `markdown` to readable plain text
+(the same mechanism as the `streamText` fallback).
+
+`markdown(streamText(source))` — or equivalently
+`streamText(source, { format: "markdown" })` — streams markdown natively:
+every draft update re-renders the accumulated markdown through the same HTML
+pipeline (unclosed markers stay literal, so partial renders are always valid),
+and the final persist sends the rendered HTML with `parse_mode: "HTML"`. On
+platforms without native markdown streaming, the drained text re-enters the
+send pipeline as `markdown` content and downgrades to plain text at worst.
 
 ---
 
@@ -156,6 +174,7 @@ Errors from photon surface as `TelegramApiError` (token-free).
 | `inbound/messages.ts` | `handleMessages` — `Update` → record |
 | `inbound/media.ts` | media detection + lazy `read()` |
 | `outbound/message.ts` | `buildSend` — content → `TelegramSendSpec` (pure) |
+| `outbound/markdown.ts` | `markdownToTelegramHtml` — markdown → Telegram HTML (pure) |
 | `outbound/send.ts` | dispatcher; builds the client inline |
 
 ---
@@ -170,10 +189,12 @@ photon's actual request serialization.
 
 - `verify.test.ts` — secret-token cases + `Update` parsing (pure).
 - `outbound/message.test.ts` — `buildSend` content→method/params/file mapping
-  (pure, no client).
+  (pure, no client), including markdown `parse_mode`.
+- `outbound/markdown.test.ts` — `markdownToTelegramHtml` tag mapping and
+  escaping (pure).
 - `outbound/send.test.ts` — `send` end to end via a `fetch` spy: `chat_id`
   injection, multipart uploads (filename preserved), reply threading, group
-  fan-out, reaction validation, typing/edit, unsupported.
+  fan-out, reaction validation, typing/edit (text and markdown), unsupported.
 - `inbound/messages.test.ts` — record mapping for all media kinds, channel posts,
   self-echo drop, reactions; the lazy-download test drives `getFile` + the file
   fetch through the `fetch` spy.

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -84,6 +84,7 @@
     "@repeaterjs/repeater": "^3.0.6",
     "better-grpc": "^0.3.2",
     "lru-cache": "^11.0.0",
+    "marked": "^18.0.5",
     "mime-types": "^3.0.1",
     "nice-grpc": "^2.1.16",
     "nice-grpc-common": "^2.0.2",

--- a/packages/spectrum-ts/src/content/effect.ts
+++ b/packages/spectrum-ts/src/content/effect.ts
@@ -1,9 +1,11 @@
 import z from "zod";
 import { attachmentSchema } from "./attachment";
+import { markdownSchema } from "./markdown";
 import { textSchema } from "./text";
 
 const effectInnerSchema = z.discriminatedUnion("type", [
   textSchema,
+  markdownSchema,
   attachmentSchema,
 ]);
 

--- a/packages/spectrum-ts/src/content/markdown.ts
+++ b/packages/spectrum-ts/src/content/markdown.ts
@@ -1,0 +1,51 @@
+import z from "zod";
+import { asStreamText } from "./stream-text";
+import type { ContentBuilder } from "./types";
+
+/**
+ * Styled text written in standard markdown (CommonMark plus GFM tables and
+ * strikethrough). Outbound-only by design: inbound messages always surface as
+ * `text` content — no provider maps platform formatting back to markdown.
+ * Each platform renders the markdown to its native format (Telegram: HTML via
+ * `parse_mode`); platforms without native support receive readable plain text
+ * via the send pipeline's markdown fallback.
+ */
+export const markdownSchema = z.object({
+  type: z.literal("markdown"),
+  markdown: z.string().nonempty(),
+});
+
+export type Markdown = z.infer<typeof markdownSchema>;
+
+export const asMarkdown = (markdown: string): Markdown =>
+  markdownSchema.parse({ type: "markdown", markdown });
+
+/**
+ * Send styled text written in standard markdown.
+ *
+ * - `markdown("**hi**")` sends the markdown as one message.
+ * - `markdown(streamText(source))` marks a text stream as markdown: it builds
+ *   the inner `streamText` content with `format: "markdown"`, so platforms
+ *   with native support stream it styled (Telegram renders drafts and the
+ *   final message via `parse_mode`) and everywhere else the accumulated text
+ *   falls back through the markdown chain instead of surfacing raw `**`.
+ *
+ * Only `streamText` builders can be wrapped — markdown describes text, and a
+ * stream is the only other content whose payload is text.
+ */
+export function markdown(source: string | ContentBuilder): ContentBuilder {
+  if (typeof source === "string") {
+    return { build: async () => asMarkdown(source) };
+  }
+  return {
+    build: async () => {
+      const inner = await source.build();
+      if (inner.type !== "streamText") {
+        throw new Error(
+          `markdown() can only wrap streamText content (got "${inner.type}") — pass a string to send static markdown`
+        );
+      }
+      return asStreamText({ stream: inner.stream, format: "markdown" });
+    },
+  };
+}

--- a/packages/spectrum-ts/src/content/markdown.ts
+++ b/packages/spectrum-ts/src/content/markdown.ts
@@ -1,5 +1,9 @@
 import z from "zod";
-import { asStreamText } from "./stream-text";
+import {
+  type StreamTextSource,
+  streamTextBuilder,
+  type TextStreamOptions,
+} from "./stream-text";
 import type { ContentBuilder } from "./types";
 
 /**
@@ -21,31 +25,30 @@ export const asMarkdown = (markdown: string): Markdown =>
   markdownSchema.parse({ type: "markdown", markdown });
 
 /**
- * Send styled text written in standard markdown.
+ * Send styled text written in standard markdown — a static string or a
+ * streaming LLM response.
  *
  * - `markdown("**hi**")` sends the markdown as one message.
- * - `markdown(streamText(source))` marks a text stream as markdown: it builds
- *   the inner `streamText` content with `format: "markdown"`, so platforms
- *   with native support stream it styled (Telegram renders drafts and the
- *   final message via `parse_mode`) and everywhere else the accumulated text
- *   falls back through the markdown chain instead of surfacing raw `**`.
+ * - `markdown(source)` marks a text stream as markdown: platforms with native
+ *   support stream it styled (Telegram renders drafts and the final message
+ *   via `parse_mode`), and everywhere else the accumulated text falls back
+ *   through the markdown chain instead of surfacing raw `**` markers.
  *
- * Only `streamText` builders can be wrapped — markdown describes text, and a
- * stream is the only other content whose payload is text.
+ * Stream sources and options work exactly as in `text()` — any SDK streaming
+ * result or `AsyncIterable` / `ReadableStream`, with `options.extract` for
+ * unrecognized chunk shapes.
  */
-export function markdown(source: string | ContentBuilder): ContentBuilder {
+export function markdown(source: string): ContentBuilder;
+export function markdown<T = unknown>(
+  source: StreamTextSource<T>,
+  options?: TextStreamOptions<T>
+): ContentBuilder;
+export function markdown<T = unknown>(
+  source: string | StreamTextSource<T>,
+  options?: TextStreamOptions<T>
+): ContentBuilder {
   if (typeof source === "string") {
     return { build: async () => asMarkdown(source) };
   }
-  return {
-    build: async () => {
-      const inner = await source.build();
-      if (inner.type !== "streamText") {
-        throw new Error(
-          `markdown() can only wrap streamText content (got "${inner.type}") — pass a string to send static markdown`
-        );
-      }
-      return asStreamText({ stream: inner.stream, format: "markdown" });
-    },
-  };
+  return streamTextBuilder("markdown", source, options);
 }

--- a/packages/spectrum-ts/src/content/markdown.ts
+++ b/packages/spectrum-ts/src/content/markdown.ts
@@ -11,8 +11,9 @@ import type { ContentBuilder } from "./types";
  * strikethrough). Outbound-only by design: inbound messages always surface as
  * `text` content — no provider maps platform formatting back to markdown.
  * Each platform renders the markdown to its native format (Telegram: HTML via
- * `parse_mode`); platforms without native support receive readable plain text
- * via the send pipeline's markdown fallback.
+ * `parse_mode`; remote iMessage: styled text via UTF-16 formatting ranges);
+ * platforms without native support receive readable plain text via the send
+ * pipeline's markdown fallback.
  */
 export const markdownSchema = z.object({
   type: z.literal("markdown"),

--- a/packages/spectrum-ts/src/content/stream-text.ts
+++ b/packages/spectrum-ts/src/content/stream-text.ts
@@ -29,6 +29,14 @@ export interface StreamTextOptions<T = unknown> {
    * messages, AI SDK text streams, and plain strings).
    */
   extract?: DeltaExtractor<T>;
+  /**
+   * How the streamed text should be interpreted. `"markdown"` marks it as
+   * standard markdown: platforms with native support render it styled
+   * (Telegram streams styled drafts and persists with `parse_mode`), and
+   * everywhere else the accumulated text is delivered through the `markdown`
+   * fallback chain (readable plain text at worst). Defaults to plain text.
+   */
+  format?: "plain" | "markdown";
 }
 
 export const streamTextSchema = z.object({
@@ -43,6 +51,8 @@ export const streamTextSchema = z.object({
         "streamText.stream must be a function returning AsyncIterable<string>",
     }
   ),
+  // How platforms should interpret the accumulated text; absent = plain.
+  format: z.enum(["plain", "markdown"]).optional(),
 });
 
 export type StreamText = z.infer<typeof streamTextSchema>;
@@ -253,8 +263,13 @@ const normalize = <T>(
 
 export const asStreamText = (input: {
   stream: () => AsyncIterable<string>;
+  format?: "plain" | "markdown";
 }): StreamText =>
-  streamTextSchema.parse({ type: "streamText", stream: input.stream });
+  streamTextSchema.parse({
+    type: "streamText",
+    stream: input.stream,
+    ...(input.format ? { format: input.format } : {}),
+  });
 
 /**
  * Consume a `streamText` content's stream to completion and return the full
@@ -279,6 +294,13 @@ export const drainStreamText = async (content: StreamText): Promise<string> => {
  * as one message. Platforms that can't stream wait for the stream to finish
  * and deliver the accumulated text as one plain message.
  *
+ * When the stream emits standard markdown, wrap the builder in
+ * `markdown(streamText(source))` — or equivalently pass
+ * `{ format: "markdown" }` — so platforms with native support deliver it
+ * styled (Telegram renders drafts and the final message via `parse_mode`),
+ * and everywhere else the accumulated text falls back through the `markdown`
+ * chain instead of surfacing raw `**` markers.
+ *
  * Accepts whatever the popular SDKs return; pass `options.extract` for any
  * chunk shape the built-in detection doesn't recognize.
  */
@@ -287,6 +309,10 @@ export function streamText<T = unknown>(
   options?: StreamTextOptions<T>
 ): ContentBuilder {
   return {
-    build: async () => asStreamText({ stream: normalize(source, options) }),
+    build: async () =>
+      asStreamText({
+        stream: normalize(source, options),
+        format: options?.format,
+      }),
   };
 }

--- a/packages/spectrum-ts/src/content/stream-text.ts
+++ b/packages/spectrum-ts/src/content/stream-text.ts
@@ -9,8 +9,9 @@ import type { ContentBuilder } from "./types";
 export type DeltaExtractor<T> = (chunk: T) => string | null | undefined;
 
 /**
- * Anything `streamText()` accepts as a source. The builder normalizes all of
- * these to an internal `AsyncIterable<string>` of text deltas:
+ * Anything the stream overloads of `text()` and `markdown()` accept as a
+ * source. The builder normalizes all of these to an internal
+ * `AsyncIterable<string>` of text deltas:
  *
  * - the Vercel AI SDK `streamText()` result (its `.textStream` is picked up
  *   automatically — pass either the whole result or `.textStream` directly),
@@ -22,21 +23,13 @@ export type StreamTextSource<T = unknown> =
   | AsyncIterable<T>
   | ReadableStream<T>;
 
-export interface StreamTextOptions<T = unknown> {
+export interface TextStreamOptions<T = unknown> {
   /**
    * Map each chunk to its incremental text. Omit to rely on built-in
    * auto-detection of the common SDK shapes (OpenAI chat/responses, Anthropic
    * messages, AI SDK text streams, and plain strings).
    */
   extract?: DeltaExtractor<T>;
-  /**
-   * How the streamed text should be interpreted. `"markdown"` marks it as
-   * standard markdown: platforms with native support render it styled
-   * (Telegram streams styled drafts and persists with `parse_mode`), and
-   * everywhere else the accumulated text is delivered through the `markdown`
-   * fallback chain (readable plain text at worst). Defaults to plain text.
-   */
-  format?: "plain" | "markdown";
 }
 
 export const streamTextSchema = z.object({
@@ -144,7 +137,7 @@ const OBJECT_EXTRACTORS: ReadonlyArray<
 
 /**
  * Auto-detect the text delta in a chunk from a popular LLM SDK. Pass a custom
- * `extract` to `streamText()` for any shape this doesn't recognize.
+ * `extract` to `text()` / `markdown()` for any shape this doesn't recognize.
  */
 const defaultExtract: DeltaExtractor<unknown> = (chunk) => {
   if (typeof chunk === "string") {
@@ -153,7 +146,7 @@ const defaultExtract: DeltaExtractor<unknown> = (chunk) => {
   const record = asRecord(chunk);
   if (!record) {
     throw new Error(
-      `streamText: cannot extract a text delta from a ${typeof chunk} chunk. Pass { extract } to map your stream's chunks to text.`
+      `text stream: cannot extract a text delta from a ${typeof chunk} chunk. Pass { extract } to map your stream's chunks to text.`
     );
   }
   for (const extractor of OBJECT_EXTRACTORS) {
@@ -163,7 +156,7 @@ const defaultExtract: DeltaExtractor<unknown> = (chunk) => {
     }
   }
   throw new Error(
-    `streamText: unrecognized chunk shape (type=${String(record.type)}). Pass an { extract } function to map your provider's chunk to a text delta.`
+    `text stream: unrecognized chunk shape (type=${String(record.type)}). Pass an { extract } function to map your provider's chunk to a text delta.`
   );
 };
 
@@ -211,7 +204,7 @@ const resolveChunkIterable = <T>(
       return textStream;
     }
     throw new Error(
-      "streamText: `.textStream` must be an AsyncIterable or a ReadableStream."
+      "text stream: `.textStream` must be an AsyncIterable or a ReadableStream."
     );
   }
   if (isReadableStream(source)) {
@@ -221,7 +214,7 @@ const resolveChunkIterable = <T>(
     return source;
   }
   throw new Error(
-    "streamText: source must be an AsyncIterable, a ReadableStream, or an object with a `.textStream` (e.g. the AI SDK streamText() result)."
+    "text stream: source must be an AsyncIterable, a ReadableStream, or an object with a `.textStream` (e.g. the AI SDK streamText() result)."
   );
 };
 
@@ -233,7 +226,7 @@ const resolveChunkIterable = <T>(
 export class StreamConsumedError extends Error {
   constructor() {
     super(
-      "streamText: this source has already been consumed — a stream can only be sent once."
+      "text stream: this source has already been consumed — a stream can only be sent once."
     );
     this.name = "StreamConsumedError";
   }
@@ -241,7 +234,7 @@ export class StreamConsumedError extends Error {
 
 const normalize = <T>(
   source: StreamTextSource<T>,
-  options?: StreamTextOptions<T>
+  options?: TextStreamOptions<T>
 ): (() => AsyncIterable<string>) => {
   const extract: DeltaExtractor<unknown> = options?.extract
     ? (options.extract as DeltaExtractor<unknown>)
@@ -286,33 +279,25 @@ export const drainStreamText = async (content: StreamText): Promise<string> => {
 };
 
 /**
- * Wrap a streaming LLM text response so it can be sent like any other content.
- *
- * Delivery is platform-specific — iMessage (remote) sends the first chunk as a
- * real message and then edits it in place as more text arrives; Telegram
- * (private chats) animates a native draft preview and persists the final text
- * as one message. Platforms that can't stream wait for the stream to finish
- * and deliver the accumulated text as one plain message.
- *
- * When the stream emits standard markdown, wrap the builder in
- * `markdown(streamText(source))` — or equivalently pass
- * `{ format: "markdown" }` — so platforms with native support deliver it
- * styled (Telegram renders drafts and the final message via `parse_mode`),
- * and everywhere else the accumulated text falls back through the `markdown`
- * chain instead of surfacing raw `**` markers.
- *
- * Accepts whatever the popular SDKs return; pass `options.extract` for any
- * chunk shape the built-in detection doesn't recognize.
+ * Shared backing for the stream overloads of `text()` and `markdown()`: the
+ * constructor name picks the wire format and labels the eager guard against
+ * passing a content builder where a raw stream source belongs.
  */
-export function streamText<T = unknown>(
+export const streamTextBuilder = <T>(
+  kind: "text" | "markdown",
   source: StreamTextSource<T>,
-  options?: StreamTextOptions<T>
-): ContentBuilder {
+  options?: TextStreamOptions<T>
+): ContentBuilder => {
+  if (typeof (source as { build?: unknown }).build === "function") {
+    throw new Error(
+      `${kind}(): pass the stream source itself (an AsyncIterable, a ReadableStream, or an SDK result with .textStream), not another content builder.`
+    );
+  }
   return {
     build: async () =>
       asStreamText({
         stream: normalize(source, options),
-        format: options?.format,
+        format: kind === "markdown" ? "markdown" : undefined,
       }),
   };
-}
+};

--- a/packages/spectrum-ts/src/content/text.ts
+++ b/packages/spectrum-ts/src/content/text.ts
@@ -1,4 +1,9 @@
 import z from "zod";
+import {
+  type StreamTextSource,
+  streamTextBuilder,
+  type TextStreamOptions,
+} from "./stream-text";
 import type { ContentBuilder } from "./types";
 
 export const textSchema = z.object({
@@ -9,8 +14,36 @@ export const textSchema = z.object({
 export const asText = (text: string): z.infer<typeof textSchema> =>
   textSchema.parse({ type: "text", text });
 
-export function text(text: string): ContentBuilder {
-  return {
-    build: async () => asText(text),
-  };
+/**
+ * Send plain text — a static string or a streaming LLM response.
+ *
+ * `text("hi")` sends one message. `text(source)` wraps a text stream so it
+ * can be sent like any other content; delivery is platform-specific —
+ * iMessage (remote) sends the first chunk as a real message and then edits it
+ * in place as more text arrives; Telegram (private chats) animates a native
+ * draft preview and persists the final text as one message. Platforms that
+ * can't stream wait for the stream to finish and deliver the accumulated text
+ * as one plain message.
+ *
+ * A stream source accepts whatever the popular SDKs return (the AI SDK
+ * `streamText()` result, OpenAI / Anthropic streaming responses, or any
+ * `AsyncIterable` / `ReadableStream`); pass `options.extract` for any chunk
+ * shape the built-in detection doesn't recognize. A stream can only be sent
+ * once. Options apply to stream sources only — they are ignored for strings.
+ *
+ * For text written in markdown, use `markdown()` instead.
+ */
+export function text(source: string): ContentBuilder;
+export function text<T = unknown>(
+  source: StreamTextSource<T>,
+  options?: TextStreamOptions<T>
+): ContentBuilder;
+export function text<T = unknown>(
+  source: string | StreamTextSource<T>,
+  options?: TextStreamOptions<T>
+): ContentBuilder {
+  if (typeof source === "string") {
+    return { build: async () => asText(source) };
+  }
+  return streamTextBuilder("text", source, options);
 }

--- a/packages/spectrum-ts/src/content/types.ts
+++ b/packages/spectrum-ts/src/content/types.ts
@@ -6,6 +6,7 @@ import { customSchema } from "./custom";
 import { editSchema } from "./edit";
 import { messageEffectSchema } from "./effect";
 import { groupSchema } from "./group";
+import { markdownSchema } from "./markdown";
 import { pollOptionSchema, pollSchema } from "./poll";
 import { reactionSchema } from "./reaction";
 import { renameSchema } from "./rename";
@@ -26,6 +27,7 @@ import { voiceSchema } from "./voice";
 // so reply/edit cannot statically wrap it.
 const baseContentSchemas = [
   textSchema,
+  markdownSchema,
   streamTextSchema,
   customSchema,
   attachmentSchema,

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -36,12 +36,11 @@ export { type Rename, rename } from "./content/rename";
 export { type Reply, reply } from "./content/reply";
 export { resolveContents } from "./content/resolve";
 export { type Richlink, richlink } from "./content/richlink";
-export {
-  type DeltaExtractor,
-  type StreamText,
-  type StreamTextOptions,
-  type StreamTextSource,
-  streamText,
+export type {
+  DeltaExtractor,
+  StreamText,
+  StreamTextSource,
+  TextStreamOptions,
 } from "./content/stream-text";
 export { text } from "./content/text";
 export type { Content, ContentBuilder, ContentInput } from "./content/types";

--- a/packages/spectrum-ts/src/index.ts
+++ b/packages/spectrum-ts/src/index.ts
@@ -18,6 +18,7 @@ export {
 export { custom } from "./content/custom";
 export { type Edit, edit } from "./content/edit";
 export { type Group, group } from "./content/group";
+export { type Markdown, markdown } from "./content/markdown";
 export {
   option,
   type Poll,

--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -1,6 +1,7 @@
 import { createLogger, withSpan } from "@photon-ai/otel";
 import { type AvatarInput, avatar as avatarContent } from "../content/avatar";
 import { edit as editContent } from "../content/edit";
+import { asMarkdown, type Markdown } from "../content/markdown";
 import {
   type Reaction,
   reaction as reactionContent,
@@ -14,13 +15,14 @@ import {
   type StreamText,
 } from "../content/stream-text";
 import { asText } from "../content/text";
-import type { Content, ContentInput } from "../content/types";
+import type { BaseContent, Content, ContentInput } from "../content/types";
 import { typing as typingContent } from "../content/typing";
 import { unsend as unsendContent } from "../content/unsend";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
 import type { AgentSender } from "../types/user";
 import { UnsupportedError } from "../utils/errors";
+import { markdownToPlainText } from "../utils/markdown";
 import type { Store } from "../utils/store";
 import { contentAttrs } from "../utils/telemetry";
 import type {
@@ -220,33 +222,133 @@ const findStreamText = (item: Content): StreamText | undefined => {
   return;
 };
 
-// Rewrite a stream-bearing content as plain text, preserving a `reply`/`edit`
-// wrapper so the fallback send keeps its target.
-const replaceStreamText = (item: Content, full: string): Content => {
-  const text = asText(full);
+// Rewrite a stream-bearing content as its accumulated text — `markdown` when
+// the stream was marked `format: "markdown"`, plain `text` otherwise —
+// preserving a `reply`/`edit` wrapper so the fallback send keeps its target.
+const replaceStreamText = (
+  item: Content,
+  source: StreamText,
+  full: string
+): Content => {
+  const inner = source.format === "markdown" ? asMarkdown(full) : asText(full);
   if (item.type === "reply" || item.type === "edit") {
-    return { ...item, content: text };
+    return { ...item, content: inner };
   }
-  return text;
+  return inner;
+};
+
+// `undefined` when the markdown renders to empty plain text (e.g. an
+// HTML-comment-only source) — there is nothing sensible to send.
+const downgradeMarkdown = (md: Markdown): BaseContent | undefined => {
+  const plain = markdownToPlainText(md.markdown);
+  return plain ? asText(plain) : undefined;
+};
+
+// Rewrite markdown-bearing content as readable plain text, preserving
+// `reply`/`edit` wrappers and `group` structure. Returns `item` itself
+// (reference-equal) when there is nothing to downgrade. Group items are
+// scanned here but deliberately not in `findStreamText`: a markdown caption
+// in an album downgrades to text meaningfully, while a live stream inside a
+// multipart bubble has no sensible downgrade.
+const replaceMarkdown = (item: Content): Content => {
+  if (item.type === "markdown") {
+    return downgradeMarkdown(item) ?? item;
+  }
+  if (
+    (item.type === "reply" || item.type === "edit") &&
+    item.content.type === "markdown"
+  ) {
+    const downgraded = downgradeMarkdown(item.content);
+    return downgraded ? { ...item, content: downgraded } : item;
+  }
+  if (item.type === "group") {
+    let changed = false;
+    const items = item.items.map((member) => {
+      if (member.content.type !== "markdown") {
+        return member;
+      }
+      const downgraded = downgradeMarkdown(member.content);
+      if (!downgraded) {
+        return member;
+      }
+      changed = true;
+      return { ...member, content: downgraded };
+    });
+    return changed ? { ...item, items } : item;
+  }
+  return item;
 };
 
 type ProviderSend = (
   content: Content
 ) => Promise<ProviderMessageRecord | undefined>;
 
+// The streamText arm of `sendWithFallbacks`: wait for the rejected stream to
+// finish, then re-send the accumulated text — as `markdown` content for a
+// markdown-formatted stream, plain `text` otherwise. The re-send goes back
+// through `sendWithFallbacks`, so a markdown re-send can downgrade once more
+// to plain text on platforms without markdown support. Rethrows the
+// provider's original `UnsupportedError` when the stream produced no text or
+// was already consumed (a native driver that streamed and then failed).
+async function resendDrainedStream(
+  send: ProviderSend,
+  item: Content,
+  source: StreamText,
+  platform: string,
+  unsupported: UnsupportedError
+): Promise<ProviderMessageRecord | undefined> {
+  platformLog.info(
+    `${platform} does not support streaming text; waiting for the stream to finish to send the full text as one message.`,
+    {
+      "spectrum.provider": platform,
+      "spectrum.stream_text.fallback": true,
+    }
+  );
+  let full: string;
+  try {
+    full = await drainStreamText(source);
+  } catch (drainErr) {
+    if (drainErr instanceof StreamConsumedError) {
+      // The provider already consumed the stream (a native driver streamed
+      // it and then failed) — re-draining is impossible, so surface the
+      // original UnsupportedError rather than the consumed-stream error.
+      throw unsupported;
+    }
+    // A genuine stream failure mid-drain propagates as-is.
+    throw drainErr;
+  }
+  if (!full) {
+    // The stream ended without any text — nothing to send.
+    throw unsupported;
+  }
+  // Recursion is bounded: the replaced content carries no stream, and the
+  // markdown branch does a one-shot send.
+  return await sendWithFallbacks(
+    send,
+    replaceStreamText(item, source, full),
+    platform
+  );
+}
+
 /**
- * Dispatch `content` to the provider, falling back to plain text on platforms
- * that can't stream. When the provider rejects a stream-bearing send with
- * `UnsupportedError`, wait for the stream to finish and re-send the
- * accumulated text as `text` content (preserving a `reply`/`edit` wrapper) —
- * so `streamText` works everywhere, just without live updates. Rethrows the
- * original error when no fallback applies (non-stream content, a stream that
- * produced no text, or a stream the provider already consumed — e.g. a native
- * driver that streamed and then failed); an `UnsupportedError` from the
- * fallback send itself propagates too. Both land in the caller's warn-and-skip
- * handling.
+ * Dispatch `content` to the provider, downgrading on platforms that reject it
+ * with `UnsupportedError`:
+ *
+ * - `streamText` (top-level or inside `reply`/`edit`): wait for the stream to
+ *   finish and re-send the accumulated text — as `markdown` content for a
+ *   markdown-formatted stream, plain `text` otherwise — so `streamText`
+ *   works everywhere, just without live updates.
+ * - `markdown` (top-level, inside `reply`/`edit`, or a `group` item): re-send
+ *   with each markdown occurrence rendered to readable plain text — so
+ *   `markdown` works everywhere, just without styling.
+ *
+ * The two chain rather than compete: a drained markdown stream re-enters this
+ * function as `markdown` content and can downgrade once more to plain text.
+ * Rethrows the original error when no fallback applies; an `UnsupportedError`
+ * from the final fallback send itself propagates too. Both land in the
+ * caller's warn-and-skip handling.
  */
-async function sendWithStreamTextFallback(
+async function sendWithFallbacks(
   send: ProviderSend,
   item: Content,
   platform: string
@@ -258,34 +360,21 @@ async function sendWithStreamTextFallback(
       throw err;
     }
     const source = findStreamText(item);
-    if (!source) {
+    if (source) {
+      return await resendDrainedStream(send, item, source, platform, err);
+    }
+    const downgraded = replaceMarkdown(item);
+    if (downgraded === item) {
       throw err;
     }
     platformLog.info(
-      `${platform} does not support streaming text; waiting for the stream to finish to send the full text as one message.`,
+      `${platform} does not support markdown; sending the content as plain text instead.`,
       {
         "spectrum.provider": platform,
-        "spectrum.stream_text.fallback": true,
+        "spectrum.markdown.fallback": true,
       }
     );
-    let full: string;
-    try {
-      full = await drainStreamText(source);
-    } catch (drainErr) {
-      if (drainErr instanceof StreamConsumedError) {
-        // The provider already consumed the stream (a native driver streamed
-        // it and then failed) — re-draining is impossible, so surface the
-        // original UnsupportedError rather than the consumed-stream error.
-        throw err;
-      }
-      // A genuine stream failure mid-drain propagates as-is.
-      throw drainErr;
-    }
-    if (!full) {
-      // The stream ended without any text — nothing to send.
-      throw err;
-    }
-    return await send(replaceStreamText(item, full));
+    return await send(downgraded);
   }
 }
 
@@ -511,11 +600,7 @@ export function buildSpace(params: BuildSpaceParams): Space {
           })) as ProviderMessageRecord | undefined;
         let raw: ProviderMessageRecord | undefined;
         try {
-          raw = await sendWithStreamTextFallback(
-            providerSend,
-            item,
-            definition.name
-          );
+          raw = await sendWithFallbacks(providerSend, item, definition.name);
         } catch (err) {
           if (err instanceof UnsupportedError) {
             warnUnsupported(err, definition.name);

--- a/packages/spectrum-ts/src/providers/imessage/content/effect.ts
+++ b/packages/spectrum-ts/src/providers/imessage/content/effect.ts
@@ -29,9 +29,13 @@ export function effect(
         );
       }
       const inner = await resolveContent(input);
-      if (inner.type !== "text" && inner.type !== "attachment") {
+      if (
+        inner.type !== "text" &&
+        inner.type !== "markdown" &&
+        inner.type !== "attachment"
+      ) {
         throw new Error(
-          `imessage effect() only supports text and attachment content, got "${inner.type}"`
+          `imessage effect() only supports text, markdown, and attachment content, got "${inner.type}"`
         );
       }
       return messageEffectSchema.parse({

--- a/packages/spectrum-ts/src/providers/imessage/remote/markdown.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/markdown.ts
@@ -1,0 +1,408 @@
+import type { TextFormatInput } from "@photon-ai/advanced-imessage";
+import { Marked, type MarkedToken, type Token, type Tokens } from "marked";
+
+// Private instance: immune to host apps reconfiguring the global `marked`
+// singleton via `marked.use()` / `marked.setOptions()`.
+const markdownLexer = new Marked();
+
+const BULLET = "• ";
+const HR_LINE = "———";
+const NESTED_LIST_INDENT = "  ";
+const BLOCK_SEPARATOR = "\n\n";
+const TABLE_CELL_SEPARATOR = " | ";
+const DEFAULT_LIST_START = 1;
+
+const LEADING_WHITESPACE = /^\s+/;
+const TRAILING_WHITESPACE = /\s+$/;
+
+// Unicode mathematical monospace alphanumerics (U+1D670–U+1D6A3 letters,
+// U+1D7F6–U+1D7FF digits). iMessage formatting has no monospace attribute,
+// so code renders through these characters instead — `npm` → 𝚗𝚙𝚖. Anything
+// outside ASCII alphanumerics (punctuation, spaces, non-ASCII) passes
+// through unchanged.
+const MONOSPACE_UPPER_A = 0x1_d6_70;
+const MONOSPACE_LOWER_A = 0x1_d6_8a;
+const MONOSPACE_DIGIT_ZERO = 0x1_d7_f6;
+const UPPER_A = 0x41;
+const UPPER_Z = 0x5a;
+const LOWER_A = 0x61;
+const LOWER_Z = 0x7a;
+const DIGIT_ZERO = 0x30;
+const DIGIT_NINE = 0x39;
+
+const monospaceCodePoint = (codePoint: number): number => {
+  if (codePoint >= UPPER_A && codePoint <= UPPER_Z) {
+    return MONOSPACE_UPPER_A + (codePoint - UPPER_A);
+  }
+  if (codePoint >= LOWER_A && codePoint <= LOWER_Z) {
+    return MONOSPACE_LOWER_A + (codePoint - LOWER_A);
+  }
+  if (codePoint >= DIGIT_ZERO && codePoint <= DIGIT_NINE) {
+    return MONOSPACE_DIGIT_ZERO + (codePoint - DIGIT_ZERO);
+  }
+  return codePoint;
+};
+
+// Monospace characters are astral (2 UTF-16 units each); offsets stay
+// correct because `finalize` measures the converted text, not the source.
+const toMonospace = (text: string): string => {
+  let out = "";
+  for (const char of text) {
+    const codePoint = char.codePointAt(0);
+    out +=
+      codePoint === undefined
+        ? char
+        : String.fromCodePoint(monospaceCodePoint(codePoint));
+  }
+  return out;
+};
+
+// The subset of `TextFormatInput` types markdown emphasis maps onto.
+// Markdown has no underline syntax, and per-character animation effects have
+// no markdown equivalent, so neither is ever emitted.
+type InlineStyle = "bold" | "italic" | "strikethrough";
+
+const STYLE_ORDER: readonly InlineStyle[] = ["bold", "italic", "strikethrough"];
+
+// One run of text whose characters all share the same style set. Block
+// constructs inject unstyled prefix/separator spans between styled runs, so
+// a formatting range can never leak onto a list marker, a `> ` prefix, or a
+// block separator. Offsets are assigned only in `finalize`, after the full
+// span sequence (including trim) is fixed — they can never be invalidated.
+interface StyledSpan {
+  /** Set on spans produced by link/image rendering — drives `hasLinks`. */
+  readonly link?: boolean;
+  readonly styles: readonly InlineStyle[];
+  readonly text: string;
+}
+
+export interface IMessageRenderedMarkdown {
+  readonly formatting: readonly TextFormatInput[];
+  readonly hasLinks: boolean;
+  readonly text: string;
+}
+
+const plain = (text: string): StyledSpan => ({ text, styles: [] });
+
+const withStyle = (spans: StyledSpan[], style: InlineStyle): StyledSpan[] =>
+  spans.map((span) =>
+    span.styles.includes(style)
+      ? span
+      : { ...span, styles: [...span.styles, style] }
+  );
+
+const asLink = (spans: StyledSpan[]): StyledSpan[] =>
+  spans.map((span) => ({ ...span, link: true }));
+
+const spanText = (spans: readonly StyledSpan[]): string => {
+  let out = "";
+  for (const span of spans) {
+    out += span.text;
+  }
+  return out;
+};
+
+// Interleave an unstyled separator between blocks. Separators only ever sit
+// *between* blocks — never leading or trailing — mirroring how the sibling
+// renderers `blocks.join(...)`.
+const joinSpans = (blocks: StyledSpan[][], separator: string): StyledSpan[] => {
+  const out: StyledSpan[] = [];
+  for (const [index, block] of blocks.entries()) {
+    if (index > 0) {
+      out.push(plain(separator));
+    }
+    out.push(...block);
+  }
+  return out;
+};
+
+// Split a span run into lines at `"\n"` so list items and blockquotes can
+// inject unstyled per-line prefixes. A newline inside a styled span (a `br`
+// under `strong`) becomes a line boundary; the rejoining newline is emitted
+// unstyled by the caller.
+const splitSpanLines = (spans: readonly StyledSpan[]): StyledSpan[][] => {
+  let current: StyledSpan[] = [];
+  const lines: StyledSpan[][] = [current];
+  for (const span of spans) {
+    const parts = span.text.split("\n");
+    for (const [index, part] of parts.entries()) {
+      if (index > 0) {
+        current = [];
+        lines.push(current);
+      }
+      if (part) {
+        current.push({ ...span, text: part });
+      }
+    }
+  }
+  return lines;
+};
+
+// `Tokens.Generic`'s string index signature defeats discriminated-union
+// narrowing on `Token`, so walkers assert down to `MarkedToken` once and
+// let the default case absorb generic/extension tokens via `raw`.
+const asMarkedToken = (token: Token): MarkedToken => token as MarkedToken;
+
+const checkboxPrefix = (item: Tokens.ListItem): string => {
+  if (!item.task) {
+    return "";
+  }
+  return item.checked ? "[x] " : "[ ] ";
+};
+
+const listMarker = (list: Tokens.List, index: number): string => {
+  if (!list.ordered) {
+    return BULLET;
+  }
+  const start = list.start === "" ? DEFAULT_LIST_START : list.start;
+  return `${start + index}. `;
+};
+
+const renderLink = (token: Tokens.Link): StyledSpan[] => {
+  // A bare autolink lexes with its label equal to its href — render the
+  // url alone instead of doubling it as "url (url)".
+  if (token.text === token.href) {
+    return [{ text: token.href, styles: [], link: true }];
+  }
+  // The label keeps its inline styling; the " (url)" suffix stays unstyled.
+  return [
+    ...asLink(renderInlineTokens(token.tokens)),
+    { text: ` (${token.href})`, styles: [], link: true },
+  ];
+};
+
+const renderImage = (token: Tokens.Image): StyledSpan[] => [
+  {
+    text: token.text ? `${token.text} (${token.href})` : token.href,
+    styles: [],
+    link: true,
+  },
+];
+
+const renderInlineToken = (token: MarkedToken): StyledSpan[] => {
+  switch (token.type) {
+    case "strong":
+      return withStyle(renderInlineTokens(token.tokens), "bold");
+    case "em":
+      return withStyle(renderInlineTokens(token.tokens), "italic");
+    case "del":
+      return withStyle(renderInlineTokens(token.tokens), "strikethrough");
+    case "codespan":
+      return [plain(toMonospace(token.text))];
+    case "br":
+      return [plain("\n")];
+    case "link":
+      return renderLink(token);
+    case "image":
+      return renderImage(token);
+    case "escape":
+      return [plain(token.text)];
+    case "text":
+      return token.tokens
+        ? renderInlineTokens(token.tokens)
+        : [plain(token.text)];
+    // Raw HTML in markdown source stays literal — styled text has no markup.
+    case "html":
+      return [plain(token.text)];
+    // Task-item checkboxes are rendered from `ListItem.task`/`checked`.
+    case "checkbox":
+      return [];
+    default:
+      return "raw" in token ? [plain(String(token.raw))] : [];
+  }
+};
+
+const renderInlineTokens = (tokens: Token[]): StyledSpan[] => {
+  const out: StyledSpan[] = [];
+  for (const token of tokens) {
+    out.push(...renderInlineToken(asMarkedToken(token)));
+  }
+  return out;
+};
+
+const renderBlockquote = (quote: Tokens.Blockquote): StyledSpan[] => {
+  const lines = splitSpanLines(renderBlockTokens(quote.tokens));
+  const out: StyledSpan[] = [];
+  for (const [index, line] of lines.entries()) {
+    if (index > 0) {
+      out.push(plain("\n"));
+    }
+    out.push(plain(line.length > 0 ? "> " : ">"), ...line);
+  }
+  return out;
+};
+
+// Blocks inside a list item stack on single newlines (a blank separator
+// would detach the lines from their marker); continuation lines are
+// indented so nested lists and wrapped blocks read as part of the item.
+const renderList = (list: Tokens.List): StyledSpan[] => {
+  const out: StyledSpan[] = [];
+  for (const [index, item] of list.items.entries()) {
+    const prefix = `${listMarker(list, index)}${checkboxPrefix(item)}`;
+    const blocks: StyledSpan[][] = [];
+    for (const token of item.tokens) {
+      const rendered = renderBlockToken(asMarkedToken(token));
+      if (spanText(rendered)) {
+        blocks.push(rendered);
+      }
+    }
+    const [first = [], ...rest] = splitSpanLines(joinSpans(blocks, "\n"));
+    if (out.length > 0) {
+      out.push(plain("\n"));
+    }
+    out.push(plain(prefix), ...first);
+    for (const line of rest) {
+      out.push(plain(`\n${NESTED_LIST_INDENT}`), ...line);
+    }
+  }
+  return out;
+};
+
+// Same row layout as the plain-text renderer ("h1 | h2" lines). Unlike
+// Telegram's <pre> fallback nothing here forces cells to drop their inline
+// styling, so emphasis ranges flow through.
+const renderTable = (table: Tokens.Table): StyledSpan[] => {
+  const out: StyledSpan[] = [];
+  const pushRow = (cells: Tokens.TableCell[], rowIndex: number): void => {
+    if (rowIndex > 0) {
+      out.push(plain("\n"));
+    }
+    for (const [cellIndex, cell] of cells.entries()) {
+      if (cellIndex > 0) {
+        out.push(plain(TABLE_CELL_SEPARATOR));
+      }
+      out.push(...renderInlineTokens(cell.tokens));
+    }
+  };
+  pushRow(table.header, 0);
+  for (const [index, row] of table.rows.entries()) {
+    pushRow(row, index + 1);
+  }
+  return out;
+};
+
+const renderBlockToken = (token: MarkedToken): StyledSpan[] => {
+  switch (token.type) {
+    // iMessage formatting has no heading sizes; bold is the conventional
+    // stand-in (Telegram precedent).
+    case "heading":
+      return withStyle(renderInlineTokens(token.tokens), "bold");
+    case "paragraph":
+      return renderInlineTokens(token.tokens);
+    case "code":
+      return [plain(toMonospace(token.text))];
+    case "blockquote":
+      return renderBlockquote(token);
+    case "list":
+      return renderList(token);
+    case "table":
+      return renderTable(token);
+    case "hr":
+      return [plain(HR_LINE)];
+    case "space":
+    case "def":
+      return [];
+    default:
+      return renderInlineToken(token);
+  }
+};
+
+const renderBlockTokens = (tokens: Token[]): StyledSpan[] => {
+  const blocks: StyledSpan[][] = [];
+  for (const token of tokens) {
+    const rendered = renderBlockToken(asMarkedToken(token));
+    if (spanText(rendered)) {
+      blocks.push(rendered);
+    }
+  }
+  return joinSpans(blocks, BLOCK_SEPARATOR);
+};
+
+// Strip leading/trailing whitespace at the span level, before offsets are
+// assigned — trimming the final string instead would invalidate every range
+// start (the sibling renderers' closing `.trim()` has no such concern).
+const trimSpans = (spans: StyledSpan[]): StyledSpan[] => {
+  const trimmed = [...spans];
+  while (trimmed.length > 0) {
+    const first = trimmed.at(0);
+    const text = first?.text.replace(LEADING_WHITESPACE, "");
+    if (first && text) {
+      trimmed[0] = { ...first, text };
+      break;
+    }
+    trimmed.shift();
+  }
+  while (trimmed.length > 0) {
+    const last = trimmed.at(-1);
+    const text = last?.text.replace(TRAILING_WHITESPACE, "");
+    if (last && text) {
+      trimmed[trimmed.length - 1] = { ...last, text };
+      break;
+    }
+    trimmed.pop();
+  }
+  return trimmed;
+};
+
+// Single offset-assigning pass. JS string lengths are UTF-16 code units —
+// exactly the unit `TextFormatInput` ranges use — so plain concatenation
+// counts correctly (an emoji surrogate pair is 2 units). Adjacent spans
+// sharing a style keep one range open (coalescing); a span missing the style
+// closes it. Unstyled separator/prefix spans therefore bound every range.
+const finalize = (spans: StyledSpan[]): IMessageRenderedMarkdown => {
+  let text = "";
+  let hasLinks = false;
+  const open = new Map<InlineStyle, number>();
+  const ranges: { type: InlineStyle; start: number; length: number }[] = [];
+
+  const close = (style: InlineStyle, end: number): void => {
+    const start = open.get(style);
+    open.delete(style);
+    if (start !== undefined && end > start) {
+      ranges.push({ type: style, start, length: end - start });
+    }
+  };
+
+  for (const span of spans) {
+    if (!span.text) {
+      continue;
+    }
+    hasLinks ||= span.link === true;
+    const offset = text.length;
+    for (const style of STYLE_ORDER) {
+      if (span.styles.includes(style)) {
+        if (!open.has(style)) {
+          open.set(style, offset);
+        }
+      } else {
+        close(style, offset);
+      }
+    }
+    text += span.text;
+  }
+  for (const style of STYLE_ORDER) {
+    close(style, text.length);
+  }
+
+  ranges.sort(
+    (a, b) =>
+      a.start - b.start ||
+      STYLE_ORDER.indexOf(a.type) - STYLE_ORDER.indexOf(b.type)
+  );
+  return { text, formatting: ranges, hasLinks };
+};
+
+/**
+ * Render standard markdown (CommonMark + GFM) to iMessage styled text: a
+ * plain string plus UTF-16 formatting ranges for `messages.sendText`'s
+ * `formatting` option. Block layout matches the plain-text renderer (list
+ * bullets, `label (url)` links); inline emphasis becomes native
+ * bold/italic/strikethrough ranges instead of being stripped, headings
+ * render as bold, and code maps to Unicode mathematical monospace
+ * characters. `hasLinks` reports whether any link or image put a URL into
+ * the text, so the sender can enable Apple's data-detector pass.
+ */
+export const markdownToIMessageText = (
+  markdown: string
+): IMessageRenderedMarkdown =>
+  finalize(trimSpans(renderBlockTokens(markdownLexer.lexer(markdown))));

--- a/packages/spectrum-ts/src/providers/imessage/remote/send.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/send.ts
@@ -5,6 +5,7 @@ import type {
   Poll,
   Message as SDKMessage,
   SendOptions,
+  TextFormatInput,
 } from "@photon-ai/advanced-imessage";
 import { asGroup } from "../../../content/group";
 import type { Content } from "../../../content/types";
@@ -23,12 +24,22 @@ import {
   toChatGuid,
   toMessageGuid,
 } from "./ids";
+import {
+  type IMessageRenderedMarkdown,
+  markdownToIMessageText,
+} from "./markdown";
 
 const GROUP_ITEM_ALLOWED: ReadonlySet<Content["type"]> = new Set([
   "text",
+  "markdown",
   "attachment",
   "contact",
   "voice",
+]);
+// Markdown renders to the group's single text part, so it shares the cap.
+const GROUP_TEXT_TYPES: ReadonlySet<Content["type"]> = new Set([
+  "text",
+  "markdown",
 ]);
 const MAX_GROUP_TEXT_ITEMS = 1;
 
@@ -76,6 +87,30 @@ const replyOptions = (
 const effectOption = (
   effect: MessageEffect | undefined
 ): Pick<SendOptions, "effect"> => (effect ? { effect } : {});
+
+const formattingOption = (
+  formatting: readonly TextFormatInput[]
+): Pick<SendOptions, "formatting"> =>
+  formatting.length > 0 ? { formatting } : {};
+
+const dataDetectionOption = (
+  hasLinks: boolean
+): Pick<SendOptions, "enableDataDetection"> =>
+  hasLinks ? { enableDataDetection: true } : {};
+
+// Markdown that renders to nothing (e.g. a whitespace-only source) throws
+// UnsupportedError so the pipeline's downgrade path handles it exactly like
+// platforms without native markdown support.
+const renderMarkdown = (markdown: string): IMessageRenderedMarkdown => {
+  const rendered = markdownToIMessageText(markdown);
+  if (!rendered.text) {
+    throw unsupportedRemoteContent(
+      "markdown",
+      "renders to empty text — nothing to send"
+    );
+  }
+  return rendered;
+};
 
 const replyTargetFromId = (messageId: string): ReplyTarget => {
   const childRef = parseChildId(messageId);
@@ -172,6 +207,22 @@ const sendContent = async (
       );
       return outboundMessage(spaceId, message, content);
     }
+    case "markdown": {
+      const rendered = renderMarkdown(content.markdown);
+      const message = await remote.messages.sendText(
+        chat,
+        rendered.text,
+        withReply(
+          {
+            ...effectOption(effect),
+            ...formattingOption(rendered.formatting),
+            ...dataDetectionOption(rendered.hasLinks),
+          },
+          replyTo
+        )
+      );
+      return outboundMessage(spaceId, message, content);
+    }
     case "richlink": {
       const message = await remote.messages.sendText(
         chat,
@@ -239,7 +290,7 @@ export const validateGroupContent = (
         `"${itemType}" items are not supported inside a group`
       );
     }
-    if (itemType === "text" && ++textCount > MAX_GROUP_TEXT_ITEMS) {
+    if (GROUP_TEXT_TYPES.has(itemType) && ++textCount > MAX_GROUP_TEXT_ITEMS) {
       throw unsupportedRemoteContent(
         "group",
         `groups can contain at most ${MAX_GROUP_TEXT_ITEMS} text item`
@@ -255,6 +306,11 @@ const resolvePart = async (
   switch (content.type) {
     case "text":
       return { text: content.text };
+    case "markdown": {
+      // `MessagePart` has no data-detection flag, so `hasLinks` is dropped.
+      const rendered = renderMarkdown(content.markdown);
+      return { text: rendered.text, ...formattingOption(rendered.formatting) };
+    }
     case "attachment": {
       const { guid, name } = await uploadAttachment(remote, content);
       return { attachmentGuid: guid, attachmentName: name };

--- a/packages/spectrum-ts/src/providers/imessage/remote/stream-text.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/stream-text.ts
@@ -37,9 +37,12 @@ export const sendStreamText = async (
 ): Promise<ProviderMessageRecord> => {
   if (content.format === "markdown") {
     // Thrown before the stream is consumed, so the send pipeline's fallback
-    // can drain it and deliver the text through the `markdown` chain instead.
-    // This native driver edits raw text in place and would otherwise expose
-    // literal markdown source mid-stream.
+    // can drain it and deliver the accumulated text through the `markdown`
+    // chain — which lands a natively formatted message (text + UTF-16
+    // formatting ranges). Streaming it here is impossible: this driver edits
+    // the message in place and `messages.edit` carries no formatting, so
+    // mid-stream updates would expose literal markdown source and the final
+    // flush could never restore the styling.
     throw unsupportedRemoteContent(
       "streamText",
       "markdown-formatted streams have no native iMessage delivery"

--- a/packages/spectrum-ts/src/providers/imessage/remote/stream-text.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/stream-text.ts
@@ -35,6 +35,16 @@ export const sendStreamText = async (
   spaceId: string,
   content: StreamText
 ): Promise<ProviderMessageRecord> => {
+  if (content.format === "markdown") {
+    // Thrown before the stream is consumed, so the send pipeline's fallback
+    // can drain it and deliver the text through the `markdown` chain instead.
+    // This native driver edits raw text in place and would otherwise expose
+    // literal markdown source mid-stream.
+    throw unsupportedRemoteContent(
+      "streamText",
+      "markdown-formatted streams have no native iMessage delivery"
+    );
+  }
   const chat = toChatGuid(spaceId);
 
   let sent: SDKMessage | undefined; // the first (and only) message we created

--- a/packages/spectrum-ts/src/providers/telegram/outbound/markdown.ts
+++ b/packages/spectrum-ts/src/providers/telegram/outbound/markdown.ts
@@ -1,0 +1,215 @@
+import { Marked, type MarkedToken, type Token, type Tokens } from "marked";
+import { renderInlineTokens as inlinePlainText } from "../../../utils/markdown";
+
+// Private instance: immune to host apps reconfiguring the global `marked`
+// singleton via `marked.use()` / `marked.setOptions()`.
+const markdownLexer = new Marked();
+
+const BULLET = "• ";
+const HR_LINE = "———";
+const NESTED_LIST_INDENT = "  ";
+const BLOCK_SEPARATOR = "\n\n";
+const TABLE_CELL_SEPARATOR = " | ";
+const DEFAULT_LIST_START = 1;
+
+const AMP_PATTERN = /&/g;
+const LT_PATTERN = /</g;
+const GT_PATTERN = />/g;
+const QUOTE_PATTERN = /"/g;
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(AMP_PATTERN, "&amp;")
+    .replace(LT_PATTERN, "&lt;")
+    .replace(GT_PATTERN, "&gt;");
+
+const escapeAttribute = (value: string): string =>
+  escapeHtml(value).replace(QUOTE_PATTERN, "&quot;");
+
+// Same narrowing dodge as utils/markdown.ts: `Tokens.Generic`'s index
+// signature defeats discriminated-union narrowing on `Token`.
+const asMarkedToken = (token: Token): MarkedToken => token as MarkedToken;
+
+const checkboxPrefix = (item: Tokens.ListItem): string => {
+  if (!item.task) {
+    return "";
+  }
+  return item.checked ? "[x] " : "[ ] ";
+};
+
+const listMarker = (list: Tokens.List, index: number): string => {
+  if (!list.ordered) {
+    return BULLET;
+  }
+  const start = list.start === "" ? DEFAULT_LIST_START : list.start;
+  return `${start + index}. `;
+};
+
+const renderLink = (token: Tokens.Link): string => {
+  // A bare autolink lexes with its label equal to its href — emit the plain
+  // url and let the Telegram client auto-link it.
+  if (token.text === token.href) {
+    return escapeHtml(token.href);
+  }
+  return `<a href="${escapeAttribute(token.href)}">${renderInlineTokens(token.tokens)}</a>`;
+};
+
+// Telegram HTML has no <img>; an image degrades to a link labeled by its
+// alt text (or the bare url when there is none).
+const renderImage = (token: Tokens.Image): string =>
+  `<a href="${escapeAttribute(token.href)}">${escapeHtml(token.text || token.href)}</a>`;
+
+const renderText = (token: Tokens.Text): string => {
+  if (token.tokens) {
+    return renderInlineTokens(token.tokens);
+  }
+  // `escaped` is set when the lexer already entity-encoded the text (raw
+  // HTML blocks); escaping again would double-encode.
+  return token.escaped ? token.text : escapeHtml(token.text);
+};
+
+const renderInlineToken = (token: MarkedToken): string => {
+  switch (token.type) {
+    case "strong":
+      return `<b>${renderInlineTokens(token.tokens)}</b>`;
+    case "em":
+      return `<i>${renderInlineTokens(token.tokens)}</i>`;
+    case "del":
+      return `<s>${renderInlineTokens(token.tokens)}</s>`;
+    case "codespan":
+      return `<code>${escapeHtml(token.text)}</code>`;
+    case "br":
+      return "\n";
+    case "link":
+      return renderLink(token);
+    case "image":
+      return renderImage(token);
+    case "escape":
+      return escapeHtml(token.text);
+    case "text":
+      return renderText(token);
+    // Raw HTML in markdown source renders literally, never passes through:
+    // a tag outside Telegram's whitelist would 400 the whole Bot API call
+    // (a TelegramApiError, not UnsupportedError — the plain-text fallback
+    // would not catch it). Escaping makes invalid output impossible.
+    case "html":
+      return escapeHtml(token.text);
+    // Task-item checkboxes are rendered from `ListItem.task`/`checked`.
+    case "checkbox":
+      return "";
+    default:
+      return "raw" in token ? escapeHtml(String(token.raw)) : "";
+  }
+};
+
+const renderInlineTokens = (tokens: Token[]): string => {
+  let out = "";
+  for (const token of tokens) {
+    out += renderInlineToken(asMarkedToken(token));
+  }
+  return out;
+};
+
+const renderCode = (token: Tokens.Code): string => {
+  if (token.lang) {
+    return `<pre><code class="language-${escapeAttribute(token.lang)}">${escapeHtml(token.text)}</code></pre>`;
+  }
+  return `<pre>${escapeHtml(token.text)}</pre>`;
+};
+
+// Telegram rejects nested <blockquote> tags, so inner quotes are flattened
+// into the single enclosing tag as plain lines.
+const renderQuoteBody = (tokens: Token[]): string => {
+  const blocks: string[] = [];
+  for (const token of tokens) {
+    const marked = asMarkedToken(token);
+    const rendered =
+      marked.type === "blockquote"
+        ? renderQuoteBody(marked.tokens)
+        : renderBlockToken(marked);
+    if (rendered) {
+      blocks.push(rendered);
+    }
+  }
+  return blocks.join("\n");
+};
+
+// Telegram has no list markup; items become `•`/`1.` text lines whose inline
+// children keep their HTML styling. Blocks inside an item stack on single
+// newlines, continuation lines indented under the marker.
+const renderList = (list: Tokens.List): string => {
+  const lines: string[] = [];
+  for (const [index, item] of list.items.entries()) {
+    const prefix = `${listMarker(list, index)}${checkboxPrefix(item)}`;
+    const blocks: string[] = [];
+    for (const token of item.tokens) {
+      const rendered = renderBlockToken(asMarkedToken(token));
+      if (rendered) {
+        blocks.push(rendered);
+      }
+    }
+    const [first = "", ...rest] = blocks.join("\n").split("\n");
+    lines.push(`${prefix}${first}`);
+    for (const line of rest) {
+      lines.push(`${NESTED_LIST_INDENT}${line}`);
+    }
+  }
+  return lines.join("\n");
+};
+
+// Telegram has no table markup; a <pre> block keeps columns aligned in
+// monospace. Cells render as plain text (inline HTML inside <pre> shows
+// literally, so styling is dropped rather than leaked as markup).
+const renderTable = (table: Tokens.Table): string => {
+  const renderRow = (cells: Tokens.TableCell[]): string =>
+    cells
+      .map((cell) => inlinePlainText(cell.tokens))
+      .join(TABLE_CELL_SEPARATOR);
+  const lines = [renderRow(table.header)];
+  for (const row of table.rows) {
+    lines.push(renderRow(row));
+  }
+  return `<pre>${escapeHtml(lines.join("\n"))}</pre>`;
+};
+
+const renderBlockToken = (token: MarkedToken): string => {
+  switch (token.type) {
+    // Telegram has no headings; bold is the conventional stand-in.
+    case "heading":
+      return `<b>${renderInlineTokens(token.tokens)}</b>`;
+    case "paragraph":
+      return renderInlineTokens(token.tokens);
+    case "code":
+      return renderCode(token);
+    case "blockquote":
+      return `<blockquote>${renderQuoteBody(token.tokens)}</blockquote>`;
+    case "list":
+      return renderList(token);
+    case "table":
+      return renderTable(token);
+    case "hr":
+      return HR_LINE;
+    case "space":
+    case "def":
+      return "";
+    default:
+      return renderInlineToken(token);
+  }
+};
+
+/**
+ * Render standard markdown (CommonMark + GFM) to Telegram-flavored HTML for
+ * `parse_mode: "HTML"` sends. Only tags Telegram accepts are emitted; all
+ * text (including raw HTML in the source) is entity-escaped so the output
+ * can never fail Bot API parsing.
+ */
+export const markdownToTelegramHtml = (markdown: string): string => {
+  const blocks: string[] = [];
+  for (const token of markdownLexer.lexer(markdown)) {
+    const rendered = renderBlockToken(asMarkedToken(token));
+    if (rendered) {
+      blocks.push(rendered);
+    }
+  }
+  return blocks.join(BLOCK_SEPARATOR).trim();
+};

--- a/packages/spectrum-ts/src/providers/telegram/outbound/message.ts
+++ b/packages/spectrum-ts/src/providers/telegram/outbound/message.ts
@@ -3,6 +3,7 @@ import { UnsupportedError } from "../../../utils/errors";
 import { toVCard } from "../../../utils/vcard";
 import { TELEGRAM_PLATFORM } from "../config";
 import type { TelegramSendSpec } from "../types";
+import { markdownToTelegramHtml } from "./markdown";
 
 const VCARD_FILENAME = "contact.vcf";
 const VCARD_MIME = "text/vcard";
@@ -92,6 +93,14 @@ export const buildSend = async (
   switch (content.type) {
     case "text":
       return { method: "sendMessage", params: { text: content.text } };
+    case "markdown":
+      return {
+        method: "sendMessage",
+        params: {
+          text: markdownToTelegramHtml(content.markdown),
+          parse_mode: "HTML",
+        },
+      };
     case "richlink":
       // Telegram auto-unfurls a bare URL in the message text.
       return { method: "sendMessage", params: { text: content.url } };

--- a/packages/spectrum-ts/src/providers/telegram/outbound/send.ts
+++ b/packages/spectrum-ts/src/providers/telegram/outbound/send.ts
@@ -13,6 +13,7 @@ import { TELEGRAM_PLATFORM, type TelegramConfig } from "../config";
 import { isAllowedReactionEmoji, normalizeReactionEmoji } from "../reactions";
 import type { TelegramSpace } from "../space";
 import type { ReactionTypeEmoji } from "../types";
+import { markdownToTelegramHtml } from "./markdown";
 import { buildSend, parseMessageId } from "./message";
 import { sendStreamText } from "./stream-text";
 
@@ -117,18 +118,26 @@ const sendEdit = async (
   space: TelegramSpace,
   content: Edit
 ): Promise<undefined> => {
-  if (content.content.type !== "text") {
+  const inner = content.content;
+  if (inner.type !== "text" && inner.type !== "markdown") {
     throw UnsupportedError.content(
       "edit",
       TELEGRAM_PLATFORM,
-      `only text content can be edited (got "${content.content.type}").`
+      `only text and markdown content can be edited (got "${inner.type}").`
     );
   }
+  const body =
+    inner.type === "markdown"
+      ? {
+          text: markdownToTelegramHtml(inner.markdown),
+          parse_mode: "HTML" as const,
+        }
+      : { text: inner.text };
   await editMessageText({
     body: {
       chat_id: space.id,
       message_id: parseMessageId(content.target.id),
-      text: content.content.text,
+      ...body,
     },
     client,
   });

--- a/packages/spectrum-ts/src/providers/telegram/outbound/stream-text.ts
+++ b/packages/spectrum-ts/src/providers/telegram/outbound/stream-text.ts
@@ -1,4 +1,5 @@
 import { sendMessageDraft } from "@photon-ai/telegram-ts";
+import { asMarkdown } from "../../../content/markdown";
 import type { StreamText } from "../../../content/stream-text";
 import { asText } from "../../../content/text";
 import type { ProviderMessageRecord } from "../../../platform/types";
@@ -6,6 +7,7 @@ import { UnsupportedError } from "../../../utils/errors";
 import { executeSpec, type TelegramClient } from "../client";
 import { TELEGRAM_PLATFORM } from "../config";
 import type { TelegramSpace } from "../space";
+import { markdownToTelegramHtml } from "./markdown";
 
 const MILLIS_PER_SECOND = 1000;
 
@@ -45,6 +47,15 @@ export const sendStreamText = async (
   const draftId = nextDraftId;
   nextDraftId += 1;
 
+  // Markdown streams re-render the full accumulated text on every update
+  // (cheap at draft pace), so drafts preview styled text, not raw source.
+  // Mid-stream markdown can be incomplete — the renderer treats unclosed
+  // markers as literal text, so a partial render is always valid HTML.
+  const renderBody = (text: string): { text: string; parse_mode?: "HTML" } =>
+    content.format === "markdown"
+      ? { text: markdownToTelegramHtml(text), parse_mode: "HTML" }
+      : { text };
+
   let lastDraftText: string | undefined;
   let lastDraftAt = 0;
   let draftsAvailable = true;
@@ -55,7 +66,7 @@ export const sendStreamText = async (
     }
     try {
       await sendMessageDraft({
-        body: { chat_id: chatId, draft_id: draftId, text },
+        body: { chat_id: chatId, draft_id: draftId, ...renderBody(text) },
         client,
       });
       lastDraftText = text;
@@ -95,11 +106,11 @@ export const sendStreamText = async (
   // replaces the draft client-side).
   const sent = await executeSpec(client, {
     method: "sendMessage",
-    params: { chat_id: space.id, text: full },
+    params: { chat_id: space.id, ...renderBody(full) },
   });
   return {
     id: String(sent.message_id),
-    content: asText(full),
+    content: content.format === "markdown" ? asMarkdown(full) : asText(full),
     space: { id: space.id },
     timestamp: new Date(sent.date * MILLIS_PER_SECOND),
   };

--- a/packages/spectrum-ts/src/utils/markdown.ts
+++ b/packages/spectrum-ts/src/utils/markdown.ts
@@ -1,0 +1,170 @@
+import { Marked, type MarkedToken, type Token, type Tokens } from "marked";
+
+// Private instance: immune to host apps reconfiguring the global `marked`
+// singleton via `marked.use()` / `marked.setOptions()`.
+const markdownLexer = new Marked();
+
+const BULLET = "• ";
+const HR_LINE = "———";
+const NESTED_LIST_INDENT = "  ";
+const BLOCK_SEPARATOR = "\n\n";
+const TABLE_CELL_SEPARATOR = " | ";
+const DEFAULT_LIST_START = 1;
+
+// `Tokens.Generic`'s string index signature defeats discriminated-union
+// narrowing on `Token`, so walkers assert down to `MarkedToken` once and
+// let the default case absorb generic/extension tokens via `raw`.
+const asMarkedToken = (token: Token): MarkedToken => token as MarkedToken;
+
+const checkboxPrefix = (item: Tokens.ListItem): string => {
+  if (!item.task) {
+    return "";
+  }
+  return item.checked ? "[x] " : "[ ] ";
+};
+
+const listMarker = (list: Tokens.List, index: number): string => {
+  if (!list.ordered) {
+    return BULLET;
+  }
+  const start = list.start === "" ? DEFAULT_LIST_START : list.start;
+  return `${start + index}. `;
+};
+
+const renderLink = (token: Tokens.Link): string => {
+  // A bare autolink lexes with its label equal to its href — render the
+  // url alone instead of doubling it as "url (url)".
+  if (token.text === token.href) {
+    return token.href;
+  }
+  return `${renderInlineTokens(token.tokens)} (${token.href})`;
+};
+
+const renderImage = (token: Tokens.Image): string =>
+  token.text ? `${token.text} (${token.href})` : token.href;
+
+const renderInlineToken = (token: MarkedToken): string => {
+  switch (token.type) {
+    case "strong":
+    case "em":
+    case "del":
+      return renderInlineTokens(token.tokens);
+    case "codespan":
+      return token.text;
+    case "br":
+      return "\n";
+    case "link":
+      return renderLink(token);
+    case "image":
+      return renderImage(token);
+    case "escape":
+      return token.text;
+    case "text":
+      return token.tokens ? renderInlineTokens(token.tokens) : token.text;
+    // Raw HTML in markdown source stays literal — plain text has no markup.
+    case "html":
+      return token.text;
+    // Task-item checkboxes are rendered from `ListItem.task`/`checked`.
+    case "checkbox":
+      return "";
+    default:
+      return "raw" in token ? String(token.raw) : "";
+  }
+};
+
+/**
+ * Render a run of inline markdown tokens (a paragraph's or table cell's
+ * children) to plain text. Package-internal: platform renderers reuse it
+ * where their native format has no inline markup (e.g. Telegram tables).
+ */
+export const renderInlineTokens = (tokens: Token[]): string => {
+  let out = "";
+  for (const token of tokens) {
+    out += renderInlineToken(asMarkedToken(token));
+  }
+  return out;
+};
+
+const renderBlockquote = (quote: Tokens.Blockquote): string =>
+  renderBlockTokens(quote.tokens)
+    .split("\n")
+    .map((line) => (line ? `> ${line}` : ">"))
+    .join("\n");
+
+// Blocks inside a list item stack on single newlines (a blank separator
+// would detach the lines from their marker); continuation lines are
+// indented so nested lists and wrapped blocks read as part of the item.
+const renderList = (list: Tokens.List): string => {
+  const lines: string[] = [];
+  for (const [index, item] of list.items.entries()) {
+    const prefix = `${listMarker(list, index)}${checkboxPrefix(item)}`;
+    const blocks: string[] = [];
+    for (const token of item.tokens) {
+      const rendered = renderBlockToken(asMarkedToken(token));
+      if (rendered) {
+        blocks.push(rendered);
+      }
+    }
+    const [first = "", ...rest] = blocks.join("\n").split("\n");
+    lines.push(`${prefix}${first}`);
+    for (const line of rest) {
+      lines.push(`${NESTED_LIST_INDENT}${line}`);
+    }
+  }
+  return lines.join("\n");
+};
+
+const renderTable = (table: Tokens.Table): string => {
+  const renderRow = (cells: Tokens.TableCell[]): string =>
+    cells
+      .map((cell) => renderInlineTokens(cell.tokens))
+      .join(TABLE_CELL_SEPARATOR);
+  const lines = [renderRow(table.header)];
+  for (const row of table.rows) {
+    lines.push(renderRow(row));
+  }
+  return lines.join("\n");
+};
+
+const renderBlockToken = (token: MarkedToken): string => {
+  switch (token.type) {
+    case "heading":
+    case "paragraph":
+      return renderInlineTokens(token.tokens);
+    case "code":
+      return token.text;
+    case "blockquote":
+      return renderBlockquote(token);
+    case "list":
+      return renderList(token);
+    case "table":
+      return renderTable(token);
+    case "hr":
+      return HR_LINE;
+    case "space":
+    case "def":
+      return "";
+    default:
+      return renderInlineToken(token);
+  }
+};
+
+const renderBlockTokens = (tokens: Token[]): string => {
+  const blocks: string[] = [];
+  for (const token of tokens) {
+    const rendered = renderBlockToken(asMarkedToken(token));
+    if (rendered) {
+      blocks.push(rendered);
+    }
+  }
+  return blocks.join(BLOCK_SEPARATOR);
+};
+
+/**
+ * Render standard markdown (CommonMark + GFM) to readable plain text:
+ * emphasis markers stripped, links as `label (url)`, list bullets kept,
+ * code verbatim. Used by the send pipeline to downgrade `markdown` content
+ * on platforms without native support.
+ */
+export const markdownToPlainText = (markdown: string): string =>
+  renderBlockTokens(markdownLexer.lexer(markdown)).trim();

--- a/packages/spectrum-ts/test/content/markdown.test.ts
+++ b/packages/spectrum-ts/test/content/markdown.test.ts
@@ -3,11 +3,12 @@ import { edit } from "@/content/edit";
 import { group } from "@/content/group";
 import { markdown } from "@/content/markdown";
 import { reply } from "@/content/reply";
-import { streamText } from "@/content/stream-text";
 import { text } from "@/content/text";
 import type { Message } from "@/types/message";
 
-async function* fromArray(items: string[]): AsyncIterable<string> {
+const CONTENT_BUILDER = /not another content builder/;
+
+async function* fromArray<T>(items: T[]): AsyncIterable<T> {
   for (const item of items) {
     yield item;
   }
@@ -66,13 +67,13 @@ describe("markdown content", () => {
     ]);
   });
 
-  it("wraps a streamText builder, marking the stream as markdown", async () => {
-    const built = await markdown(streamText(fromArray(["**a", "**"]))).build();
+  it("marks a stream source as markdown", async () => {
+    const built = await markdown(fromArray(["**a", "**"])).build();
     if (built.type !== "streamText") {
       throw new Error("expected streamText content");
     }
     expect(built.format).toBe("markdown");
-    // The wrapped stream is intact and drainable.
+    // The stream is intact and drainable.
     let full = "";
     for await (const delta of built.stream()) {
       full += delta;
@@ -80,9 +81,23 @@ describe("markdown content", () => {
     expect(full).toBe("**a**");
   });
 
-  it("rejects wrapping non-stream content builders", async () => {
-    await expect(markdown(text("plain")).build()).rejects.toThrow(
-      'can only wrap streamText content (got "text")'
-    );
+  it("uses a custom extract for stream sources", async () => {
+    const built = await markdown(fromArray([{ piece: "**a**" }]), {
+      extract: (chunk) => chunk.piece,
+    }).build();
+    if (built.type !== "streamText") {
+      throw new Error("expected streamText content");
+    }
+    let full = "";
+    for await (const delta of built.stream()) {
+      full += delta;
+    }
+    expect(full).toBe("**a**");
+  });
+
+  it("rejects a content builder passed as a stream source", () => {
+    expect(() =>
+      markdown(text("plain") as unknown as AsyncIterable<string>)
+    ).toThrow(CONTENT_BUILDER);
   });
 });

--- a/packages/spectrum-ts/test/content/markdown.test.ts
+++ b/packages/spectrum-ts/test/content/markdown.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import { edit } from "@/content/edit";
+import { group } from "@/content/group";
+import { markdown } from "@/content/markdown";
+import { reply } from "@/content/reply";
+import { streamText } from "@/content/stream-text";
+import { text } from "@/content/text";
+import type { Message } from "@/types/message";
+
+async function* fromArray(items: string[]): AsyncIterable<string> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+const inboundTarget = {
+  id: "1",
+  content: { type: "text", text: "x" },
+  direction: "inbound",
+} as unknown as Message;
+
+const outboundTarget = {
+  id: "2",
+  content: { type: "text", text: "x" },
+  direction: "outbound",
+} as unknown as Message;
+
+describe("markdown content", () => {
+  it("builds a markdown content value", async () => {
+    expect(await markdown("**hi**").build()).toEqual({
+      type: "markdown",
+      markdown: "**hi**",
+    });
+  });
+
+  it("rejects an empty string at build time", async () => {
+    await expect(markdown("").build()).rejects.toThrow();
+  });
+
+  it("can be wrapped in a reply", async () => {
+    const built = await reply(markdown("**hi**"), inboundTarget).build();
+    expect(built).toEqual({
+      type: "reply",
+      content: { type: "markdown", markdown: "**hi**" },
+      target: inboundTarget,
+    });
+  });
+
+  it("can be wrapped in an edit", async () => {
+    const built = await edit(markdown("**hi**"), outboundTarget).build();
+    expect(built).toEqual({
+      type: "edit",
+      content: { type: "markdown", markdown: "**hi**" },
+      target: outboundTarget,
+    });
+  });
+
+  it("can be a group item", async () => {
+    const built = await group(markdown("**caption**"), "plain").build();
+    if (built.type !== "group") {
+      throw new Error("expected a group content value");
+    }
+    expect(built.items.map((item) => item.content)).toEqual([
+      { type: "markdown", markdown: "**caption**" },
+      { type: "text", text: "plain" },
+    ]);
+  });
+
+  it("wraps a streamText builder, marking the stream as markdown", async () => {
+    const built = await markdown(streamText(fromArray(["**a", "**"]))).build();
+    if (built.type !== "streamText") {
+      throw new Error("expected streamText content");
+    }
+    expect(built.format).toBe("markdown");
+    // The wrapped stream is intact and drainable.
+    let full = "";
+    for await (const delta of built.stream()) {
+      full += delta;
+    }
+    expect(full).toBe("**a**");
+  });
+
+  it("rejects wrapping non-stream content builders", async () => {
+    await expect(markdown(text("plain")).build()).rejects.toThrow(
+      'can only wrap streamText content (got "text")'
+    );
+  });
+});

--- a/packages/spectrum-ts/test/content/stream-text.test.ts
+++ b/packages/spectrum-ts/test/content/stream-text.test.ts
@@ -37,6 +37,20 @@ const collect = async (source: StreamTextSource): Promise<string[]> => {
   return drain(content.stream());
 };
 
+describe("streamText format", () => {
+  it("carries the markdown format flag", async () => {
+    const content = (await streamText(fromArray(["x"]), {
+      format: "markdown",
+    }).build()) as StreamText;
+    expect(content.format).toBe("markdown");
+  });
+
+  it("has no format by default", async () => {
+    const content = (await streamText(fromArray(["x"])).build()) as StreamText;
+    expect(content.format).toBeUndefined();
+  });
+});
+
 describe("streamText normalization", () => {
   it("passes through a raw string async iterable", async () => {
     expect(await collect(fromArray(["Hel", "lo"]))).toEqual(["Hel", "lo"]);

--- a/packages/spectrum-ts/test/content/text.test.ts
+++ b/packages/spectrum-ts/test/content/text.test.ts
@@ -1,12 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import {
-  type StreamText,
-  type StreamTextSource,
-  streamText,
-} from "@/content/stream-text";
+import type { StreamText, StreamTextSource } from "@/content/stream-text";
+import { text } from "@/content/text";
+import type { ContentBuilder } from "@/content/types";
 
 const UNRECOGNIZED_SHAPE = /unrecognized chunk shape/;
 const ALREADY_CONSUMED = /already been consumed/;
+const CONTENT_BUILDER = /not another content builder/;
 
 async function* fromArray<T>(items: T[]): AsyncIterable<T> {
   for (const item of items) {
@@ -33,25 +32,44 @@ const drain = async (stream: AsyncIterable<string>): Promise<string[]> => {
 };
 
 const collect = async (source: StreamTextSource): Promise<string[]> => {
-  const content = (await streamText(source).build()) as StreamText;
+  const content = (await text(source).build()) as StreamText;
   return drain(content.stream());
 };
 
-describe("streamText format", () => {
-  it("carries the markdown format flag", async () => {
-    const content = (await streamText(fromArray(["x"]), {
-      format: "markdown",
-    }).build()) as StreamText;
-    expect(content.format).toBe("markdown");
+describe("text strings", () => {
+  it("builds a text content value", async () => {
+    expect(await text("hi").build()).toEqual({ type: "text", text: "hi" });
   });
 
-  it("has no format by default", async () => {
-    const content = (await streamText(fromArray(["x"])).build()) as StreamText;
-    expect(content.format).toBeUndefined();
+  it("rejects an empty string at build time", async () => {
+    await expect(text("").build()).rejects.toThrow();
+  });
+
+  it("ignores stream options on a string source", async () => {
+    const callText = text as unknown as (
+      source: string,
+      options?: unknown
+    ) => ContentBuilder;
+    expect(await callText("hi", { extract: () => "nope" }).build()).toEqual({
+      type: "text",
+      text: "hi",
+    });
   });
 });
 
-describe("streamText normalization", () => {
+describe("text streams", () => {
+  it("builds streamText content with no format", async () => {
+    const content = (await text(fromArray(["x"])).build()) as StreamText;
+    expect(content.type).toBe("streamText");
+    expect(content.format).toBeUndefined();
+  });
+
+  it("rejects a content builder passed as a stream source", () => {
+    expect(() => text(text("hi") as unknown as AsyncIterable<string>)).toThrow(
+      CONTENT_BUILDER
+    );
+  });
+
   it("passes through a raw string async iterable", async () => {
     expect(await collect(fromArray(["Hel", "lo"]))).toEqual(["Hel", "lo"]);
   });
@@ -117,7 +135,7 @@ describe("streamText normalization", () => {
 
   it("uses a custom extract over the built-in detection", async () => {
     const chunks = [{ piece: "Hel" }, { piece: "lo" }, { piece: null }];
-    const content = (await streamText(fromArray(chunks), {
+    const content = (await text(fromArray(chunks), {
       extract: (chunk) => chunk.piece,
     }).build()) as StreamText;
     expect(await drain(content.stream())).toEqual(["Hel", "lo"]);
@@ -128,16 +146,14 @@ describe("streamText normalization", () => {
   });
 
   it("throws a helpful error on an unrecognized chunk shape", async () => {
-    const content = (await streamText(
+    const content = (await text(
       fromArray([{ mystery: 1 }])
     ).build()) as StreamText;
     await expect(drain(content.stream())).rejects.toThrow(UNRECOGNIZED_SHAPE);
   });
 
   it("throws when the source is consumed twice", async () => {
-    const content = (await streamText(
-      fromArray(["a", "b"])
-    ).build()) as StreamText;
+    const content = (await text(fromArray(["a", "b"])).build()) as StreamText;
     await drain(content.stream());
     await expect(drain(content.stream())).rejects.toThrow(ALREADY_CONSUMED);
   });

--- a/packages/spectrum-ts/test/core/send-markdown-fallback.test.ts
+++ b/packages/spectrum-ts/test/core/send-markdown-fallback.test.ts
@@ -1,0 +1,295 @@
+import { describe, expect, it } from "bun:test";
+import { stubCloud } from "@test/support/cloud";
+import { baseConfig, makeQueue, record } from "@test/support/platform";
+import z from "zod";
+import { group } from "@/content/group";
+import { markdown } from "@/content/markdown";
+import { poll } from "@/content/poll";
+import type { Content } from "@/content/types";
+import { definePlatform } from "@/platform/define";
+import type { ProviderMessage, ProviderMessageRecord } from "@/platform/types";
+import { Spectrum } from "@/spectrum";
+import { UnsupportedError } from "@/utils/errors";
+
+stubCloud();
+
+const SENT_TIMESTAMP = new Date(123);
+
+type SendImpl = (
+  content: Content
+) => Promise<ProviderMessageRecord | undefined>;
+
+// One inbound text message, then a `send` whose behavior the test controls.
+// Mirrors makeProvider in send-stream-text-fallback.test.ts.
+const makeProvider = (name: string, sendImpl: SendImpl) => {
+  const queue = makeQueue<ProviderMessage<{ id: string }, { id: string }>>();
+  queue.push(record("m1"));
+  queue.close();
+  return definePlatform(name, {
+    config: z.object({}),
+    lifecycle: {
+      createClient: () => Promise.resolve({}),
+    },
+    user: { resolve: ({ input }) => Promise.resolve({ id: input.userID }) },
+    space: {
+      create: ({ input }) =>
+        Promise.resolve({ id: input.users[0]?.id ?? "s1" }),
+    },
+    messages: () => queue.iter,
+    send: ({ content }) => sendImpl(content),
+  });
+};
+
+const firstMessage = async (app: Awaited<ReturnType<typeof Spectrum>>) => {
+  const iterator = app.messages[Symbol.asyncIterator]();
+  const first = await iterator.next();
+  if (first.done) {
+    throw new Error("expected an inbound message");
+  }
+  return first.value;
+};
+
+const carriesMarkdown = (content: Content): boolean => {
+  if (content.type === "markdown") {
+    return true;
+  }
+  if (content.type === "reply" || content.type === "edit") {
+    return content.content.type === "markdown";
+  }
+  if (content.type === "group") {
+    return content.items.some((item) => item.content.type === "markdown");
+  }
+  return false;
+};
+
+// A provider without markdown support: rejects any content carrying a
+// `markdown` (top-level, wrapped in reply/edit, or a group item) but handles
+// everything else, recording each dispatch.
+const noMarkdownSend = (platform: string) => {
+  const seen: Content[] = [];
+  const sendImpl: SendImpl = (content) => {
+    seen.push(content);
+    if (carriesMarkdown(content)) {
+      return Promise.reject(UnsupportedError.content("markdown", platform));
+    }
+    if (content.type === "edit") {
+      // Edits are fire-and-forget; providers may return void.
+      return Promise.resolve(undefined);
+    }
+    // Groups echo a simple text record: the assertions read `seen`, and a
+    // group's stub items carry no provider message ids to wrap.
+    return Promise.resolve({
+      id: `${content.type}-${seen.length}`,
+      content:
+        content.type === "group" ? { type: "text", text: "group" } : content,
+      space: { id: "s1" },
+      timestamp: SENT_TIMESTAMP,
+    });
+  };
+  return { seen, sendImpl };
+};
+
+describe("markdown plain-text fallback", () => {
+  it("re-sends the markdown as readable plain text", async () => {
+    const { seen, sendImpl } = noMarkdownSend("md-fallback-text");
+    const provider = makeProvider("md-fallback-text", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const sent = await space.send(markdown("**Hi** [docs](https://d.test)"));
+
+      expect(seen.map((c) => c.type)).toEqual(["markdown", "text"]);
+      expect(seen.at(-1)).toEqual({
+        type: "text",
+        text: "Hi docs (https://d.test)",
+      });
+      // The fallback send produces a real Message handle.
+      expect(sent?.content).toEqual({
+        type: "text",
+        text: "Hi docs (https://d.test)",
+      });
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("preserves the reply wrapper (and its target) in the fallback send", async () => {
+    const { seen, sendImpl } = noMarkdownSend("md-fallback-reply");
+    const provider = makeProvider("md-fallback-reply", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [, message] = await firstMessage(app);
+      const sent = await message.reply(markdown("**hey**"));
+
+      expect(seen.map((c) => c.type)).toEqual(["reply", "reply"]);
+      const fallback = seen.at(-1);
+      if (fallback?.type !== "reply") {
+        throw new Error("expected a reply fallback dispatch");
+      }
+      expect(fallback.content).toEqual({ type: "text", text: "hey" });
+      expect(fallback.target).toBe(message);
+      expect(sent?.id).toBeDefined();
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("preserves the edit wrapper in the fallback send", async () => {
+    const { seen, sendImpl } = noMarkdownSend("md-fallback-edit");
+    const provider = makeProvider("md-fallback-edit", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const sent = await space.send("hi");
+      if (!sent) {
+        throw new Error("expected the plain send to produce a message");
+      }
+      await sent.edit(markdown("**revised**"));
+
+      expect(seen.map((c) => c.type)).toEqual(["text", "edit", "edit"]);
+      const fallback = seen.at(-1);
+      if (fallback?.type !== "edit") {
+        throw new Error("expected an edit fallback dispatch");
+      }
+      expect(fallback.content).toEqual({ type: "text", text: "revised" });
+      expect(fallback.target).toBe(sent);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("downgrades markdown group items in place, leaving the rest untouched", async () => {
+    const { seen, sendImpl } = noMarkdownSend("md-fallback-group");
+    const provider = makeProvider("md-fallback-group", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      await space.send(group(markdown("**caption**"), "plain"));
+
+      expect(seen.map((c) => c.type)).toEqual(["group", "group"]);
+      const [first, fallback] = seen;
+      if (first?.type !== "group" || fallback?.type !== "group") {
+        throw new Error("expected two group dispatches");
+      }
+      expect(fallback.items.map((item) => item.content)).toEqual([
+        { type: "text", text: "caption" },
+        { type: "text", text: "plain" },
+      ]);
+      // Non-markdown members are reused as-is, not rebuilt.
+      expect(fallback.items[1]).toBe(
+        first.items[1] as (typeof fallback.items)[1]
+      );
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("warn-and-skips when the fallback send is unsupported too", async () => {
+    const seen: Content[] = [];
+    const sendImpl: SendImpl = (content) => {
+      seen.push(content);
+      return Promise.reject(
+        UnsupportedError.content(content.type, "md-fallback-none")
+      );
+    };
+    const provider = makeProvider("md-fallback-none", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const sent = await space.send(markdown("**lost**"));
+
+      expect(sent).toBeUndefined();
+      expect(seen.map((c) => c.type)).toEqual(["markdown", "text"]);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("warn-and-skips when the markdown renders to empty plain text", async () => {
+    const { seen, sendImpl } = noMarkdownSend("md-fallback-empty");
+    const provider = makeProvider("md-fallback-empty", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const sent = await space.send(markdown(" "));
+
+      // Nothing sensible to send — warn-and-skip, no second dispatch.
+      expect(sent).toBeUndefined();
+      expect(seen.map((c) => c.type)).toEqual(["markdown"]);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("does not trigger for non-markdown unsupported content", async () => {
+    const seen: Content[] = [];
+    const sendImpl: SendImpl = (content) => {
+      seen.push(content);
+      return Promise.reject(
+        UnsupportedError.content(content.type, "md-fallback-other")
+      );
+    };
+    const provider = makeProvider("md-fallback-other", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const sent = await space.send(poll("Q?", "a", "b"));
+
+      expect(sent).toBeUndefined();
+      expect(seen.map((c) => c.type)).toEqual(["poll"]);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("does not interfere with platforms that support markdown natively", async () => {
+    const seen: Content[] = [];
+    const sendImpl: SendImpl = (content) => {
+      seen.push(content);
+      return Promise.resolve({
+        id: `${content.type}-${seen.length}`,
+        content,
+        space: { id: "s1" },
+        timestamp: SENT_TIMESTAMP,
+      });
+    };
+    const provider = makeProvider("md-native", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const sent = await space.send(markdown("**styled**"));
+
+      expect(seen.map((c) => c.type)).toEqual(["markdown"]);
+      expect(sent?.content).toEqual({
+        type: "markdown",
+        markdown: "**styled**",
+      });
+    } finally {
+      await app.stop();
+    }
+  });
+});

--- a/packages/spectrum-ts/test/core/send-stream-text-fallback.test.ts
+++ b/packages/spectrum-ts/test/core/send-stream-text-fallback.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from "bun:test";
 import { stubCloud } from "@test/support/cloud";
 import { baseConfig, makeQueue, record } from "@test/support/platform";
 import z from "zod";
-import { streamText } from "@/content/stream-text";
+import { markdown } from "@/content/markdown";
+import { text } from "@/content/text";
 import type { Content } from "@/content/types";
 import { definePlatform } from "@/platform/define";
 import type { ProviderMessage, ProviderMessageRecord } from "@/platform/types";
@@ -91,7 +92,7 @@ describe("streamText plain-text fallback", () => {
     });
     try {
       const [space] = await firstMessage(app);
-      const sent = await space.send(streamText(chunks("Hello, ", "world!")));
+      const sent = await space.send(text(chunks("Hello, ", "world!")));
 
       expect(seen.map((c) => c.type)).toEqual(["streamText", "text"]);
       expect(seen.at(-1)).toEqual({ type: "text", text: "Hello, world!" });
@@ -111,7 +112,7 @@ describe("streamText plain-text fallback", () => {
     });
     try {
       const [, message] = await firstMessage(app);
-      const sent = await message.reply(streamText(chunks("a", "b", "c")));
+      const sent = await message.reply(text(chunks("a", "b", "c")));
 
       expect(seen.map((c) => c.type)).toEqual(["reply", "reply"]);
       const fallback = seen.at(-1);
@@ -139,7 +140,7 @@ describe("streamText plain-text fallback", () => {
       if (!sent) {
         throw new Error("expected the plain send to produce a message");
       }
-      await sent.edit(streamText(chunks("re", "vised")));
+      await sent.edit(text(chunks("re", "vised")));
 
       expect(seen.map((c) => c.type)).toEqual(["text", "edit", "edit"]);
       const fallback = seen.at(-1);
@@ -162,7 +163,7 @@ describe("streamText plain-text fallback", () => {
     });
     try {
       const [space] = await firstMessage(app);
-      const sent = await space.send(streamText(chunks()));
+      const sent = await space.send(text(chunks()));
 
       // Nothing to send — warn-and-skip, no second dispatch.
       expect(sent).toBeUndefined();
@@ -203,7 +204,7 @@ describe("streamText plain-text fallback", () => {
     });
     try {
       const [space] = await firstMessage(app);
-      const sent = await space.send(streamText(chunks()));
+      const sent = await space.send(text(chunks()));
 
       // The original UnsupportedError lands in warn-and-skip — the consumed
       // stream must not surface as a hard "already consumed" error.
@@ -229,7 +230,7 @@ describe("streamText plain-text fallback", () => {
     });
     try {
       const [space] = await firstMessage(app);
-      const sent = await space.send(streamText(chunks("lost")));
+      const sent = await space.send(text(chunks("lost")));
 
       expect(sent).toBeUndefined();
       expect(seen.map((c) => c.type)).toEqual(["streamText", "text"]);
@@ -251,9 +252,7 @@ describe("streamText plain-text fallback", () => {
         yield "partial";
         throw new Error("stream blew up");
       }
-      await expect(space.send(streamText(boom()))).rejects.toThrow(
-        "stream blew up"
-      );
+      await expect(space.send(text(boom()))).rejects.toThrow("stream blew up");
     } finally {
       await app.stop();
     }
@@ -270,9 +269,7 @@ describe("streamText plain-text fallback", () => {
     });
     try {
       const [space] = await firstMessage(app);
-      const sent = await space.send(
-        streamText(chunks("**Hi**"), { format: "markdown" })
-      );
+      const sent = await space.send(markdown(chunks("**Hi**")));
 
       expect(seen.map((c) => c.type)).toEqual(["streamText", "markdown"]);
       expect(seen.at(-1)).toEqual({ type: "markdown", markdown: "**Hi**" });
@@ -310,9 +307,7 @@ describe("streamText plain-text fallback", () => {
     try {
       const [space] = await firstMessage(app);
       const sent = await space.send(
-        streamText(chunks("**Hi** [docs](https://d.test)"), {
-          format: "markdown",
-        })
+        markdown(chunks("**Hi** [docs](https://d.test)"))
       );
 
       expect(seen.map((c) => c.type)).toEqual([
@@ -357,9 +352,7 @@ describe("streamText plain-text fallback", () => {
     });
     try {
       const [, message] = await firstMessage(app);
-      await message.reply(
-        streamText(chunks("**hey**"), { format: "markdown" })
-      );
+      await message.reply(markdown(chunks("**hey**")));
 
       expect(seen.map((c) => c.type)).toEqual(["reply", "reply", "reply"]);
       const fallback = seen.at(-1);
@@ -405,7 +398,7 @@ describe("streamText plain-text fallback", () => {
     });
     try {
       const [space] = await firstMessage(app);
-      const sent = await space.send(streamText(chunks("live ", "stream")));
+      const sent = await space.send(text(chunks("live ", "stream")));
 
       expect(seen.map((c) => c.type)).toEqual(["streamText"]);
       expect(sent?.content).toEqual({ type: "text", text: "live stream" });

--- a/packages/spectrum-ts/test/core/send-stream-text-fallback.test.ts
+++ b/packages/spectrum-ts/test/core/send-stream-text-fallback.test.ts
@@ -259,6 +259,120 @@ describe("streamText plain-text fallback", () => {
     }
   });
 
+  it("re-sends a drained markdown-formatted stream as markdown content", async () => {
+    // `noStreamingSend` accepts everything except streams — so the drained
+    // markdown lands natively, without a second downgrade.
+    const { seen, sendImpl } = noStreamingSend("stream-md-supported");
+    const provider = makeProvider("stream-md-supported", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const sent = await space.send(
+        streamText(chunks("**Hi**"), { format: "markdown" })
+      );
+
+      expect(seen.map((c) => c.type)).toEqual(["streamText", "markdown"]);
+      expect(seen.at(-1)).toEqual({ type: "markdown", markdown: "**Hi**" });
+      expect(sent?.content).toEqual({ type: "markdown", markdown: "**Hi**" });
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("chains down to plain text when markdown is unsupported too", async () => {
+    const seen: Content[] = [];
+    const sendImpl: SendImpl = (content) => {
+      seen.push(content);
+      const inner =
+        content.type === "reply" || content.type === "edit"
+          ? content.content
+          : content;
+      if (inner.type === "streamText" || inner.type === "markdown") {
+        return Promise.reject(
+          UnsupportedError.content(inner.type, "stream-md-chain")
+        );
+      }
+      return Promise.resolve({
+        id: `${content.type}-${seen.length}`,
+        content,
+        space: { id: "s1" },
+        timestamp: SENT_TIMESTAMP,
+      });
+    };
+    const provider = makeProvider("stream-md-chain", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const sent = await space.send(
+        streamText(chunks("**Hi** [docs](https://d.test)"), {
+          format: "markdown",
+        })
+      );
+
+      expect(seen.map((c) => c.type)).toEqual([
+        "streamText",
+        "markdown",
+        "text",
+      ]);
+      expect(seen.at(-1)).toEqual({
+        type: "text",
+        text: "Hi docs (https://d.test)",
+      });
+      expect(sent?.content).toEqual({
+        type: "text",
+        text: "Hi docs (https://d.test)",
+      });
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("preserves the reply wrapper through the chained fallback", async () => {
+    const seen: Content[] = [];
+    const sendImpl: SendImpl = (content) => {
+      seen.push(content);
+      const inner = content.type === "reply" ? content.content : content;
+      if (inner.type === "streamText" || inner.type === "markdown") {
+        return Promise.reject(
+          UnsupportedError.content(inner.type, "stream-md-reply")
+        );
+      }
+      return Promise.resolve({
+        id: `${content.type}-${seen.length}`,
+        content,
+        space: { id: "s1" },
+        timestamp: SENT_TIMESTAMP,
+      });
+    };
+    const provider = makeProvider("stream-md-reply", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [, message] = await firstMessage(app);
+      await message.reply(
+        streamText(chunks("**hey**"), { format: "markdown" })
+      );
+
+      expect(seen.map((c) => c.type)).toEqual(["reply", "reply", "reply"]);
+      const fallback = seen.at(-1);
+      if (fallback?.type !== "reply") {
+        throw new Error("expected a reply fallback dispatch");
+      }
+      expect(fallback.content).toEqual({ type: "text", text: "hey" });
+      expect(fallback.target).toBe(message);
+    } finally {
+      await app.stop();
+    }
+  });
+
   it("does not interfere with platforms that stream natively", async () => {
     const seen: Content[] = [];
     const sendImpl: SendImpl = async (content) => {

--- a/packages/spectrum-ts/test/providers/_imessage/remote/markdown.test.ts
+++ b/packages/spectrum-ts/test/providers/_imessage/remote/markdown.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "bun:test";
+import { markdownToIMessageText } from "@/providers/imessage/remote/markdown";
+
+describe("markdownToIMessageText", () => {
+  it("passes plain text through with no ranges", () => {
+    expect(markdownToIMessageText("hello")).toEqual({
+      text: "hello",
+      formatting: [],
+      hasLinks: false,
+    });
+  });
+
+  it("maps bold to a range at the correct offset", () => {
+    expect(markdownToIMessageText("a **b** c")).toEqual({
+      text: "a b c",
+      formatting: [{ type: "bold", start: 2, length: 1 }],
+      hasLinks: false,
+    });
+  });
+
+  it("maps italic and strikethrough to their range types", () => {
+    expect(markdownToIMessageText("*i* ~~gone~~").formatting).toEqual([
+      { type: "italic", start: 0, length: 1 },
+      { type: "strikethrough", start: 2, length: 4 },
+    ]);
+  });
+
+  it("counts offsets in UTF-16 code units (emoji are 2)", () => {
+    expect(markdownToIMessageText("🎉 **x**")).toEqual({
+      text: "🎉 x",
+      formatting: [{ type: "bold", start: 3, length: 1 }],
+      hasLinks: false,
+    });
+  });
+
+  it("emits overlapping ranges for nested emphasis", () => {
+    expect(markdownToIMessageText("***x***").formatting).toEqual([
+      { type: "bold", start: 0, length: 1 },
+      { type: "italic", start: 0, length: 1 },
+    ]);
+  });
+
+  it("keeps the outer range whole around a styled inner run", () => {
+    expect(markdownToIMessageText("**bold _it_ tail**")).toEqual({
+      text: "bold it tail",
+      formatting: [
+        { type: "bold", start: 0, length: 12 },
+        { type: "italic", start: 5, length: 2 },
+      ],
+      hasLinks: false,
+    });
+  });
+
+  it("coalesces adjacent spans sharing a style into one range", () => {
+    // The heading's bold covers both child spans; the italic nests inside.
+    expect(markdownToIMessageText("# A *b*")).toEqual({
+      text: "A b",
+      formatting: [
+        { type: "bold", start: 0, length: 3 },
+        { type: "italic", start: 2, length: 1 },
+      ],
+      hasLinks: false,
+    });
+  });
+
+  it("never extends a range across a block separator", () => {
+    expect(markdownToIMessageText("# A\n\n# B")).toEqual({
+      text: "A\n\nB",
+      formatting: [
+        { type: "bold", start: 0, length: 1 },
+        { type: "bold", start: 3, length: 1 },
+      ],
+      hasLinks: false,
+    });
+  });
+
+  it("renders headings as bold over exactly the heading text", () => {
+    expect(markdownToIMessageText("# Title\n\nbody")).toEqual({
+      text: "Title\n\nbody",
+      formatting: [{ type: "bold", start: 0, length: 5 }],
+      hasLinks: false,
+    });
+  });
+
+  it("renders links as label (url) and reports hasLinks", () => {
+    expect(markdownToIMessageText("[docs](https://d.test)")).toEqual({
+      text: "docs (https://d.test)",
+      formatting: [],
+      hasLinks: true,
+    });
+  });
+
+  it("keeps inline styling on a link label, not its url suffix", () => {
+    expect(markdownToIMessageText("[**a**](https://d.test)")).toEqual({
+      text: "a (https://d.test)",
+      formatting: [{ type: "bold", start: 0, length: 1 }],
+      hasLinks: true,
+    });
+  });
+
+  it("renders a bare autolink as the url alone", () => {
+    expect(markdownToIMessageText("see https://bare.example")).toEqual({
+      text: "see https://bare.example",
+      formatting: [],
+      hasLinks: true,
+    });
+  });
+
+  it("renders images as alt (url)", () => {
+    expect(markdownToIMessageText("![chart](https://i.test/p.png)")).toEqual({
+      text: "chart (https://i.test/p.png)",
+      formatting: [],
+      hasLinks: true,
+    });
+  });
+
+  it("renders code spans as Unicode monospace with no ranges", () => {
+    expect(markdownToIMessageText("`npm install spectrum-ts`")).toEqual({
+      text: "𝚗𝚙𝚖 𝚒𝚗𝚜𝚝𝚊𝚕𝚕 𝚜𝚙𝚎𝚌𝚝𝚛𝚞𝚖-𝚝𝚜",
+      formatting: [],
+      hasLinks: false,
+    });
+  });
+
+  it("maps all ASCII alphanumerics and keeps other characters", () => {
+    expect(markdownToIMessageText("`Ab9 <&_>`").text).toBe("𝙰𝚋𝟿 <&_>");
+  });
+
+  it("renders fenced blocks as monospace regardless of language", () => {
+    expect(markdownToIMessageText("```ts\na < b\n```").text).toBe("𝚊 < 𝚋");
+  });
+
+  it("keeps range offsets correct after astral monospace characters", () => {
+    // Each monospace character is 2 UTF-16 units: "𝚊𝚋 " spans 5 units.
+    expect(markdownToIMessageText("`ab` **c**")).toEqual({
+      text: "𝚊𝚋 c",
+      formatting: [{ type: "bold", start: 5, length: 1 }],
+      hasLinks: false,
+    });
+  });
+
+  it("renders lists as bullet lines with styled inline children", () => {
+    expect(markdownToIMessageText("- **a**\n- b")).toEqual({
+      text: "• a\n• b",
+      formatting: [{ type: "bold", start: 2, length: 1 }],
+      hasLinks: false,
+    });
+  });
+
+  it("keeps ordered list numbering from the start value", () => {
+    expect(markdownToIMessageText("3. x\n4. y").text).toBe("3. x\n4. y");
+  });
+
+  it("marks task list items with their checkbox state", () => {
+    expect(markdownToIMessageText("- [x] done\n- [ ] todo").text).toBe(
+      "• [x] done\n• [ ] todo"
+    );
+  });
+
+  it("indents nested list items under their parent", () => {
+    expect(markdownToIMessageText("- a\n  - b").text).toBe("• a\n  • b");
+  });
+
+  it("prefixes blockquote lines without styling the marker", () => {
+    expect(markdownToIMessageText("> **q**")).toEqual({
+      text: "> q",
+      formatting: [{ type: "bold", start: 2, length: 1 }],
+      hasLinks: false,
+    });
+  });
+
+  it("separates blockquote paragraphs with a bare marker line", () => {
+    expect(markdownToIMessageText("> a\n>\n> b").text).toBe("> a\n>\n> b");
+  });
+
+  it("renders tables as pipe-separated rows with styled cells", () => {
+    expect(
+      markdownToIMessageText("| h1 | h2 |\n|---|---|\n| **a** | b |")
+    ).toEqual({
+      text: "h1 | h2\na | b",
+      formatting: [{ type: "bold", start: 8, length: 1 }],
+      hasLinks: false,
+    });
+  });
+
+  it("renders horizontal rules as a dash line", () => {
+    expect(markdownToIMessageText("a\n\n---\n\nb").text).toBe("a\n\n———\n\nb");
+  });
+
+  it("keeps raw HTML literal", () => {
+    expect(markdownToIMessageText("<u>under</u> ok")).toEqual({
+      text: "<u>under</u> ok",
+      formatting: [],
+      hasLinks: false,
+    });
+  });
+
+  it("keeps a bold range across a soft line break", () => {
+    expect(markdownToIMessageText("**line one\nline two**")).toEqual({
+      text: "line one\nline two",
+      formatting: [{ type: "bold", start: 0, length: 17 }],
+      hasLinks: false,
+    });
+  });
+
+  it("trims leading blank lines without shifting range starts", () => {
+    expect(markdownToIMessageText("\n\n# A")).toEqual({
+      text: "A",
+      formatting: [{ type: "bold", start: 0, length: 1 }],
+      hasLinks: false,
+    });
+  });
+
+  it("renders whitespace-only markdown to an empty result", () => {
+    expect(markdownToIMessageText("   ")).toEqual({
+      text: "",
+      formatting: [],
+      hasLinks: false,
+    });
+  });
+});

--- a/packages/spectrum-ts/test/providers/_imessage/remote/send-markdown.test.ts
+++ b/packages/spectrum-ts/test/providers/_imessage/remote/send-markdown.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it, mock } from "bun:test";
+import type {
+  AdvancedIMessage,
+  Message as SDKMessage,
+} from "@photon-ai/advanced-imessage";
+import { asAttachment } from "@/content/attachment";
+import { asGroup } from "@/content/group";
+import { asMarkdown } from "@/content/markdown";
+import { asText } from "@/content/text";
+import type { Content } from "@/content/types";
+import {
+  editMessage,
+  replyToMessage,
+  send,
+} from "@/providers/imessage/remote/send";
+import type { Message } from "@/types/message";
+import { UnsupportedError } from "@/utils/errors";
+
+const SENT_DATE = new Date(1_700_000_000_000);
+const SLAM = "com.apple.MobileSMS.expressivesend.impact";
+
+const makeRemote = () => {
+  const reply = {
+    guid: "msg-guid",
+    dateCreated: SENT_DATE,
+  } as unknown as SDKMessage;
+  const sendText = mock((_chat: string, _text: string, _options?: unknown) =>
+    Promise.resolve(reply)
+  );
+  const sendMultipart = mock((_chat: string, _parts: unknown) =>
+    Promise.resolve(reply)
+  );
+  const edit = mock(() => Promise.resolve(reply));
+  const upload = mock(() =>
+    Promise.resolve({ attachment: { guid: "att-guid" } })
+  );
+  const remote = {
+    messages: { sendText, sendMultipart, edit },
+    attachments: { upload },
+  } as unknown as AdvancedIMessage;
+  return { remote, sendText, sendMultipart, edit, upload };
+};
+
+// Outbound group items are stub messages — providers only read `.content`
+// (mirrors `group()`'s internal stubOutboundMessage).
+const groupOf = (...contents: Content[]) =>
+  asGroup({
+    items: contents.map(
+      (content) => ({ id: "", content }) as unknown as Message
+    ),
+  });
+
+describe("send (markdown)", () => {
+  it("sends rendered text with formatting ranges", async () => {
+    const { remote, sendText } = makeRemote();
+    const content = asMarkdown("# Hi\n\n**bold** move");
+
+    const record = await send(remote, "chat", content);
+
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(sendText.mock.calls[0]).toEqual([
+      "chat",
+      "Hi\n\nbold move",
+      {
+        formatting: [
+          { type: "bold", start: 0, length: 2 },
+          { type: "bold", start: 4, length: 4 },
+        ],
+      },
+    ]);
+    expect(record.id).toBe("msg-guid");
+    expect(record.timestamp).toEqual(SENT_DATE);
+    // The record keeps the original markdown content, not the rendered text.
+    expect(record.content).toEqual(content);
+    expect(record.space).toEqual({ id: "chat" });
+  });
+
+  it("omits formatting and data detection for unstyled, link-free markdown", async () => {
+    const { remote, sendText } = makeRemote();
+
+    await send(remote, "chat", asMarkdown("just words"));
+
+    expect(sendText.mock.calls[0]).toEqual(["chat", "just words", {}]);
+  });
+
+  it("enables data detection when the markdown contains links", async () => {
+    const { remote, sendText } = makeRemote();
+
+    await send(remote, "chat", asMarkdown("[docs](https://d.test)"));
+
+    expect(sendText.mock.calls[0]).toEqual([
+      "chat",
+      "docs (https://d.test)",
+      { enableDataDetection: true },
+    ]);
+  });
+
+  it("sends markdown replies with formatting and the reply target", async () => {
+    const { remote, sendText } = makeRemote();
+
+    await replyToMessage(remote, "chat", "target-id", asMarkdown("**a**"));
+
+    expect(sendText.mock.calls[0]).toEqual([
+      "chat",
+      "a",
+      {
+        formatting: [{ type: "bold", start: 0, length: 1 }],
+        replyTo: "target-id",
+      },
+    ]);
+  });
+
+  it("carries an effect wrapper alongside formatting", async () => {
+    const { remote, sendText } = makeRemote();
+    const content = {
+      type: "effect",
+      content: asMarkdown("**a**"),
+      effect: SLAM,
+    } as unknown as Content;
+
+    await send(remote, "chat", content);
+
+    expect(sendText.mock.calls[0]).toEqual([
+      "chat",
+      "a",
+      {
+        effect: SLAM,
+        formatting: [{ type: "bold", start: 0, length: 1 }],
+      },
+    ]);
+  });
+
+  it("renders a markdown group item as a formatted multipart text part", async () => {
+    const { remote, sendMultipart, upload } = makeRemote();
+    const pic = asAttachment({
+      name: "pic.png",
+      mimeType: "image/png",
+      read: () => Promise.resolve(Buffer.from("x")),
+    });
+
+    await send(remote, "chat", groupOf(asMarkdown("**a** b"), pic));
+
+    expect(upload).toHaveBeenCalledTimes(1);
+    expect(sendMultipart).toHaveBeenCalledTimes(1);
+    expect(sendMultipart.mock.calls[0]).toEqual([
+      "chat",
+      [
+        {
+          text: "a b",
+          formatting: [{ type: "bold", start: 0, length: 1 }],
+          bubbleIndex: 0,
+        },
+        {
+          attachmentGuid: "att-guid",
+          attachmentName: "pic.png",
+          bubbleIndex: 1,
+        },
+      ],
+    ]);
+  });
+
+  it("counts markdown toward the group text-item cap", async () => {
+    const { remote, sendMultipart } = makeRemote();
+
+    await expect(
+      send(remote, "chat", groupOf(asMarkdown("**a**"), asText("b")))
+    ).rejects.toBeInstanceOf(UnsupportedError);
+    expect(sendMultipart).not.toHaveBeenCalled();
+  });
+
+  it("rejects markdown that renders to empty text without sending", async () => {
+    const { remote, sendText } = makeRemote();
+
+    await expect(
+      send(remote, "chat", asMarkdown("   "))
+    ).rejects.toBeInstanceOf(UnsupportedError);
+    expect(sendText).not.toHaveBeenCalled();
+  });
+
+  it("still rejects markdown edits (the wire carries no formatting)", async () => {
+    const { remote, edit } = makeRemote();
+
+    await expect(
+      editMessage(remote, "chat", "msg-1", asMarkdown("**a**"))
+    ).rejects.toBeInstanceOf(UnsupportedError);
+    expect(edit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/spectrum-ts/test/providers/_imessage/remote/send-markdown.test.ts
+++ b/packages/spectrum-ts/test/providers/_imessage/remote/send-markdown.test.ts
@@ -5,9 +5,10 @@ import type {
 } from "@photon-ai/advanced-imessage";
 import { asAttachment } from "@/content/attachment";
 import { asGroup } from "@/content/group";
-import { asMarkdown } from "@/content/markdown";
+import { asMarkdown, markdown } from "@/content/markdown";
 import { asText } from "@/content/text";
 import type { Content } from "@/content/types";
+import { effect } from "@/providers/imessage/content/effect";
 import {
   editMessage,
   replyToMessage,
@@ -112,11 +113,9 @@ describe("send (markdown)", () => {
 
   it("carries an effect wrapper alongside formatting", async () => {
     const { remote, sendText } = makeRemote();
-    const content = {
-      type: "effect",
-      content: asMarkdown("**a**"),
-      effect: SLAM,
-    } as unknown as Content;
+    // Built via the real builder so the effect schema's inner-content union
+    // is exercised, not bypassed.
+    const content = await effect(markdown("**a**"), SLAM).build();
 
     await send(remote, "chat", content);
 

--- a/packages/spectrum-ts/test/providers/_imessage/remote/stream-text.test.ts
+++ b/packages/spectrum-ts/test/providers/_imessage/remote/stream-text.test.ts
@@ -4,7 +4,9 @@ import type {
   Message as SDKMessage,
 } from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
-import { type StreamText, streamText } from "@/content/stream-text";
+import { markdown } from "@/content/markdown";
+import type { StreamText } from "@/content/stream-text";
+import { text } from "@/content/text";
 import { imessage } from "@/providers/imessage";
 import { sendStreamText } from "@/providers/imessage/remote/stream-text";
 import { UnsupportedError } from "@/utils/errors";
@@ -60,7 +62,7 @@ function timed(items: string[], stepMs: number): AsyncIterable<string> {
 }
 
 const build = async (source: AsyncIterable<string>): Promise<StreamText> =>
-  (await streamText(source).build()) as StreamText;
+  (await text(source).build()) as StreamText;
 
 // `editArgs` → the new-text argument of each edit call, in order.
 const editArgs = (edit: ReturnType<typeof makeRemote>["edit"]): string[] =>
@@ -74,9 +76,7 @@ describe("sendStreamText", () => {
       pulled = true;
       yield "x";
     }
-    const content = (await streamText(tracking(), {
-      format: "markdown",
-    }).build()) as StreamText;
+    const content = (await markdown(tracking()).build()) as StreamText;
 
     await expect(
       sendStreamText(remote, "chat", content)

--- a/packages/spectrum-ts/test/providers/_imessage/remote/stream-text.test.ts
+++ b/packages/spectrum-ts/test/providers/_imessage/remote/stream-text.test.ts
@@ -67,6 +67,26 @@ const editArgs = (edit: ReturnType<typeof makeRemote>["edit"]): string[] =>
   edit.mock.calls.map((call) => call[2]);
 
 describe("sendStreamText", () => {
+  it("rejects a markdown-formatted stream before consuming it", async () => {
+    const { remote, sendText, edit } = makeRemote();
+    let pulled = false;
+    async function* tracking(): AsyncIterable<string> {
+      pulled = true;
+      yield "x";
+    }
+    const content = (await streamText(tracking(), {
+      format: "markdown",
+    }).build()) as StreamText;
+
+    await expect(
+      sendStreamText(remote, "chat", content)
+    ).rejects.toBeInstanceOf(UnsupportedError);
+    // The stream stays drainable for the pipeline's markdown fallback chain.
+    expect(pulled).toBe(false);
+    expect(sendText).not.toHaveBeenCalled();
+    expect(edit).not.toHaveBeenCalled();
+  });
+
   it("sends the first delta then flushes the full text on completion", async () => {
     setSystemTime(new Date(0)); // freeze: no time passes, so no interim edits
     const { remote, sendText, edit } = makeRemote();

--- a/packages/spectrum-ts/test/providers/telegram/outbound/markdown.test.ts
+++ b/packages/spectrum-ts/test/providers/telegram/outbound/markdown.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import { markdownToTelegramHtml } from "@/providers/telegram/outbound/markdown";
+
+describe("markdownToTelegramHtml", () => {
+  it("maps nested emphasis to Telegram tags", () => {
+    expect(markdownToTelegramHtml("**bold _italic_** ~~gone~~")).toBe(
+      "<b>bold <i>italic</i></b> <s>gone</s>"
+    );
+  });
+
+  it("escapes & < > in plain text", () => {
+    expect(markdownToTelegramHtml("a < b & c > d")).toBe(
+      "a &lt; b &amp; c &gt; d"
+    );
+  });
+
+  it("escapes code span content inside <code>", () => {
+    expect(markdownToTelegramHtml("`a<b&c`")).toBe("<code>a&lt;b&amp;c</code>");
+  });
+
+  it("renders a fenced block with a language as <pre><code class>", () => {
+    expect(markdownToTelegramHtml("```ts\na < b\n```")).toBe(
+      '<pre><code class="language-ts">a &lt; b</code></pre>'
+    );
+  });
+
+  it("renders a fenced block without a language as bare <pre>", () => {
+    expect(markdownToTelegramHtml("```\nplain\n```")).toBe("<pre>plain</pre>");
+  });
+
+  it("escapes link hrefs in the attribute", () => {
+    expect(markdownToTelegramHtml("[docs](https://e.test?a=1&b=2)")).toBe(
+      '<a href="https://e.test?a=1&amp;b=2">docs</a>'
+    );
+  });
+
+  it("renders a bare autolink as plain text for Telegram to auto-link", () => {
+    expect(markdownToTelegramHtml("see https://bare.example")).toBe(
+      "see https://bare.example"
+    );
+  });
+
+  it("degrades images to links labeled by alt text", () => {
+    expect(markdownToTelegramHtml("![chart](https://i.test/p.png)")).toBe(
+      '<a href="https://i.test/p.png">chart</a>'
+    );
+  });
+
+  it("renders headings as bold blocks", () => {
+    expect(markdownToTelegramHtml("# Title\n\nbody")).toBe(
+      "<b>Title</b>\n\nbody"
+    );
+  });
+
+  it("flattens nested blockquotes into one tag", () => {
+    expect(markdownToTelegramHtml("> outer\n>> inner")).toBe(
+      "<blockquote>outer\ninner</blockquote>"
+    );
+  });
+
+  it("renders lists as bullet lines with styled inline children", () => {
+    expect(markdownToTelegramHtml("- **a**\n- b")).toBe("• <b>a</b>\n• b");
+  });
+
+  it("marks task list items with their checkbox state", () => {
+    expect(markdownToTelegramHtml("- [x] done\n- [ ] todo")).toBe(
+      "• [x] done\n• [ ] todo"
+    );
+  });
+
+  it("escapes raw HTML instead of passing it through", () => {
+    expect(markdownToTelegramHtml("<u>under</u> ok")).toBe(
+      "&lt;u&gt;under&lt;/u&gt; ok"
+    );
+  });
+
+  it("renders tables as escaped <pre> blocks with plain cells", () => {
+    expect(
+      markdownToTelegramHtml("| h1 | h2 |\n|---|---|\n| **a** | b |")
+    ).toBe("<pre>h1 | h2\na | b</pre>");
+  });
+
+  it("renders a horizontal rule as a dash line", () => {
+    expect(markdownToTelegramHtml("---")).toBe("———");
+  });
+});

--- a/packages/spectrum-ts/test/providers/telegram/outbound/message.test.ts
+++ b/packages/spectrum-ts/test/providers/telegram/outbound/message.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { attachment } from "@/content/attachment";
 import { contact } from "@/content/contact";
+import { markdown } from "@/content/markdown";
 import { poll } from "@/content/poll";
 import { reply } from "@/content/reply";
 import { richlink } from "@/content/richlink";
@@ -23,6 +24,25 @@ describe("buildSend", () => {
     expect(await buildSend(await text("hi").build())).toEqual({
       method: "sendMessage",
       params: { text: "hi" },
+    });
+  });
+
+  it("maps markdown to sendMessage with rendered HTML and parse_mode", async () => {
+    expect(await buildSend(await markdown("**hi** _there_").build())).toEqual({
+      method: "sendMessage",
+      params: { text: "<b>hi</b> <i>there</i>", parse_mode: "HTML" },
+    });
+  });
+
+  it("threads a reply around markdown, keeping parse_mode", async () => {
+    const spec = await buildSend(
+      await reply(markdown("**hey**"), target).build()
+    );
+    expect(spec.method).toBe("sendMessage");
+    expect(spec.params).toEqual({
+      text: "<b>hey</b>",
+      parse_mode: "HTML",
+      reply_parameters: { message_id: 42 },
     });
   });
 

--- a/packages/spectrum-ts/test/providers/telegram/outbound/send.test.ts
+++ b/packages/spectrum-ts/test/providers/telegram/outbound/send.test.ts
@@ -8,6 +8,7 @@ import {
   spyOn,
 } from "bun:test";
 import { attachment } from "@/content/attachment";
+import { markdown } from "@/content/markdown";
 import { poll } from "@/content/poll";
 import { reaction } from "@/content/reaction";
 import { reply } from "@/content/reply";
@@ -96,6 +97,39 @@ describe("send — messages", () => {
     expect(result?.timestamp).toEqual(new Date(TS_SEC * 1000));
     expect(calls[0]?.method).toBe("sendMessage");
     expect(calls[0]?.json).toEqual({ chat_id: "100", text: "hi" });
+  });
+
+  it("sends markdown as sendMessage with rendered HTML and parse_mode", async () => {
+    const result = await send({
+      space,
+      content: await markdown("**hi**").build(),
+      config,
+    });
+    expect(result?.id).toBe("555");
+    expect(calls[0]?.method).toBe("sendMessage");
+    expect(calls[0]?.json).toEqual({
+      chat_id: "100",
+      text: "<b>hi</b>",
+      parse_mode: "HTML",
+    });
+  });
+
+  it("sends markdown group items with parse_mode", async () => {
+    const groupContent = {
+      type: "group",
+      items: [
+        { id: "a", content: await text("one").build() },
+        { id: "b", content: await markdown("**two**").build() },
+      ],
+    } as unknown as Content;
+    await send({ space, content: groupContent, config });
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.json).toEqual({ chat_id: "100", text: "one" });
+    expect(calls[1]?.json).toEqual({
+      chat_id: "100",
+      text: "<b>two</b>",
+      parse_mode: "HTML",
+    });
   });
 
   it("sends an image attachment via sendPhoto as multipart, preserving the filename", async () => {
@@ -218,6 +252,25 @@ describe("send — fire-and-forget", () => {
       config,
     });
     expect(calls).toHaveLength(0);
+  });
+
+  it("edits markdown via editMessageText with parse_mode", async () => {
+    await send({
+      space,
+      content: {
+        type: "edit",
+        content: { type: "markdown", markdown: "**new**" },
+        target,
+      } as unknown as Content,
+      config,
+    });
+    expect(calls[0]?.method).toBe("editMessageText");
+    expect(calls[0]?.json).toEqual({
+      chat_id: "100",
+      message_id: 42,
+      text: "<b>new</b>",
+      parse_mode: "HTML",
+    });
   });
 
   it("edits text via editMessageText", async () => {

--- a/packages/spectrum-ts/test/providers/telegram/outbound/stream-text.test.ts
+++ b/packages/spectrum-ts/test/providers/telegram/outbound/stream-text.test.ts
@@ -8,6 +8,7 @@ import {
   setSystemTime,
   spyOn,
 } from "bun:test";
+import { markdown } from "@/content/markdown";
 import { streamText } from "@/content/stream-text";
 import { configSchema } from "@/providers/telegram/config";
 import { send } from "@/providers/telegram/outbound/send";
@@ -188,6 +189,44 @@ describe("telegram sendStreamText", () => {
     expect(drafts()).toHaveLength(1);
     expect(finalSends().map((c) => c.json.text)).toEqual(["abc"]);
     expect(result?.id).toBe("555");
+  });
+
+  it("renders markdown drafts and the final send as HTML with parse_mode", async () => {
+    const result = await send({
+      space,
+      content: await markdown(
+        streamText(timed(["**Hello", " world**"], 1000))
+      ).build(),
+      config,
+    });
+
+    // Each draft re-renders the accumulated markdown; an unclosed marker
+    // mid-stream stays literal text, so every preview is valid HTML.
+    expect(drafts().map((c) => [c.json.text, c.json.parse_mode])).toEqual([
+      ["", "HTML"],
+      ["**Hello", "HTML"],
+      ["<b>Hello world</b>", "HTML"],
+    ]);
+    expect(finalSends().map((c) => c.json)).toEqual([
+      { chat_id: "100", text: "<b>Hello world</b>", parse_mode: "HTML" },
+    ]);
+    // The record carries the markdown source, not the rendered HTML.
+    expect(result?.content).toEqual({
+      type: "markdown",
+      markdown: "**Hello world**",
+    });
+  });
+
+  it("keeps plain streams free of parse_mode", async () => {
+    await send({
+      space,
+      content: await streamText(timed(["hi"], 1000)).build(),
+      config,
+    });
+
+    for (const call of calls) {
+      expect(call.json.parse_mode).toBeUndefined();
+    }
   });
 
   it("propagates a mid-stream error without sending the message", async () => {

--- a/packages/spectrum-ts/test/providers/telegram/outbound/stream-text.test.ts
+++ b/packages/spectrum-ts/test/providers/telegram/outbound/stream-text.test.ts
@@ -9,7 +9,7 @@ import {
   spyOn,
 } from "bun:test";
 import { markdown } from "@/content/markdown";
-import { streamText } from "@/content/stream-text";
+import { text } from "@/content/text";
 import { configSchema } from "@/providers/telegram/config";
 import { send } from "@/providers/telegram/outbound/send";
 import { UnsupportedError } from "@/utils/errors";
@@ -101,7 +101,7 @@ describe("telegram sendStreamText", () => {
   it("streams drafts and persists the full text with sendMessage", async () => {
     const result = await send({
       space,
-      content: await streamText(timed(["Hello", " world", "!"], 1000)).build(),
+      content: await text(timed(["Hello", " world", "!"], 1000)).build(),
       config,
     });
 
@@ -136,7 +136,7 @@ describe("telegram sendStreamText", () => {
     setSystemTime(new Date(BASE_MS)); // freeze: no time passes, no interim drafts
     await send({
       space,
-      content: await streamText(fromArray(["a", "b", "c"])).build(),
+      content: await text(fromArray(["a", "b", "c"])).build(),
       config,
     });
 
@@ -155,7 +155,7 @@ describe("telegram sendStreamText", () => {
     await expect(
       send({
         space: { id: "-100123" },
-        content: await streamText(tracking()).build(),
+        content: await text(tracking()).build(),
         config,
       })
     ).rejects.toBeInstanceOf(UnsupportedError);
@@ -167,7 +167,7 @@ describe("telegram sendStreamText", () => {
     await expect(
       send({
         space,
-        content: await streamText(fromArray([])).build(),
+        content: await text(fromArray([])).build(),
         config,
       })
     ).rejects.toBeInstanceOf(UnsupportedError);
@@ -181,7 +181,7 @@ describe("telegram sendStreamText", () => {
     failDrafts = true;
     const result = await send({
       space,
-      content: await streamText(timed(["a", "b", "c"], 1000)).build(),
+      content: await text(timed(["a", "b", "c"], 1000)).build(),
       config,
     });
 
@@ -194,9 +194,7 @@ describe("telegram sendStreamText", () => {
   it("renders markdown drafts and the final send as HTML with parse_mode", async () => {
     const result = await send({
       space,
-      content: await markdown(
-        streamText(timed(["**Hello", " world**"], 1000))
-      ).build(),
+      content: await markdown(timed(["**Hello", " world**"], 1000)).build(),
       config,
     });
 
@@ -220,7 +218,7 @@ describe("telegram sendStreamText", () => {
   it("keeps plain streams free of parse_mode", async () => {
     await send({
       space,
-      content: await streamText(timed(["hi"], 1000)).build(),
+      content: await text(timed(["hi"], 1000)).build(),
       config,
     });
 
@@ -237,7 +235,7 @@ describe("telegram sendStreamText", () => {
     }
 
     await expect(
-      send({ space, content: await streamText(throwing()).build(), config })
+      send({ space, content: await text(throwing()).build(), config })
     ).rejects.toThrow(BOOM);
     expect(finalSends()).toEqual([]);
   });

--- a/packages/spectrum-ts/test/utils/markdown.test.ts
+++ b/packages/spectrum-ts/test/utils/markdown.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+import { markdownToPlainText } from "@/utils/markdown";
+
+describe("markdownToPlainText", () => {
+  it("strips nested emphasis markers", () => {
+    expect(markdownToPlainText("**bold _italic_ ~~gone~~**")).toBe(
+      "bold italic gone"
+    );
+  });
+
+  it("keeps code span text verbatim, without entity encoding", () => {
+    expect(markdownToPlainText("run `a < b & c` now")).toBe(
+      "run a < b & c now"
+    );
+  });
+
+  it("keeps fenced code blocks verbatim", () => {
+    expect(markdownToPlainText("```ts\nconst ok = a < b;\n```")).toBe(
+      "const ok = a < b;"
+    );
+  });
+
+  it("renders links as label (url)", () => {
+    expect(markdownToPlainText("see [docs](https://d.test)")).toBe(
+      "see docs (https://d.test)"
+    );
+  });
+
+  it("renders a bare autolink as the url alone", () => {
+    expect(markdownToPlainText("see https://d.test")).toBe(
+      "see https://d.test"
+    );
+  });
+
+  it("renders images as alt (url), or the url when alt is empty", () => {
+    expect(markdownToPlainText("![chart](https://i.test/p.png)")).toBe(
+      "chart (https://i.test/p.png)"
+    );
+    expect(markdownToPlainText("![](https://i.test/p.png)")).toBe(
+      "https://i.test/p.png"
+    );
+  });
+
+  it("renders unordered lists with bullets", () => {
+    expect(markdownToPlainText("- one\n- two")).toBe("• one\n• two");
+  });
+
+  it("honors the start number of ordered lists", () => {
+    expect(markdownToPlainText("3. three\n4. four")).toBe("3. three\n4. four");
+  });
+
+  it("indents nested lists under their parent item", () => {
+    expect(markdownToPlainText("- a\n  - b")).toBe("• a\n  • b");
+  });
+
+  it("marks task list items with their checkbox state", () => {
+    expect(markdownToPlainText("- [x] done\n- [ ] todo")).toBe(
+      "• [x] done\n• [ ] todo"
+    );
+  });
+
+  it("renders headings as their own undecorated block", () => {
+    expect(markdownToPlainText("# Title\n\nbody")).toBe("Title\n\nbody");
+  });
+
+  it("prefixes blockquote lines, flattening nesting as quoted quotes", () => {
+    expect(markdownToPlainText("> outer\n>> inner")).toBe(
+      "> outer\n>\n> > inner"
+    );
+  });
+
+  it("renders a horizontal rule as a dash line", () => {
+    expect(markdownToPlainText("above\n\n---\n\nbelow")).toBe(
+      "above\n\n———\n\nbelow"
+    );
+  });
+
+  it("renders tables as pipe-joined rows", () => {
+    expect(markdownToPlainText("| h1 | h2 |\n|---|---|\n| **a** | b |")).toBe(
+      "h1 | h2\na | b"
+    );
+  });
+
+  it("keeps raw HTML literal", () => {
+    expect(markdownToPlainText("<u>under</u> ok")).toBe("<u>under</u> ok");
+  });
+
+  it("renders hard line breaks as newlines", () => {
+    expect(markdownToPlainText("line  \nbreak")).toBe("line\nbreak");
+  });
+
+  it("separates blocks with a blank line", () => {
+    expect(markdownToPlainText("one\n\ntwo")).toBe("one\n\ntwo");
+  });
+});


### PR DESCRIPTION
## Summary

- Removes `streamText()` as a public API — `text()` and `markdown()` now accept stream sources directly via overloaded signatures, so the call site no longer needs a wrapper
- `TextStreamOptions` replaces `StreamTextOptions`; the `format` option is dropped in favour of using `markdown()` explicitly
- Adds native markdown rendering for remote iMessage: `markdownToIMessageText` converts markdown to plain text with UTF-16 bold/italic/strikethrough formatting ranges, Unicode mathematical monospace for code spans/blocks, `label (url)` link expansion, and `hasLinks` to trigger Apple's data-detector pass
- `effect()` now accepts `markdown` content; group sends include formatted text parts
- Updates Telegram docs to reflect the new `markdown(source)` call shape

## Usage

```ts
import { text, markdown } from "spectrum-ts";

// Static string — unchanged
await space.send(text("Hello!"));
await space.send(markdown("**Hello!**"));

// Stream source — no more streamText() wrapper needed
const stream = myLLM.stream("Tell me a joke");
await space.send(text(stream));       // plain text streaming
await space.send(markdown(stream));   // markdown streaming (native on iMessage / Telegram)
```

On iMessage, `markdown(source)` renders to styled text with UTF-16 formatting ranges. On platforms without native markdown streaming, the drained text re-enters the send pipeline as `markdown` content and downgrades to plain text at worst.

## Changes

| File | Change |
|---|---|
| `src/content/text.ts` | Overloaded to accept `StreamTextSource` in addition to `string`; uses `TextStreamOptions` |
| `src/content/markdown.ts` | Overloaded to accept `StreamTextSource` in addition to `string`; drops `asStreamText` import |
| `src/content/stream-text.ts` | `StreamConsumedError` and `StreamTextSource` kept as internals; `streamText()` builder removed from public API |
| `src/index.ts` | Removes `streamText` and `StreamTextOptions` from public exports; adds `TextStreamOptions` |
| `src/providers/imessage/remote/markdown.ts` | New `markdownToIMessageText` — AST-walk that produces a plain-text string + UTF-16 formatting ranges for bold/italic/strikethrough/code, monospace via Unicode math block, link expansion, `hasLinks` flag |
| `src/providers/imessage/remote/send.ts` | Wires `markdown` content through `markdownToIMessageText`; group sends include formatted text parts |
| `src/providers/imessage/remote/stream-text.ts` | Uses new `text()`/`markdown()` overloads internally |
| `src/providers/imessage/content/effect.ts` | Accepts `markdown` in addition to existing content types |
| `docs/telegram.md` | Updates streaming examples to `markdown(source)` call shape |
| `test/content/markdown.test.ts` | Extended to cover stream-source overload |
| `test/content/text.test.ts` | Renamed from `stream-text.test.ts`; covers both static and stream overloads |
| `test/core/send-stream-text-fallback.test.ts` | Adapted to new API surface |
| `test/providers/_imessage/remote/markdown.test.ts` | New suite — `markdownToIMessageText` unit tests (bold, italic, strikethrough, code, links, headings, mixed) |
| `test/providers/_imessage/remote/send-markdown.test.ts` | New suite — end-to-end markdown send tests on iMessage |
| `test/providers/_imessage/remote/stream-text.test.ts` | Updated to use `text(stream)` / `markdown(stream)` |
| `test/providers/telegram/outbound/stream-text.test.ts` | Updated call sites |

## Test plan

- [ ] `bun test test/content/markdown.test.ts` — passes
- [ ] `bun test test/content/text.test.ts` — passes
- [ ] `bun test test/providers/_imessage/remote/markdown.test.ts` — all new markdown-rendering cases pass
- [ ] `bun test test/providers/_imessage/remote/send-markdown.test.ts` — all new send cases pass
- [ ] `bun test` — full suite green
- [ ] `bun x ultracite check` — no lint/format issues
- [ ] Send `markdown("**bold** and _italic_")` to iMessage — confirm styled output with correct formatting ranges
- [ ] Send `markdown(llmStream)` to iMessage — confirm live streaming with styled final flush
- [ ] Send `markdown(llmStream)` to Telegram — confirm draft-preview updates and `parse_mode: "HTML"` final send
- [ ] Confirm `streamText()` is no longer exported (TypeScript error at call site)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783744001&installation_id=127326493&pr_number=119&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F119&signature=5013dc384a226b72cf5ac4712f1acd2a38a3b60289daecd980f13ac5960c5ef9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class markdown content: native rendering for Telegram (HTML) and iMessage (native styling), streaming markdown with live draft updates, and automatic plain-text fallback when a platform lacks markdown support.

* **Documentation**
  * Clarified Telegram outbound markdown behavior, inbound text handling, edit/typing semantics, and streaming/downgrade details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->