### PR TITLE
feat(webhook): unify native and fusor webhooks into a single app.webhook() handler

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "packages/spectrum-ts": {
       "name": "spectrum-ts",
-      "version": "4.3.0",
+      "version": "4.4.0",
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.11.0",
         "@photon-ai/imessage-kit": "^3.0.0",
@@ -39,22 +39,29 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@types/express": "^5",
         "@types/mime-types": "^3.0.1",
         "@types/vcf": "^2.0.7",
         "clean-publish": "^7.0.0",
         "elysia": "^1",
+        "express": "^5",
+        "hono": "^4",
         "hotscript": "^1.0.13",
         "tsup": "^8.4.0",
         "unicode-emoji-json": "^0.9.0",
       },
       "peerDependencies": {
         "elysia": "^1",
+        "express": "^4 || ^5",
         "ffmpeg-static": "^5",
+        "hono": "^4",
         "typescript": "^5 || ^6.0.0",
       },
       "optionalPeers": [
         "elysia",
+        "express",
         "ffmpeg-static",
+        "hono",
       ],
     },
   },
@@ -287,17 +294,37 @@
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-/08CwpKJl3oRY8nOlh2YgilZVJDHsr60XTNxRhuDeuFXONpUZ5X+Nv65izbG/xBew9qxcJFbDX9/sAmAX+ITcQ=="],
 
