### PR TITLE
fix(ENG-1569): propagate direction on reaction targets so outbound messages expose edit affordance

### DIFF
--- a/packages/spectrum-ts/src/platform/build.ts
+++ b/packages/spectrum-ts/src/platform/build.ts
@@ -433,6 +433,7 @@ export interface BuildSpaceParams {
 // is platform-specific extras (e.g. `partIndex` for iMessage).
 export const providerMessageCoreKeys: ReadonlySet<string> = new Set([
   "content",
+  "direction",
   "id",
   "sender",
   "space",
@@ -461,12 +462,22 @@ const extractExtras = (
   ) as Record<string, unknown>;
 };
 
+const rawDirection = (
+  raw: ProviderMessageRecord
+): "inbound" | "outbound" | undefined =>
+  raw.direction === "inbound" || raw.direction === "outbound"
+    ? raw.direction
+    : undefined;
+
 /**
  * Wrap a raw provider message record (and any nested raw targets/items inside
  * its content) into a fully-built `Message`. The same path serves inbound
  * (`messages`, `actions.getMessage`) and outbound (`send`) flows — the only
  * difference is `direction`, which decides whether the resulting Message
- * exposes inbound (`react`/`reply`) or outbound (`edit`) affordances.
+ * exposes inbound (`react`/`reply`) or outbound (`edit`) affordances. A raw
+ * record can carry its own `direction` when the provider knows better than the
+ * wrapping context, which matters for inbound reactions targeting outbound
+ * messages.
  * Recursion through `wrapNestedContent` handles reaction targets and group
  * items, which providers return as nested raw records.
  */
@@ -475,7 +486,12 @@ export function wrapProviderMessage(
   ctx: WrapContext,
   direction: "inbound" | "outbound"
 ): Message {
-  const wrappedContent = wrapNestedContent(raw.content, ctx, direction);
+  const effectiveDirection = rawDirection(raw) ?? direction;
+  const wrappedContent = wrapNestedContent(
+    raw.content,
+    ctx,
+    effectiveDirection
+  );
   const base = {
     id: raw.id,
     content: wrappedContent,
@@ -493,7 +509,7 @@ export function wrapProviderMessage(
   // `Message.sender` is `| undefined` and `buildMessage` maps a missing sender to
   // `undefined`, so senderless inbound is allowed rather than rejected. The
   // branch keeps `direction` a literal so it narrows BuildMessageParams.
-  if (direction === "inbound") {
+  if (effectiveDirection === "inbound") {
     return buildMessage({ ...base, sender: raw.sender, direction: "inbound" });
   }
   return buildMessage({ ...base, sender: raw.sender, direction: "outbound" });
@@ -507,13 +523,9 @@ const wrapNestedContent = (
   if (content.type === "reaction") {
     const target = content.target as unknown;
     if (isRawProviderRecord(target)) {
-      // Reaction targets are always wrapped as "inbound": the target refers to
-      // the original received message, not the reaction event itself. So even
-      // when the wrapping reaction is outbound (e.g. our own reaction sent via
-      // `space.send(reaction(...))`), the *target* it points at is a message
-      // we received. This differs from `group.items`, which propagate the
-      // wrapping direction because each item is itself one piece of the same
-      // send.
+      // Most providers can only synthesize an inbound target stub for reaction
+      // events. Providers that can resolve the real target may set
+      // `target.direction`, and wrapProviderMessage will honor it.
       return {
         ...content,
         target: wrapProviderMessage(target, ctx, "inbound"),

--- a/packages/spectrum-ts/src/platform/types.ts
+++ b/packages/spectrum-ts/src/platform/types.ts
@@ -169,6 +169,7 @@ export type ProviderMessage<
 export type ProviderMessageRecord = {
   id: string;
   content: Content;
+  direction?: "inbound" | "outbound";
   sender?: { id: string } & Record<string, unknown>;
   space: { id: string } & Record<string, unknown>;
   timestamp?: Date;

--- a/packages/spectrum-ts/src/providers/imessage/index.ts
+++ b/packages/spectrum-ts/src/providers/imessage/index.ts
@@ -1,4 +1,8 @@
-import { createClient, MessageEffect } from "@photon-ai/advanced-imessage";
+import {
+  type AdvancedIMessage,
+  createClient,
+  MessageEffect,
+} from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
 import { withSpan } from "@photon-ai/otel";
 import type { Attachment } from "../../content/attachment";
@@ -25,6 +29,7 @@ export { effect, type IMessageMessageEffect } from "./content/effect";
 export { read } from "./content/read";
 
 import { createCloudClients, disposeCloudAuth } from "./auth";
+import { getMessageCache } from "./cache";
 import {
   type Background,
   type BackgroundInput,
@@ -67,6 +72,7 @@ import {
   randomPhone,
 } from "./remote/client";
 import { chatTypeFromGuid, dmChatGuid } from "./remote/ids";
+import { cacheMessage } from "./remote/inbound";
 import {
   configSchema,
   type IMessageClient,
@@ -80,6 +86,27 @@ import {
 
 const isPollContent = (content: { type: string }): boolean =>
   content.type === "poll" || content.type === "poll_option";
+
+const cacheRemoteOutbound = <T extends ProviderMessageRecord | undefined>(
+  remote: AdvancedIMessage,
+  space: { id: string; phone: string; type: "dm" | "group" },
+  record: T
+): T => {
+  if (!record) {
+    return record;
+  }
+  cacheMessage(getMessageCache(remote), {
+    ...record,
+    direction: record.direction ?? "outbound",
+    space: {
+      ...record.space,
+      id: record.space.id,
+      phone: space.phone,
+      type: space.type,
+    },
+  } as IMessageMessage);
+  return record;
+};
 
 const handleEdit = async (
   client: IMessageClient,
@@ -138,7 +165,7 @@ const handleUnsend = async (
 
 const handleStreamText = async (
   client: IMessageClient,
-  space: { id: string; phone: string },
+  space: { id: string; phone: string; type: "dm" | "group" },
   content: StreamText
 ): Promise<ProviderMessageRecord> => {
   if (isLocal(client)) {
@@ -149,7 +176,11 @@ const handleStreamText = async (
     );
   }
   const remote = clientForPhone(client, space.phone);
-  return await remoteSendStreamText(remote, space.id, content);
+  return cacheRemoteOutbound(
+    remote,
+    space,
+    await remoteSendStreamText(remote, space.id, content)
+  );
 };
 
 const handleBackground = async (
@@ -170,7 +201,7 @@ const handleBackground = async (
 
 const handleCustomizedMiniApp = async (
   client: IMessageClient,
-  space: { id: string; phone: string },
+  space: { id: string; phone: string; type: "dm" | "group" },
   content: CustomizedMiniApp
 ): Promise<ProviderMessageRecord> => {
   if (isLocal(client)) {
@@ -181,7 +212,11 @@ const handleCustomizedMiniApp = async (
     );
   }
   const remote = clientForPhone(client, space.phone);
-  return await remoteSendCustomizedMiniApp(remote, space.id, content);
+  return cacheRemoteOutbound(
+    remote,
+    space,
+    await remoteSendCustomizedMiniApp(remote, space.id, content)
+  );
 };
 
 const handleRead = async (
@@ -452,11 +487,15 @@ export const imessage = definePlatform("iMessage", {
         );
       }
       const remote = clientForPhone(client, space.phone);
-      return await remoteReplyToMessage(
+      return cacheRemoteOutbound(
         remote,
-        space.id,
-        content.target.id,
-        content.content
+        space,
+        await remoteReplyToMessage(
+          remote,
+          space.id,
+          content.target.id,
+          content.content
+        )
       );
     }
     if (content.type === "reaction") {
@@ -474,11 +513,15 @@ export const imessage = definePlatform("iMessage", {
       // `content.target` is statically typed as the generic `Message`, but
       // execution only reaches this iMessage `send` action when the target
       // came from the iMessage stream — hence the unknown-cast widen.
-      return await remoteReactToMessage(
+      return cacheRemoteOutbound(
         remote,
-        space.id,
-        content.target as unknown as IMessageMessage,
-        content.emoji
+        space,
+        await remoteReactToMessage(
+          remote,
+          space.id,
+          content.target as unknown as IMessageMessage,
+          content.emoji
+        )
       );
     }
     if (content.type === "typing") {
@@ -525,7 +568,11 @@ export const imessage = definePlatform("iMessage", {
       return await localSend(client, space.id, content);
     }
     const remote = clientForPhone(client, space.phone);
-    return await remoteSend(remote, space.id, content);
+    return cacheRemoteOutbound(
+      remote,
+      space,
+      await remoteSend(remote, space.id, content)
+    );
   },
 
   actions: {

--- a/packages/spectrum-ts/src/providers/imessage/remote/customized-mini-app.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/customized-mini-app.ts
@@ -23,6 +23,7 @@ export const sendCustomizedMiniApp = async (
   return {
     id: message.guid,
     content: content as unknown as Content,
+    direction: "outbound",
     space: { id: spaceId },
     timestamp: message.dateCreated,
   };

--- a/packages/spectrum-ts/src/providers/imessage/remote/inbound.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/inbound.ts
@@ -65,8 +65,6 @@ export const isIMessageMessage = (value: unknown): value is IMessageMessage => {
     record.id.length > 0 &&
     typeof record.content === "object" &&
     record.content !== null &&
-    typeof record.sender === "object" &&
-    record.sender !== null &&
     typeof record.space === "object" &&
     record.space !== null
   );
@@ -83,6 +81,7 @@ export const buildMessageBase = (
 ): RemoteMessageBase => {
   const chat = resolveChatGuid(message, chatGuidHint);
   return {
+    direction: message.isFromMe ? "outbound" : "inbound",
     sender: { id: resolveSenderId(message) },
     space: {
       id: chat,

--- a/packages/spectrum-ts/src/providers/imessage/remote/reactions.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/reactions.ts
@@ -171,6 +171,7 @@ export const reactToMessage = async (
   return {
     id: sent.guid,
     content: asProviderReaction(reaction, target),
+    direction: "outbound",
     space: { id: spaceId },
     timestamp: sent.dateCreated,
   };

--- a/packages/spectrum-ts/src/providers/imessage/remote/send.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/send.ts
@@ -54,6 +54,7 @@ const outboundRecord = (
 ): ProviderMessageRecord => ({
   id,
   content,
+  direction: "outbound",
   space: { id: spaceId },
   timestamp,
   ...extras,

--- a/packages/spectrum-ts/src/providers/imessage/remote/stream-text.ts
+++ b/packages/spectrum-ts/src/providers/imessage/remote/stream-text.ts
@@ -103,6 +103,7 @@ export const sendStreamText = async (
   return {
     id: sent.guid,
     content: asText(full),
+    direction: "outbound",
     space: { id: spaceId },
     timestamp: sent.dateCreated,
   };

--- a/packages/spectrum-ts/src/providers/imessage/types.ts
+++ b/packages/spectrum-ts/src/providers/imessage/types.ts
@@ -62,6 +62,7 @@ export type IMessageMessage = SchemaMessage<
   typeof userSchema,
   typeof spaceSchema
 > & {
+  direction?: "inbound" | "outbound";
   partIndex?: number;
   parentId?: string;
 };

--- a/packages/spectrum-ts/test/core/send-reaction.test.ts
+++ b/packages/spectrum-ts/test/core/send-reaction.test.ts
@@ -2,11 +2,12 @@ import { describe, expect, it } from "bun:test";
 import { stubCloud } from "@test/support/cloud";
 import { baseConfig, makeQueue, record } from "@test/support/platform";
 import z from "zod";
-import { reaction } from "@/content/reaction";
+import { asReaction, reaction } from "@/content/reaction";
 import type { Content } from "@/content/types";
 import { definePlatform } from "@/platform/define";
 import type { ProviderMessage, ProviderMessageRecord } from "@/platform/types";
 import { Spectrum } from "@/spectrum";
+import type { Message } from "@/types/message";
 import { UnsupportedError } from "@/utils/errors";
 
 stubCloud();
@@ -146,6 +147,88 @@ describe("reaction sends return a Message", () => {
     try {
       const [, message] = await firstMessage(app);
       await expect(message.react("👍")).rejects.toThrow(NO_MESSAGE_ID);
+    } finally {
+      await app.stop();
+    }
+  });
+});
+
+describe("inbound reaction target direction", () => {
+  const makeInboundReactionProvider = (
+    name: string,
+    target: ProviderMessageRecord
+  ) => {
+    const queue = makeQueue<ProviderMessage<{ id: string }, { id: string }>>();
+    queue.push({
+      id: "reaction-1",
+      content: asReaction({
+        emoji: "👍",
+        target: target as unknown as Message,
+      }),
+      sender: { id: "u1" },
+      space: { id: "s1" },
+      timestamp: REACTION_TIMESTAMP,
+    });
+    queue.close();
+    return definePlatform(name, {
+      config: z.object({}),
+      lifecycle: {
+        createClient: () => Promise.resolve({}),
+      },
+      user: { resolve: ({ input }) => Promise.resolve({ id: input.userID }) },
+      space: {
+        create: ({ input }) =>
+          Promise.resolve({ id: input.users[0]?.id ?? "s1" }),
+      },
+      messages: () => queue.iter,
+      send: () => Promise.resolve(undefined),
+    });
+  };
+
+  it("honors a provider-supplied outbound direction on a raw reaction target", async () => {
+    const provider = makeInboundReactionProvider("react-target-outbound", {
+      id: "bot-message",
+      content: { type: "text", text: "from the bot" },
+      direction: "outbound",
+      space: { id: "s1" },
+      timestamp: new Date(0),
+    });
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [, message] = await firstMessage(app);
+
+      expect(message.direction).toBe("inbound");
+      expect(message.content.type).toBe("reaction");
+      if (message.content.type === "reaction") {
+        expect(message.content.target.direction).toBe("outbound");
+        expect(message.content.target.id).toBe("bot-message");
+      }
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("keeps the legacy inbound fallback when a raw reaction target has no direction", async () => {
+    const provider = makeInboundReactionProvider("react-target-fallback", {
+      id: "unknown-message",
+      content: { type: "text", text: "unknown owner" },
+      space: { id: "s1" },
+      timestamp: new Date(0),
+    });
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [, message] = await firstMessage(app);
+
+      expect(message.content.type).toBe("reaction");
+      if (message.content.type === "reaction") {
+        expect(message.content.target.direction).toBe("inbound");
+      }
     } finally {
       await app.stop();
     }

--- a/packages/spectrum-ts/test/providers/_imessage/remote/reactions.test.ts
+++ b/packages/spectrum-ts/test/providers/_imessage/remote/reactions.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it, mock } from "bun:test";
 import type {
   AdvancedIMessage,
+  MessageEvent,
   Message as SDKMessage,
   SettableMessageReaction,
 } from "@photon-ai/advanced-imessage";
-import { reactToMessage } from "@/providers/imessage/remote/reactions";
+import { text } from "@/content/text";
+import { imessage } from "@/providers/imessage";
+import { getMessageCache, MessageCache } from "@/providers/imessage/cache";
+import {
+  reactToMessage,
+  toReactionMessages,
+} from "@/providers/imessage/remote/reactions";
 import type { IMessageMessage } from "@/providers/imessage/types";
 
 const SENT_DATE = new Date(1_700_000_000_000);
@@ -38,6 +45,45 @@ const target = (overrides: Partial<IMessageMessage> = {}): IMessageMessage =>
     timestamp: new Date(0),
     ...overrides,
   }) as unknown as IMessageMessage;
+
+async function* fromArray(items: string[]): AsyncIterable<string> {
+  for (const item of items) {
+    yield item;
+  }
+}
+
+const sdkMessage = (overrides: Partial<SDKMessage> = {}): SDKMessage =>
+  ({
+    guid: "msg-guid",
+    chatGuids: ["s1"],
+    content: {
+      attachments: [],
+      formatting: [],
+      mentions: [],
+      text: "from the bot",
+    },
+    dateCreated: SENT_DATE,
+    isFromMe: true,
+    sender: { address: "+15551234567" },
+    ...overrides,
+  }) as unknown as SDKMessage;
+
+const reactionEvent = (
+  overrides: Partial<
+    Extract<MessageEvent, { type: "message.reactionAdded" }>
+  > = {}
+): Extract<MessageEvent, { type: "message.reactionAdded" }> =>
+  ({
+    actor: { address: "user@example.com" },
+    chatGuid: "s1",
+    isFromMe: false,
+    messageGuid: "msg-guid",
+    occurredAt: SENT_DATE,
+    reaction: { kind: "like" },
+    sequence: 1,
+    type: "message.reactionAdded",
+    ...overrides,
+  }) as unknown as Extract<MessageEvent, { type: "message.reactionAdded" }>;
 
 describe("iMessage remote reactToMessage", () => {
   it("maps a native tapback emoji and returns the tapback record", async () => {
@@ -77,5 +123,80 @@ describe("iMessage remote reactToMessage", () => {
     const [, message, , , options] = setReaction.mock.calls[0] ?? [];
     expect(message).toContain("parent-guid");
     expect(options).toEqual({ partIndex: 2 });
+  });
+});
+
+describe("iMessage remote toReactionMessages", () => {
+  it("marks a fetched self-authored reaction target as outbound", async () => {
+    const get = mock((_message: string) => Promise.resolve(sdkMessage()));
+    const remote = {
+      messages: { get },
+    } as unknown as AdvancedIMessage;
+
+    const messages = await toReactionMessages(
+      remote,
+      new MessageCache(),
+      reactionEvent(),
+      "+15551234567"
+    );
+
+    expect(messages).toHaveLength(1);
+    const message = messages[0];
+    expect(message?.content.type).toBe("reaction");
+    if (message?.content.type === "reaction") {
+      expect(message.content.target.direction).toBe("outbound");
+      expect(message.content.target.id).toBe("msg-guid");
+    }
+  });
+
+  it("resolves tapbacks on a just-sent streamText message from the outbound cache", async () => {
+    const sent = sdkMessage({ guid: "outbound-stream-guid" });
+    const sendText = mock((_chat: string, _text: string) =>
+      Promise.resolve(sent)
+    );
+    const edit = mock((_chat: string, _guid: string, _text: string) =>
+      Promise.resolve(sent)
+    );
+    const get = mock((_message: string) =>
+      Promise.reject(new Error("message API has not caught up"))
+    );
+    const remote = {
+      messages: { edit, get, sendText },
+    } as unknown as AdvancedIMessage;
+    const send = imessage.config().__definition.send;
+
+    const record = await send({
+      client: [{ client: remote, phone: "+15551234567" }],
+      content: await text(fromArray(["hello"])).build(),
+      space: {
+        __platform: "iMessage",
+        id: "s1",
+        phone: "+15551234567",
+        type: "dm",
+      },
+    });
+
+    expect(record?.id).toBe("outbound-stream-guid");
+    expect(sendText).toHaveBeenCalledTimes(1);
+
+    const messages = await toReactionMessages(
+      remote,
+      getMessageCache(remote),
+      reactionEvent({ messageGuid: "outbound-stream-guid" }),
+      "+15551234567"
+    );
+
+    expect(get).not.toHaveBeenCalled();
+    expect(messages).toHaveLength(1);
+    const message = messages[0];
+    expect(message?.content.type).toBe("reaction");
+    if (message?.content.type === "reaction") {
+      expect(message.content.target.direction).toBe("outbound");
+      expect(message.content.target.id).toBe("outbound-stream-guid");
+      expect(message.content.target.content).toEqual({
+        text: "hello",
+        type: "text",
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause (ENG-1569):** Reaction targets were always wrapped as `direction: "inbound"`, even when the reacted-to message was sent by the bot. This meant outbound messages surfaced in reaction events with `react`/`reply` affordances instead of `edit`.
- **Fix:** Add an optional `direction` field to `ProviderMessageRecord` and `IMessageMessage`; `wrapProviderMessage` now honors a provider-supplied `direction` on the raw record instead of blindly inheriting the outer context's direction.
- **iMessage wiring:** All remote send paths (`send`, `reactions`, `stream-text`, `customized-mini-app`) set `direction: "outbound"` on their returned records. `buildMessageBase` uses `isFromMe` to set direction when building from an SDK message, so API-fetched targets also get the right direction. Outbound sends are cached so `toReactionMessages` can resolve just-sent messages from the cache without waiting for the API to catch up.
- **Guard loosened:** `isIMessageMessage` no longer requires a `sender` field — outbound provider records don't carry one.

## Changes

| File | Change |
|---|---|
| `src/platform/types.ts` | Adds optional `direction?: "inbound" \| "outbound"` to `ProviderMessageRecord` |
| `src/platform/build.ts` | `wrapProviderMessage` picks up `direction` from the raw record via `rawDirection()`; adds `"direction"` to `providerMessageCoreKeys`; updates `wrapNestedContent` comment |
| `src/providers/imessage/types.ts` | Adds optional `direction?: "inbound" \| "outbound"` to `IMessageMessage` |
| `src/providers/imessage/remote/inbound.ts` | `buildMessageBase` sets `direction` from `isFromMe`; `isIMessageMessage` no longer requires `sender` |
| `src/providers/imessage/remote/send.ts` | `outboundRecord` sets `direction: "outbound"` |
| `src/providers/imessage/remote/reactions.ts` | `reactToMessage` sets `direction: "outbound"` on the returned record |
| `src/providers/imessage/remote/stream-text.ts` | `sendStreamText` sets `direction: "outbound"` |
| `src/providers/imessage/remote/customized-mini-app.ts` | `sendCustomizedMiniApp` sets `direction: "outbound"` |
| `src/providers/imessage/index.ts` | New `cacheRemoteOutbound` helper wraps all remote send paths to cache sent records; `handleStreamText`, `handleCustomizedMiniApp`, reply, reaction, and plain sends all go through it |
| `test/core/send-reaction.test.ts` | Two new cases: provider-supplied outbound direction honored on reaction target; legacy inbound fallback preserved when no direction set |
| `test/providers/_imessage/remote/reactions.test.ts` | Two new cases: `toReactionMessages` marks a fetched self-authored target as outbound via `isFromMe`; cache hit on a just-sent streamText avoids the API and returns the outbound record |

## Test plan

- [ ] `bun test packages/spectrum-ts/test/core/send-reaction.test.ts` — both new direction cases pass
- [ ] `bun test packages/spectrum-ts/test/providers/_imessage/remote/reactions.test.ts` — all cases including outbound-cache hit pass
- [ ] `bun test` — full suite green
- [ ] `bun x ultracite check` — no lint/format issues
- [ ] On a live farm user: send a message, have another device react to it, confirm the reaction event's `target.direction` is `"outbound"` and `target.edit()` is available
- [ ] Confirm inbound reactions on inbound messages still surface `target.direction === "inbound"` with `react`/`reply` affordances

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of message direction detection across send, reply, and reaction operations.

* **Refactor**
  * Enhanced message handling infrastructure to consistently track sent versus received messages.
  * Improved caching of outbound messages for replies, reactions, and streaming operations.

* **Tests**
  * Added tests validating message direction handling and reaction target tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783797603&installation_id=127326493&pr_number=121&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F121&signature=c4cd58da13b4197a15ecff8fb8b7f9e86aa7f4e142e8c00b38736678cd902145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->