### PR TITLE
fix(ENG-1566): replace isRetryableError with cursor-rejection semantics to fix silent stream death

### DIFF
--- a/packages/spectrum-ts/src/providers/imessage/remote/stream.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/stream.ts
@@ -1,13 +1,11 @@
 import {
   type AdvancedIMessage,
-  AuthenticationError,
   type CatchUpEvent,
-  IMessageError,
   type MessageEvent,
-  NotFoundError,
   type PollEvent,
   ValidationError,
 } from "@photon-ai/advanced-imessage";
+import { sanitizePhone } from "@photon-ai/otel";
 import type { ProjectData } from "../../../utils/cloud";
 import {
   type CloseableAsyncIterable,
@@ -26,19 +24,14 @@ import { toInboundMessages } from "./inbound";
 import { cachePollEvent, toPollDeltaMessages } from "./polls";
 import { toReactionMessages } from "./reactions";
 
-const isRetryableIMessageStreamError = (error: unknown): boolean => {
-  if (
-    error instanceof AuthenticationError ||
-    error instanceof NotFoundError ||
-    error instanceof ValidationError
-  ) {
-    return false;
-  }
-  if (error instanceof IMessageError) {
-    return true;
-  }
-  return false;
-};
+// The proxy rejects an unknown/pruned resume cursor with INVALID_ARGUMENT,
+// which the client surfaces as ValidationError — the only ValidationError the
+// catch-up RPC produces (ENG-1566).
+const isCursorRejectedIMessageError = (error: unknown): boolean =>
+  error instanceof ValidationError;
+
+const streamLabel = (kind: "messages" | "polls", phone: string): string =>
+  `imessage.${kind}:${phone === SHARED_PHONE ? phone : sanitizePhone(phone)}`;
 
 const isEventFromCurrentAccount = (
   event: Pick<MessageEvent | PollEvent, "actor" | "isFromMe">,
@@ -210,7 +203,8 @@ const messageStream = (
 ): ManagedStream<IMessageMessage> =>
   resumableOrderedStream<MessageEvent, MessageCatchUpEvent, IMessageMessage>({
     fetchMissed: (cursor) => catchUpEvents(client, cursor, isMessageEvent),
-    isRetryableError: isRetryableIMessageStreamError,
+    isCursorRejectedError: isCursorRejectedIMessageError,
+    label: streamLabel("messages", phone),
     processLive: (event) =>
       toMessageItem(client, event, phone, String(event.sequence), onInbound),
     processMissed: (event) =>
@@ -234,7 +228,8 @@ const pollStream = (
 ): ManagedStream<IMessageMessage> =>
   resumableOrderedStream<PollEvent, PollCatchUpEvent, IMessageMessage>({
     fetchMissed: (cursor) => catchUpEvents(client, cursor, isPollEvent),
-    isRetryableError: isRetryableIMessageStreamError,
+    isCursorRejectedError: isCursorRejectedIMessageError,
+    label: streamLabel("polls", phone),
     processLive: (event) =>
       toPollItem(client, pollCache, event, phone, String(event.sequence)),
     processMissed: (event) =>

--- a/packages/spectrum-ts/src/utils/resumable-stream.ts
+++ b/packages/spectrum-ts/src/utils/resumable-stream.ts
@@ -1,9 +1,16 @@
+import { createLogger } from "@photon-ai/otel";
 import { type ManagedStream, stream } from "./stream";
 
 export const CATCH_UP_PAGE_SIZE = 100;
 export const MAX_BUFFERED_LIVE_EVENTS = 1000;
 export const RECONNECT_INITIAL_DELAY_MS = 500;
 export const RECONNECT_MAX_DELAY_MS = 30_000;
+// After this many consecutive failures the reconnect log escalates from warn
+// to error so persistent causes (credential mismatch, dead proxy, DNS) surface
+// in telemetry while the stream keeps retrying.
+export const PERSISTENT_FAILURE_ERROR_THRESHOLD = 5;
+
+const log = createLogger("spectrum.stream");
 
 export interface CloseableAsyncIterable<T> extends AsyncIterable<T> {
   close?: () => Promise<void> | void;
@@ -27,7 +34,17 @@ export interface ResumableOrderedStreamOptions<TLive, TMissed, TOutput> {
     options: FetchMissedOptions
   ) => AsyncIterable<TMissed>;
   initialRetryDelayMs?: number;
-  isRetryableError: (error: unknown) => boolean;
+  /**
+   * Recognizes a `fetchMissed` failure that means the server rejected the
+   * resume cursor (e.g. it was pruned). The stream then drops the cursor,
+   * accepts the event gap, and resumes live. Only errors raised by the
+   * `fetchMissed` iteration itself are classified.
+   */
+  isCursorRejectedError?: (error: unknown) => boolean;
+  /** Maps a nominal retry delay to the actual sleep; injectable for tests. */
+  jitter?: (delayMs: number) => number;
+  /** Log provenance, e.g. "imessage.messages:+1555…". */
+  label?: string;
   maxRetryDelayMs?: number;
   processLive: (event: TLive) => Promise<ResumableStreamItem<TOutput>>;
   processMissed: (event: TMissed) => Promise<ResumableStreamItem<TOutput>>;
@@ -48,6 +65,15 @@ class LiveBufferOverflowError extends RetryableStreamError {
   }
 }
 
+// Sentinel for a server-rejected resume cursor: the only recovery is to drop
+// the cursor, accept the event gap, and resume live.
+class CursorRejectedError extends Error {
+  constructor(cause: unknown) {
+    super("Server rejected resume cursor", { cause });
+    this.name = "CursorRejectedError";
+  }
+}
+
 const closeIterable = async <T>(
   iterable: CloseableAsyncIterable<T> | undefined
 ): Promise<void> => {
@@ -59,7 +85,27 @@ const closeIterable = async <T>(
 
 const ignoreCleanupError = () => undefined;
 
-const jitterDelay = (delayMs: number): number => Math.random() * delayMs;
+// Equal jitter: a near-zero random draw must not defeat backoff during an
+// outage, so the floor is half the nominal delay.
+const jitterDelay = (delayMs: number): number =>
+  delayMs * (0.5 + Math.random() * 0.5);
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+// Classifies only rejections raised by `source` itself: errors thrown by the
+// consuming for-await body exit a `yield*` through return(), not this catch,
+// so a processMissed/live error can never masquerade as a cursor rejection.
+async function* throwOnCursorRejection<T>(
+  source: AsyncIterable<T>,
+  isCursorRejected: (error: unknown) => boolean
+): AsyncGenerator<T> {
+  try {
+    yield* source;
+  } catch (error) {
+    throw isCursorRejected(error) ? new CursorRejectedError(error) : error;
+  }
+}
 
 const numericCursor = (cursor: string | undefined): number | undefined => {
   if (!cursor) {
@@ -82,6 +128,13 @@ const isCursorRegression = (
   );
 };
 
+/**
+ * Wraps a live event stream with cursor-based catch-up and reconnects forever
+ * with capped, jittered exponential backoff — the stream never ends with an
+ * error. The only terminal events are `close()` and consumer disconnect. When
+ * the server rejects the resume cursor, the cursor is dropped and consumption
+ * falls back to live, accepting (and logging) the event gap.
+ */
 export const resumableOrderedStream = <TLive, TMissed, TOutput>(
   options: ResumableOrderedStreamOptions<TLive, TMissed, TOutput>
 ): ManagedStream<TOutput> =>
@@ -91,17 +144,25 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
     const initialRetryDelayMs =
       options.initialRetryDelayMs ?? RECONNECT_INITIAL_DELAY_MS;
     const maxRetryDelayMs = options.maxRetryDelayMs ?? RECONNECT_MAX_DELAY_MS;
+    const jitter = options.jitter ?? jitterDelay;
+    const label = options.label;
 
     let activeLive: CloseableAsyncIterable<TLive> | undefined;
     let closed = false;
+    let failedAttempts = 0;
     let lastCursor: string | undefined;
     let retryDelayMs = initialRetryDelayMs;
     let sleepTimer: ReturnType<typeof setTimeout> | undefined;
     let wakeSleep: (() => void) | undefined;
     const deliveredSinceCursor = new Set<string>();
 
-    const resetRetryDelay = () => {
+    const noteRecovery = () => {
       retryDelayMs = initialRetryDelayMs;
+      if (failedAttempts === 0) {
+        return;
+      }
+      log.info("stream recovered", { attempts: failedAttempts, label });
+      failedAttempts = 0;
     };
 
     const advanceCursor = (
@@ -135,12 +196,12 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
       advanceCursor(item.cursor, clearOnCursorAdvance);
       deliveredSinceCursor.add(item.id);
       if (resetRetry) {
-        resetRetryDelay();
+        noteRecovery();
       }
     };
 
-    const retryable = (error: unknown): boolean =>
-      error instanceof RetryableStreamError || options.isRetryableError(error);
+    const isCursorRejected = (error: unknown): boolean =>
+      options.isCursorRejectedError?.(error) === true;
 
     const sleep = async (delayMs: number): Promise<void> => {
       if (delayMs <= 0 || closed) {
@@ -148,7 +209,7 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
       }
       await new Promise<void>((resolve) => {
         wakeSleep = resolve;
-        sleepTimer = setTimeout(resolve, jitterDelay(delayMs));
+        sleepTimer = setTimeout(resolve, jitter(delayMs));
       });
       sleepTimer = undefined;
       wakeSleep = undefined;
@@ -167,6 +228,38 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
       const delay = retryDelayMs;
       retryDelayMs = Math.min(retryDelayMs * 2, maxRetryDelayMs);
       return delay;
+    };
+
+    const handleFailure = (error: unknown): number => {
+      failedAttempts += 1;
+      const delayMs = nextRetryDelay();
+      if (error instanceof CursorRejectedError) {
+        lastCursor = undefined;
+        deliveredSinceCursor.clear();
+        log.warn(
+          "resume cursor rejected; accepting event gap and resuming live",
+          {
+            attempt: failedAttempts,
+            delayMs,
+            error: errorMessage(error.cause),
+            label,
+          }
+        );
+        return delayMs;
+      }
+      const attrs = {
+        attempt: failedAttempts,
+        delayMs,
+        error: errorMessage(error),
+        hasCursor: lastCursor !== undefined,
+        label,
+      };
+      if (failedAttempts >= PERSISTENT_FAILURE_ERROR_THRESHOLD) {
+        log.error("stream persistently failing; still retrying", attrs, error);
+        return delayMs;
+      }
+      log.warn("stream interrupted; reconnecting", attrs);
+      return delayMs;
     };
 
     const consumeLive = async (): Promise<void> => {
@@ -228,9 +321,11 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
       cursor: string,
       getLiveError: () => unknown
     ) => {
-      for await (const event of options.fetchMissed(cursor, {
-        limit: catchUpPageSize,
-      })) {
+      const missed = throwOnCursorRejection(
+        options.fetchMissed(cursor, { limit: catchUpPageSize }),
+        isCursorRejected
+      );
+      for await (const event of missed) {
         throwLiveError(getLiveError());
         await deliverItem(await options.processMissed(event), false, false);
       }
@@ -239,8 +334,9 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
 
     const flushLiveBuffer = async (
       liveBuffer: TLive[],
-      getLiveError: () => unknown
-    ): Promise<string | undefined> => {
+      getLiveError: () => unknown,
+      stopBuffering: () => void
+    ): Promise<void> => {
       let index = 0;
       let lastFlushedId: string | undefined;
       // The live pump keeps appending while buffering remains true, and JS
@@ -259,7 +355,11 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
       }
       liveBuffer.length = 0;
       throwLiveError(getLiveError());
-      return lastFlushedId;
+      // Compact and stop buffering synchronously with the final emptiness
+      // check above — an await in between would let the pump buffer an event
+      // that nothing ever flushes (stranded and silently dropped).
+      compactDeliveredIds(lastFlushedId);
+      stopBuffering();
     };
 
     const compactDeliveredIds = (lastId: string | undefined) => {
@@ -280,13 +380,10 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
 
       try {
         await replayMissed(cursor, livePump.getError);
-        const lastFlushedId = await flushLiveBuffer(
-          liveBuffer,
-          livePump.getError
-        );
-        compactDeliveredIds(lastFlushedId);
-        buffering = false;
-        resetRetryDelay();
+        await flushLiveBuffer(liveBuffer, livePump.getError, () => {
+          buffering = false;
+        });
+        noteRecovery();
 
         await livePump.pump;
         throwLiveError(livePump.getError());
@@ -309,22 +406,22 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
             await consumeLive();
           }
         } catch (error) {
-          await closeIterable(activeLive);
+          await closeIterable(activeLive).catch(ignoreCleanupError);
           activeLive = undefined;
           if (closed) {
             break;
           }
-          if (!retryable(error)) {
-            end(error);
-            return;
-          }
-          await sleep(nextRetryDelay());
+          await sleep(handleFailure(error));
         }
       }
       end();
     };
 
+    // Defensive invariant: run() retries everything internally, so this catch
+    // should be unreachable — if it ever fires, fail loudly instead of dying
+    // in silence.
     const pump = run().catch((error) => {
+      log.error("resumable stream loop crashed", { label }, error);
       if (!closed) {
         end(error);
       }

--- a/packages/spectrum-ts/test/utils/resumable-stream.test.ts
+++ b/packages/spectrum-ts/test/utils/resumable-stream.test.ts
@@ -1,0 +1,408 @@
+import { describe, expect, it } from "bun:test";
+import { flush, withinMs } from "@test/support/timing";
+import {
+  type CloseableAsyncIterable,
+  PERSISTENT_FAILURE_ERROR_THRESHOLD,
+  type ResumableStreamItem,
+  resumableOrderedStream,
+} from "@/utils/resumable-stream";
+
+type Item = ResumableStreamItem<string>;
+
+class FakeCursorError extends Error {
+  constructor() {
+    super("unknown cursor");
+    this.name = "FakeCursorError";
+  }
+}
+
+const isFakeCursorError = (error: unknown): boolean =>
+  error instanceof FakeCursorError;
+
+const item = (id: string, value: string): Item => ({
+  cursor: id,
+  id,
+  values: [value],
+});
+
+const gate = () => {
+  let open: () => void = () => undefined;
+  const opened = new Promise<void>((resolve) => {
+    open = resolve;
+  });
+  return { open, opened };
+};
+
+// Scripted live session: yields `events`, then throws, ends naturally, or
+// parks until close() (mirroring a gRPC stream that settles when aborted).
+const liveSession = (
+  events: Item[],
+  outcome: "throw" | "end" | "pending",
+  error?: () => unknown
+): CloseableAsyncIterable<Item> => {
+  const parked = gate();
+  return {
+    async *[Symbol.asyncIterator]() {
+      yield* events;
+      if (outcome === "throw") {
+        throw error?.() ?? new Error("live drop");
+      }
+      if (outcome === "pending") {
+        await parked.opened;
+      }
+    },
+    close: () => parked.open(),
+  };
+};
+
+const emptyCatchUp = async function* (): AsyncGenerator<Item> {
+  // no missed events
+};
+
+// A source whose first pull fails (optionally after `ready` resolves) — a
+// plain iterator object because a yield-less generator trips lint useYield.
+const failingSource = (
+  makeError: () => unknown,
+  ready: Promise<void> = Promise.resolve()
+): CloseableAsyncIterable<Item> => ({
+  [Symbol.asyncIterator]: () => ({
+    next: async () => {
+      await ready;
+      throw makeError();
+    },
+  }),
+});
+
+interface FixtureConfig {
+  bufferLimit?: number;
+  fetchMissed?: (call: number, cursor: string) => AsyncIterable<Item>;
+  initialRetryDelayMs?: number;
+  isCursorRejectedError?: (error: unknown) => boolean;
+  jitter?: (delayMs: number) => number;
+  live: (
+    call: number,
+    cursor: string | undefined
+  ) => CloseableAsyncIterable<Item>;
+  maxRetryDelayMs?: number;
+  processMissed?: (event: Item) => Promise<Item>;
+}
+
+const buildStream = (config: FixtureConfig) => {
+  const delays: number[] = [];
+  const liveCalls: (string | undefined)[] = [];
+  const fetchCalls: string[] = [];
+  const received: string[] = [];
+
+  const source = resumableOrderedStream<Item, Item, string>({
+    bufferLimit: config.bufferLimit,
+    fetchMissed: (cursor) => {
+      fetchCalls.push(cursor);
+      return (config.fetchMissed ?? (() => emptyCatchUp()))(
+        fetchCalls.length,
+        cursor
+      );
+    },
+    initialRetryDelayMs: config.initialRetryDelayMs ?? 1,
+    isCursorRejectedError: config.isCursorRejectedError,
+    jitter:
+      config.jitter ??
+      ((delayMs) => {
+        delays.push(delayMs);
+        return 0;
+      }),
+    maxRetryDelayMs: config.maxRetryDelayMs ?? 8,
+    processLive: (event) => Promise.resolve(event),
+    processMissed: config.processMissed ?? ((event) => Promise.resolve(event)),
+    subscribeLive: (cursor) => {
+      liveCalls.push(cursor);
+      return config.live(liveCalls.length, cursor);
+    },
+  });
+
+  const ended = (async () => {
+    try {
+      for await (const value of source) {
+        received.push(value);
+      }
+      return "done" as const;
+    } catch {
+      return "error" as const;
+    }
+  })();
+
+  return {
+    close: () => source.close(),
+    delays,
+    ended,
+    fetchCalls,
+    liveCalls,
+    received,
+  };
+};
+
+// Yields through the timer queue (not just the check phase) so the stream's
+// jittered setTimeout backoff sleeps get a chance to fire between turns.
+const waitUntil = async (condition: () => boolean): Promise<void> => {
+  const maxTurns = 500;
+  for (let turn = 0; turn < maxTurns && !condition(); turn += 1) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+  if (!condition()) {
+    throw new Error("waitUntil: condition not met");
+  }
+};
+
+describe("resumableOrderedStream", () => {
+  it("reconnects through catch-up after a transient live error without duplicates", async () => {
+    const fx = buildStream({
+      fetchMissed: () =>
+        (async function* (): AsyncGenerator<Item> {
+          yield item("2", "v2"); // replay of the already-delivered event
+          yield item("3", "v3");
+        })(),
+      live: (call) =>
+        call === 1
+          ? liveSession([item("1", "v1"), item("2", "v2")], "throw")
+          : liveSession([item("4", "v4")], "pending"),
+    });
+
+    await waitUntil(() => fx.received.includes("v4"));
+    expect(fx.received).toEqual(["v1", "v2", "v3", "v4"]);
+    expect(fx.liveCalls).toEqual([undefined, "2"]);
+    expect(fx.fetchCalls).toEqual(["2"]);
+    expect(fx.delays).toEqual([1]);
+    await fx.close();
+    expect(await fx.ended).toBe("done");
+  });
+
+  it("drops the cursor and resumes live when catch-up rejects it", async () => {
+    const fx = buildStream({
+      fetchMissed: () => failingSource(() => new FakeCursorError()),
+      isCursorRejectedError: isFakeCursorError,
+      live: (call) => {
+        if (call === 1) {
+          return liveSession([item("1", "v1"), item("2", "v2")], "throw");
+        }
+        if (call === 2) {
+          return liveSession([], "pending");
+        }
+        // Reuses a previously delivered id: must be re-delivered because the
+        // dedup state is cleared along with the rejected cursor.
+        return liveSession(
+          [{ cursor: "9", id: "2", values: ["v2-again"] }],
+          "pending"
+        );
+      },
+    });
+
+    await waitUntil(() => fx.received.includes("v2-again"));
+    expect(fx.received).toEqual(["v1", "v2", "v2-again"]);
+    expect(fx.liveCalls).toEqual([undefined, "2", undefined]);
+    expect(fx.fetchCalls).toEqual(["2"]);
+    await fx.close();
+    expect(await fx.ended).toBe("done");
+  });
+
+  it("keeps the cursor when a live error matches the cursor-rejection predicate", async () => {
+    const fx = buildStream({
+      isCursorRejectedError: isFakeCursorError,
+      live: (call) =>
+        call === 1
+          ? liveSession([item("1", "v1")], "throw", () => new FakeCursorError())
+          : liveSession([], "pending"),
+    });
+
+    await waitUntil(() => fx.fetchCalls.length === 1);
+    expect(fx.fetchCalls).toEqual(["1"]);
+    expect(fx.liveCalls).toEqual([undefined, "1"]);
+    await fx.close();
+    expect(await fx.ended).toBe("done");
+  });
+
+  it("keeps the cursor when the catch-up live pump fails with a predicate-matching error", async () => {
+    const gateLive = gate();
+    const gateFetch = gate();
+    const fx = buildStream({
+      fetchMissed: (call) =>
+        call === 1
+          ? (async function* (): AsyncGenerator<Item> {
+              yield item("2", "v2");
+              await gateFetch.opened;
+              yield item("3", "v3");
+            })()
+          : emptyCatchUp(),
+      isCursorRejectedError: isFakeCursorError,
+      live: (call) => {
+        if (call === 1) {
+          return liveSession([item("1", "v1")], "throw");
+        }
+        if (call === 2) {
+          return failingSource(() => new FakeCursorError(), gateLive.opened);
+        }
+        return liveSession([], "pending");
+      },
+    });
+
+    await waitUntil(() => fx.received.includes("v2"));
+    gateLive.open();
+    await flush();
+    gateFetch.open();
+    await waitUntil(() => fx.liveCalls.length === 3);
+    // The live error surfaced mid-replay must not clear the cursor, which has
+    // already advanced past the replayed event.
+    expect(fx.liveCalls).toEqual([undefined, "1", "2"]);
+    expect(fx.fetchCalls).toEqual(["1", "2"]);
+    await fx.close();
+    expect(await fx.ended).toBe("done");
+  });
+
+  it("does not treat processMissed failures as cursor rejection", async () => {
+    let processCalls = 0;
+    const fx = buildStream({
+      fetchMissed: () =>
+        (async function* (): AsyncGenerator<Item> {
+          yield item("2", "v2");
+        })(),
+      isCursorRejectedError: isFakeCursorError,
+      live: (call) =>
+        call === 1
+          ? liveSession([item("1", "v1")], "throw")
+          : liveSession([], "pending"),
+      processMissed: (event) => {
+        processCalls += 1;
+        if (processCalls === 1) {
+          return Promise.reject(new FakeCursorError());
+        }
+        return Promise.resolve(event);
+      },
+    });
+
+    await waitUntil(() => fx.received.includes("v2"));
+    expect(fx.fetchCalls).toEqual(["1", "1"]);
+    expect(fx.received).toEqual(["v1", "v2"]);
+    await fx.close();
+    expect(await fx.ended).toBe("done");
+  });
+
+  it("never ends the stream on persistent errors", async () => {
+    let attempts = 0;
+    const fx = buildStream({
+      live: () => {
+        attempts += 1;
+        return failingSource(() => new Error("unauthenticated"));
+      },
+    });
+
+    await waitUntil(() => attempts >= PERSISTENT_FAILURE_ERROR_THRESHOLD + 2);
+    expect(await withinMs(fx.ended, 20)).toBe("timeout");
+    await fx.close();
+    expect(await fx.ended).toBe("done");
+  });
+
+  it("doubles the delay to the cap and resets after recovery", async () => {
+    const fx = buildStream({
+      live: (call) => {
+        if (call <= 5) {
+          return liveSession([], "throw");
+        }
+        if (call === 6) {
+          return liveSession([item("1", "v1")], "throw");
+        }
+        return liveSession([], "pending");
+      },
+    });
+
+    await waitUntil(() => fx.delays.length === 6);
+    expect(fx.delays).toEqual([1, 2, 4, 8, 8, 1]);
+    await fx.close();
+    expect(await fx.ended).toBe("done");
+  });
+
+  it("close() interrupts a long backoff sleep promptly", async () => {
+    const fx = buildStream({
+      initialRetryDelayMs: 60_000,
+      jitter: (delayMs) => delayMs,
+      live: () => liveSession([], "throw"),
+      maxRetryDelayMs: 60_000,
+    });
+
+    await waitUntil(() => fx.liveCalls.length === 1);
+    await flush();
+    expect(await withinMs(fx.close(), 200)).toBe("resolved");
+    expect(await fx.ended).toBe("done");
+  });
+
+  it("close() during catch-up replay ends cleanly", async () => {
+    const fx = buildStream({
+      fetchMissed: () =>
+        (async function* (): AsyncGenerator<Item> {
+          let next = 2;
+          for (;;) {
+            yield item(String(next), `v${next}`);
+            next += 1;
+            await flush();
+          }
+        })(),
+      live: (call) =>
+        call === 1
+          ? liveSession([item("1", "v1")], "throw")
+          : liveSession([], "pending"),
+    });
+
+    await waitUntil(() => fx.received.length >= 5);
+    expect(await withinMs(fx.close(), 200)).toBe("resolved");
+    expect(await fx.ended).toBe("done");
+  });
+
+  it("recovers from live-buffer overflow during catch-up", async () => {
+    const gateFetch = gate();
+    const fx = buildStream({
+      bufferLimit: 1,
+      fetchMissed: (call) =>
+        call === 1
+          ? (async function* (): AsyncGenerator<Item> {
+              await gateFetch.opened;
+              yield item("2", "v2");
+            })()
+          : emptyCatchUp(),
+      live: (call) => {
+        if (call === 1) {
+          return liveSession([item("1", "v1")], "throw");
+        }
+        if (call === 2) {
+          return liveSession([item("2", "v2"), item("3", "v3")], "pending");
+        }
+        return liveSession([item("4", "v4")], "pending");
+      },
+    });
+
+    await waitUntil(() => fx.liveCalls.length === 2);
+    await flush();
+    gateFetch.open();
+    await waitUntil(() => fx.received.includes("v4"));
+    expect(fx.liveCalls).toEqual([undefined, "1", "1"]);
+    expect(fx.fetchCalls).toEqual(["1", "1"]);
+    await fx.close();
+    expect(await fx.ended).toBe("done");
+  });
+
+  it("reconnects with catch-up after the live stream ends naturally", async () => {
+    const fx = buildStream({
+      fetchMissed: () =>
+        (async function* (): AsyncGenerator<Item> {
+          yield item("2", "v2");
+        })(),
+      live: (call) =>
+        call === 1
+          ? liveSession([item("1", "v1")], "end")
+          : liveSession([], "pending"),
+    });
+
+    await waitUntil(() => fx.received.includes("v2"));
+    expect(fx.liveCalls).toEqual([undefined, "1"]);
+    expect(fx.fetchCalls).toEqual(["1"]);
+    expect(fx.delays).toEqual([1]);
+    await fx.close();
+    expect(await fx.ended).toBe("done");
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause (ENG-1566):** An invalid/pruned resume cursor causes the proxy to return `INVALID_ARGUMENT`, which the client surfaces as `ValidationError`. The old `isRetryableError` classified this as non-retryable (fatal), permanently killing the stream with no recovery.
- **Fix:** Replace `isRetryableError` with `isCursorRejectedError` — when the server rejects the cursor during `fetchMissed`, the stream clears the cursor, accepts the event gap, and falls back to live consumption instead of dying.
- **Key invariant:** Cursor-rejection detection is scoped strictly to errors thrown by `fetchMissed` itself; errors from `processMissed`/`processLive` cannot masquerade as cursor rejections (via `throwOnCursorRejection` wrapper).

## Changes

### `packages/spectrum-ts/src/utils/resumable-stream.ts`
- Removed `isRetryableError` option; all errors are now retried — stream never terminates on error
- Added `isCursorRejectedError` option: cursor-rejection drops the cursor + dedup state and resumes live
- Added `label` option for log provenance
- Added `jitter` option (injectable for tests); improved jitter to equal-jitter (floor at 50% of nominal delay so slow starts can't produce near-zero sleeps)
- Added structured logging via `createLogger("spectrum.stream")`: warn on transient failures, error after `PERSISTENT_FAILURE_ERROR_THRESHOLD` (5) consecutive failures
- Fixed `flushLiveBuffer`: moved `compactDeliveredIds` + `buffering = false` into the flush itself to close a race where an `await` between the empty-check and the flag-clear could let the live pump buffer an event that nothing flushes
- Added `CursorRejectedError` sentinel class to safely classify rejections without leaking the predicate into consumer code

### `packages/spectrum-ts/src/providers/imessage/remote/stream.ts`
- Replaced `isRetryableIMessageStreamError` with `isCursorRejectedIMessageError` (`ValidationError` → cursor rejected)
- Added `label` via `streamLabel()` using `sanitizePhone` from `@photon-ai/otel`

### `packages/spectrum-ts/test/utils/resumable-stream.test.ts` (new)
- 11 tests covering: reconnect with dedup, cursor-rejection drop + dedup-state clear, cursor-rejection predicate scoped to fetchMissed only, processMissed errors not treated as cursor rejection, never-fatal on persistent errors, backoff + reset, close() interrupts sleep, close() during catch-up, live-buffer overflow recovery, natural stream end reconnect

## Test plan

- [ ] `bun test packages/spectrum-ts/test/utils/resumable-stream.test.ts` — all 11 tests pass
- [ ] `bun x ultracite check` — no lint/format issues
- [ ] Deploy to a macrocosm farm user and verify iMessage stream survives a cursor prune (previously caused silent permanent death)
- [ ] Confirm `stream interrupted; reconnecting` warn logs appear on transient drops and `stream recovered` appears on reconnect

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783759638&installation_id=127326493&pr_number=120&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F120&signature=d87b0bef9a42b961bbeaf6222e4fb8e5b67b51e9d172868e5cb2756fd9e9dd05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cursor rejection handling in iMessage streams with proper server recovery.
  * Enhanced reconnection behavior with refined exponential backoff logic during network failures.
  * Better error classification and logging for persistent stream failures.
  * Eliminated duplicate message delivery during stream reconnection and recovery.

* **Tests**
  * Added comprehensive test coverage for stream reconnection scenarios and cursor rejection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->