+    "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/express": ["@types/express@5.0.6", "", { "dependencies": { "@types/body-parser": "*", "@types/express-serve-static-core": "^5.0.0", "@types/serve-static": "^2" } }, "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA=="],
+
+    "@types/express-serve-static-core": ["@types/express-serve-static-core@5.1.1", "", { "dependencies": { "@types/node": "*", "@types/qs": "*", "@types/range-parser": "*", "@types/send": "*" } }, "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A=="],
+
+    "@types/http-errors": ["@types/http-errors@2.0.5", "", {}, "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg=="],
 
     "@types/mime-types": ["@types/mime-types@3.0.1", "", {}, "sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ=="],
 
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
+    "@types/qs": ["@types/qs@6.15.1", "", {}, "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw=="],
+
+    "@types/range-parser": ["@types/range-parser@1.2.7", "", {}, "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="],
+
+    "@types/send": ["@types/send@1.2.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ=="],
+
+    "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
+
     "@types/vcf": ["@types/vcf@2.0.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-PFZg6Ix/hMvURL4JpExCU3jTVEzGrfW+3RYSca+hlGsmW+PQGScc/vH6czR7tAxF01TZTLK8i3tPKE1EYvBOkg=="],
 
     "abort-controller-x": ["abort-controller-x@0.5.0", "", {}, "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -317,6 +344,8 @@
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
     "brace-expansion": ["brace-expansion@5.0.3", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA=="],
@@ -327,7 +356,13 @@
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
@@ -357,7 +392,13 @@
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -373,6 +414,8 @@
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
@@ -383,9 +426,15 @@
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "elysia": ["elysia@1.4.28", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-Vrx8sBnvq8squS/3yNBzR1jBXI+SgmnmvwawPjNuEHndUe5l1jV2Gp6JJ4ulDkEB8On6bWmmuyPpA+bq4t+WYg=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
 
@@ -393,13 +442,25 @@
 
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
     "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
     "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
 
     "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
     "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
@@ -415,15 +476,27 @@
 
     "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
 
     "foldline": ["foldline@1.1.0", "", {}, "sha512-9SheyADS50hjvFYjFJ3OB/GlDz2mD1T2CHd7auIk4Uto5YYWPBcw8iYo3F+gENJ+/SOeH9tT0loHZSqlUlumTA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
@@ -431,9 +504,19 @@
 
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
+
+    "hono": ["hono@4.12.25", "", {}, "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="],
+
     "hotscript": ["hotscript@1.0.13", "", {}, "sha512-C++tTF1GqkGYecL+2S1wJTfoH6APGAsbb7PAWQ3iVIwgG/EFseAfEVOKFgAFq4yK3+6j1EjUD4UQ9dRJHX/sSQ=="],
 
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -443,7 +526,11 @@
 
     "ini": ["ini@1.3.8", "", {}, "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="],
 
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -467,7 +554,13 @@
 
     "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
     "memoirist": ["memoirist@0.4.0", "", {}, "sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
@@ -491,6 +584,8 @@
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "nice-grpc": ["nice-grpc@2.1.16", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.5.0", "nice-grpc-common": "^2.0.3" } }, "sha512-Cl3Pn00212Hl8/U6bpgMxmhZj5lyv3nWoJov4cd3FjWarktrMHP4DNvSjCnDwkMWYx4W1tyscEia4JX6Y4GVCQ=="],
 
     "nice-grpc-common": ["nice-grpc-common@2.0.3", "", { "dependencies": { "ts-error": "^1.0.6" } }, "sha512-MEhnD3JMah0mgyivpb9hpRDbOBuXBxI/TVO+OK1h6rC97WM42HsPMR+zzRNQ0C5BqYJTw1nyWiQRD0DucO+pjQ=="],
@@ -502,6 +597,10 @@
     "nypm": ["nypm@0.6.6", "", { "dependencies": { "citty": "^0.2.2", "pathe": "^2.0.3", "tinyexec": "^1.1.1" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -515,9 +614,13 @@
 
     "parse5-parser-stream": ["parse5-parser-stream@7.1.2", "", { "dependencies": { "parse5": "^7.0.0" } }, "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-scurry": ["path-scurry@2.0.2", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -535,7 +638,15 @@
 
     "protobufjs": ["protobufjs@8.0.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "pump": ["pump@3.0.4", "", { "dependencies": { "end-of-stream": "^1.1.0", "once": "^1.3.1" } }, "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA=="],
+
+    "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": { "rc": "./cli.js" } }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
 
@@ -551,15 +662,31 @@
 
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
 
@@ -570,6 +697,8 @@
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "spectrum-ts": ["spectrum-ts@workspace:packages/spectrum-ts"],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -597,6 +726,8 @@
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
@@ -615,6 +746,8 @@
 
     "type-fest": ["type-fest@5.4.1", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-xygQcmneDyzsEuKZrFbRMne5HDqMs++aFzefrJTgEIKjQ3rekM+RPfFCVq2Gp1VIDqddoYeppCj4Pcb+RZW0GQ=="],
 
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
@@ -629,7 +762,11 @@
 
     "unicode-emoji-json": ["unicode-emoji-json@0.9.0", "", {}, "sha512-HdrQW/7SdbXUsTd8uTATv7LvQJkCSgbAgRCDCtOhQ6xn3EAx+xZHQtRniOXWJK3ywIqPegkNhP4U4EbuFsiQng=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vcf": ["vcf@2.1.2", "", { "dependencies": { "camelcase": "^5.0.0", "foldline": "^1.1.0" } }, "sha512-oLYtZ+GJPjpKS950fw70+HavdP7ZO2Q+xMCMeCyiUKuXkJJJG1/wUjCKTagPryS1gApYjZOWW/khmdLsch8jxg=="],
 
@@ -661,6 +798,8 @@
 
     "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
+    "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
@@ -670,6 +809,8 @@
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
     "tsup/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
     },
     "packages/spectrum-ts": {
       "name": "spectrum-ts",
-      "version": "3.1.0",
+      "version": "4.3.0",
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.11.0",
         "@photon-ai/imessage-kit": "^3.0.0",
@@ -42,15 +42,18 @@
         "@types/mime-types": "^3.0.1",
         "@types/vcf": "^2.0.7",
         "clean-publish": "^7.0.0",
+        "elysia": "^1",
         "hotscript": "^1.0.13",
         "tsup": "^8.4.0",
         "unicode-emoji-json": "^0.9.0",
       },
       "peerDependencies": {
+        "elysia": "^1",
         "ffmpeg-static": "^5",
         "typescript": "^5 || ^6.0.0",
       },
       "optionalPeers": [
+        "elysia",
         "ffmpeg-static",
       ],
     },
@@ -73,6 +76,8 @@
     "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig=="],
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.12", "", { "os": "win32", "cpu": "x64" }, "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA=="],
+
+    "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
     "@bufbuild/protobuf": ["@bufbuild/protobuf@2.12.0", "", {}, "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA=="],
 
@@ -262,7 +267,13 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ=="],
 
+    "@sinclair/typebox": ["@sinclair/typebox@0.34.49", "", {}, "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A=="],
+
     "@spectrum-ts/example-basic": ["@spectrum-ts/example-basic@workspace:examples/basic"],
+
+    "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
+
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
     "@turbo/darwin-64": ["@turbo/darwin-64@2.9.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-P8foouaP+y/p+hhEGBoZpzMbpVvUMwPjDpcy6wN7EYfvvyISD1USuV27qWkczecihwuPJzQ1lDBuL8ERcavTyg=="],
 
@@ -346,6 +357,8 @@
 
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
@@ -370,6 +383,8 @@
 
     "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
+    "elysia": ["elysia@1.4.28", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-Vrx8sBnvq8squS/3yNBzR1jBXI+SgmnmvwawPjNuEHndUe5l1jV2Gp6JJ4ulDkEB8On6bWmmuyPpA+bq4t+WYg=="],
+
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "encoding-sniffer": ["encoding-sniffer@0.2.1", "", { "dependencies": { "iconv-lite": "^0.6.3", "whatwg-encoding": "^3.1.1" } }, "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw=="],
@@ -382,7 +397,11 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
+
     "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
+    "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
     "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
 
@@ -391,6 +410,8 @@
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-type": ["file-type@22.0.1", "", { "dependencies": { "@tokenizer/inflate": "^0.4.1", "strtok3": "^10.3.5", "token-types": "^6.1.2", "uint8array-extras": "^1.5.0" } }, "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA=="],
 
     "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
@@ -446,6 +467,8 @@
 
     "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
 
+    "memoirist": ["memoirist@0.4.0", "", {}, "sha512-zxTgA0mSYELa66DimuNQDvyLq36AwDlTuVRbnQtB+VuTcKWm5Qc4z3WkSpgsFWHNhexqkIooqpv4hdcqrX5Nmg=="],
+
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
@@ -483,6 +506,8 @@
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "open-graph-scraper": ["open-graph-scraper@6.11.0", "", { "dependencies": { "chardet": "^2.1.1", "cheerio": "^1.1.2", "iconv-lite": "^0.7.0", "undici": "^7.16.0" } }, "sha512-KkO3qMMzJj9KYGtCl19dRtncb+RuBiG/P9BgukcAG4p2w9wSAWTE90vL6/xqth1K9ThkYF/+xfTGrVvU79TJtQ=="],
+
+    "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
     "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -554,6 +579,8 @@
 
     "strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
 
+    "strtok3": ["strtok3@10.3.5", "", { "dependencies": { "@tokenizer/token": "^0.3.0" } }, "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA=="],
+
     "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
@@ -569,6 +596,8 @@
     "tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "token-types": ["token-types@6.1.2", "", { "dependencies": { "@borewit/text-codec": "^0.2.1", "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww=="],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
@@ -589,6 +618,8 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
+
+    "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
     "ultracite": ["ultracite@7.8.3", "", { "dependencies": { "@clack/prompts": "^1.5.1", "commander": "^15.0.0", "cross-spawn": "^7.0.6", "deepmerge": "^4.3.1", "glob": "^13.0.6", "jsonc-parser": "^3.3.1", "nypm": "^0.6.6", "yaml": "^2.9.0", "zod": "^4.4.3" }, "peerDependencies": { "oxfmt": ">=0.1.0", "oxlint": "^1.0.0" }, "optionalPeers": ["oxfmt", "oxlint"], "bin": { "ultracite": "dist/index.js" } }, "sha512-Fsj9aYJfh57uDB6DrdKVafKhF0QNekwqTrZKoTMYePjZp1npyFCnfZVj2SnPZdOcxAGHJfmLYUIDq0YPh8acVA=="],
 

--- a/docs/elysia.md
+++ b/docs/elysia.md
@@ -1,0 +1,77 @@
+# ElysiaJS plugin
+
+`spectrum-ts/elysia` is a first-party [ElysiaJS](https://elysiajs.com) plugin that
+mounts a Spectrum webhook endpoint in a single `.use()`. It wraps
+[`app.webhook()`](./fusor.md#webhook-mode--appwebhook), so it handles **both**
+webhook formats — the [native Spectrum webhook](./native-webhook.md) (HMAC-signed
+JSON) and the [Fusor webhook](./fusor.md) (protobuf) — and hands your `onMessage`
+the same `(space, message)` either way.
+
+## Why a plugin (and not just a route)
+
+Elysia's `parse` lifecycle auto-parses `application/json` request bodies **before**
+your handler runs, which consumes the `Request` body stream. So the naive
+
+```ts
+new Elysia().post("/webhook", ({ request }) => app.webhook(request, handler)); // ✗
+```
+
+throws `body already used`, and — because Spectrum verifies the HMAC over the
+**exact wire bytes** — any framework that re-encodes the JSON would also break
+signature verification. The plugin sets `parse: "none"` on its route so Elysia
+leaves the body untouched, then forwards the raw `Request` straight to
+`app.webhook()`.
+
+## Install
+
+```bash
+bun add elysia spectrum-ts
+```
+
+`elysia` is an optional peer dependency — you only need it if you use this subpath.
+
+## Usage
+
+```ts
+import { Elysia } from "elysia";
+import { Spectrum } from "spectrum-ts";
+import { imessage } from "spectrum-ts/providers/imessage";
+import { spectrum } from "spectrum-ts/elysia";
+
+const app = await Spectrum({
+  projectId: process.env.PROJECT_ID,
+  projectSecret: process.env.PROJECT_SECRET,
+  providers: [imessage.config()],
+  webhookSecret: process.env.SPECTRUM_WEBHOOK_SECRET, // for native webhooks
+});
+
+new Elysia()
+  .use(
+    spectrum({
+      app,
+      onMessage: async (space, message) => {
+        if (message.content.type === "text") {
+          await space.send(`echo: ${message.content.text}`);
+        }
+      },
+    })
+  )
+  .listen(3000);
+```
+
+## Options
+
+| Option | Type | Default | Notes |
+|---|---|---|---|
+| `app` | `Spectrum` instance | — | The instance returned by `await Spectrum({...})`. |
+| `onMessage` | `(space, message) => void \| Promise<void>` | — | Invoked once per inbound message, **fire-and-forget** after the response (a throw is logged, never surfaced). Dedupe on `message.id` for exactly-once side effects. |
+| `path` | `string` | `"/spectrum/webhook"` | Route the endpoint is mounted on. |
+
+Everything else — signature verification, native-vs-fusor detection,
+deserialization, attachment rehydration, status codes, and at-least-once retry
+semantics — is exactly [what `app.webhook()` does](./native-webhook.md#what-the-sdk-does-for-you).
+
+## Reference
+
+- Plugin source — `src/elysia.ts`
+- `app.webhook(request, handler)` — `src/spectrum.ts`

--- a/docs/express.md
+++ b/docs/express.md
@@ -1,0 +1,103 @@
+# Express plugin
+
+`spectrum-ts/express` is a first-party [Express](https://expressjs.com) plugin
+that mounts a Spectrum webhook endpoint in a single `.use()`. It wraps
+[`app.webhook()`](./fusor.md#webhook-mode--appwebhook), so it handles **both**
+webhook formats — the [native Spectrum webhook](./native-webhook.md) (HMAC-signed
+JSON) and the [Fusor webhook](./fusor.md) (protobuf) — and hands your `onMessage`
+the same `(space, message)` either way.
+
+## Why a plugin (and not just a route)
+
+Express runs on Node `req`/`res`, not the Web `Request`/`Response`, so wiring the
+webhook by hand means three fiddly things: reach for `app.webhook()`'s raw
+overload, capture the body as bytes with `express.raw(...)` (Spectrum verifies the
+HMAC over the **exact wire bytes**, so a parsed-and-re-encoded body breaks
+verification), and write the result back onto `res` yourself:
+
+```ts
+app.post(
+  "/spectrum/webhook",
+  express.raw({ type: "*/*" }),
+  async (req, res) => {
+    const result = await app.webhook(
+      { body: req.body, headers: req.headers },
+      onMessage
+    );
+    res.status(result.status).set(result.headers).send(Buffer.from(result.body));
+  }
+);
+```
+
+The plugin owns all of that — the route, the `express.raw` parser, and the
+response writing — behind one `app.use()`.
+
+> ⚠️ **Mount it before any global `express.json()`.** A global JSON parser runs on
+> every request and consumes the body stream first, so by the time the plugin's
+> `express.raw` runs, `req.body` is a parsed object, not the raw bytes — and
+> signature verification fails. Either mount `spectrum(...)` before
+> `express.json()` (as below), or scope `express.json()` so it never matches the
+> webhook path.
+
+## Install
+
+```bash
+bun add express spectrum-ts
+```
+
+`express` is an optional peer dependency — you only need it if you use this subpath.
+
+## Usage
+
+```ts
+import express from "express";
+import { Spectrum } from "spectrum-ts";
+import { imessage } from "spectrum-ts/providers/imessage";
+import { spectrum } from "spectrum-ts/express";
+
+const app = await Spectrum({
+  projectId: process.env.PROJECT_ID,
+  projectSecret: process.env.PROJECT_SECRET,
+  providers: [imessage.config()],
+  webhookSecret: process.env.SPECTRUM_WEBHOOK_SECRET, // for native webhooks
+});
+
+const server = express();
+
+server.use(
+  // Mount before any global express.json().
+  spectrum({
+    app,
+    onMessage: async (space, message) => {
+      if (message.content.type === "text") {
+        await space.send(`echo: ${message.content.text}`);
+      }
+    },
+  })
+);
+
+server.use(express.json()); // your other routes can parse JSON freely
+server.listen(3000);
+```
+
+## Options
+
+| Option | Type | Default | Notes |
+|---|---|---|---|
+| `app` | `Spectrum` instance | — | The instance returned by `await Spectrum({...})`. |
+| `onMessage` | `(space, message) => void \| Promise<void>` | — | Invoked once per inbound message, **fire-and-forget** after the response (a throw is logged, never surfaced). Dedupe on `message.id` for exactly-once side effects. |
+| `path` | `string` | `"/spectrum/webhook"` | Route the endpoint is mounted on. |
+
+`spectrum(...)` returns an Express `Router`, so an Express mount prefix stacks on
+top of `path` — `server.use("/hooks", spectrum({ app, onMessage }))` serves
+`POST /hooks/spectrum/webhook`. Prefer setting `path` for a single, explicit
+endpoint.
+
+Everything else — signature verification, native-vs-fusor detection,
+deserialization, attachment rehydration, status codes, and at-least-once retry
+semantics — is exactly [what `app.webhook()` does](./native-webhook.md#what-the-sdk-does-for-you).
+
+## Reference
+
+- Plugin source — `src/express.ts`
+- `app.webhook(request, handler)` — `src/spectrum.ts`

--- a/docs/fusor.md
+++ b/docs/fusor.md
@@ -178,6 +178,9 @@ The reply Hono sends is the platform ack, produced by the pipeline — not
 whatever your handler does. `space.send(...)` posts a *new* message back to the
 platform out-of-band; it is not the HTTP response.
 
+> 🔌 Prefer the first-party **[`spectrum-ts/hono`](./hono.md)** plugin to mount
+> this endpoint in one `app.route(...)`.
+
 **Bun.serve / Next.js App Router / Cloudflare Workers** — native `Request` →
 `Response`:
 
@@ -207,6 +210,9 @@ app.post(
   }
 );
 ```
+
+> 🔌 Prefer the first-party **[`spectrum-ts/express`](./express.md)** plugin — it
+> bundles `express.raw` and the response writing behind one `app.use(...)`.
 
 **ElysiaJS** — use the first-party plugin (it handles the raw-body parsing for
 you); see **[ElysiaJS plugin](./elysia.md)**:

--- a/docs/fusor.md
+++ b/docs/fusor.md
@@ -208,6 +208,22 @@ app.post(
 );
 ```
 
+**ElysiaJS** — use the first-party plugin (it handles the raw-body parsing for
+you); see **[ElysiaJS plugin](./elysia.md)**:
+
+```typescript
+import { spectrum } from "spectrum-ts/elysia";
+
+new Elysia().use(
+  spectrum({
+    app,
+    onMessage: async (space, message) => {
+      await space.send("got it");
+    },
+  })
+);
+```
+
 ### What's automatic vs. your job
 
 - **Automatic:** decode the envelope, route by platform, verify the platform

--- a/docs/fusor.md
+++ b/docs/fusor.md
@@ -115,6 +115,13 @@ the same pipeline, returns the HTTP response Fusor relays back to the platform
 message fire-and-forget — the handler runs after the response and never affects
 it.
 
+> ℹ️ **Two webhook formats, one method.** `app.webhook()` also accepts the
+> **native Spectrum webhook** — Spectrum Cloud's own HMAC-signed, already-normalized
+> JSON deliveries (no raw provider request, no protobuf). It auto-detects the
+> format per request (the native one carries an `X-Spectrum-Signature` header) and
+> hands your handler the same `(space, message)` either way. The native format
+> needs a signing secret — see **[Native Spectrum webhooks](./native-webhook.md)**.
+
 ### Enable it
 
 There's nothing extra to configure — just call `app.webhook()` from your POST
@@ -131,7 +138,8 @@ check.
 app.webhook(request: Request, handler: WebhookHandler): Promise<Response>;
 
 // Raw — for Express / raw Node. Returns a plain result you write back yourself.
-// `headers` are accepted (so passing `req.headers` is fine) but unused.
+// `headers` are accepted (passing `req.headers` is fine); they're unused for the
+// fusor format but ARE read for native Spectrum webhooks (signature verification).
 app.webhook(
   request: { body: Uint8Array | ArrayBuffer; headers?: Record<string, string> },
   handler: WebhookHandler

--- a/docs/fusor.md
+++ b/docs/fusor.md
@@ -118,9 +118,10 @@ it.
 > ℹ️ **Two webhook formats, one method.** `app.webhook()` also accepts the
 > **native Spectrum webhook** — Spectrum Cloud's own HMAC-signed, already-normalized
 > JSON deliveries (no raw provider request, no protobuf). It auto-detects the
-> format per request (the native one carries an `X-Spectrum-Signature` header) and
-> hands your handler the same `(space, message)` either way. The native format
-> needs a signing secret — see **[Native Spectrum webhooks](./native-webhook.md)**.
+> format per request by the payload shape — native is JSON, fusor is protobuf
+> (both are signed, so the signature header can't discriminate) — and hands your
+> handler the same `(space, message)` either way. The native format needs a
+> signing secret — see **[Native Spectrum webhooks](./native-webhook.md)**.
 
 ### Enable it
 

--- a/docs/hono.md
+++ b/docs/hono.md
@@ -1,0 +1,85 @@
+# Hono plugin
+
+`spectrum-ts/hono` is a first-party [Hono](https://hono.dev) plugin that mounts a
+Spectrum webhook endpoint in a single `.route()`. It wraps
+[`app.webhook()`](./fusor.md#webhook-mode--appwebhook), so it handles **both**
+webhook formats — the [native Spectrum webhook](./native-webhook.md) (HMAC-signed
+JSON) and the [Fusor webhook](./fusor.md) (protobuf) — and hands your `onMessage`
+the same `(space, message)` either way.
+
+## Why a plugin (and not just a route)
+
+Unlike Elysia, Hono needs **no** body-parsing workaround: it never auto-parses a
+request body, so `c.req.raw` is the exact, untouched Web `Request` (the body is
+only consumed if you call `c.req.json()` / `c.req.parseBody()`). That matters
+because Spectrum verifies the native webhook's HMAC over the **exact wire bytes** —
+re-encoding the body would break it.
+
+So the raw route is already a clean one-liner:
+
+```ts
+server.post("/spectrum/webhook", (c) => app.webhook(c.req.raw, onMessage)); // ✓
+```
+
+The plugin is the same thing with the ergonomics matched to Elysia and Express: a
+single import, the route + default path owned for you, and a typed `onMessage`. It
+returns a mountable Hono sub-app, so you compose it with `app.route(...)`.
+
+> ⚠️ The one rule, plugin or not: pass `c.req.raw` — never `c.req.json()` or
+> `c.req.parseBody()`. Reading the body re-encodes it and breaks signature
+> verification.
+
+## Install
+
+```bash
+bun add hono spectrum-ts
+```
+
+`hono` is an optional peer dependency — you only need it if you use this subpath.
+
+## Usage
+
+```ts
+import { Hono } from "hono";
+import { Spectrum } from "spectrum-ts";
+import { imessage } from "spectrum-ts/providers/imessage";
+import { spectrum } from "spectrum-ts/hono";
+
+const app = await Spectrum({
+  projectId: process.env.PROJECT_ID,
+  projectSecret: process.env.PROJECT_SECRET,
+  providers: [imessage.config()],
+  webhookSecret: process.env.SPECTRUM_WEBHOOK_SECRET, // for native webhooks
+});
+
+const server = new Hono().route(
+  "/",
+  spectrum({
+    app,
+    onMessage: async (space, message) => {
+      if (message.content.type === "text") {
+        await space.send(`echo: ${message.content.text}`);
+      }
+    },
+  })
+);
+
+export default server; // Bun.serve, Cloudflare Workers, Deno, Node adapter, …
+```
+
+## Options
+
+| Option | Type | Default | Notes |
+|---|---|---|---|
+| `app` | `Spectrum` instance | — | The instance returned by `await Spectrum({...})`. |
+| `onMessage` | `(space, message) => void \| Promise<void>` | — | Invoked once per inbound message, **fire-and-forget** after the response (a throw is logged, never surfaced). Dedupe on `message.id` for exactly-once side effects. |
+| `path` | `string` | `"/spectrum/webhook"` | Route the endpoint is mounted on. |
+
+Everything else — signature verification, native-vs-fusor detection,
+deserialization, attachment rehydration, status codes, and at-least-once retry
+semantics — is exactly [what `app.webhook()` does](./native-webhook.md#what-the-sdk-does-for-you).
+
+## Reference
+
+- Plugin source — `src/hono.ts`
+- `app.webhook(request, handler)` — `src/spectrum.ts`

--- a/docs/native-webhook.md
+++ b/docs/native-webhook.md
@@ -78,6 +78,10 @@ app.post(
 > the SDK sees it, the bytes change and verification fails. Use `c.req.raw` /
 > `express.raw(...)` — never `req.json()`.
 
+> 🦊 **ElysiaJS** auto-parses JSON bodies, which would break this — use the
+> first-party **[`spectrum-ts/elysia`](./elysia.md)** plugin, which disables body
+> parsing on its route and forwards the raw request for you.
+
 ## What the SDK does for you
 
 - **Verifies the signature** — `HMAC-SHA256` over `v0:<timestamp>:<rawBody>`,

--- a/docs/native-webhook.md
+++ b/docs/native-webhook.md
@@ -78,9 +78,11 @@ app.post(
 > the SDK sees it, the bytes change and verification fails. Use `c.req.raw` /
 > `express.raw(...)` — never `req.json()`.
 
-> 🦊 **ElysiaJS** auto-parses JSON bodies, which would break this — use the
-> first-party **[`spectrum-ts/elysia`](./elysia.md)** plugin, which disables body
-> parsing on its route and forwards the raw request for you.
+> 🔌 **First-party plugins** mount the endpoint for you in one call, with the
+> raw-body handling already correct: **[`spectrum-ts/hono`](./hono.md)**,
+> **[`spectrum-ts/express`](./express.md)**, and
+> **[`spectrum-ts/elysia`](./elysia.md)** (Elysia auto-parses JSON bodies, so the
+> plugin disables parsing on its route and forwards the raw request).
 
 ## What the SDK does for you
 

--- a/docs/native-webhook.md
+++ b/docs/native-webhook.md
@@ -1,0 +1,115 @@
+# Native Spectrum webhooks
+
+Spectrum Cloud can **POST already-normalized, signed JSON** to your HTTPS
+endpoint — Spectrum's own message model (`text`, `attachment`, `contact`,
+`richlink`, `reaction`, `group`), with raw bytes and SDK methods stripped, signed
+with an HMAC. This is the webhook documented at
+<https://photon.codes/docs/webhooks>.
+
+It's a different wire format from the [Fusor webhook](./fusor.md#webhook-mode--appwebhook),
+which relays a **raw** provider request inside a protobuf envelope. You don't pick
+one: **`app.webhook()` handles both**, auto-detecting per request and handing your
+handler the same `(space, message)` pair either way.
+
+| | Native Spectrum webhook | Fusor webhook |
+|---|---|---|
+| Body | signed, normalized JSON | protobuf envelope (raw provider request) |
+| Auth | HMAC over the body, verified with your `webhookSecret` | the platform's own signature, via the provider `verify()` |
+| Detection | has `X-Spectrum-Signature` | no signature header |
+| Works without a fusor provider | ✅ | ❌ (needs the fusor provider) |
+
+## Configure the signing secret
+
+When you register a webhook URL with Spectrum, you receive a **signing secret
+once**. Give it to the SDK so deliveries can be verified:
+
+```typescript
+const app = await Spectrum({
+  projectId: process.env.PROJECT_ID,
+  projectSecret: process.env.PROJECT_SECRET,
+  providers: [imessage.config()],
+  webhookSecret: process.env.SPECTRUM_WEBHOOK_SECRET, // the per-webhook secret
+});
+```
+
+`webhookSecret` may also be supplied via the `SPECTRUM_WEBHOOK_SECRET` environment
+variable (the explicit option wins). A native delivery that arrives without a
+configured secret is answered `500` and logged — it's a setup error, not an
+attacker.
+
+> The secret is shown only once at registration and cannot be fetched back. If you
+> lose it, rotate it (delete + re-register) and update `webhookSecret`.
+
+## Receive deliveries
+
+Exactly the same call as the fusor webhook — there's nothing format-specific in
+your code:
+
+```typescript
+// Hono / Bun.serve / Next.js / Workers — c.req.raw is a Web Request
+server.post("/spectrum-webhook", (c) =>
+  app.webhook(c.req.raw, async (space, message) => {
+    if (message.content.type === "text") {
+      await space.send(`echo: ${message.content.text}`);
+    }
+  })
+);
+```
+
+```typescript
+// Express / raw Node — pass the RAW body bytes + headers
+app.post(
+  "/spectrum-webhook",
+  express.raw({ type: "*/*" }),
+  async (req, res) => {
+    const result = await app.webhook(
+      { body: req.body, headers: req.headers },
+      async (space, message) => {
+        /* … */
+      }
+    );
+    res.status(result.status).set(result.headers).send(result.body);
+  }
+);
+```
+
+> ⚠️ **Pass the raw body bytes.** The HMAC is computed over the exact bytes on the
+> wire. If your framework parses the body to JSON and you re-stringify it before
+> the SDK sees it, the bytes change and verification fails. Use `c.req.raw` /
+> `express.raw(...)` — never `req.json()`.
+
+## What the SDK does for you
+
+- **Verifies the signature** — `HMAC-SHA256` over `v0:<timestamp>:<rawBody>`,
+  constant-time compared, with a 5-minute replay window. A bad signature → `401`,
+  an expired timestamp → `401`, a missing signature header → `400`. The handler is
+  never dispatched on a failed verification.
+- **Deserializes** the slim JSON into the normal `Message`/`Space`, including
+  reaction targets and album (`group`) items.
+- **Rehydrates attachments** — the webhook carries metadata only. `message.content`
+  exposes `name`/`mimeType`/`size` immediately; `read()`/`stream()` fetch the bytes
+  lazily via the platform (e.g. iMessage's `getAttachment`). On a platform without
+  that capability, `read()` rejects with a clear error.
+
+## Status codes & delivery semantics
+
+`app.webhook()` returns `200` once a native delivery is verified and accepted; the
+handler then runs **fire-and-forget** (after the response, not awaited — a throw is
+logged, never surfaced). Unknown event types and messages for platforms you haven't
+configured are acknowledged with `200` (a retry wouldn't help) and logged.
+
+Spectrum delivers **at-least-once** and retries non-2xx responses, so dedupe on
+`message.id` (optionally combined with the `X-Spectrum-Webhook-Id` header) for
+exactly-once side effects.
+
+Like the fusor webhook, this path is stateless and request-scoped: it does **not**
+feed `app.messages`, and it never opens the streaming connection. See
+[Keeping handler work alive](./fusor.md#keeping-handler-work-alive) for the
+serverless caveat.
+
+## Reference
+
+- `app.webhook(request, handler)` — `src/spectrum.ts`
+- Signature verification — `src/webhook/verify.ts`
+- Slim-JSON deserialization — `src/webhook/deserialize.ts`
+- Wire schemas — `src/webhook/types.ts`

--- a/docs/native-webhook.md
+++ b/docs/native-webhook.md
@@ -15,7 +15,7 @@ handler the same `(space, message)` pair either way.
 |---|---|---|
 | Body | signed, normalized JSON | protobuf envelope (raw provider request) |
 | Auth | HMAC over the body, verified with your `webhookSecret` | the platform's own signature, via the provider `verify()` |
-| Detection | has `X-Spectrum-Signature` | no signature header |
+| Detection | JSON body (`{…`) | protobuf body |
 | Works without a fusor provider | ✅ | ❌ (needs the fusor provider) |
 
 ## Configure the signing secret

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectrum-ts",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Bring agents to any interface — unified messaging SDK for TypeScript.",
   "repository": {
     "type": "git",
@@ -29,6 +29,11 @@
       "types": "./src/authoring.ts",
       "default": "./dist/authoring.js"
     },
+    "./elysia": {
+      "bun": "./src/elysia.ts",
+      "types": "./src/elysia.ts",
+      "default": "./dist/elysia.js"
+    },
     "./providers": {
       "bun": "./src/providers/index.ts",
       "types": "./src/providers/index.ts",
@@ -50,6 +55,10 @@
       "./authoring": {
         "types": "./dist/authoring.d.ts",
         "default": "./dist/authoring.js"
+      },
+      "./elysia": {
+        "types": "./dist/elysia.d.ts",
+        "default": "./dist/elysia.js"
       },
       "./providers": {
         "types": "./dist/providers/index.d.ts",
@@ -95,15 +104,20 @@
     "@types/mime-types": "^3.0.1",
     "@types/vcf": "^2.0.7",
     "clean-publish": "^7.0.0",
+    "elysia": "^1",
     "hotscript": "^1.0.13",
     "tsup": "^8.4.0",
     "unicode-emoji-json": "^0.9.0"
   },
   "peerDependencies": {
+    "elysia": "^1",
     "ffmpeg-static": "^5",
     "typescript": "^5 || ^6.0.0"
   },
   "peerDependenciesMeta": {
+    "elysia": {
+      "optional": true
+    },
     "ffmpeg-static": {
       "optional": true
     }

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectrum-ts",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Bring agents to any interface — unified messaging SDK for TypeScript.",
   "repository": {
     "type": "git",
@@ -34,6 +34,16 @@
       "types": "./src/elysia.ts",
       "default": "./dist/elysia.js"
     },
+    "./express": {
+      "bun": "./src/express.ts",
+      "types": "./src/express.ts",
+      "default": "./dist/express.js"
+    },
+    "./hono": {
+      "bun": "./src/hono.ts",
+      "types": "./src/hono.ts",
+      "default": "./dist/hono.js"
+    },
     "./providers": {
       "bun": "./src/providers/index.ts",
       "types": "./src/providers/index.ts",
@@ -59,6 +69,14 @@
       "./elysia": {
         "types": "./dist/elysia.d.ts",
         "default": "./dist/elysia.js"
+      },
+      "./express": {
+        "types": "./dist/express.d.ts",
+        "default": "./dist/express.js"
+      },
+      "./hono": {
+        "types": "./dist/hono.d.ts",
+        "default": "./dist/hono.js"
       },
       "./providers": {
         "types": "./dist/providers/index.d.ts",
@@ -101,24 +119,35 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "@types/express": "^5",
     "@types/mime-types": "^3.0.1",
     "@types/vcf": "^2.0.7",
     "clean-publish": "^7.0.0",
     "elysia": "^1",
+    "express": "^5",
+    "hono": "^4",
     "hotscript": "^1.0.13",
     "tsup": "^8.4.0",
     "unicode-emoji-json": "^0.9.0"
   },
   "peerDependencies": {
     "elysia": "^1",
+    "express": "^4 || ^5",
     "ffmpeg-static": "^5",
+    "hono": "^4",
     "typescript": "^5 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "elysia": {
       "optional": true
     },
+    "express": {
+      "optional": true
+    },
     "ffmpeg-static": {
+      "optional": true
+    },
+    "hono": {
       "optional": true
     }
   },

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectrum-ts",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "Bring agents to any interface — unified messaging SDK for TypeScript.",
   "repository": {
     "type": "git",

--- a/packages/spectrum-ts/src/elysia.ts
+++ b/packages/spectrum-ts/src/elysia.ts
@@ -1,0 +1,82 @@
+// Spectrum webhook receiver as a first-party ElysiaJS plugin.
+//
+// Elysia's `parse` lifecycle auto-parses application/json bodies before the
+// route handler runs, which consumes the `Request` body stream. That breaks
+// Spectrum's HMAC verification, which is computed over the EXACT wire bytes
+// (`HMAC-SHA256(secret, "v0:<ts>:<rawBody>")`) — once Elysia has read (and
+// possibly re-encoded) the body, `app.webhook()` either throws "body already
+// used" or verifies against the wrong bytes.
+//
+// Setting `parse: "none"` on the route makes Elysia skip body parsing entirely,
+// leaving the raw `Request` untouched. We hand it straight to the Web-standard
+// `app.webhook(request, handler)` overload and return the `Response` it produces
+// unchanged — so this plugin is a thin transport adapter that inherits all of
+// `app.webhook()`'s behavior (native + fusor detection, signature verification,
+// fire-and-forget dispatch) for free.
+
+import { Elysia } from "elysia";
+import type { WebhookHandler } from "./fusor";
+
+/**
+ * The minimal structural surface of a Spectrum instance the plugin needs. Kept
+ * structural (rather than importing the generic `SpectrumInstance<Providers>`)
+ * so the plugin stays decoupled from provider typing; a real instance is
+ * assignable via its Web `Request` webhook overload.
+ */
+interface WebhookReceiver {
+  webhook(request: Request, handler: WebhookHandler): Promise<Response>;
+}
+
+export interface SpectrumPluginOptions {
+  /** The Spectrum instance returned by `await Spectrum({...})`. */
+  app: WebhookReceiver;
+  /**
+   * Invoked once per inbound message, fire-and-forget after the response — the
+   * same `(space, message)` contract as `app.webhook(request, handler)`. Covers
+   * both native Spectrum webhooks and fusor webhooks identically.
+   */
+  onMessage: WebhookHandler;
+  /**
+   * Route the webhook is mounted on.
+   *
+   * @default "/spectrum/webhook"
+   */
+  path?: string;
+}
+
+/**
+ * Mount a Spectrum webhook endpoint on an Elysia app.
+ *
+ * @example
+ * ```ts
+ * import { Elysia } from "elysia";
+ * import { Spectrum } from "spectrum-ts";
+ * import { spectrum } from "spectrum-ts/elysia";
+ *
+ * const app = await Spectrum({ ...,  webhookSecret: process.env.SPECTRUM_WEBHOOK_SECRET });
+ *
+ * new Elysia()
+ *   .use(spectrum({
+ *     app,
+ *     onMessage: async (space, message) => {
+ *       if (message.content.type === "text") await space.send(`echo: ${message.content.text}`);
+ *     },
+ *   }))
+ *   .listen(3000);
+ * ```
+ */
+export function spectrum(options: SpectrumPluginOptions) {
+  const { app, onMessage, path = "/spectrum/webhook" } = options;
+
+  // `seed: path` keeps the plugin dedupe-safe (Elysia collapses same-name +
+  // same-seed instances) while still allowing distinct paths to coexist.
+  return new Elysia({ name: "spectrum-webhook", seed: path }).post(
+    path,
+    ({ request }) => app.webhook(request, onMessage),
+    { parse: "none" }
+  );
+}
+
+export type { WebhookHandler } from "./fusor";
+export type { Message } from "./types/message";
+export type { Space } from "./types/space";

--- a/packages/spectrum-ts/src/express.ts
+++ b/packages/spectrum-ts/src/express.ts
@@ -1,0 +1,102 @@
+// Spectrum webhook receiver as a first-party Express plugin.
+//
+// Express runs on Node `req`/`res`, not the Web `Request`/`Response`, so this
+// plugin uses `app.webhook()`'s raw overload (`{ body, headers }` →
+// `{ status, headers, body }`) and writes the result back itself. The raw body
+// bytes only exist if a body parser captures them as a Buffer, so the plugin
+// mounts `express.raw({ type: "*/*" })` on its own route — Spectrum verifies the
+// native webhook's HMAC over the EXACT wire bytes
+// (`HMAC-SHA256(secret, "v0:<ts>:<rawBody>")`), so a parsed-and-re-encoded body
+// would break verification (and the fusor protobuf body would fail to decode).
+//
+// ⚠️ Ordering hazard (the Express analog of Elysia's parse lifecycle): a global
+// `express.json()` mounted BEFORE this router consumes the request stream first,
+// leaving `req.body` a parsed object rather than the raw bytes — verification
+// then fails. Mount this plugin before any global `express.json()`, or scope
+// `json()` so it never matches the webhook path.
+//
+// It returns an Express `Router`, so a host app composes it with one
+// `app.use(spectrum(...))` — the route, the raw-body parser, and the response
+// writing are all owned by the plugin.
+
+import express, { type Router } from "express";
+import type { WebhookHandler } from "./fusor";
+
+/**
+ * The minimal structural surface of a Spectrum instance the plugin needs. Kept
+ * structural (rather than importing the generic `SpectrumInstance<Providers>`)
+ * so the plugin stays decoupled from provider typing; a real instance is
+ * assignable via its raw (`{ body, headers }`) webhook overload.
+ */
+interface WebhookReceiver {
+  webhook(
+    request: {
+      body: Uint8Array | ArrayBuffer;
+      headers?: Record<string, string>;
+    },
+    handler: WebhookHandler
+  ): Promise<{
+    body: Uint8Array;
+    headers: Record<string, string>;
+    status: number;
+  }>;
+}
+
+export interface SpectrumPluginOptions {
+  /** The Spectrum instance returned by `await Spectrum({...})`. */
+  app: WebhookReceiver;
+  /**
+   * Invoked once per inbound message, fire-and-forget after the response — the
+   * same `(space, message)` contract as `app.webhook(request, handler)`. Covers
+   * both native Spectrum webhooks and fusor webhooks identically.
+   */
+  onMessage: WebhookHandler;
+  /**
+   * Route the webhook is mounted on.
+   *
+   * @default "/spectrum/webhook"
+   */
+  path?: string;
+}
+
+/**
+ * Mount a Spectrum webhook endpoint on an Express app.
+ *
+ * @example
+ * ```ts
+ * import express from "express";
+ * import { Spectrum } from "spectrum-ts";
+ * import { spectrum } from "spectrum-ts/express";
+ *
+ * const app = await Spectrum({ ...,  webhookSecret: process.env.SPECTRUM_WEBHOOK_SECRET });
+ *
+ * const server = express();
+ * server.use(spectrum({ // mount before any global express.json()
+ *   app,
+ *   onMessage: async (space, message) => {
+ *     if (message.content.type === "text") await space.send(`echo: ${message.content.text}`);
+ *   },
+ * }));
+ * server.listen(3000);
+ * ```
+ */
+export function spectrum(options: SpectrumPluginOptions): Router {
+  const { app, onMessage, path = "/spectrum/webhook" } = options;
+
+  const router = express.Router();
+  router.post(path, express.raw({ type: "*/*" }), async (req, res) => {
+    const result = await app.webhook(
+      { body: req.body, headers: req.headers as Record<string, string> },
+      onMessage
+    );
+    res
+      .status(result.status)
+      .set(result.headers)
+      .send(Buffer.from(result.body));
+  });
+  return router;
+}
+
+export type { WebhookHandler } from "./fusor";
+export type { Message } from "./types/message";
+export type { Space } from "./types/space";

--- a/packages/spectrum-ts/src/fusor/types.ts
+++ b/packages/spectrum-ts/src/fusor/types.ts
@@ -83,11 +83,16 @@ export type WebhookHandler = (
 
 /**
  * Raw webhook input for HTTP servers without Web `Request`/`Response` (Express,
- * raw Node). `body` MUST be the exact bytes fusor POSTed — never a re-encoded
- * JSON/text body — so the protobuf decode works. `headers` are accepted (so the
- * natural `{ headers: req.headers, body: req.body }` shape keeps working) but are
- * not read: inbound authenticity is established by the per-platform `verify()`,
- * which reads the inner request reconstructed from the envelope.
+ * raw Node). `body` MUST be the exact bytes POSTed — never a re-encoded
+ * JSON/text body — so both the protobuf decode (fusor) and the HMAC
+ * verification (native Spectrum webhook) work.
+ *
+ * `headers` ARE read for **native Spectrum webhooks**: `X-Spectrum-Signature` /
+ * `X-Spectrum-Timestamp` carry the HMAC verified against
+ * `Spectrum({ webhookSecret })`, and the signature header also selects the
+ * native path. For **fusor** envelopes they are ignored (authenticity is the
+ * per-platform `verify()` reading the inner reconstructed request). The natural
+ * `{ headers: req.headers, body: req.body }` shape works for both.
  */
 export interface WebhookRawRequest {
   body: Uint8Array | ArrayBuffer;

--- a/packages/spectrum-ts/src/hono.ts
+++ b/packages/spectrum-ts/src/hono.ts
@@ -1,0 +1,75 @@
+// Spectrum webhook receiver as a first-party Hono plugin.
+//
+// Unlike Elysia, Hono needs no body-parsing workaround: it never auto-parses a
+// request body, so `c.req.raw` is the EXACT, untouched Web `Request` — the body
+// stream is only consumed if you call `c.req.json()` / `c.req.parseBody()`. That
+// matters because Spectrum verifies the native webhook's HMAC over the exact wire
+// bytes (`HMAC-SHA256(secret, "v0:<ts>:<rawBody>")`); re-encoding the body would
+// break it. We hand `c.req.raw` straight to the Web-standard
+// `app.webhook(request, handler)` overload and return the `Response` it produces
+// unchanged — so this plugin is a thin transport adapter that inherits all of
+// `app.webhook()`'s behavior (native + fusor detection, signature verification,
+// fire-and-forget dispatch) for free.
+//
+// It returns a mountable Hono sub-app (Hono's "grouping" pattern), so a host app
+// composes it with `app.route("/", spectrum(...))` — the direct analog of
+// Elysia's `.use(spectrum(...))`.
+
+import { Hono } from "hono";
+import type { WebhookHandler } from "./fusor";
+
+/**
+ * The minimal structural surface of a Spectrum instance the plugin needs. Kept
+ * structural (rather than importing the generic `SpectrumInstance<Providers>`)
+ * so the plugin stays decoupled from provider typing; a real instance is
+ * assignable via its Web `Request` webhook overload.
+ */
+interface WebhookReceiver {
+  webhook(request: Request, handler: WebhookHandler): Promise<Response>;
+}
+
+export interface SpectrumPluginOptions {
+  /** The Spectrum instance returned by `await Spectrum({...})`. */
+  app: WebhookReceiver;
+  /**
+   * Invoked once per inbound message, fire-and-forget after the response — the
+   * same `(space, message)` contract as `app.webhook(request, handler)`. Covers
+   * both native Spectrum webhooks and fusor webhooks identically.
+   */
+  onMessage: WebhookHandler;
+  /**
+   * Route the webhook is mounted on.
+   *
+   * @default "/spectrum/webhook"
+   */
+  path?: string;
+}
+
+/**
+ * Mount a Spectrum webhook endpoint on a Hono app.
+ *
+ * @example
+ * ```ts
+ * import { Hono } from "hono";
+ * import { Spectrum } from "spectrum-ts";
+ * import { spectrum } from "spectrum-ts/hono";
+ *
+ * const app = await Spectrum({ ...,  webhookSecret: process.env.SPECTRUM_WEBHOOK_SECRET });
+ *
+ * const server = new Hono().route("/", spectrum({
+ *   app,
+ *   onMessage: async (space, message) => {
+ *     if (message.content.type === "text") await space.send(`echo: ${message.content.text}`);
+ *   },
+ * }));
+ * ```
+ */
+export function spectrum(options: SpectrumPluginOptions) {
+  const { app, onMessage, path = "/spectrum/webhook" } = options;
+
+  return new Hono().post(path, (c) => app.webhook(c.req.raw, onMessage));
+}
+
+export type { WebhookHandler } from "./fusor";
+export type { Message } from "./types/message";
+export type { Space } from "./types/space";

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -90,16 +90,19 @@ export type SpectrumInstance<
      * POST route — it auto-detects which of the two Spectrum webhook formats the
      * request carries and routes accordingly:
      *
-     * - **Native Spectrum webhook** (`X-Spectrum-Signature` header present):
-     *   Spectrum Cloud POSTs already-normalized, HMAC-signed JSON. The signature
-     *   is verified against `Spectrum({ webhookSecret })` (a bad signature →
-     *   401), the slim payload is deserialized into `[space, message]`, and a
-     *   `200` is returned. Works without any fusor provider configured.
-     * - **Fusor webhook** (no signature header): a protobuf envelope wrapping a
+     * - **Native Spectrum webhook** (the body is normalized JSON): Spectrum Cloud
+     *   POSTs already-normalized, HMAC-signed JSON. The signature is verified
+     *   against `Spectrum({ webhookSecret })` (a bad signature → 401), the slim
+     *   payload is deserialized into `[space, message]`, and a `200` is returned.
+     *   Works without any fusor provider configured.
+     * - **Fusor webhook** (the body is a protobuf envelope): a protobuf wrapping a
      *   raw provider request is decoded and routed to the matching provider's
      *   verify + message pipeline; the HTTP response is that platform's
      *   `respond()` reply (including protocol echoes like Slack
      *   `url_verification`), computed synchronously and returned immediately.
+     *
+     * Detection is by payload shape, not headers — Spectrum signs both kinds with
+     * `X-Spectrum-Signature`, so the header can't discriminate.
      *
      * `handler` is invoked once per resolved message **fire-and-forget** — it is
      * dispatched after the response is computed and is NOT awaited, so its
@@ -1028,9 +1031,20 @@ export async function Spectrum<
 
   // --- Native Spectrum webhook (signed, normalized JSON) -------------------
 
-  // The header that distinguishes a native (signed-JSON) webhook from a fusor
-  // (protobuf) one — fusor envelopes never carry it.
-  const SPECTRUM_SIGNATURE_HEADER = "x-spectrum-signature";
+  // Distinguish a native Spectrum webhook from a fusor one by the PAYLOAD, not a
+  // header: Spectrum signs both kinds with `x-spectrum-signature`, so the header
+  // can't tell them apart. A native body is a JSON object (`{…`); a fusor body is
+  // a binary protobuf `RawInboundEvent`, which never starts with `{`.
+  const looksLikeNativePayload = (bodyBytes: Uint8Array): boolean => {
+    for (const byte of bodyBytes) {
+      // Skip leading ASCII whitespace (space, tab, LF, CR).
+      if (byte === 0x20 || byte === 0x09 || byte === 0x0a || byte === 0x0d) {
+        continue;
+      }
+      return byte === 0x7b; // "{"
+    }
+    return false;
+  };
 
   const webhookText = (status: number, text: string): WebhookRawResult => ({
     status,
@@ -1183,9 +1197,9 @@ export async function Spectrum<
   ): Promise<Response | WebhookRawResult> => {
     const { asWeb, bodyBytes, headers } = await readWebhookInput(request);
 
-    // Native Spectrum webhooks always carry a signature header; fusor (protobuf)
-    // envelopes never do — route on its presence.
-    if (headers[SPECTRUM_SIGNATURE_HEADER] !== undefined) {
+    // Route by payload shape: a native webhook is JSON, a fusor one is protobuf.
+    // Both may carry an `x-spectrum-signature` header, so it can't discriminate.
+    if (looksLikeNativePayload(bodyBytes)) {
       const spectrumResult = await handleSpectrumWebhook(
         bodyBytes,
         headers,

--- a/packages/spectrum-ts/src/spectrum.ts
+++ b/packages/spectrum-ts/src/spectrum.ts
@@ -44,6 +44,12 @@ import {
   stream,
 } from "./utils/stream";
 import { contentAttrs, senderAttrs } from "./utils/telemetry";
+import {
+  type DeserializeContext,
+  deserializeSpectrumMessage,
+} from "./webhook/deserialize";
+import { type SlimEnvelope, slimEnvelopeSchema } from "./webhook/types";
+import { verifySpectrumSignature } from "./webhook/verify";
 
 // Default OTLP endpoint used when `telemetry: true` opts into Photon. Standard
 // OTEL_EXPORTER_OTLP_* env vars always override this.
@@ -80,12 +86,20 @@ export type SpectrumInstance<
     edit(message: Message, newContent: ContentInput): Promise<void>;
     responding<T>(space: Space, fn: () => T | Promise<T>): Promise<T>;
     /**
-     * Handle one inbound fusor webhook delivery. Call this from your HTTP
-     * server's POST route — it verifies, decodes, routes to the matching
-     * provider's verify + message pipeline, and returns the HTTP response fusor
-     * relays back to the platform: the platform's `respond()` reply (including
-     * protocol echoes like Slack `url_verification`), computed synchronously and
-     * returned immediately.
+     * Handle one inbound webhook delivery. Call this from your HTTP server's
+     * POST route — it auto-detects which of the two Spectrum webhook formats the
+     * request carries and routes accordingly:
+     *
+     * - **Native Spectrum webhook** (`X-Spectrum-Signature` header present):
+     *   Spectrum Cloud POSTs already-normalized, HMAC-signed JSON. The signature
+     *   is verified against `Spectrum({ webhookSecret })` (a bad signature →
+     *   401), the slim payload is deserialized into `[space, message]`, and a
+     *   `200` is returned. Works without any fusor provider configured.
+     * - **Fusor webhook** (no signature header): a protobuf envelope wrapping a
+     *   raw provider request is decoded and routed to the matching provider's
+     *   verify + message pipeline; the HTTP response is that platform's
+     *   `respond()` reply (including protocol echoes like Slack
+     *   `url_verification`), computed synchronously and returned immediately.
      *
      * `handler` is invoked once per resolved message **fire-and-forget** — it is
      * dispatched after the response is computed and is NOT awaited, so its
@@ -95,8 +109,9 @@ export type SpectrumInstance<
      * and process in a separate worker).
      *
      * Stateless and request-scoped: it does NOT feed `spectrum.messages`, and it
-     * never opens the gRPC stream. fusor delivers at-least-once, so `handler`
-     * should dedupe on `message`/the event id for exactly-once side effects.
+     * never opens the streaming connection. Both formats deliver at-least-once,
+     * so `handler` should dedupe on `message`/the event id for exactly-once side
+     * effects.
      */
     webhook(request: Request, handler: WebhookHandler): Promise<Response>;
     webhook(
@@ -143,6 +158,7 @@ const spectrumConfigSchema = z.union([
     providers: z.array(z.custom<PlatformProviderConfig>()),
     options: spectrumOptionsSchema,
     telemetry: z.boolean().optional(),
+    webhookSecret: z.string().min(1).optional(),
   }),
   z.object({
     projectId: z.undefined().optional(),
@@ -150,6 +166,7 @@ const spectrumConfigSchema = z.union([
     providers: z.array(z.custom<PlatformProviderConfig>()),
     options: spectrumOptionsSchema,
     telemetry: z.boolean().optional(),
+    webhookSecret: z.string().min(1).optional(),
   }),
 ]);
 
@@ -193,6 +210,7 @@ export async function Spectrum<
   providers: [...Providers];
   options?: SpectrumOptions;
   telemetry?: boolean;
+  webhookSecret?: string;
 }): Promise<SpectrumInstance<Providers> & { readonly config: ProjectData }>;
 export async function Spectrum<
   const Providers extends PlatformProviderConfig[],
@@ -202,6 +220,7 @@ export async function Spectrum<
   providers: [...Providers];
   options?: SpectrumOptions;
   telemetry?: boolean;
+  webhookSecret?: string;
 }): Promise<SpectrumInstance<Providers>>;
 export async function Spectrum<
   const Providers extends PlatformProviderConfig[],
@@ -213,6 +232,7 @@ export async function Spectrum<
         providers: [...Providers];
         options?: SpectrumOptions;
         telemetry?: boolean;
+        webhookSecret?: string;
       }
     | {
         projectId?: never;
@@ -220,6 +240,7 @@ export async function Spectrum<
         providers: [...Providers];
         options?: SpectrumOptions;
         telemetry?: boolean;
+        webhookSecret?: string;
       }
 ): Promise<SpectrumInstance<Providers>> {
   spectrumConfigSchema.parse(options);
@@ -230,8 +251,13 @@ export async function Spectrum<
     providers,
     options: runtimeOptions,
     telemetry,
+    webhookSecret,
   } = options;
   const flattenGroups = runtimeOptions?.flattenGroups ?? false;
+  // The per-webhook signing secret for native Spectrum webhooks. Explicit option
+  // wins; otherwise fall back to the env var so deployments can inject it.
+  const resolvedWebhookSecret =
+    webhookSecret ?? process.env.SPECTRUM_WEBHOOK_SECRET;
 
   const otelHandle = telemetry
     ? bootstrapTelemetry({ projectId, projectSecret })
@@ -865,26 +891,37 @@ export async function Spectrum<
     return result;
   };
 
-  // Read the RAW request bytes without re-encoding — the protobuf decode needs
-  // the exact bytes fusor sent. `asWeb` records whether to reply with a Web
-  // `Response` or the raw result shape.
+  // Read the RAW request bytes without re-encoding — both the protobuf decode
+  // (fusor) and the HMAC verification (native) need the exact bytes received.
+  // `asWeb` records whether to reply with a Web `Response` or the raw result
+  // shape; `headers` (keys lowercased) carry the native webhook's signature.
   const readWebhookInput = async (
     request: Request | WebhookRawRequest
   ): Promise<{
     asWeb: boolean;
     bodyBytes: Uint8Array;
+    headers: Record<string, string>;
   }> => {
     if (typeof Request !== "undefined" && request instanceof Request) {
+      const headers: Record<string, string> = {};
+      for (const [key, value] of request.headers) {
+        headers[key.toLowerCase()] = value;
+      }
       return {
         asWeb: true,
         bodyBytes: new Uint8Array(await request.arrayBuffer()),
+        headers,
       };
     }
     // The compound `typeof Request` guard above doesn't narrow the union here.
     const raw = request as WebhookRawRequest;
     const bodyBytes =
       raw.body instanceof ArrayBuffer ? new Uint8Array(raw.body) : raw.body;
-    return { asWeb: false, bodyBytes };
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(raw.headers ?? {})) {
+      headers[key.toLowerCase()] = String(value);
+    }
+    return { asWeb: false, bodyBytes, headers };
   };
 
   // Resolve each collected record and hand it to the request-scoped handler.
@@ -894,7 +931,7 @@ export async function Spectrum<
     collected: ProviderMessageRecord[],
     runtime: PlatformRuntime,
     handler: WebhookHandler,
-    event: RawInboundEvent
+    context: { eventId?: string; platform: string }
   ): Promise<void> => {
     for (const record of collected) {
       const tuples = await resolveRecordToMessages(record, runtime);
@@ -905,8 +942,8 @@ export async function Spectrum<
           lifecycleLog.error(
             `spectrum.webhook: handler threw (async), ${error}`,
             {
-              eventId: event.eventId,
-              platform: event.platform,
+              eventId: context.eventId,
+              platform: context.platform,
               messageId: message.id,
               error: error instanceof Error ? error.message : String(error),
             }
@@ -989,17 +1026,179 @@ export async function Spectrum<
     return result;
   };
 
+  // --- Native Spectrum webhook (signed, normalized JSON) -------------------
+
+  // The header that distinguishes a native (signed-JSON) webhook from a fusor
+  // (protobuf) one — fusor envelopes never carry it.
+  const SPECTRUM_SIGNATURE_HEADER = "x-spectrum-signature";
+
+  const webhookText = (status: number, text: string): WebhookRawResult => ({
+    status,
+    headers: {},
+    body: encodeText(text),
+  });
+
+  // A platform's optional attachment-fetch capability (e.g. iMessage's
+  // `getAttachment`). Used to lazily back a native webhook attachment's
+  // read()/stream(), since the webhook delivers metadata only.
+  type GetAttachmentAction = (
+    ctx: { client: unknown; config: unknown; store: Store },
+    attachmentId: string,
+    phone?: string
+  ) => Promise<
+    | {
+        read: () => Promise<Buffer>;
+        stream?: () => Promise<ReadableStream<Uint8Array>>;
+      }
+    | undefined
+  >;
+
+  const resolveWebhookAttachment: DeserializeContext["resolveAttachment"] = (
+    platform,
+    spaceRef,
+    attachmentId
+  ) => {
+    const runtime = platformStates.get(platform);
+    const action = (
+      runtime?.definition as { actions?: Record<string, unknown> } | undefined
+    )?.actions?.getAttachment;
+    if (!runtime || typeof action !== "function") {
+      return;
+    }
+    const getAttachment = action as GetAttachmentAction;
+    const phone =
+      typeof spaceRef.phone === "string" ? spaceRef.phone : undefined;
+    let cached: ReturnType<GetAttachmentAction> | undefined;
+    const fetchOnce = (): ReturnType<GetAttachmentAction> => {
+      cached ??= getAttachment(
+        {
+          client: runtime.client,
+          config: runtime.config,
+          store: runtime.store,
+        },
+        attachmentId,
+        phone
+      );
+      return cached;
+    };
+    return {
+      read: async () => {
+        const found = await fetchOnce();
+        if (!found) {
+          throw new Error(
+            `Spectrum webhook attachment "${attachmentId}" not found on "${platform}"`
+          );
+        }
+        return found.read();
+      },
+      stream: async () => {
+        const found = await fetchOnce();
+        if (!found?.stream) {
+          throw new Error(
+            `Spectrum webhook attachment "${attachmentId}" has no stream on "${platform}"`
+          );
+        }
+        return found.stream();
+      },
+    };
+  };
+
+  // Verify the HMAC signature, deserialize the slim JSON into a [space, message],
+  // and deliver fire-and-forget (mirroring the fusor path). Verification runs
+  // BEFORE any parse/dispatch, so a forged body is rejected (401) without ever
+  // reaching the handler.
+  const handleSpectrumWebhook = async (
+    bodyBytes: Uint8Array,
+    headers: Record<string, string>,
+    handler: WebhookHandler
+  ): Promise<WebhookRawResult> => {
+    if (!resolvedWebhookSecret) {
+      lifecycleLog.error(
+        "spectrum.webhook: received a signed Spectrum webhook but no webhookSecret is configured (set Spectrum({ webhookSecret }) or SPECTRUM_WEBHOOK_SECRET)"
+      );
+      return webhookText(500, "webhook secret not configured");
+    }
+
+    const verification = verifySpectrumSignature({
+      rawBody: bodyBytes,
+      headers,
+      secret: resolvedWebhookSecret,
+    });
+    if (!verification.ok) {
+      // Bad signature / expired timestamp → unauthenticated (401); a missing
+      // signature header → malformed (400). Neither is retryable.
+      const status = verification.reason === "missing-headers" ? 400 : 401;
+      return webhookText(status, verification.reason);
+    }
+
+    let envelope: SlimEnvelope;
+    try {
+      const parsed = JSON.parse(new TextDecoder().decode(bodyBytes));
+      envelope = slimEnvelopeSchema.parse(parsed);
+    } catch (error) {
+      lifecycleLog.warn(
+        `spectrum.webhook: malformed Spectrum webhook payload, ${error}`
+      );
+      return webhookText(400, "malformed payload");
+    }
+
+    const deserialized = deserializeSpectrumMessage(envelope, {
+      resolveAttachment: resolveWebhookAttachment,
+    });
+    if (!deserialized) {
+      // Unknown event type or unroutable message — acknowledge so Spectrum does
+      // not retry (neither is fixed by retrying).
+      return webhookText(200, "ok");
+    }
+
+    const { platform, record } = deserialized;
+    const runtime = platformStates.get(platform);
+    if (!runtime) {
+      lifecycleLog.warn(
+        `spectrum.webhook: no provider configured for platform "${platform}"; acknowledging without delivery`,
+        { platform }
+      );
+      return webhookText(200, "ok");
+    }
+
+    // Fire-and-forget, mirroring the fusor path: acknowledge now, deliver after.
+    deliverWebhookMessages([record], runtime, handler, { platform }).catch(
+      (error) => {
+        lifecycleLog.error(
+          `spectrum.webhook: Spectrum delivery failed (async), ${error}`,
+          {
+            platform,
+            messageId: record.id,
+            error: error instanceof Error ? error.message : String(error),
+          }
+        );
+      }
+    );
+    return webhookText(200, "ok");
+  };
+
   const handleWebhook = async (
     request: Request | WebhookRawRequest,
     handler: WebhookHandler
   ): Promise<Response | WebhookRawResult> => {
-    if (!fusorCore) {
-      throw new Error(
-        "spectrum.webhook() requires at least one fusor provider; none are configured"
+    const { asWeb, bodyBytes, headers } = await readWebhookInput(request);
+
+    // Native Spectrum webhooks always carry a signature header; fusor (protobuf)
+    // envelopes never do — route on its presence.
+    if (headers[SPECTRUM_SIGNATURE_HEADER] !== undefined) {
+      const spectrumResult = await handleSpectrumWebhook(
+        bodyBytes,
+        headers,
+        handler
       );
+      return buildWebhookResult(asWeb, spectrumResult);
     }
 
-    const { asWeb, bodyBytes } = await readWebhookInput(request);
+    if (!fusorCore) {
+      throw new Error(
+        "spectrum.webhook() received a non-Spectrum (fusor) request but no fusor provider is configured"
+      );
+    }
 
     const event = decodeWebhookEvent(bodyBytes);
     if (!event) {

--- a/packages/spectrum-ts/src/webhook/deserialize.ts
+++ b/packages/spectrum-ts/src/webhook/deserialize.ts
@@ -1,0 +1,305 @@
+import { asAttachment } from "../content/attachment";
+import {
+  asContact,
+  type ContactInput,
+  type ContactPhone,
+} from "../content/contact";
+import { asCustom } from "../content/custom";
+import { asRichlink } from "../content/richlink";
+import type { Content } from "../content/types";
+import type { ProviderMessageRecord } from "../platform/build";
+import { UnsupportedError } from "../utils/errors";
+import type {
+  SlimContent,
+  SlimEnvelope,
+  SlimMessage,
+  SlimMessageRef,
+} from "./types";
+
+/** The single event type that carries a message today. */
+const MESSAGES_EVENT = "messages";
+const DEFAULT_ATTACHMENT_NAME = "attachment";
+const DEFAULT_MIME_TYPE = "application/octet-stream";
+
+/**
+ * Lazy byte accessors for an attachment whose bytes are fetched on demand —
+ * the native webhook delivers attachment metadata only.
+ */
+export interface AttachmentBytes {
+  read: () => Promise<Buffer>;
+  stream?: () => Promise<ReadableStream<Uint8Array>>;
+}
+
+export interface DeserializeContext {
+  /**
+   * Reconstruct lazy byte accessors for a slim attachment by delegating to the
+   * owning platform (e.g. iMessage's `getAttachment`). Returns `undefined` when
+   * the platform exposes no such capability, in which case the attachment is
+   * delivered metadata-only with a `read()`/`stream()` that throws on use.
+   */
+  resolveAttachment?: (
+    platform: string,
+    spaceRef: { id: string } & Record<string, unknown>,
+    attachmentId: string
+  ) => AttachmentBytes | undefined;
+}
+
+export interface DeserializeResult {
+  platform: string;
+  record: ProviderMessageRecord;
+}
+
+type SpaceRef = { id: string } & Record<string, unknown>;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
+const asString = (value: unknown): string =>
+  typeof value === "string" ? value : "";
+
+const asOptionalDate = (value: unknown): Date | undefined =>
+  typeof value === "string" ? new Date(value) : undefined;
+
+/**
+ * Map a native Spectrum webhook envelope to a `ProviderMessageRecord` plus the
+ * platform that owns it, ready for `resolveRecordToMessages`. Returns `null`
+ * when the delivery carries nothing to route (an unknown `event` type, or a
+ * message with no resolvable platform) — the caller acknowledges it (200)
+ * rather than failing, since neither is fixed by a retry.
+ *
+ * Reaction targets and group items are emitted as **raw nested records**; the
+ * `wrapProviderMessage`/`wrapNestedContent` pipeline turns them into fully-built
+ * Messages, exactly as a provider's own `messages` handler would.
+ */
+export function deserializeSpectrumMessage(
+  envelope: SlimEnvelope,
+  ctx: DeserializeContext
+): DeserializeResult | null {
+  if (envelope.event !== MESSAGES_EVENT) {
+    return null;
+  }
+  const message = envelope.message;
+  const platform = resolvePlatform(message);
+  if (!platform) {
+    return null;
+  }
+  const spaceRef: SpaceRef = { ...message.space };
+  return {
+    platform,
+    record: {
+      id: message.id,
+      direction: "inbound",
+      content: deserializeContent(message.content, platform, spaceRef, ctx),
+      space: spaceRef,
+      sender: message.sender ? { ...message.sender } : undefined,
+      timestamp: asOptionalDate(message.timestamp),
+    },
+  };
+}
+
+const resolvePlatform = (message: SlimMessage): string | undefined =>
+  message.platform ?? message.space.platform;
+
+// A wire content arm we couldn't map cleanly still reaches the handler as
+// `custom` (carrying the original JSON) rather than failing the whole delivery.
+const deserializeContent = (
+  content: SlimContent,
+  platform: string,
+  spaceRef: SpaceRef,
+  ctx: DeserializeContext
+): Content => {
+  try {
+    return mapContent(content, platform, spaceRef, ctx);
+  } catch {
+    return asCustom(content);
+  }
+};
+
+const mapContent = (
+  content: SlimContent,
+  platform: string,
+  spaceRef: SpaceRef,
+  ctx: DeserializeContext
+): Content => {
+  const raw = content as Record<string, unknown>;
+  switch (content.type) {
+    case "text":
+      return { type: "text", text: asString(raw.text) };
+    case "richlink":
+      return asRichlink({ url: asString(raw.url) });
+    case "contact":
+      return deserializeContact(raw);
+    case "reaction":
+      return deserializeReaction(raw, spaceRef);
+    case "group":
+      return deserializeGroup(raw, platform, spaceRef, ctx);
+    case "attachment":
+      return deserializeAttachment(raw, platform, spaceRef, ctx);
+    default:
+      return asCustom(content);
+  }
+};
+
+const deserializeAttachment = (
+  raw: Record<string, unknown>,
+  platform: string,
+  spaceRef: SpaceRef,
+  ctx: DeserializeContext
+): Content => {
+  const id = asString(raw.id);
+  const bytes = ctx.resolveAttachment?.(platform, spaceRef, id);
+  const unavailable = (): Promise<never> =>
+    Promise.reject(
+      UnsupportedError.action(
+        "getAttachment",
+        platform,
+        `attachment "${id}" arrived without bytes over the Spectrum webhook and "${platform}" exposes no getAttachment`
+      )
+    );
+  return asAttachment({
+    id,
+    name: asString(raw.name) || DEFAULT_ATTACHMENT_NAME,
+    mimeType: asString(raw.mimeType) || DEFAULT_MIME_TYPE,
+    size: typeof raw.size === "number" ? raw.size : undefined,
+    read: bytes ? bytes.read : unavailable,
+    stream: bytes?.stream,
+  });
+};
+
+const deserializeReaction = (
+  raw: Record<string, unknown>,
+  spaceRef: SpaceRef
+): Content =>
+  // `target` is a raw record; `wrapNestedContent` wraps it into a Message.
+  ({
+    type: "reaction",
+    emoji: asString(raw.emoji),
+    target: buildTargetRecord(raw.target, spaceRef),
+  }) as unknown as Content;
+
+const buildTargetRecord = (
+  target: unknown,
+  spaceRef: SpaceRef
+): ProviderMessageRecord => {
+  const ref = (isRecord(target) ? target : {}) as Partial<SlimMessageRef>;
+  return {
+    id: asString(ref.id),
+    // The target's full content is not delivered; the 80-char `contentPreview`
+    // (text targets only) is the best available stand-in.
+    content: { type: "text", text: asString(ref.contentPreview) },
+    space: { ...spaceRef },
+    sender: ref.sender ? { ...ref.sender } : undefined,
+    timestamp: asOptionalDate(ref.timestamp),
+  };
+};
+
+const deserializeGroup = (
+  raw: Record<string, unknown>,
+  platform: string,
+  spaceRef: SpaceRef,
+  ctx: DeserializeContext
+): Content => {
+  const rawItems = Array.isArray(raw.items) ? raw.items : [];
+  // Each item is a raw record; `wrapNestedContent` wraps it into a Message.
+  return {
+    type: "group",
+    items: rawItems.map((item) =>
+      buildItemRecord(item, platform, spaceRef, ctx)
+    ),
+  } as unknown as Content;
+};
+
+const buildItemRecord = (
+  item: unknown,
+  platform: string,
+  spaceRef: SpaceRef,
+  ctx: DeserializeContext
+): ProviderMessageRecord => {
+  const record = isRecord(item) ? item : {};
+  const itemSpace: SpaceRef = isRecord(record.space)
+    ? {
+        ...(record.space as Record<string, unknown>),
+        id:
+          asString((record.space as Record<string, unknown>).id) || spaceRef.id,
+      }
+    : spaceRef;
+  const content = isRecord(record.content)
+    ? deserializeContent(
+        record.content as SlimContent,
+        platform,
+        itemSpace,
+        ctx
+      )
+    : asCustom(record.content);
+  return {
+    id: asString(record.id),
+    content,
+    space: itemSpace,
+    sender: isRecord(record.sender)
+      ? { ...record.sender, id: asString(record.sender.id) }
+      : undefined,
+    timestamp: asOptionalDate(record.timestamp),
+  };
+};
+
+const deserializeContact = (raw: Record<string, unknown>): Content => {
+  const input: ContactInput = {};
+  const name = normalizeContactName(raw.name);
+  if (name) {
+    input.name = name;
+  }
+  const phones = normalizeContactPhones(raw.phones);
+  if (phones) {
+    input.phones = phones;
+  }
+  if (typeof raw.note === "string") {
+    input.note = raw.note;
+  }
+  if (raw.raw !== undefined) {
+    input.raw = raw.raw;
+  }
+  return asContact(input);
+};
+
+const CONTACT_NAME_KEYS = [
+  "formatted",
+  "first",
+  "last",
+  "middle",
+  "prefix",
+  "suffix",
+] as const;
+
+const normalizeContactName = (
+  value: unknown
+): ContactInput["name"] | undefined => {
+  if (typeof value === "string") {
+    return { formatted: value };
+  }
+  if (!isRecord(value)) {
+    return;
+  }
+  const name: NonNullable<ContactInput["name"]> = {};
+  for (const key of CONTACT_NAME_KEYS) {
+    const part = value[key];
+    if (typeof part === "string") {
+      name[key] = part;
+    }
+  }
+  return Object.keys(name).length > 0 ? name : undefined;
+};
+
+const normalizeContactPhones = (value: unknown): ContactPhone[] | undefined => {
+  if (!Array.isArray(value)) {
+    return;
+  }
+  const phones: ContactPhone[] = [];
+  for (const entry of value) {
+    if (typeof entry === "string") {
+      phones.push({ value: entry });
+    } else if (isRecord(entry) && typeof entry.value === "string") {
+      phones.push({ value: entry.value });
+    }
+  }
+  return phones.length > 0 ? phones : undefined;
+};

--- a/packages/spectrum-ts/src/webhook/types.ts
+++ b/packages/spectrum-ts/src/webhook/types.ts
@@ -1,0 +1,64 @@
+import z from "zod";
+
+/**
+ * Wire schemas for the **native Spectrum webhook**
+ * (https://photon.codes/docs/webhooks).
+ *
+ * Unlike the fusor webhook — which relays a raw provider request inside a
+ * protobuf envelope — the native webhook delivers Spectrum's own message model
+ * already normalized to slim JSON (methods and byte payloads stripped), signed
+ * with an HMAC. These schemas validate the fields the deserializer depends on
+ * while **preserving** unknown/extra fields (`z.looseObject`), so additive
+ * changes — new platform-specific space fields, future content arms — never
+ * break an older SDK. Content is discriminated by hand in `deserialize.ts`
+ * rather than here, so an unknown content `type` survives parsing instead of
+ * throwing.
+ */
+
+export const slimSenderSchema = z.looseObject({
+  id: z.string(),
+  platform: z.string().optional(),
+});
+
+export const slimSpaceSchema = z.looseObject({
+  id: z.string(),
+  platform: z.string().optional(),
+});
+
+export const slimContentSchema = z.looseObject({
+  type: z.string(),
+});
+
+/** A slim reference to another message — e.g. a reaction's `target`. */
+export const slimMessageRefSchema = z.looseObject({
+  id: z.string(),
+  platform: z.string().optional(),
+  timestamp: z.string().optional(),
+  sender: slimSenderSchema.optional(),
+  contentPreview: z.string().optional(),
+});
+
+export const slimMessageSchema = z.looseObject({
+  id: z.string(),
+  platform: z.string().optional(),
+  // Webhooks are inbound-only; `direction` is left loose (not a `"inbound"`
+  // literal) so a future direction value cannot fail an older SDK's parse.
+  direction: z.string().optional(),
+  timestamp: z.string().optional(),
+  sender: slimSenderSchema.optional(),
+  space: slimSpaceSchema,
+  content: slimContentSchema,
+});
+
+export const slimEnvelopeSchema = z.looseObject({
+  event: z.string(),
+  space: slimSpaceSchema.optional(),
+  message: slimMessageSchema,
+});
+
+export type SlimSender = z.infer<typeof slimSenderSchema>;
+export type SlimSpace = z.infer<typeof slimSpaceSchema>;
+export type SlimContent = z.infer<typeof slimContentSchema>;
+export type SlimMessageRef = z.infer<typeof slimMessageRefSchema>;
+export type SlimMessage = z.infer<typeof slimMessageSchema>;
+export type SlimEnvelope = z.infer<typeof slimEnvelopeSchema>;

--- a/packages/spectrum-ts/src/webhook/verify.ts
+++ b/packages/spectrum-ts/src/webhook/verify.ts
@@ -1,0 +1,76 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const SIGNATURE_HEADER = "x-spectrum-signature";
+const TIMESTAMP_HEADER = "x-spectrum-timestamp";
+const SIGNATURE_PREFIX = "v0=";
+const SIGNATURE_SCHEME = "v0";
+
+/**
+ * Replay-protection window, in seconds. Spectrum signs each delivery with a
+ * timestamp; a delivery whose timestamp is further than this from now (past or
+ * future) is rejected, so a captured request cannot be replayed indefinitely.
+ * Matches the documented 5-minute tolerance.
+ */
+const REPLAY_TOLERANCE_SECONDS = 300;
+const MILLIS_PER_SECOND = 1000;
+
+export type VerifyResult =
+  | { ok: true }
+  | { ok: false; reason: "missing-headers" | "expired" | "signature-mismatch" };
+
+export interface VerifyInput {
+  /** Request headers, keys lowercased. */
+  headers: Record<string, string>;
+  /** Epoch milliseconds; injectable for deterministic tests. */
+  now?: number;
+  /** The exact bytes received on the wire — never a re-encoded body. */
+  rawBody: Uint8Array;
+  /** The per-webhook signing secret. */
+  secret: string;
+}
+
+/**
+ * Verify a native Spectrum webhook signature.
+ *
+ * The header is `X-Spectrum-Signature: v0=<lowercase-hex>` where the hex digest
+ * is `HMAC-SHA256(secret, "v0:" + timestamp + ":" + rawBody)` and `timestamp`
+ * is the `X-Spectrum-Timestamp` header (unix seconds). The base string is built
+ * over the **exact body bytes**: never JSON-parse-then-restringify before
+ * verifying, or the bytes (key order, whitespace) change and the MAC won't
+ * match. The digest comparison is constant-time.
+ */
+export function verifySpectrumSignature(input: VerifyInput): VerifyResult {
+  const { rawBody, headers, secret, now = Date.now() } = input;
+  const provided = headers[SIGNATURE_HEADER];
+  const timestamp = headers[TIMESTAMP_HEADER];
+  if (!(provided && timestamp)) {
+    return { ok: false, reason: "missing-headers" };
+  }
+
+  const timestampSeconds = Number(timestamp);
+  if (!Number.isFinite(timestampSeconds)) {
+    return { ok: false, reason: "missing-headers" };
+  }
+  const nowSeconds = Math.floor(now / MILLIS_PER_SECOND);
+  if (Math.abs(nowSeconds - timestampSeconds) > REPLAY_TOLERANCE_SECONDS) {
+    return { ok: false, reason: "expired" };
+  }
+
+  const base = Buffer.concat([
+    Buffer.from(`${SIGNATURE_SCHEME}:${timestamp}:`, "utf8"),
+    Buffer.from(rawBody),
+  ]);
+  const expected = createHmac("sha256", secret).update(base).digest();
+
+  const providedHex = provided.startsWith(SIGNATURE_PREFIX)
+    ? provided.slice(SIGNATURE_PREFIX.length)
+    : provided;
+  const providedBytes = Buffer.from(providedHex, "hex");
+  if (
+    providedBytes.length !== expected.length ||
+    !timingSafeEqual(providedBytes, expected)
+  ) {
+    return { ok: false, reason: "signature-mismatch" };
+  }
+  return { ok: true };
+}

--- a/packages/spectrum-ts/test/core/fusor/webhook.test.ts
+++ b/packages/spectrum-ts/test/core/fusor/webhook.test.ts
@@ -17,7 +17,7 @@ import type { Message } from "@/types/message";
 
 stubCloud();
 
-const NO_FUSOR_PROVIDER_ERROR = /requires at least one fusor provider/;
+const NO_FUSOR_PROVIDER_ERROR = /no fusor provider is configured/;
 
 describe("spectrum.webhook", () => {
   it("routes by platform, resolves [space, message], and delivers to the handler", async () => {

--- a/packages/spectrum-ts/test/support/webhook.ts
+++ b/packages/spectrum-ts/test/support/webhook.ts
@@ -1,0 +1,80 @@
+import { createHmac } from "node:crypto";
+
+// A fixed per-webhook signing secret for the native Spectrum webhook tests.
+export const SPECTRUM_WEBHOOK_SECRET =
+  "whsec_test_0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+
+const MILLIS_PER_SECOND = 1000;
+
+export interface SignedSpectrumWebhook {
+  body: Uint8Array;
+  headers: Record<string, string>;
+}
+
+export interface SignSpectrumOptions {
+  event?: string;
+  secret?: string;
+  /**
+   * Sign over these bytes instead of the encoded payload — used to simulate a
+   * tampered body (signature computed over different bytes than delivered).
+   */
+  signOver?: Uint8Array;
+  /** Unix seconds; defaults to now. */
+  timestamp?: number;
+  webhookId?: string;
+}
+
+const encode = (payload: unknown): Uint8Array =>
+  new TextEncoder().encode(
+    typeof payload === "string" ? payload : JSON.stringify(payload)
+  );
+
+/**
+ * Build a signed native Spectrum webhook request exactly as the SDK verifies it:
+ * `HMAC-SHA256(secret, "v0:" + timestamp + ":" + rawBody)`, hex, `v0=` prefix.
+ */
+export const signSpectrum = (
+  payload: unknown,
+  opts: SignSpectrumOptions = {}
+): SignedSpectrumWebhook => {
+  const secret = opts.secret ?? SPECTRUM_WEBHOOK_SECRET;
+  const timestamp =
+    opts.timestamp ?? Math.floor(Date.now() / MILLIS_PER_SECOND);
+  const body = encode(payload);
+  const signedOver = opts.signOver ?? body;
+  const base = Buffer.concat([
+    Buffer.from(`v0:${timestamp}:`, "utf8"),
+    Buffer.from(signedOver),
+  ]);
+  const hex = createHmac("sha256", secret).update(base).digest("hex");
+  return {
+    headers: {
+      "x-spectrum-event": opts.event ?? "messages",
+      "x-spectrum-signature": `v0=${hex}`,
+      "x-spectrum-timestamp": String(timestamp),
+      "x-spectrum-webhook-id": opts.webhookId ?? "wh-1",
+      "content-type": "application/json",
+    },
+    body,
+  };
+};
+
+/** A minimal native `messages` envelope for a text message on `platform`. */
+export const textEnvelope = (
+  platform: string,
+  text: string,
+  overrides: Record<string, unknown> = {}
+) => ({
+  event: "messages",
+  space: { id: "s1", platform },
+  message: {
+    id: "m-webhook-1",
+    platform,
+    direction: "inbound",
+    timestamp: "2026-06-12T10:00:00.000Z",
+    sender: { id: "u1", platform },
+    space: { id: "s1", platform },
+    content: { type: "text", text },
+    ...overrides,
+  },
+});

--- a/packages/spectrum-ts/test/webhook/deserialize.test.ts
+++ b/packages/spectrum-ts/test/webhook/deserialize.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from "bun:test";
+import type { Attachment } from "@/content/attachment";
+import type { Reaction } from "@/content/reaction";
+import type { Richlink } from "@/content/richlink";
+import {
+  type DeserializeContext,
+  deserializeSpectrumMessage,
+} from "@/webhook/deserialize";
+import { slimEnvelopeSchema } from "@/webhook/types";
+
+const PLATFORM = "im";
+const UNSUPPORTED_ATTACHMENT_ERROR = /does not support/;
+
+const parse = (raw: unknown) => slimEnvelopeSchema.parse(raw);
+
+const envelope = (content: unknown, overrides: Record<string, unknown> = {}) =>
+  parse({
+    event: "messages",
+    space: { id: "s1", platform: PLATFORM },
+    message: {
+      id: "m1",
+      platform: PLATFORM,
+      direction: "inbound",
+      timestamp: "2026-06-12T10:00:00.000Z",
+      sender: { id: "u1", platform: PLATFORM },
+      space: { id: "s1", platform: PLATFORM },
+      content,
+      ...overrides,
+    },
+  });
+
+const NO_CTX: DeserializeContext = {};
+
+const deserialize = (content: unknown, ctx: DeserializeContext = NO_CTX) => {
+  const result = deserializeSpectrumMessage(envelope(content), ctx);
+  if (!result) {
+    throw new Error("expected a deserialized message");
+  }
+  return result;
+};
+
+describe("deserializeSpectrumMessage", () => {
+  it("resolves the platform and base record fields", () => {
+    const { platform, record } = deserialize({ type: "text", text: "hi" });
+    expect(platform).toBe(PLATFORM);
+    expect(record.id).toBe("m1");
+    expect(record.direction).toBe("inbound");
+    expect(record.sender).toEqual({ id: "u1", platform: PLATFORM });
+    expect(record.space).toMatchObject({ id: "s1", platform: PLATFORM });
+    expect(record.timestamp).toEqual(new Date("2026-06-12T10:00:00.000Z"));
+  });
+
+  it("falls back to space.platform when message.platform is absent", () => {
+    const result = deserializeSpectrumMessage(
+      parse({
+        event: "messages",
+        message: {
+          id: "m1",
+          space: { id: "s1", platform: PLATFORM },
+          content: { type: "text", text: "hi" },
+        },
+      }),
+      NO_CTX
+    );
+    expect(result?.platform).toBe(PLATFORM);
+  });
+
+  it("returns null for an unknown event type", () => {
+    const result = deserializeSpectrumMessage(
+      parse({
+        event: "presence",
+        message: {
+          id: "m1",
+          space: { id: "s1", platform: PLATFORM },
+          content: { type: "text", text: "hi" },
+        },
+      }),
+      NO_CTX
+    );
+    expect(result).toBeNull();
+  });
+
+  it("maps text content", () => {
+    const { record } = deserialize({ type: "text", text: "hello" });
+    expect(record.content).toEqual({ type: "text", text: "hello" });
+  });
+
+  it("maps a reaction to a raw text target carrying the contentPreview", () => {
+    const { record } = deserialize({
+      type: "reaction",
+      emoji: "👍",
+      target: {
+        id: "target-1",
+        platform: PLATFORM,
+        timestamp: "2026-06-12T09:59:00.000Z",
+        sender: { id: "u2", platform: PLATFORM },
+        contentPreview: "earlier message",
+      },
+    });
+    const content = record.content as unknown as Reaction;
+    expect(content.type).toBe("reaction");
+    expect(content.emoji).toBe("👍");
+    const target = content.target as unknown as {
+      id: string;
+      content: { type: string; text: string };
+    };
+    expect(target.id).toBe("target-1");
+    expect(target.content).toEqual({ type: "text", text: "earlier message" });
+    // A raw record (no methods) so wrapNestedContent wraps it into a Message.
+    expect((target as { react?: unknown }).react).toBeUndefined();
+  });
+
+  it("maps a group to raw item records", () => {
+    const { record } = deserialize({
+      type: "group",
+      items: [
+        {
+          id: "g0",
+          sender: { id: "u1" },
+          content: { type: "text", text: "a" },
+        },
+        {
+          id: "g1",
+          sender: { id: "u1" },
+          content: { type: "text", text: "b" },
+        },
+      ],
+    });
+    const content = record.content as unknown as {
+      type: string;
+      items: { id: string; content: { type: string; text: string } }[];
+    };
+    expect(content.type).toBe("group");
+    expect(content.items).toHaveLength(2);
+    expect(content.items[0]?.content).toEqual({ type: "text", text: "a" });
+    expect(content.items[1]?.id).toBe("g1");
+  });
+
+  it("maps a richlink with lazy accessors", () => {
+    const { record } = deserialize({
+      type: "richlink",
+      url: "https://example.com/post",
+    });
+    const content = record.content as Richlink;
+    expect(content.type).toBe("richlink");
+    expect(content.url).toBe("https://example.com/post");
+    expect(typeof content.title).toBe("function");
+    expect(typeof content.cover).toBe("function");
+  });
+
+  it("maps a contact's name and phones", () => {
+    const { record } = deserialize({
+      type: "contact",
+      name: { first: "Ada", last: "Lovelace" },
+      phones: ["+15550100", { value: "+15550101", type: "work" }],
+    });
+    const content = record.content as {
+      type: string;
+      name?: { first?: string; last?: string };
+      phones?: { value: string }[];
+    };
+    expect(content.type).toBe("contact");
+    expect(content.name).toEqual({ first: "Ada", last: "Lovelace" });
+    expect(content.phones).toEqual([
+      { value: "+15550100" },
+      { value: "+15550101" },
+    ]);
+  });
+
+  it("reconstructs attachment bytes via the resolver", async () => {
+    const bytes = Buffer.from("attachment-bytes");
+    const ctx: DeserializeContext = {
+      resolveAttachment: (platform, _spaceRef, attachmentId) => {
+        expect(platform).toBe(PLATFORM);
+        expect(attachmentId).toBe("att-1");
+        return { read: () => Promise.resolve(bytes) };
+      },
+    };
+    const { record } = deserialize(
+      {
+        type: "attachment",
+        id: "att-1",
+        name: "photo.jpg",
+        mimeType: "image/jpeg",
+        size: 16,
+      },
+      ctx
+    );
+    const content = record.content as Attachment;
+    expect(content.type).toBe("attachment");
+    expect(content.name).toBe("photo.jpg");
+    expect(content.mimeType).toBe("image/jpeg");
+    expect(content.size).toBe(16);
+    expect(await content.read()).toEqual(bytes);
+  });
+
+  it("delivers attachment metadata with a throwing read() when no resolver exists", async () => {
+    const { record } = deserialize({
+      type: "attachment",
+      id: "att-2",
+      name: "doc.pdf",
+      mimeType: "application/pdf",
+    });
+    const content = record.content as Attachment;
+    expect(content.name).toBe("doc.pdf");
+    expect(content.mimeType).toBe("application/pdf");
+    await expect(content.read()).rejects.toThrow(UNSUPPORTED_ATTACHMENT_ERROR);
+  });
+
+  it("delivers an unknown content type as custom", () => {
+    const { record } = deserialize({ type: "future-thing", foo: "bar" });
+    expect(record.content).toEqual({
+      type: "custom",
+      raw: { type: "future-thing", foo: "bar" },
+    });
+  });
+});

--- a/packages/spectrum-ts/test/webhook/elysia.test.ts
+++ b/packages/spectrum-ts/test/webhook/elysia.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "bun:test";
+import { stubCloud } from "@test/support/cloud";
+import { baseConfig, makeManagedProvider } from "@test/support/platform";
+import { flush } from "@test/support/timing";
+import {
+  type SignedSpectrumWebhook,
+  SPECTRUM_WEBHOOK_SECRET,
+  signSpectrum,
+  textEnvelope,
+} from "@test/support/webhook";
+import { Elysia } from "elysia";
+import { spectrum } from "@/elysia";
+import { Spectrum } from "@/spectrum";
+import type { Message } from "@/types/message";
+
+stubCloud();
+
+// Don't let a host env secret leak into the wrong-secret case.
+process.env.SPECTRUM_WEBHOOK_SECRET = "";
+
+const PLATFORM = "im";
+const DEFAULT_URL = "https://example.com/spectrum/webhook";
+
+const makeApp = (overrides: Record<string, unknown> = {}) =>
+  Spectrum({
+    ...baseConfig,
+    providers: [makeManagedProvider(PLATFORM).config({})],
+    webhookSecret: SPECTRUM_WEBHOOK_SECRET,
+    ...overrides,
+  });
+
+const post = (signed: SignedSpectrumWebhook, url = DEFAULT_URL) =>
+  new Request(url, {
+    method: "POST",
+    headers: signed.headers,
+    body: signed.body,
+  });
+
+describe("spectrum (elysia plugin)", () => {
+  it("verifies and delivers a signed webhook (raw body survives Elysia parsing)", async () => {
+    const app = await makeApp();
+    try {
+      const received: Message[] = [];
+      const { promise: finished, resolve: done } =
+        Promise.withResolvers<void>();
+
+      const elysia = new Elysia().use(
+        spectrum({
+          app,
+          onMessage: (_space, message) => {
+            received.push(message);
+            done();
+          },
+        })
+      );
+
+      const signed = signSpectrum(textEnvelope(PLATFORM, "hello there"));
+      const response = await elysia.handle(post(signed));
+      await finished;
+
+      // A valid signature only verifies if the exact wire bytes reached the SDK
+      // — so a 200 here proves Elysia never consumed or re-encoded the body.
+      expect(response.status).toBe(200);
+      expect(received).toHaveLength(1);
+      expect(received[0]?.content).toEqual({
+        type: "text",
+        text: "hello there",
+      });
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("rejects a bad signature with 401 and never calls onMessage", async () => {
+    const app = await makeApp();
+    try {
+      let called = false;
+      const elysia = new Elysia().use(
+        spectrum({
+          app,
+          onMessage: () => {
+            called = true;
+          },
+        })
+      );
+
+      const signed = signSpectrum(textEnvelope(PLATFORM, "hi"), {
+        secret: "the-wrong-secret",
+      });
+      const response = await elysia.handle(post(signed));
+      await flush();
+
+      expect(response.status).toBe(401);
+      expect(called).toBe(false);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("honors a custom path", async () => {
+    const app = await makeApp();
+    try {
+      const { promise: finished, resolve: done } =
+        Promise.withResolvers<void>();
+      const elysia = new Elysia().use(
+        spectrum({
+          app,
+          path: "/hooks/spectrum",
+          onMessage: () => done(),
+        })
+      );
+
+      const signed = signSpectrum(textEnvelope(PLATFORM, "custom path"));
+      const response = await elysia.handle(
+        post(signed, "https://example.com/hooks/spectrum")
+      );
+      await finished;
+
+      expect(response.status).toBe(200);
+    } finally {
+      await app.stop();
+    }
+  });
+});

--- a/packages/spectrum-ts/test/webhook/express.test.ts
+++ b/packages/spectrum-ts/test/webhook/express.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test";
+import type { AddressInfo } from "node:net";
+import { stubCloud } from "@test/support/cloud";
+import { baseConfig, makeManagedProvider } from "@test/support/platform";
+import { flush } from "@test/support/timing";
+import {
+  type SignedSpectrumWebhook,
+  SPECTRUM_WEBHOOK_SECRET,
+  signSpectrum,
+  textEnvelope,
+} from "@test/support/webhook";
+import express from "express";
+import { spectrum } from "@/express";
+import { Spectrum } from "@/spectrum";
+import type { Message } from "@/types/message";
+
+stubCloud();
+
+// Don't let a host env secret leak into the wrong-secret case.
+process.env.SPECTRUM_WEBHOOK_SECRET = "";
+
+const PLATFORM = "im";
+
+const makeApp = (overrides: Record<string, unknown> = {}) =>
+  Spectrum({
+    ...baseConfig,
+    providers: [makeManagedProvider(PLATFORM).config({})],
+    webhookSecret: SPECTRUM_WEBHOOK_SECRET,
+    ...overrides,
+  });
+
+/** Boot the express app on an ephemeral port; returns the base URL + a closer. */
+const listen = async (server: express.Express) => {
+  const http = server.listen(0);
+  await new Promise<void>((resolve) => http.once("listening", resolve));
+  const { port } = http.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((resolve) => http.close(() => resolve())),
+  };
+};
+
+const post = (url: string, signed: SignedSpectrumWebhook) =>
+  fetch(url, {
+    method: "POST",
+    headers: signed.headers,
+    body: signed.body,
+  });
+
+describe("spectrum (express plugin)", () => {
+  it("verifies and delivers a signed webhook (raw body survives express.raw)", async () => {
+    const app = await makeApp();
+    const received: Message[] = [];
+    const { promise: finished, resolve: done } = Promise.withResolvers<void>();
+
+    const server = express().use(
+      spectrum({
+        app,
+        onMessage: (_space, message) => {
+          received.push(message);
+          done();
+        },
+      })
+    );
+    const { url, close } = await listen(server);
+
+    try {
+      const signed = signSpectrum(textEnvelope(PLATFORM, "hello there"));
+      const response = await post(`${url}/spectrum/webhook`, signed);
+      await finished;
+
+      // A valid signature only verifies if the exact wire bytes reached the SDK
+      // — so a 200 here proves express.raw handed over the untouched body.
+      expect(response.status).toBe(200);
+      expect(received).toHaveLength(1);
+      expect(received[0]?.content).toEqual({
+        type: "text",
+        text: "hello there",
+      });
+    } finally {
+      await close();
+      await app.stop();
+    }
+  });
+
+  it("rejects a bad signature with 401 and never calls onMessage", async () => {
+    const app = await makeApp();
+    let called = false;
+
+    const server = express().use(
+      spectrum({
+        app,
+        onMessage: () => {
+          called = true;
+        },
+      })
+    );
+    const { url, close } = await listen(server);
+
+    try {
+      const signed = signSpectrum(textEnvelope(PLATFORM, "hi"), {
+        secret: "the-wrong-secret",
+      });
+      const response = await post(`${url}/spectrum/webhook`, signed);
+      await flush();
+
+      expect(response.status).toBe(401);
+      expect(called).toBe(false);
+    } finally {
+      await close();
+      await app.stop();
+    }
+  });
+
+  it("honors a custom path", async () => {
+    const app = await makeApp();
+    const { promise: finished, resolve: done } = Promise.withResolvers<void>();
+
+    const server = express().use(
+      spectrum({
+        app,
+        path: "/hooks/spectrum",
+        onMessage: () => done(),
+      })
+    );
+    const { url, close } = await listen(server);
+
+    try {
+      const signed = signSpectrum(textEnvelope(PLATFORM, "custom path"));
+      const response = await post(`${url}/hooks/spectrum`, signed);
+      await finished;
+
+      expect(response.status).toBe(200);
+    } finally {
+      await close();
+      await app.stop();
+    }
+  });
+});

--- a/packages/spectrum-ts/test/webhook/hono.test.ts
+++ b/packages/spectrum-ts/test/webhook/hono.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "bun:test";
+import { stubCloud } from "@test/support/cloud";
+import { baseConfig, makeManagedProvider } from "@test/support/platform";
+import { flush } from "@test/support/timing";
+import {
+  type SignedSpectrumWebhook,
+  SPECTRUM_WEBHOOK_SECRET,
+  signSpectrum,
+  textEnvelope,
+} from "@test/support/webhook";
+import { Hono } from "hono";
+import { spectrum } from "@/hono";
+import { Spectrum } from "@/spectrum";
+import type { Message } from "@/types/message";
+
+stubCloud();
+
+// Don't let a host env secret leak into the wrong-secret case.
+process.env.SPECTRUM_WEBHOOK_SECRET = "";
+
+const PLATFORM = "im";
+const DEFAULT_URL = "https://example.com/spectrum/webhook";
+
+const makeApp = (overrides: Record<string, unknown> = {}) =>
+  Spectrum({
+    ...baseConfig,
+    providers: [makeManagedProvider(PLATFORM).config({})],
+    webhookSecret: SPECTRUM_WEBHOOK_SECRET,
+    ...overrides,
+  });
+
+const post = (signed: SignedSpectrumWebhook, url = DEFAULT_URL) =>
+  new Request(url, {
+    method: "POST",
+    headers: signed.headers,
+    body: signed.body,
+  });
+
+describe("spectrum (hono plugin)", () => {
+  it("verifies and delivers a signed webhook (raw body survives Hono)", async () => {
+    const app = await makeApp();
+    try {
+      const received: Message[] = [];
+      const { promise: finished, resolve: done } =
+        Promise.withResolvers<void>();
+
+      const hono = new Hono().route(
+        "/",
+        spectrum({
+          app,
+          onMessage: (_space, message) => {
+            received.push(message);
+            done();
+          },
+        })
+      );
+
+      const signed = signSpectrum(textEnvelope(PLATFORM, "hello there"));
+      const response = await hono.request(post(signed));
+      await finished;
+
+      // A valid signature only verifies if the exact wire bytes reached the SDK
+      // — so a 200 here proves Hono never consumed or re-encoded the body.
+      expect(response.status).toBe(200);
+      expect(received).toHaveLength(1);
+      expect(received[0]?.content).toEqual({
+        type: "text",
+        text: "hello there",
+      });
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("rejects a bad signature with 401 and never calls onMessage", async () => {
+    const app = await makeApp();
+    try {
+      let called = false;
+      const hono = new Hono().route(
+        "/",
+        spectrum({
+          app,
+          onMessage: () => {
+            called = true;
+          },
+        })
+      );
+
+      const signed = signSpectrum(textEnvelope(PLATFORM, "hi"), {
+        secret: "the-wrong-secret",
+      });
+      const response = await hono.request(post(signed));
+      await flush();
+
+      expect(response.status).toBe(401);
+      expect(called).toBe(false);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("honors a custom path", async () => {
+    const app = await makeApp();
+    try {
+      const { promise: finished, resolve: done } =
+        Promise.withResolvers<void>();
+      const hono = new Hono().route(
+        "/",
+        spectrum({
+          app,
+          path: "/hooks/spectrum",
+          onMessage: () => done(),
+        })
+      );
+
+      const signed = signSpectrum(textEnvelope(PLATFORM, "custom path"));
+      const response = await hono.request(
+        post(signed, "https://example.com/hooks/spectrum")
+      );
+      await finished;
+
+      expect(response.status).toBe(200);
+    } finally {
+      await app.stop();
+    }
+  });
+});

--- a/packages/spectrum-ts/test/webhook/spectrum.test.ts
+++ b/packages/spectrum-ts/test/webhook/spectrum.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "bun:test";
+import { stubCloud } from "@test/support/cloud";
+import { encodeEvent, makeSlack } from "@test/support/fusor";
+import { baseConfig, makeManagedProvider } from "@test/support/platform";
+import { flush } from "@test/support/timing";
+import {
+  SPECTRUM_WEBHOOK_SECRET,
+  signSpectrum,
+  textEnvelope,
+} from "@test/support/webhook";
+import { Spectrum } from "@/spectrum";
+import type { Message } from "@/types/message";
+
+stubCloud();
+
+// The env fallback must not leak in from the host so the missing-secret path is
+// exercised deterministically (empty string is falsy → treated as unset).
+process.env.SPECTRUM_WEBHOOK_SECRET = "";
+
+const PLATFORM = "im";
+const NO_FUSOR_PROVIDER_ERROR = /no fusor provider is configured/;
+
+const withSpectrum = async (
+  overrides: Record<string, unknown>,
+  fn: (spectrum: Awaited<ReturnType<typeof Spectrum>>) => Promise<void>
+) => {
+  const spectrum = await Spectrum({
+    ...baseConfig,
+    providers: [makeManagedProvider(PLATFORM).config({})],
+    ...overrides,
+  });
+  try {
+    await fn(spectrum);
+  } finally {
+    await spectrum.stop();
+  }
+};
+
+describe("spectrum.webhook (native Spectrum webhook)", () => {
+  it("verifies, deserializes, and delivers a signed message", async () => {
+    await withSpectrum(
+      { webhookSecret: SPECTRUM_WEBHOOK_SECRET },
+      async (spectrum) => {
+        const received: [unknown, Message][] = [];
+        const { promise: finished, resolve: done } =
+          Promise.withResolvers<void>();
+
+        const signed = signSpectrum(textEnvelope(PLATFORM, "hello there"));
+        const result = await spectrum.webhook(signed, (space, message) => {
+          received.push([space, message]);
+          done();
+        });
+        await finished;
+
+        expect(result.status).toBe(200);
+        expect(received).toHaveLength(1);
+        const [space, message] = received[0] ?? [];
+        expect((space as { __platform: string }).__platform).toBe(PLATFORM);
+        expect(message?.direction).toBe("inbound");
+        expect(message?.content).toEqual({ type: "text", text: "hello there" });
+      }
+    );
+  });
+
+  it("rejects a bad signature with 401 and never calls the handler", async () => {
+    await withSpectrum(
+      { webhookSecret: SPECTRUM_WEBHOOK_SECRET },
+      async (spectrum) => {
+        let called = false;
+        const signed = signSpectrum(textEnvelope(PLATFORM, "hi"), {
+          secret: "the-wrong-secret",
+        });
+        const result = await spectrum.webhook(signed, () => {
+          called = true;
+        });
+        await flush();
+
+        expect(result.status).toBe(401);
+        expect(called).toBe(false);
+      }
+    );
+  });
+
+  it("rejects an expired timestamp with 401", async () => {
+    await withSpectrum(
+      { webhookSecret: SPECTRUM_WEBHOOK_SECRET },
+      async (spectrum) => {
+        const signed = signSpectrum(textEnvelope(PLATFORM, "hi"), {
+          timestamp: Math.floor(Date.now() / 1000) - 1000,
+        });
+        const result = await spectrum.webhook(signed, () => {
+          // unreachable
+        });
+        expect(result.status).toBe(401);
+      }
+    );
+  });
+
+  it("returns 500 when no webhookSecret is configured", async () => {
+    await withSpectrum({}, async (spectrum) => {
+      let called = false;
+      const signed = signSpectrum(textEnvelope(PLATFORM, "hi"));
+      const result = await spectrum.webhook(signed, () => {
+        called = true;
+      });
+      await flush();
+      expect(result.status).toBe(500);
+      expect(called).toBe(false);
+    });
+  });
+
+  it("acknowledges (200) an unknown event without calling the handler", async () => {
+    await withSpectrum(
+      { webhookSecret: SPECTRUM_WEBHOOK_SECRET },
+      async (spectrum) => {
+        let called = false;
+        const signed = signSpectrum(
+          { event: "presence", message: textEnvelope(PLATFORM, "x").message },
+          { event: "presence" }
+        );
+        const result = await spectrum.webhook(signed, () => {
+          called = true;
+        });
+        await flush();
+        expect(result.status).toBe(200);
+        expect(called).toBe(false);
+      }
+    );
+  });
+
+  it("acknowledges (200) a message for an unregistered platform", async () => {
+    await withSpectrum(
+      { webhookSecret: SPECTRUM_WEBHOOK_SECRET },
+      async (spectrum) => {
+        let called = false;
+        const signed = signSpectrum(textEnvelope("not-registered", "hi"));
+        const result = await spectrum.webhook(signed, () => {
+          called = true;
+        });
+        await flush();
+        expect(result.status).toBe(200);
+        expect(called).toBe(false);
+      }
+    );
+  });
+
+  it("returns 200 even when the handler throws (fire-and-forget)", async () => {
+    await withSpectrum(
+      { webhookSecret: SPECTRUM_WEBHOOK_SECRET },
+      async (spectrum) => {
+        const signed = signSpectrum(textEnvelope(PLATFORM, "boom"));
+        const result = await spectrum.webhook(signed, () => {
+          throw new Error("handler blew up");
+        });
+        await flush();
+        expect(result.status).toBe(200);
+      }
+    );
+  });
+
+  it("delivers identically through a Web Request", async () => {
+    await withSpectrum(
+      { webhookSecret: SPECTRUM_WEBHOOK_SECRET },
+      async (spectrum) => {
+        const received: Message[] = [];
+        const { promise: finished, resolve: done } =
+          Promise.withResolvers<void>();
+
+        const signed = signSpectrum(textEnvelope(PLATFORM, "via request"));
+        const request = new Request("https://example.com/webhook", {
+          method: "POST",
+          headers: signed.headers,
+          body: signed.body,
+        });
+        const response = await spectrum.webhook(request, (_space, message) => {
+          received.push(message);
+          done();
+        });
+        await finished;
+
+        expect(response.status).toBe(200);
+        expect(received[0]?.content).toEqual({
+          type: "text",
+          text: "via request",
+        });
+      }
+    );
+  });
+});
+
+describe("spectrum.webhook (dispatch / fusor coexistence)", () => {
+  it("routes a protobuf body (no signature header) to the fusor path", async () => {
+    const spectrum = await Spectrum({
+      ...baseConfig,
+      providers: [makeSlack().config({})],
+      webhookSecret: SPECTRUM_WEBHOOK_SECRET,
+    });
+    const { promise: finished, resolve: done } = Promise.withResolvers<void>();
+    const received: Message[] = [];
+
+    const result = await spectrum.webhook(
+      {
+        headers: { "content-type": "application/x-protobuf" },
+        body: encodeEvent(
+          "slack",
+          JSON.stringify({ type: "message", text: "hello" })
+        ),
+      },
+      (_space, message) => {
+        received.push(message);
+        done();
+      }
+    );
+    await finished;
+
+    expect(result.status).toBe(200);
+    expect(received[0]?.content).toEqual({ type: "text", text: "hello" });
+
+    await spectrum.stop();
+  });
+
+  it("throws on a fusor request when no fusor provider is configured", async () => {
+    await withSpectrum(
+      { webhookSecret: SPECTRUM_WEBHOOK_SECRET },
+      async (spectrum) => {
+        await expect(
+          spectrum.webhook(
+            {
+              headers: { "content-type": "application/x-protobuf" },
+              body: encodeEvent("slack", JSON.stringify({ type: "message" })),
+            },
+            () => {
+              // unreachable
+            }
+          )
+        ).rejects.toThrow(NO_FUSOR_PROVIDER_ERROR);
+      }
+    );
+  });
+});

--- a/packages/spectrum-ts/test/webhook/spectrum.test.ts
+++ b/packages/spectrum-ts/test/webhook/spectrum.test.ts
@@ -219,6 +219,45 @@ describe("spectrum.webhook (dispatch / fusor coexistence)", () => {
     await spectrum.stop();
   });
 
+  it("routes a SIGNED protobuf body to the fusor path (header doesn't force native)", async () => {
+    // Spectrum signs fusor deliveries too, so an `x-spectrum-signature` header on
+    // a protobuf body must NOT be misrouted into the native JSON parser.
+    const spectrum = await Spectrum({
+      ...baseConfig,
+      providers: [makeSlack().config({})],
+      webhookSecret: SPECTRUM_WEBHOOK_SECRET,
+    });
+    const { promise: finished, resolve: done } = Promise.withResolvers<void>();
+    const received: Message[] = [];
+
+    const result = await spectrum.webhook(
+      {
+        headers: {
+          "content-type": "application/x-protobuf",
+          "x-spectrum-signature": "v0=deadbeef",
+          "x-spectrum-timestamp": String(Math.floor(Date.now() / 1000)),
+        },
+        body: encodeEvent(
+          "slack",
+          JSON.stringify({ type: "message", text: "signed-protobuf" })
+        ),
+      },
+      (_space, message) => {
+        received.push(message);
+        done();
+      }
+    );
+    await finished;
+
+    expect(result.status).toBe(200);
+    expect(received[0]?.content).toEqual({
+      type: "text",
+      text: "signed-protobuf",
+    });
+
+    await spectrum.stop();
+  });
+
   it("throws on a fusor request when no fusor provider is configured", async () => {
     await withSpectrum(
       { webhookSecret: SPECTRUM_WEBHOOK_SECRET },

--- a/packages/spectrum-ts/test/webhook/verify.test.ts
+++ b/packages/spectrum-ts/test/webhook/verify.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "bun:test";
+import { createHmac } from "node:crypto";
+import { verifySpectrumSignature } from "@/webhook/verify";
+
+const SECRET = "whsec_unit_test_secret";
+const NOW_SECONDS = 1_700_000_000;
+const NOW_MS = NOW_SECONDS * 1000;
+const TOLERANCE_SECONDS = 300;
+
+const encode = (text: string): Uint8Array => new TextEncoder().encode(text);
+
+// Independently compute the signature header the way the docs specify, so the
+// test is a real known-answer check rather than calling the impl twice.
+const sign = (body: Uint8Array, timestamp: number, secret = SECRET): string => {
+  const base = Buffer.concat([
+    Buffer.from(`v0:${timestamp}:`, "utf8"),
+    Buffer.from(body),
+  ]);
+  return `v0=${createHmac("sha256", secret).update(base).digest("hex")}`;
+};
+
+const headersFor = (
+  signature: string,
+  timestamp: number
+): Record<string, string> => ({
+  "x-spectrum-signature": signature,
+  "x-spectrum-timestamp": String(timestamp),
+});
+
+describe("verifySpectrumSignature", () => {
+  it("accepts a correctly signed body", () => {
+    const body = encode('{"event":"messages"}');
+    const result = verifySpectrumSignature({
+      rawBody: body,
+      headers: headersFor(sign(body, NOW_SECONDS), NOW_SECONDS),
+      secret: SECRET,
+      now: NOW_MS,
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("accepts a bare hex signature without the v0= prefix", () => {
+    const body = encode("payload");
+    const signature = sign(body, NOW_SECONDS).slice("v0=".length);
+    const result = verifySpectrumSignature({
+      rawBody: body,
+      headers: headersFor(signature, NOW_SECONDS),
+      secret: SECRET,
+      now: NOW_MS,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a tampered body", () => {
+    const signedBody = encode("original");
+    const deliveredBody = encode("tampered!");
+    const result = verifySpectrumSignature({
+      rawBody: deliveredBody,
+      headers: headersFor(sign(signedBody, NOW_SECONDS), NOW_SECONDS),
+      secret: SECRET,
+      now: NOW_MS,
+    });
+    expect(result).toEqual({ ok: false, reason: "signature-mismatch" });
+  });
+
+  it("rejects a wrong secret", () => {
+    const body = encode("payload");
+    const result = verifySpectrumSignature({
+      rawBody: body,
+      headers: headersFor(sign(body, NOW_SECONDS, "other-secret"), NOW_SECONDS),
+      secret: SECRET,
+      now: NOW_MS,
+    });
+    expect(result).toEqual({ ok: false, reason: "signature-mismatch" });
+  });
+
+  it("accepts a timestamp at the edge of the tolerance window", () => {
+    const body = encode("payload");
+    const timestamp = NOW_SECONDS - TOLERANCE_SECONDS;
+    const result = verifySpectrumSignature({
+      rawBody: body,
+      headers: headersFor(sign(body, timestamp), timestamp),
+      secret: SECRET,
+      now: NOW_MS,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects a timestamp just outside the tolerance window", () => {
+    const body = encode("payload");
+    const timestamp = NOW_SECONDS - TOLERANCE_SECONDS - 1;
+    const result = verifySpectrumSignature({
+      rawBody: body,
+      headers: headersFor(sign(body, timestamp), timestamp),
+      secret: SECRET,
+      now: NOW_MS,
+    });
+    expect(result).toEqual({ ok: false, reason: "expired" });
+  });
+
+  it("rejects when the signature header is missing", () => {
+    const body = encode("payload");
+    const result = verifySpectrumSignature({
+      rawBody: body,
+      headers: { "x-spectrum-timestamp": String(NOW_SECONDS) },
+      secret: SECRET,
+      now: NOW_MS,
+    });
+    expect(result).toEqual({ ok: false, reason: "missing-headers" });
+  });
+
+  it("rejects when the timestamp header is missing", () => {
+    const body = encode("payload");
+    const result = verifySpectrumSignature({
+      rawBody: body,
+      headers: { "x-spectrum-signature": sign(body, NOW_SECONDS) },
+      secret: SECRET,
+      now: NOW_MS,
+    });
+    expect(result).toEqual({ ok: false, reason: "missing-headers" });
+  });
+
+  it("rejects a non-numeric timestamp header", () => {
+    const body = encode("payload");
+    const result = verifySpectrumSignature({
+      rawBody: body,
+      headers: {
+        "x-spectrum-signature": sign(body, NOW_SECONDS),
+        "x-spectrum-timestamp": "not-a-number",
+      },
+      secret: SECRET,
+      now: NOW_MS,
+    });
+    expect(result).toEqual({ ok: false, reason: "missing-headers" });
+  });
+
+  it("rejects a non-hex / wrong-length signature without throwing", () => {
+    const body = encode("payload");
+    const result = verifySpectrumSignature({
+      rawBody: body,
+      headers: headersFor("v0=not-hex-zzzz", NOW_SECONDS),
+      secret: SECRET,
+      now: NOW_MS,
+    });
+    expect(result).toEqual({ ok: false, reason: "signature-mismatch" });
+  });
+});

--- a/packages/spectrum-ts/tsup.config.ts
+++ b/packages/spectrum-ts/tsup.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
     index: "src/index.ts",
     authoring: "src/authoring.ts",
     elysia: "src/elysia.ts",
+    express: "src/express.ts",
+    hono: "src/hono.ts",
     "providers/index": "src/providers/index.ts",
     "providers/imessage/index": "src/providers/imessage/index.ts",
     "providers/slack/index": "src/providers/slack/index.ts",
@@ -19,7 +21,7 @@ export default defineConfig({
   clean: true,
   outDir: "dist",
   target: "esnext",
-  external: ["elysia", "ffmpeg-static"],
+  external: ["elysia", "express", "hono", "ffmpeg-static"],
   // esbuild bundles CommonJS dependencies (e.g. `vcf`, `mime-types`) into
   // this ESM output and rewrites their `require(...)` calls to a `__require` shim
   // whose fallback throws `Dynamic require of "x" is not supported` — because

--- a/packages/spectrum-ts/tsup.config.ts
+++ b/packages/spectrum-ts/tsup.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: {
     index: "src/index.ts",
     authoring: "src/authoring.ts",
+    elysia: "src/elysia.ts",
     "providers/index": "src/providers/index.ts",
     "providers/imessage/index": "src/providers/imessage/index.ts",
     "providers/slack/index": "src/providers/slack/index.ts",
@@ -18,7 +19,7 @@ export default defineConfig({
   clean: true,
   outDir: "dist",
   target: "esnext",
-  external: ["ffmpeg-static"],
+  external: ["elysia", "ffmpeg-static"],
   // esbuild bundles CommonJS dependencies (e.g. `vcf`, `mime-types`) into
   // this ESM output and rewrites their `require(...)` calls to a `__require` shim
   // whose fallback throws `Dynamic require of "x" is not supported` — because


### PR DESCRIPTION
## Summary

- `app.webhook()` now auto-detects and handles both **native Spectrum webhooks** (normalized JSON, HMAC-signed) and **fusor webhooks** (raw provider protobuf envelope) — one handler, same `(space, message)` callback for both
- Add first-party framework plugins: `spectrum-ts/hono`, `spectrum-ts/express`, and `spectrum-ts/elysia` — each mounts the webhook endpoint with correct raw-body handling out of the box
- Add HMAC-SHA256 signature verification with a 5-minute replay window; bad/missing signature returns `401`/`400` before the handler is ever dispatched
- Add slim-JSON deserializer that converts the native webhook envelope into the full `Message`/`Space` model, including reaction targets, album items, and lazy attachment rehydration
- Wire schemas use `z.looseObject` so additive server-side changes (new platforms, new content arms) never break an older SDK

## Changes

| File | What changed |
|------|-------------|
| `src/spectrum.ts` | New `app.webhook(request, handler)` overload; auto-detects native vs fusor by payload shape; fire-and-forget dispatch after `200` |
| `src/webhook/types.ts` | Zod wire schemas for the native webhook envelope (`SlimEnvelope`, `SlimMessage`, etc.) |
| `src/webhook/deserialize.ts` | Converts slim JSON envelope → full `Message`/`Space` including all content types |
| `src/webhook/verify.ts` | HMAC-SHA256 signature verification (`v0:<ts>:<rawBody>`, constant-time compare, replay window) |
| `src/hono.ts` | Hono sub-app plugin — forwards `c.req.raw` straight to `app.webhook()` |
| `src/express.ts` | Express middleware plugin — reads raw body bytes, maps result to `res.status/set/send` |
| `src/elysia.ts` | ElysiaJS plugin — disables auto JSON parsing on the route, extracts raw bytes before forwarding |
| `src/fusor/types.ts` | Export `WebhookHandler` type so framework plugins can re-export it |
| `docs/native-webhook.md` | New — covers configuration, raw-body requirement, verification, delivery semantics |
| `docs/hono.md` | New — Hono plugin usage |
| `docs/express.md` | New — Express plugin usage |
| `docs/elysia.md` | New — ElysiaJS plugin usage |
| `docs/fusor.md` | Updated — links to native webhook doc, notes unified handler |
| `tsup.config.ts` | Export `hono`, `express`, `elysia` entry points |
| `package.json` | Add `hono`, `express`, `elysia` as optional peer deps |

## Detection logic

```
POST body starts with `{`  →  native Spectrum webhook (JSON + HMAC)
otherwise                  →  fusor webhook (protobuf envelope)
```

Both paths call the same `(space, message)` handler — no branching in user code.

## Usage

```ts
// Any Web-standard Request runtime (Hono, Bun.serve, Next.js, Workers)
const app = await Spectrum({
  ...,
  webhookSecret: process.env.SPECTRUM_WEBHOOK_SECRET,
});

server.post("/spectrum/webhook", (c) =>
  app.webhook(c.req.raw, async (space, message) => {
    if (message.content.type === "text") {
      await space.send(`echo: ${message.content.text}`);
    }
  })
);
```

```ts
// First-party Hono plugin (raw-body handling automatic)
import { spectrum } from "spectrum-ts/hono";
new Hono().route("/", spectrum({ app, onMessage }));

// First-party Express plugin
import { spectrum } from "spectrum-ts/express";
expressApp.use(spectrum({ app, onMessage }));

// First-party ElysiaJS plugin
import { spectrum } from "spectrum-ts/elysia";
new Elysia().use(spectrum({ app, onMessage }));
```

## Test plan

- [x] `test/webhook/deserialize.test.ts` — all content types (text, attachment, richlink, contact, reaction, group/album), unknown type passthrough, missing fields
- [x] `test/webhook/verify.test.ts` — valid signature, bad signature → 401, expired timestamp → 401, missing header → 400, no secret configured → 500
- [x] `test/webhook/spectrum.test.ts` — end-to-end native + fusor dispatch, fire-and-forget behavior, handler errors logged not surfaced
- [x] `test/webhook/hono.test.ts` — route mounting, raw body preserved through plugin
- [x] `test/webhook/express.test.ts` — middleware, status/header/body mapping
- [x] `test/webhook/elysia.test.ts` — JSON parse bypass, raw bytes forwarded correctly

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783931810&installation_id=127326493&pr_number=126&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F126&signature=5fc65100c2ed79e8e234b334cf97b1fd963fa8ba454382df7d2bdd8673de9189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added first-party webhook plugins for Elysia, Express, and Hono frameworks to simplify integration
  * Added native Spectrum webhook support with automatic format detection and HMAC-SHA256 signature verification
  * Version updated to 4.4.0

* **Documentation**
  * Added guides for native webhooks, Elysia, Express, and Hono plugin setup and usage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->