### PR TITLE
feat: convert standard Markdown to Slack mrkdwn and WhatsApp formatting on fallback

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -40,6 +40,7 @@
         "@types/vcf": "^2.0.7",
         "elysia": "^1",
         "express": "^5",
+        "fastify": "^5.0.0",
         "hono": "^4",
         "hotscript": "^1.0.13",
         "tsdown": "^0.22.2",
@@ -48,6 +49,7 @@
       "peerDependencies": {
         "elysia": "^1",
         "express": "^4 || ^5",
+        "fastify": "^4 || ^5",
         "ffmpeg-static": "^5",
         "hono": "^4",
         "typescript": "^5 || ^6.0.0",
@@ -55,6 +57,7 @@
       "optionalPeers": [
         "elysia",
         "express",
+        "fastify",
         "ffmpeg-static",
         "hono",
       ],
@@ -288,6 +291,18 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
+    "@fastify/ajv-compiler": ["@fastify/ajv-compiler@4.0.5", "", { "dependencies": { "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0" } }, "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A=="],
+
+    "@fastify/error": ["@fastify/error@4.2.0", "", {}, "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ=="],
+
+    "@fastify/fast-json-stringify-compiler": ["@fastify/fast-json-stringify-compiler@5.0.3", "", { "dependencies": { "fast-json-stringify": "^6.0.0" } }, "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ=="],
+
+    "@fastify/forwarded": ["@fastify/forwarded@3.0.1", "", {}, "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw=="],
+
+    "@fastify/merge-json-schemas": ["@fastify/merge-json-schemas@0.2.1", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A=="],
+
+    "@fastify/proxy-addr": ["@fastify/proxy-addr@5.1.0", "", { "dependencies": { "@fastify/forwarded": "^3.0.0", "ipaddr.js": "^2.1.0" } }, "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw=="],
+
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
@@ -351,6 +366,8 @@
     "@photon-ai/telegram-ts": ["@photon-ai/telegram-ts@10.0.0", "", { "dependencies": { "zod": "^4.4.3" } }, "sha512-kYGj/ieKOCG+OxoD1R69xHoT7zHl9dboF52LMPUl4FnorbwA8b2pid0uFoDYF55WIfoeo+VSqwlmY84GgpSedg=="],
 
     "@photon-ai/whatsapp-business": ["@photon-ai/whatsapp-business@0.1.1", "", { "dependencies": { "@grpc/grpc-js": "^1.14.3", "long": "^5.3.2", "nice-grpc": "^2.1.15", "nice-grpc-common": "^2.0.3", "protobufjs": "^8.0.1" } }, "sha512-JAf/gHh92+H6h/7AMOQ6l+WFYBWdeRH5fZ+tvOUYJJnX1C4aJPDFa23VTH4ndhKPgA5bK/h++cxUZx2lMubvYQ=="],
+
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -480,7 +497,13 @@
 
     "abort-controller-x": ["abort-controller-x@0.5.0", "", {}, "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ=="],
 
+    "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
@@ -493,6 +516,10 @@
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
     "ast-kit": ["ast-kit@3.0.0-beta.1", "", { "dependencies": { "@babel/parser": "^8.0.0-beta.4", "estree-walker": "^3.0.3", "pathe": "^2.0.3" } }, "sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw=="],
+
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
+
+    "avvio": ["avvio@9.2.0", "", { "dependencies": { "@fastify/error": "^4.0.0", "fastq": "^1.17.1" } }, "sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -582,6 +609,8 @@
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
@@ -640,11 +669,23 @@
 
     "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stringify": ["fast-json-stringify@6.4.0", "", { "dependencies": { "@fastify/merge-json-schemas": "^0.2.0", "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0", "json-schema-ref-resolver": "^3.0.0", "rfdc": "^1.2.0" } }, "sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ=="],
+
+    "fast-querystring": ["fast-querystring@1.1.2", "", { "dependencies": { "fast-decode-uri-component": "^1.0.1" } }, "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg=="],
+
     "fast-string-truncated-width": ["fast-string-truncated-width@3.0.3", "", {}, "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g=="],
 
     "fast-string-width": ["fast-string-width@3.0.2", "", { "dependencies": { "fast-string-truncated-width": "^3.0.2" } }, "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg=="],
 
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
     "fast-wrap-ansi": ["fast-wrap-ansi@0.2.0", "", { "dependencies": { "fast-string-width": "^3.0.2" } }, "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w=="],
+
+    "fastify": ["fastify@5.8.5", "", { "dependencies": { "@fastify/ajv-compiler": "^4.0.5", "@fastify/error": "^4.0.0", "@fastify/fast-json-stringify-compiler": "^5.0.0", "@fastify/proxy-addr": "^5.0.0", "abstract-logging": "^2.0.1", "avvio": "^9.0.0", "fast-json-stringify": "^6.0.0", "find-my-way": "^9.0.0", "light-my-request": "^6.0.0", "pino": "^9.14.0 || ^10.1.0", "process-warning": "^5.0.0", "rfdc": "^1.3.1", "secure-json-parse": "^4.0.0", "semver": "^7.6.0", "toad-cache": "^3.7.0" } }, "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
@@ -655,6 +696,8 @@
     "file-uri-to-path": ["file-uri-to-path@1.0.0", "", {}, "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "find-my-way": ["find-my-way@9.6.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-querystring": "^1.0.0", "safe-regex2": "^5.0.0" } }, "sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ=="],
 
     "foldline": ["foldline@1.1.0", "", {}, "sha512-9SheyADS50hjvFYjFJ3OB/GlDz2mD1T2CHd7auIk4Uto5YYWPBcw8iYo3F+gENJ+/SOeH9tT0loHZSqlUlumTA=="],
 
@@ -720,7 +763,13 @@
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
+    "json-schema-ref-resolver": ["json-schema-ref-resolver@3.0.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
+
+    "light-my-request": ["light-my-request@6.6.0", "", { "dependencies": { "cookie": "^1.0.1", "process-warning": "^4.0.0", "set-cookie-parser": "^2.6.0" } }, "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A=="],
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
@@ -784,6 +833,8 @@
 
     "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
 
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
+
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
@@ -814,7 +865,15 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
+
+    "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
     "protobufjs": ["protobufjs@8.0.1", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w=="],
 
@@ -828,6 +887,8 @@
 
     "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
 
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
+
     "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
@@ -836,9 +897,19 @@
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
+    "ret": ["ret@0.5.0", "", {}, "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
     "rolldown": ["rolldown@1.1.1", "", { "dependencies": { "@oxc-project/types": "=0.135.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.1", "@rolldown/binding-darwin-arm64": "1.1.1", "@rolldown/binding-darwin-x64": "1.1.1", "@rolldown/binding-freebsd-x64": "1.1.1", "@rolldown/binding-linux-arm-gnueabihf": "1.1.1", "@rolldown/binding-linux-arm64-gnu": "1.1.1", "@rolldown/binding-linux-arm64-musl": "1.1.1", "@rolldown/binding-linux-ppc64-gnu": "1.1.1", "@rolldown/binding-linux-s390x-gnu": "1.1.1", "@rolldown/binding-linux-x64-gnu": "1.1.1", "@rolldown/binding-linux-x64-musl": "1.1.1", "@rolldown/binding-openharmony-arm64": "1.1.1", "@rolldown/binding-wasm32-wasi": "1.1.1", "@rolldown/binding-win32-arm64-msvc": "1.1.1", "@rolldown/binding-win32-x64-msvc": "1.1.1" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-IN750c0p+s3jqJIsFLRZrQazmbAB1kkQDTtQjSt/gbS2ywLhlv4R5Shazer0FZKmuo/BsO3/w2UoYnUjuOZqHg=="],
 
@@ -850,13 +921,21 @@
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "safe-regex2": ["safe-regex2@5.1.1", "", { "dependencies": { "ret": "~0.5.0" }, "bin": { "safe-regex2": "bin/safe-regex2.js" } }, "sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA=="],
+
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
 
     "semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
@@ -880,7 +959,11 @@
 
     "skin-tone": ["skin-tone@2.0.0", "", { "dependencies": { "unicode-emoji-modifier-base": "^1.0.0" } }, "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA=="],
 
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
     "spectrum-ts": ["spectrum-ts@workspace:packages/spectrum-ts"],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
@@ -906,9 +989,13 @@
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
+    "thread-stream": ["thread-stream@4.2.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ=="],
+
     "tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "toad-cache": ["toad-cache@3.7.1", "", {}, "sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
@@ -980,6 +1067,8 @@
 
     "@arethetypeswrong/core/typescript": ["typescript@5.6.1-rc", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ=="],
 
+    "@fastify/proxy-addr/ipaddr.js": ["ipaddr.js@2.4.0", "", {}, "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ=="],
+
     "@grpc/proto-loader/protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
     "@grpc/proto-loader/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
@@ -1000,6 +1089,8 @@
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
+    "light-my-request/process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
+
     "marked-terminal/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "marked-terminal/marked": ["marked@9.1.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q=="],
@@ -1011,6 +1102,8 @@
     "protobufjs/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
     "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
 
     "tsdown/tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,11 @@
       "bun": "./src/hono.ts",
       "types": "./src/hono.ts",
       "default": "./dist/hono.js"
+    },
+    "./fastify": {
+      "bun": "./src/fastify.ts",
+      "types": "./src/fastify.ts",
+      "default": "./dist/fastify.js"
     }
   },
   "publishConfig": {
@@ -67,6 +72,10 @@
       "./hono": {
         "types": "./dist/hono.d.ts",
         "default": "./dist/hono.js"
+      },
+      "./fastify": {
+        "types": "./dist/fastify.d.ts",
+        "default": "./dist/fastify.js"
       }
     }
   },
@@ -96,6 +105,7 @@
     "@types/vcf": "^2.0.7",
     "elysia": "^1",
     "express": "^5",
+    "fastify": "^5.0.0",
     "hono": "^4",
     "hotscript": "^1.0.13",
     "tsdown": "^0.22.2",
@@ -105,6 +115,7 @@
     "elysia": "^1",
     "express": "^4 || ^5",
     "ffmpeg-static": "^5",
+    "fastify": "^4 || ^5",
     "hono": "^4",
     "typescript": "^5 || ^6.0.0"
   },
@@ -116,6 +127,9 @@
       "optional": true
     },
     "ffmpeg-static": {
+      "optional": true
+    },
+    "fastify": {
       "optional": true
     },
     "hono": {

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -35,7 +35,11 @@ export type { ProviderMessageRecord } from "./platform/types";
 
 // Generic translation helpers (from `utils/`).
 export { ensureM4a } from "./utils/audio";
-export { renderInlineTokens } from "./utils/markdown";
+export {
+  markdownToSlack,
+  markdownToWhatsapp,
+  renderInlineTokens,
+} from "./utils/markdown";
 export {
   buildPhotoAction,
   type PhotoInput,

--- a/packages/core/src/express.ts
+++ b/packages/core/src/express.ts
@@ -86,7 +86,7 @@ export function spectrum(options: SpectrumPluginOptions): Router {
   const router = express.Router();
   router.post(path, express.raw({ type: "*/*" }), async (req, res) => {
     const result = await app.webhook(
-      { body: req.body, headers: req.headers as Record<string, string> },
+      { body: req.body, headers: normalizeHeaders(req.headers) },
       onMessage
     );
     res
@@ -95,6 +95,19 @@ export function spectrum(options: SpectrumPluginOptions): Router {
       .send(Buffer.from(result.body));
   });
   return router;
+}
+
+function normalizeHeaders(
+  headers: Record<string, string | string[] | undefined>
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined) {
+      continue;
+    }
+    normalized[key] = Array.isArray(value) ? (value[0] ?? "") : value;
+  }
+  return normalized;
 }
 
 export type { WebhookHandler } from "./fusor";

--- a/packages/core/src/fastify.ts
+++ b/packages/core/src/fastify.ts
@@ -100,7 +100,7 @@ export async function spectrum(
     const result = await app.webhook(
       {
         body: request.body as Buffer,
-        headers: request.headers as Record<string, string>,
+        headers: normalizeHeaders(request.headers),
       },
       onMessage
     );
@@ -110,6 +110,19 @@ export async function spectrum(
       .headers(result.headers)
       .send(Buffer.from(result.body));
   });
+}
+
+function normalizeHeaders(
+  headers: Record<string, string | string[] | undefined>
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined) {
+      continue;
+    }
+    normalized[key] = Array.isArray(value) ? (value[0] ?? "") : value;
+  }
+  return normalized;
 }
 
 export type { WebhookHandler } from "./fusor";

--- a/packages/core/src/fastify.ts
+++ b/packages/core/src/fastify.ts
@@ -1,0 +1,117 @@
+// Spectrum webhook receiver as a first-party Fastify plugin.
+//
+// Fastify runs on its own Request/Reply abstraction model. This plugin
+// registers a custom content type parser for `*` (all content types) to capture
+// the raw request body payload bytes as a `Buffer`.
+//
+// ⚠️ Encapsulation: Registering the content type parser inside this plugin scope
+// ensures it only applies to this route, preventing interference with global parsers.
+//
+// It returns an async Fastify plugin function.
+
+import type { FastifyInstance } from "fastify";
+import type { WebhookHandler } from "./fusor";
+
+/**
+ * The minimal structural surface of a Spectrum instance the plugin needs. Kept
+ * structural (rather than importing the generic `SpectrumInstance<Providers>`)
+ * so the plugin stays decoupled from provider typing; a real instance is
+ * assignable via its raw (`{ body, headers }`) webhook overload.
+ */
+interface WebhookReceiver {
+  webhook(
+    request: {
+      body: Uint8Array | ArrayBuffer;
+      headers?: Record<string, string>;
+    },
+    handler: WebhookHandler
+  ): Promise<{
+    body: Uint8Array;
+    headers: Record<string, string>;
+    status: number;
+  }>;
+}
+
+export interface SpectrumPluginOptions {
+  /** The Spectrum instance returned by `await Spectrum({...})`. */
+  app: WebhookReceiver;
+  /**
+   * Invoked once per inbound message, fire-and-forget after the response — the
+   * same `(space, message)` contract as `app.webhook(request, handler)`. Covers
+   * both native Spectrum webhooks and fusor webhooks identically.
+   */
+  onMessage: WebhookHandler;
+  /**
+   * Route the webhook is mounted on.
+   *
+   * @default "/spectrum/webhook"
+   */
+  path?: string;
+}
+
+/**
+ * Mount a Spectrum webhook endpoint on a Fastify app.
+ *
+ * @example
+ * ```ts
+ * import Fastify from "fastify";
+ * import { Spectrum } from "spectrum-ts";
+ * import { spectrum } from "spectrum-ts/fastify";
+ *
+ * const app = await Spectrum({ ...,  webhookSecret: process.env.SPECTRUM_WEBHOOK_SECRET });
+ *
+ * const server = Fastify();
+ * server.register(spectrum, {
+ *   app,
+ *   onMessage: async (space, message) => {
+ *     if (message.content.type === "text") await space.send(`echo: ${message.content.text}`);
+ *   },
+ * });
+ * server.listen({ port: 3000 });
+ * ```
+ */
+export async function spectrum(
+  fastify: FastifyInstance,
+  options: SpectrumPluginOptions
+) {
+  const { app, onMessage, path = "/spectrum/webhook" } = options;
+
+  // Remove default/global content type parsers inside this plugin's scope
+  // to ensure they don't override our wildcard/raw body parser.
+  fastify.removeAllContentTypeParsers();
+
+  // Custom parser to capture the exact raw body bytes as a Buffer.
+  // Using "*" captures all content types (application/json, application/x-protobuf, etc.)
+  // under the scope of this plugin.
+  fastify.addContentTypeParser("*", (_request, payload, done) => {
+    const chunks: Uint8Array[] = [];
+    payload.on("data", (chunk) => {
+      chunks.push(chunk);
+    });
+    payload.on("end", () => {
+      done(null, Buffer.concat(chunks));
+    });
+    payload.on("error", (err) => {
+      done(err);
+    });
+  });
+
+  fastify.post(path, async (request, reply) => {
+    const result = await app.webhook(
+      {
+        body: request.body as Buffer,
+        headers: request.headers as Record<string, string>,
+      },
+      onMessage
+    );
+
+    return reply
+      .status(result.status)
+      .headers(result.headers)
+      .send(Buffer.from(result.body));
+  });
+}
+
+export type { WebhookHandler } from "./fusor";
+export type { Message } from "./types/message";
+export type { Space } from "./types/space";

--- a/packages/core/src/platform/build.ts
+++ b/packages/core/src/platform/build.ts
@@ -387,7 +387,7 @@ async function sendWithFallbacks(
       throw err;
     }
     platformLog.info(
-      `${platform} does not support markdown; sending the content as plain text instead.`,
+      `${platform} does not support markdown; sending downgraded content instead.`,
       {
         "spectrum.provider": platform,
         "spectrum.markdown.fallback": true,

--- a/packages/core/src/platform/build.ts
+++ b/packages/core/src/platform/build.ts
@@ -23,7 +23,11 @@ import type { Message } from "../types/message";
 import type { Space } from "../types/space";
 import type { AgentSender } from "../types/user";
 import { UnsupportedError } from "../utils/errors";
-import { markdownToPlainText } from "../utils/markdown";
+import {
+  markdownToPlainText,
+  markdownToSlack,
+  markdownToWhatsapp,
+} from "../utils/markdown";
 import type { Store } from "../utils/store";
 import { contentAttrs } from "../utils/telemetry";
 import type {
@@ -243,26 +247,37 @@ const replaceStreamText = (
 
 // `undefined` when the markdown renders to empty plain text (e.g. an
 // HTML-comment-only source) — there is nothing sensible to send.
-const downgradeMarkdown = (md: Markdown): BaseContent | undefined => {
-  const plain = markdownToPlainText(md.markdown);
-  return plain ? asText(plain) : undefined;
+const downgradeMarkdown = (
+  md: Markdown,
+  platform: string
+): BaseContent | undefined => {
+  const platformLower = platform.toLowerCase();
+  let textContent: string;
+  if (platformLower === "slack") {
+    textContent = markdownToSlack(md.markdown);
+  } else if (platformLower.includes("whatsapp")) {
+    textContent = markdownToWhatsapp(md.markdown);
+  } else {
+    textContent = markdownToPlainText(md.markdown);
+  }
+  return textContent ? asText(textContent) : undefined;
 };
 
-// Rewrite markdown-bearing content as readable plain text, preserving
-// `reply`/`edit` wrappers and `group` structure. Returns `item` itself
+// Rewrite markdown-bearing content as readable plain text or platform-specific rich text,
+// preserving `reply`/`edit` wrappers and `group` structure. Returns `item` itself
 // (reference-equal) when there is nothing to downgrade. Group items are
 // scanned here but deliberately not in `findStreamText`: a markdown caption
 // in an album downgrades to text meaningfully, while a live stream inside a
 // multipart bubble has no sensible downgrade.
-const replaceMarkdown = (item: Content): Content => {
+const replaceMarkdown = (item: Content, platform: string): Content => {
   if (item.type === "markdown") {
-    return downgradeMarkdown(item) ?? item;
+    return downgradeMarkdown(item, platform) ?? item;
   }
   if (
     (item.type === "reply" || item.type === "edit") &&
     item.content.type === "markdown"
   ) {
-    const downgraded = downgradeMarkdown(item.content);
+    const downgraded = downgradeMarkdown(item.content, platform);
     return downgraded ? { ...item, content: downgraded } : item;
   }
   if (item.type === "group") {
@@ -271,7 +286,7 @@ const replaceMarkdown = (item: Content): Content => {
       if (member.content.type !== "markdown") {
         return member;
       }
-      const downgraded = downgradeMarkdown(member.content);
+      const downgraded = downgradeMarkdown(member.content, platform);
       if (!downgraded) {
         return member;
       }
@@ -367,7 +382,7 @@ async function sendWithFallbacks(
     if (source) {
       return await resendDrainedStream(send, item, source, platform, err);
     }
-    const downgraded = replaceMarkdown(item);
+    const downgraded = replaceMarkdown(item, platform);
     if (downgraded === item) {
       throw err;
     }

--- a/packages/core/src/utils/markdown.ts
+++ b/packages/core/src/utils/markdown.ts
@@ -160,11 +160,300 @@ const renderBlockTokens = (tokens: Token[]): string => {
   return blocks.join(BLOCK_SEPARATOR);
 };
 
-/**
- * Render standard markdown (CommonMark + GFM) to readable plain text:
- * emphasis markers stripped, links as `label (url)`, list bullets kept,
- * code verbatim. Used by the send pipeline to downgrade `markdown` content
- * on platforms without native support.
- */
 export const markdownToPlainText = (markdown: string): string =>
   renderBlockTokens(markdownLexer.lexer(markdown)).trim();
+
+// --- Slack mrkdwn Converter ---
+
+const escapeSlack = (value: string): string =>
+  value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+const renderSlackLink = (token: Tokens.Link): string => {
+  const text = renderSlackInlineTokens(token.tokens);
+  const escapedHref = escapeSlack(token.href);
+  if (text === token.href) {
+    return `<${escapedHref}>`;
+  }
+  return `<${escapedHref}|${text}>`;
+};
+
+const renderSlackImage = (token: Tokens.Image): string => {
+  const escapedHref = escapeSlack(token.href);
+  const text = token.text ? escapeSlack(token.text) : "";
+  if (text) {
+    return `<${escapedHref}|${text}>`;
+  }
+  return `<${escapedHref}>`;
+};
+
+const renderSlackInlineToken = (token: MarkedToken): string => {
+  switch (token.type) {
+    case "strong":
+      return `*${renderSlackInlineTokens(token.tokens)}*`;
+    case "em":
+      return `_${renderSlackInlineTokens(token.tokens)}_`;
+    case "del":
+      return `~${renderSlackInlineTokens(token.tokens)}~`;
+    case "codespan":
+      return `\`${token.text}\``;
+    case "br":
+      return "\n";
+    case "link":
+      return renderSlackLink(token);
+    case "image":
+      return renderSlackImage(token);
+    case "escape":
+      return escapeSlack(token.text);
+    case "text":
+      return token.tokens
+        ? renderSlackInlineTokens(token.tokens)
+        : escapeSlack(token.text);
+    case "html":
+      return escapeSlack(token.text);
+    case "checkbox":
+      return "";
+    default:
+      return "raw" in token ? escapeSlack(String(token.raw)) : "";
+  }
+};
+
+const renderSlackInlineTokens = (tokens: Token[]): string => {
+  let out = "";
+  for (const token of tokens) {
+    out += renderSlackInlineToken(asMarkedToken(token));
+  }
+  return out;
+};
+
+const renderSlackQuoteBody = (tokens: Token[]): string => {
+  const blocks: string[] = [];
+  for (const token of tokens) {
+    const marked = asMarkedToken(token);
+    const rendered =
+      marked.type === "blockquote"
+        ? renderSlackQuoteBody(marked.tokens)
+        : renderSlackBlockToken(marked);
+    if (rendered) {
+      blocks.push(rendered);
+    }
+  }
+  return blocks.join("\n");
+};
+
+const renderSlackList = (list: Tokens.List): string => {
+  const lines: string[] = [];
+  for (const [index, item] of list.items.entries()) {
+    const prefix = `${listMarker(list, index)}${checkboxPrefix(item)}`;
+    const blocks: string[] = [];
+    for (const token of item.tokens) {
+      const rendered = renderSlackBlockToken(asMarkedToken(token));
+      if (rendered) {
+        blocks.push(rendered);
+      }
+    }
+    const [first = "", ...rest] = blocks.join("\n").split("\n");
+    lines.push(`${prefix}${first}`);
+    for (const line of rest) {
+      lines.push(`${NESTED_LIST_INDENT}${line}`);
+    }
+  }
+  return lines.join("\n");
+};
+
+const renderSlackTable = (table: Tokens.Table): string => {
+  const renderRow = (cells: Tokens.TableCell[]): string =>
+    cells
+      .map((cell) => renderInlineTokens(cell.tokens))
+      .join(TABLE_CELL_SEPARATOR);
+  const lines = [renderRow(table.header)];
+  for (const row of table.rows) {
+    lines.push(renderRow(row));
+  }
+  return `\`\`\`\n${lines.join("\n")}\n\`\`\``;
+};
+
+const renderSlackBlockToken = (token: MarkedToken): string => {
+  switch (token.type) {
+    case "heading":
+      return `*${renderSlackInlineTokens(token.tokens)}*`;
+    case "paragraph":
+      return renderSlackInlineTokens(token.tokens);
+    case "code":
+      return `\`\`\`\n${token.text}\n\`\`\``;
+    case "blockquote":
+      return renderSlackQuoteBody(token.tokens)
+        .split("\n")
+        .map((line) => `> ${line}`)
+        .join("\n");
+    case "list":
+      return renderSlackList(token);
+    case "table":
+      return renderSlackTable(token);
+    case "hr":
+      return HR_LINE;
+    case "space":
+    case "def":
+      return "";
+    default:
+      return renderSlackInlineToken(token);
+  }
+};
+
+const renderSlackBlockTokens = (tokens: Token[]): string => {
+  const blocks: string[] = [];
+  for (const token of tokens) {
+    const rendered = renderSlackBlockToken(asMarkedToken(token));
+    if (rendered) {
+      blocks.push(rendered);
+    }
+  }
+  return blocks.join(BLOCK_SEPARATOR);
+};
+
+export const markdownToSlack = (markdown: string): string =>
+  renderSlackBlockTokens(markdownLexer.lexer(markdown)).trim();
+
+// --- WhatsApp Formatting Converter ---
+
+const renderWhatsappLink = (token: Tokens.Link): string => {
+  const text = renderWhatsappInlineTokens(token.tokens);
+  if (text === token.href) {
+    return token.href;
+  }
+  return `${text} (${token.href})`;
+};
+
+const renderWhatsappImage = (token: Tokens.Image): string => {
+  const text = token.text || "";
+  if (text) {
+    return `${text} (${token.href})`;
+  }
+  return token.href;
+};
+
+const renderWhatsappInlineToken = (token: MarkedToken): string => {
+  switch (token.type) {
+    case "strong":
+      return `*${renderWhatsappInlineTokens(token.tokens)}*`;
+    case "em":
+      return `_${renderWhatsappInlineTokens(token.tokens)}_`;
+    case "del":
+      return `~${renderWhatsappInlineTokens(token.tokens)}~`;
+    case "codespan":
+      return `\`${token.text}\``;
+    case "br":
+      return "\n";
+    case "link":
+      return renderWhatsappLink(token);
+    case "image":
+      return renderWhatsappImage(token);
+    case "escape":
+      return token.text;
+    case "text":
+      return token.tokens
+        ? renderWhatsappInlineTokens(token.tokens)
+        : token.text;
+    case "html":
+      return token.text;
+    case "checkbox":
+      return "";
+    default:
+      return "raw" in token ? String(token.raw) : "";
+  }
+};
+
+const renderWhatsappInlineTokens = (tokens: Token[]): string => {
+  let out = "";
+  for (const token of tokens) {
+    out += renderWhatsappInlineToken(asMarkedToken(token));
+  }
+  return out;
+};
+
+const renderWhatsappQuoteBody = (tokens: Token[]): string => {
+  const blocks: string[] = [];
+  for (const token of tokens) {
+    const marked = asMarkedToken(token);
+    const rendered =
+      marked.type === "blockquote"
+        ? renderWhatsappQuoteBody(marked.tokens)
+        : renderWhatsappBlockToken(marked);
+    if (rendered) {
+      blocks.push(rendered);
+    }
+  }
+  return blocks.join("\n");
+};
+
+const renderWhatsappList = (list: Tokens.List): string => {
+  const lines: string[] = [];
+  for (const [index, item] of list.items.entries()) {
+    const prefix = `${listMarker(list, index)}${checkboxPrefix(item)}`;
+    const blocks: string[] = [];
+    for (const token of item.tokens) {
+      const rendered = renderWhatsappBlockToken(asMarkedToken(token));
+      if (rendered) {
+        blocks.push(rendered);
+      }
+    }
+    const [first = "", ...rest] = blocks.join("\n").split("\n");
+    lines.push(`${prefix}${first}`);
+    for (const line of rest) {
+      lines.push(`${NESTED_LIST_INDENT}${line}`);
+    }
+  }
+  return lines.join("\n");
+};
+
+const renderWhatsappTable = (table: Tokens.Table): string => {
+  const renderRow = (cells: Tokens.TableCell[]): string =>
+    cells
+      .map((cell) => renderInlineTokens(cell.tokens))
+      .join(TABLE_CELL_SEPARATOR);
+  const lines = [renderRow(table.header)];
+  for (const row of table.rows) {
+    lines.push(renderRow(row));
+  }
+  return `\`\`\`\n${lines.join("\n")}\n\`\`\``;
+};
+
+const renderWhatsappBlockToken = (token: MarkedToken): string => {
+  switch (token.type) {
+    case "heading":
+      return `*${renderWhatsappInlineTokens(token.tokens)}*`;
+    case "paragraph":
+      return renderWhatsappInlineTokens(token.tokens);
+    case "code":
+      return `\`\`\`\n${token.text}\n\`\`\``;
+    case "blockquote":
+      return renderWhatsappQuoteBody(token.tokens)
+        .split("\n")
+        .map((line) => `> ${line}`)
+        .join("\n");
+    case "list":
+      return renderWhatsappList(token);
+    case "table":
+      return renderWhatsappTable(token);
+    case "hr":
+      return HR_LINE;
+    case "space":
+    case "def":
+      return "";
+    default:
+      return renderWhatsappInlineToken(token);
+  }
+};
+
+const renderWhatsappBlockTokens = (tokens: Token[]): string => {
+  const blocks: string[] = [];
+  for (const token of tokens) {
+    const rendered = renderWhatsappBlockToken(asMarkedToken(token));
+    if (rendered) {
+      blocks.push(rendered);
+    }
+  }
+  return blocks.join(BLOCK_SEPARATOR);
+};
+
+export const markdownToWhatsapp = (markdown: string): string =>
+  renderWhatsappBlockTokens(markdownLexer.lexer(markdown)).trim();

--- a/packages/core/test/core/send-markdown-fallback.test.ts
+++ b/packages/core/test/core/send-markdown-fallback.test.ts
@@ -296,4 +296,54 @@ describe("markdown plain-text fallback", () => {
       await app.stop();
     }
   });
+
+  it("re-sends the markdown formatted for Slack when the platform is Slack", async () => {
+    const { seen, sendImpl } = noMarkdownSend("Slack");
+    const provider = makeProvider("Slack", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const sent = await space.send(markdown("**Hi** [docs](https://d.test)"));
+
+      expect(seen.map((c) => c.type)).toEqual(["markdown", "text"]);
+      expect(seen.at(-1)).toEqual({
+        type: "text",
+        text: "*Hi* <https://d.test|docs>",
+      });
+      expect(sent?.content).toEqual({
+        type: "text",
+        text: "*Hi* <https://d.test|docs>",
+      });
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("re-sends the markdown formatted for WhatsApp when the platform is WhatsApp Business", async () => {
+    const { seen, sendImpl } = noMarkdownSend("WhatsApp Business");
+    const provider = makeProvider("WhatsApp Business", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const sent = await space.send(markdown("**Hi** [docs](https://d.test)"));
+
+      expect(seen.map((c) => c.type)).toEqual(["markdown", "text"]);
+      expect(seen.at(-1)).toEqual({
+        type: "text",
+        text: "*Hi* docs (https://d.test)",
+      });
+      expect(sent?.content).toEqual({
+        type: "text",
+        text: "*Hi* docs (https://d.test)",
+      });
+    } finally {
+      await app.stop();
+    }
+  });
 });

--- a/packages/core/test/utils/markdown.test.ts
+++ b/packages/core/test/utils/markdown.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { markdownToPlainText } from "@/utils/markdown";
+import {
+  markdownToPlainText,
+  markdownToSlack,
+  markdownToWhatsapp,
+} from "@/utils/markdown";
 
 describe("markdownToPlainText", () => {
   it("strips nested emphasis markers", () => {
@@ -91,5 +95,68 @@ describe("markdownToPlainText", () => {
 
   it("separates blocks with a blank line", () => {
     expect(markdownToPlainText("one\n\ntwo")).toBe("one\n\ntwo");
+  });
+});
+
+describe("markdownToSlack", () => {
+  it("converts strong, em, and del to slack mrkdwn style", () => {
+    expect(markdownToSlack("**bold _italic_ ~~strike~~**")).toBe(
+      "*bold _italic_ ~strike~*"
+    );
+  });
+
+  it("converts codespan", () => {
+    expect(markdownToSlack("run `a < b` now")).toBe("run `a < b` now");
+  });
+
+  it("escapes Slack special characters &, <, and >", () => {
+    expect(markdownToSlack("a & b < c > d")).toBe("a &amp; b &lt; c &gt; d");
+  });
+
+  it("converts markdown links to Slack mrkdwn links", () => {
+    expect(markdownToSlack("see [docs](https://d.test)")).toBe(
+      "see <https://d.test|docs>"
+    );
+    expect(markdownToSlack("see [https://d.test](https://d.test)")).toBe(
+      "see <https://d.test>"
+    );
+  });
+
+  it("converts headings to bold text", () => {
+    expect(markdownToSlack("# Title\n\nbody")).toBe("*Title*\n\nbody");
+  });
+
+  it("converts lists and blockquotes", () => {
+    expect(markdownToSlack("- item 1\n- item 2")).toBe("• item 1\n• item 2");
+    expect(markdownToSlack("> quote line")).toBe("> quote line");
+  });
+});
+
+describe("markdownToWhatsapp", () => {
+  it("converts strong, em, and del to whatsapp style", () => {
+    expect(markdownToWhatsapp("**bold _italic_ ~~strike~~**")).toBe(
+      "*bold _italic_ ~strike~*"
+    );
+  });
+
+  it("converts codespan", () => {
+    expect(markdownToWhatsapp("run `a < b` now")).toBe("run `a < b` now");
+  });
+
+  it("does not escape HTML entities for whatsapp", () => {
+    expect(markdownToWhatsapp("a & b < c > d")).toBe("a & b < c > d");
+  });
+
+  it("degrades markdown links to label (url) for whatsapp", () => {
+    expect(markdownToWhatsapp("see [docs](https://d.test)")).toBe(
+      "see docs (https://d.test)"
+    );
+    expect(markdownToWhatsapp("see [https://d.test](https://d.test)")).toBe(
+      "see https://d.test"
+    );
+  });
+
+  it("converts headings to bold text", () => {
+    expect(markdownToWhatsapp("# Title\n\nbody")).toBe("*Title*\n\nbody");
   });
 });

--- a/packages/core/test/webhook/fastify.test.ts
+++ b/packages/core/test/webhook/fastify.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
   baseConfig,
@@ -18,8 +18,17 @@ import type { Message } from "@/types/message";
 
 stubCloud();
 
-// Don't let a host env secret leak into the wrong-secret case.
-process.env.SPECTRUM_WEBHOOK_SECRET = "";
+let originalSecret: string | undefined;
+
+beforeAll(() => {
+  originalSecret = process.env.SPECTRUM_WEBHOOK_SECRET;
+  // Don't let a host env secret leak into the wrong-secret case.
+  process.env.SPECTRUM_WEBHOOK_SECRET = "";
+});
+
+afterAll(() => {
+  process.env.SPECTRUM_WEBHOOK_SECRET = originalSecret;
+});
 
 const PLATFORM = "im";
 

--- a/packages/core/test/webhook/fastify.test.ts
+++ b/packages/core/test/webhook/fastify.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "bun:test";
+import { stubCloud } from "@spectrum-ts/test-support/cloud";
+import {
+  baseConfig,
+  makeManagedProvider,
+} from "@spectrum-ts/test-support/platform";
+import { flush } from "@spectrum-ts/test-support/timing";
+import {
+  type SignedSpectrumWebhook,
+  SPECTRUM_WEBHOOK_SECRET,
+  signSpectrum,
+  textEnvelope,
+} from "@spectrum-ts/test-support/webhook";
+import Fastify from "fastify";
+import { spectrum } from "@/fastify";
+import { Spectrum } from "@/spectrum";
+import type { Message } from "@/types/message";
+
+stubCloud();
+
+// Don't let a host env secret leak into the wrong-secret case.
+process.env.SPECTRUM_WEBHOOK_SECRET = "";
+
+const PLATFORM = "im";
+
+const makeApp = (overrides: Record<string, unknown> = {}) =>
+  Spectrum({
+    ...baseConfig,
+    providers: [makeManagedProvider(PLATFORM).config({})],
+    webhookSecret: SPECTRUM_WEBHOOK_SECRET,
+    ...overrides,
+  });
+
+/** Boot the fastify app on an ephemeral port; returns the base URL + a closer. */
+const listen = async (server: ReturnType<typeof Fastify>) => {
+  const address = await server.listen({ host: "127.0.0.1", port: 0 });
+  return {
+    url: address,
+    close: () => server.close(),
+  };
+};
+
+const post = (url: string, signed: SignedSpectrumWebhook) =>
+  fetch(url, {
+    method: "POST",
+    headers: signed.headers,
+    body: signed.body,
+  });
+
+describe("spectrum (fastify plugin)", () => {
+  it("verifies and delivers a signed webhook (raw body survives fastify)", async () => {
+    const app = await makeApp();
+    const received: Message[] = [];
+    const { promise: finished, resolve: done } = Promise.withResolvers<void>();
+
+    const server = Fastify();
+    await server.register(spectrum, {
+      app,
+      onMessage: (_space, message) => {
+        received.push(message);
+        done();
+      },
+    });
+
+    const { url, close } = await listen(server);
+
+    try {
+      const signed = signSpectrum(textEnvelope(PLATFORM, "hello there"));
+      const response = await post(`${url}/spectrum/webhook`, signed);
+      await finished;
+
+      // A valid signature only verifies if the exact wire bytes reached the SDK
+      // — so a 200 here proves Fastify custom parser handed over the untouched body.
+      expect(response.status).toBe(200);
+      expect(received).toHaveLength(1);
+      expect(received[0]?.content).toEqual({
+        type: "text",
+        text: "hello there",
+      });
+    } finally {
+      await close();
+      await app.stop();
+    }
+  });
+
+  it("rejects a bad signature with 401 and never calls onMessage", async () => {
+    const app = await makeApp();
+    let called = false;
+
+    const server = Fastify();
+    await server.register(spectrum, {
+      app,
+      onMessage: () => {
+        called = true;
+      },
+    });
+
+    const { url, close } = await listen(server);
+
+    try {
+      const signed = signSpectrum(textEnvelope(PLATFORM, "hi"), {
+        secret: "the-wrong-secret",
+      });
+      const response = await post(`${url}/spectrum/webhook`, signed);
+      await flush();
+
+      expect(response.status).toBe(401);
+      expect(called).toBe(false);
+    } finally {
+      await close();
+      await app.stop();
+    }
+  });
+
+  it("honors a custom path", async () => {
+    const app = await makeApp();
+    const { promise: finished, resolve: done } = Promise.withResolvers<void>();
+
+    const server = Fastify();
+    await server.register(spectrum, {
+      app,
+      path: "/hooks/spectrum",
+      onMessage: () => done(),
+    });
+
+    const { url, close } = await listen(server);
+
+    try {
+      const signed = signSpectrum(textEnvelope(PLATFORM, "custom path"));
+      const response = await post(`${url}/hooks/spectrum`, signed);
+      await finished;
+
+      expect(response.status).toBe(200);
+    } finally {
+      await close();
+      await app.stop();
+    }
+  });
+});

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -7,11 +7,12 @@ export default defineConfig({
     elysia: "src/elysia.ts",
     express: "src/express.ts",
     hono: "src/hono.ts",
+    fastify: "src/fastify.ts",
   },
   format: "esm",
   fixedExtension: false,
   dts: true,
   clean: true,
   platform: "node",
-  external: ["ffmpeg-static", "elysia", "express", "hono"],
+  external: ["ffmpeg-static", "elysia", "express", "hono", "fastify"],
 });

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -44,6 +44,11 @@
       "types": "./src/hono.ts",
       "default": "./dist/hono.js"
     },
+    "./fastify": {
+      "bun": "./src/fastify.ts",
+      "types": "./src/fastify.ts",
+      "default": "./dist/fastify.js"
+    },
     "./providers": {
       "bun": "./src/providers/index.ts",
       "types": "./src/providers/index.ts",
@@ -78,6 +83,10 @@
       "./hono": {
         "types": "./dist/hono.d.ts",
         "default": "./dist/hono.js"
+      },
+      "./fastify": {
+        "types": "./dist/fastify.d.ts",
+        "default": "./dist/fastify.js"
       },
       "./providers": {
         "types": "./dist/providers/index.d.ts",

--- a/packages/spectrum-ts/src/express.ts
+++ b/packages/spectrum-ts/src/express.ts
@@ -1,3 +1,9 @@
 // Re-export of the runtime's Express webhook router so the
 // `spectrum-ts/express` import path works through the metapackage.
-export * from "@spectrum-ts/core/express";
+export type {
+  Message,
+  Space,
+  SpectrumPluginOptions,
+  WebhookHandler,
+} from "@spectrum-ts/core/express";
+export { spectrum } from "@spectrum-ts/core/express";

--- a/packages/spectrum-ts/src/fastify.ts
+++ b/packages/spectrum-ts/src/fastify.ts
@@ -1,0 +1,4 @@
+// Re-export of the runtime's Fastify webhook handler so the
+// `spectrum-ts/fastify` import path works through the metapackage.
+// biome-ignore lint/performance/noBarrelFile: clean entrypoint for the fastify adapter
+export * from "@spectrum-ts/core/fastify";

--- a/packages/spectrum-ts/src/fastify.ts
+++ b/packages/spectrum-ts/src/fastify.ts
@@ -1,4 +1,10 @@
 // Re-export of the runtime's Fastify webhook handler so the
 // `spectrum-ts/fastify` import path works through the metapackage.
+export type {
+  Message,
+  Space,
+  SpectrumPluginOptions,
+  WebhookHandler,
+} from "@spectrum-ts/core/fastify";
 // biome-ignore lint/performance/noBarrelFile: clean entrypoint for the fastify adapter
-export * from "@spectrum-ts/core/fastify";
+export { spectrum } from "@spectrum-ts/core/fastify";

--- a/packages/spectrum-ts/tsdown.config.ts
+++ b/packages/spectrum-ts/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     elysia: "src/elysia.ts",
     express: "src/express.ts",
     hono: "src/hono.ts",
+    fastify: "src/fastify.ts",
     "providers/index": "src/providers/index.ts",
     "providers/imessage/index": "src/providers/imessage/index.ts",
     "providers/slack/index": "src/providers/slack/index.ts",


### PR DESCRIPTION
This PR implements automatic conversion of standard Markdown (CommonMark + GFM) into platform-specific rich text styles (Slack mrkdwn, WhatsApp formatting, and plain text fallbacks) inside the core send fallbacks pipeline.

### Key Changes
- **Slack & WhatsApp Renderers**: Added `markdownToSlack` and `markdownToWhatsapp` under `packages/core/src/utils/markdown.ts` using `marked` token parsing.
- **Pipeline Integration**: Modified the `sendWithFallbacks` pipeline (`replaceMarkdown` / `downgradeMarkdown`) to receive the platform name and apply these translations.
- **Unit and Integration Tests**: Added comprehensive test coverage validating elements (bold/italic/strike/links/escaping) and routing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784418356&installation_id=127326493&pr_number=137&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F137&signature=5dafe87b16318e1f3a917c7fff2ab4b8abd776769c1ea20b6b666c74d574a85c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Fastify adapter support with a Spectrum webhook plugin available via a dedicated `fastify` entrypoint.
  * Exposed `markdownToSlack` and `markdownToWhatsapp` for richer platform-specific formatting.

* **Improvements**
  * Improved markdown fallback when a provider doesn’t support markdown, using Slack/WhatsApp formatting across top-level and nested reply/edit/group content.

* **Bug Fixes**
  * Normalized Express webhook headers passed to the app to ensure consistent webhook handling.

* **Developer Experience**
  * Refined public entrypoint exports and added/updated coverage for Fastify/webhook and markdown conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->