### PR TITLE
feat(telemetry): structured logging across providers — `errorAttrs`, `logLevel` option, otel v1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
       "name": "@spectrum-ts/core",
       "version": "5.0.0",
       "dependencies": {
-        "@photon-ai/otel": "^0.1.1",
+        "@photon-ai/otel": "^1.0.0",
         "@photon-ai/proto": "^0.2.4",
         "@repeaterjs/repeater": "^3.0.6",
         "marked": "^18.0.5",
@@ -65,7 +65,7 @@
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.11.0",
         "@photon-ai/imessage-kit": "^3.0.0",
-        "@photon-ai/otel": "^0.1.1",
+        "@photon-ai/otel": "^1.0.0",
         "lru-cache": "^11.0.0",
         "marked": "^18.0.5",
         "zod": "^4.2.1",
@@ -308,23 +308,23 @@
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
-    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.216.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-KmGTgvxTJ0J01d4mOeX1wMV5NUTNf9HebIuOOGDfIn0a/IrnXIQbOnlylDyl9tkDv4h0DUpdI/GqCdLzfTkUXg=="],
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.218.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-fmEWp5kXlGEc3i/lR698Hz41DfGyN4Tbe4g7L1AxSc7fF8Xeh/FQ9Quqpa9dVA413Q1Ad43QOLzU4JoXgbFPWw=="],
 
     "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@2.7.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OPFBYuXEn1E4ja3Y6eeA7O+ZnLBNcXTV5Cgsn1VaqBZ6hC5FnpZPLBNme1LJY8ZtF4aOujPKFoeWN4ik487KuQ=="],
 
     "@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
 
-    "@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.216.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.216.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.216.0", "@opentelemetry/otlp-transformer": "0.216.0", "@opentelemetry/sdk-logs": "0.216.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-8SUzQY/aExKkz6Ab3vOf6gu690Xk4wHH90dGwXinejQzazn5HCIRR7yPVU/2fEuiZ73R92MU4qI3djHfYP7NJg=="],
+    "@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/sdk-logs": "0.218.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw=="],
 
-    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.216.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.216.0", "@opentelemetry/otlp-transformer": "0.216.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-DhWjvj0PUPFwFnhOEivpum8sJzj6FTuyx88zff+oHVLUhfd6cLyw4AIai/F4j0PZqYZBFuMT/OTMUd9wdXnBEQ=="],
+    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw=="],
 
-    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.216.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-transformer": "0.216.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-sSnvb5f+FYa4mfYxj03rmmUh+aDwo3jok62dgIWUDw8ZCUPzEbgtv/YhZyKUSlKNNey7Uc5xmJgmtTLLIV6UDQ=="],
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-transformer": "0.218.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA=="],
 
-    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.216.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.216.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-logs": "0.216.0", "@opentelemetry/sdk-metrics": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1", "protobufjs": "8.0.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-g4Rb6sAsxQAo11eDjixfKxelruBsQFdJ8Wo23FCj7D6OXbidgXMu2xaRSYs4RdlomzAXSJuc86RcS3xmE8A6uA=="],
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-logs": "0.218.0", "@opentelemetry/sdk-metrics": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ=="],
 
     "@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
 
-    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.216.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.216.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-KB3rcwQuitq0JbbsCcNdqMhRJX3kArAYz/ovb0jGRaBQAIrt2roik3xQXuhYxS37zx0jSkUZcJu1z3Y2UCxbDA=="],
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-QvnNdugatFTVCJXH0Mcu7GOOJSylA9j127kIezOE4YwTI4YbowRons2K4WZTv5FMS8T4q9P0NdaRHdkSmeAIag=="],
 
     "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ=="],
 
@@ -342,7 +342,7 @@
 
     "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-GGDETlRbrPXP5eaRvswaead7MCBGQkm8f7d3aVbx8+rXhB4GEyPiw7Q1/yz5ix53rmxqKRevWywOfG7n+kZDBw=="],
 
-    "@photon-ai/otel": ["@photon-ai/otel@0.1.1", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/api-logs": "^0.216.0", "@opentelemetry/context-async-hooks": "^2.7.1", "@opentelemetry/exporter-logs-otlp-http": "^0.216.0", "@opentelemetry/exporter-trace-otlp-http": "^0.216.0", "@opentelemetry/resources": "^2.7.1", "@opentelemetry/sdk-logs": "^0.216.0", "@opentelemetry/sdk-trace-base": "^2.7.1" }, "peerDependencies": { "typescript": "^5 || ^6.0.0" } }, "sha512-t/NVepO5+fHOLWDI+Eht+RC8PTik0wi7HQsKhU4yPqBjY5JncXmoBZLnWFvG+/qJ/pn6w+tveabKG9pykfkqKg=="],
+    "@photon-ai/otel": ["@photon-ai/otel@1.0.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/api-logs": "^0.218.0", "@opentelemetry/context-async-hooks": "^2.7.1", "@opentelemetry/exporter-logs-otlp-http": "^0.218.0", "@opentelemetry/exporter-trace-otlp-http": "^0.218.0", "@opentelemetry/resources": "^2.7.1", "@opentelemetry/sdk-logs": "^0.218.0", "@opentelemetry/sdk-trace-base": "^2.7.1" }, "peerDependencies": { "typescript": "^5 || ^6.0.0" } }, "sha512-5fACVHN7BtGS+phglVAxun5QLckNUSS4p750oCxR//m9JNVzFQMoLFWfC6DnWBP/W0/+B2yP75+3NMVLodEJEg=="],
 
     "@photon-ai/proto": ["@photon-ai/proto@0.2.4", "", { "dependencies": { "@bufbuild/protobuf": "^2.12.0", "nice-grpc-common": "^2.0.3" } }, "sha512-DQANEp0gHvtwqpMGEF0ufa0hs1nniRdsSuo0Q/TG6GoL1WjC5tp59tHFSLUeIm6fvnAuRjREsGzURz3+/69g7g=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -80,7 +80,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@photon-ai/otel": "^0.1.1",
+    "@photon-ai/otel": "^1.0.0",
     "@photon-ai/proto": "^0.2.4",
     "@repeaterjs/repeater": "^3.0.6",
     "marked": "^18.0.5",

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -18,6 +18,21 @@
 // lazy `read()` for authenticated media, a stub target for inbound reactions —
 // which is exactly what a provider needs when mapping inbound events.
 
+// Logging & telemetry — the structured logger, level control, and PII helpers
+// a provider reaches for so its logs share the SDK's namespaces, severity
+// gating, and OTLP pipeline (a single `@photon-ai/otel` instance lives in
+// core). Use `createLogger("spectrum.<provider>")` and attach `errorAttrs(err)`
+// instead of dumping raw errors.
+export {
+  createLogger,
+  type LogAttrs,
+  type LogLevel,
+  type PhotonLogger,
+  sanitizeEmail,
+  sanitizeErrorMessage,
+  sanitizePhone,
+  setLogLevel,
+} from "@photon-ai/otel";
 // Content factories, schemas, and the inbound-record type (from `content/`).
 export { asAttachment } from "./content/attachment";
 export { asContact } from "./content/contact";
@@ -32,7 +47,6 @@ export { asRichlink } from "./content/richlink";
 export { asText } from "./content/text";
 export { asVoice } from "./content/voice";
 export type { ProviderMessageRecord } from "./platform/types";
-
 // Generic translation helpers (from `utils/`).
 export { ensureM4a } from "./utils/audio";
 export { renderInlineTokens } from "./utils/markdown";
@@ -46,3 +60,4 @@ export {
   type ResumableStreamItem,
   resumableOrderedStream,
 } from "./utils/resumable-stream";
+export { errorAttrs } from "./utils/telemetry";

--- a/packages/core/src/fusor/auth.ts
+++ b/packages/core/src/fusor/auth.ts
@@ -112,6 +112,7 @@ export function createFusorTokenProvider(
       async getToken(): Promise<string> {
         if (Date.now() >= tokenExpiresAt - EXPIRY_BUFFER_MS) {
           await refresh();
+          onRefreshSuccess();
           scheduleRenewal();
         }
         return tokenData.token;

--- a/packages/core/src/fusor/auth.ts
+++ b/packages/core/src/fusor/auth.ts
@@ -1,4 +1,8 @@
+import { createLogger } from "@photon-ai/otel";
 import { cloud } from "../utils/cloud";
+import { errorAttrs } from "../utils/telemetry";
+
+const log = createLogger("spectrum.fusor.auth");
 
 const RENEWAL_RATIO = 0.8;
 const EXPIRY_BUFFER_MS = 30_000;
@@ -24,6 +28,7 @@ export function createFusorTokenProvider(
     let tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
     let disposed = false;
     let renewalTimer: ReturnType<typeof setTimeout> | undefined;
+    let refreshFailures = 0;
 
     const clearRenewalTimer = () => {
       if (renewalTimer !== undefined) {
@@ -37,6 +42,28 @@ export function createFusorTokenProvider(
       tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
     };
 
+    const onRefreshSuccess = () => {
+      if (refreshFailures > 0) {
+        log.info("fusor token refresh recovered", {
+          "spectrum.fusor.auth.attempt": refreshFailures,
+        });
+        refreshFailures = 0;
+      }
+    };
+
+    const onRefreshFailure = (error: unknown) => {
+      refreshFailures += 1;
+      log.warn(
+        "fusor token refresh failed; retrying",
+        {
+          "spectrum.fusor.auth.attempt": refreshFailures,
+          "spectrum.fusor.auth.retry_in_ms": RETRY_DELAY_MS,
+          ...errorAttrs(error),
+        },
+        error
+      );
+    };
+
     const scheduleRetry = () => {
       if (disposed) {
         return;
@@ -48,12 +75,10 @@ export function createFusorTokenProvider(
         }
         try {
           await refresh();
+          onRefreshSuccess();
           scheduleRenewal();
         } catch (retryErr) {
-          console.warn(
-            `[spectrum-ts] Fusor token refresh failed; retrying in ${RETRY_DELAY_MS}ms.`,
-            retryErr
-          );
+          onRefreshFailure(retryErr);
           scheduleRetry();
         }
       }, RETRY_DELAY_MS);
@@ -71,12 +96,10 @@ export function createFusorTokenProvider(
       renewalTimer = setTimeout(async () => {
         try {
           await refresh();
+          onRefreshSuccess();
           scheduleRenewal();
         } catch (err) {
-          console.warn(
-            `[spectrum-ts] Fusor token refresh failed; retrying in ${RETRY_DELAY_MS}ms.`,
-            err
-          );
+          onRefreshFailure(err);
           scheduleRetry();
         }
       }, renewInMs);

--- a/packages/core/src/fusor/core.ts
+++ b/packages/core/src/fusor/core.ts
@@ -5,6 +5,7 @@ import type {
 } from "@photon-ai/proto/photon/fusor/v1/inbound";
 import type { ProviderMessageRecord } from "../platform/types";
 import { officialProviderInstallHint } from "../utils/provider-packages";
+import { errorAttrs } from "../utils/telemetry";
 import { createFusorTokenProvider, type FusorTokenProvider } from "./auth";
 import { FUSOR_MESSAGES_CHANNEL, isFusorEvent } from "./event";
 import { type ParsedHttpRequest, parseHttpRequest } from "./parse";
@@ -225,7 +226,7 @@ export class FusorCore {
       this.options.projectSecret
     );
     this.connectionLoop = this.runConnectionLoop().catch((error) => {
-      log.error("fusor connection loop crashed", { error });
+      log.error("fusor connection loop crashed", errorAttrs(error), error);
     });
   }
 
@@ -262,9 +263,11 @@ export class FusorCore {
         this.tokenProvider?.invalidate();
       }
       if (!this.stopped) {
-        log.warn("fusor websocket stream errored; reconnecting", {
-          error: errorText(error),
-        });
+        log.warn(
+          "fusor websocket stream errored; reconnecting",
+          errorAttrs(error),
+          error
+        );
       }
       return false;
     }
@@ -335,7 +338,10 @@ export class FusorCore {
         hint
           ? `fusor: no handler for platform — ${hint}`
           : "fusor: no handler for platform",
-        { platform: event.platform }
+        {
+          "spectrum.fusor.platform": event.platform,
+          "spectrum.fusor.event_id": event.eventId,
+        }
       );
       return {
         eventId: event.eventId,
@@ -352,8 +358,9 @@ export class FusorCore {
     } catch (error) {
       const errorReason = errorText(error);
       log.warn("fusor: failed to parse raw_request", {
-        platform: event.platform,
-        error: errorReason,
+        "spectrum.fusor.platform": event.platform,
+        "spectrum.fusor.event_id": event.eventId,
+        ...errorAttrs(error),
       });
       return {
         eventId: event.eventId,

--- a/packages/core/src/fusor/websocket.ts
+++ b/packages/core/src/fusor/websocket.ts
@@ -3,6 +3,7 @@ import type {
   InboundReply,
   RawInboundEvent,
 } from "@photon-ai/proto/photon/fusor/v1/inbound";
+import { errorAttrs } from "../utils/telemetry";
 
 // fusor.v1.json WebSocket transport — the streaming transport.
 //
@@ -183,7 +184,7 @@ export function runFusorWsSession(
     }
     watchdog = setTimeout(() => {
       log.warn("fusor ws: no frame within staleness budget; closing", {
-        budgetMs: stalenessBudgetMs,
+        "spectrum.fusor.ws.staleness_budget_ms": stalenessBudgetMs,
       });
       settle(new FusorWsError("websocket heartbeat timeout"));
       try {
@@ -219,8 +220,10 @@ export function runFusorWsSession(
       stalenessBudgetMs = 2 * interval + STALENESS_GRACE_MS;
     }
     log.info("fusor ws stream ready", {
-      projectId: typeof frame.projectId === "string" ? frame.projectId : "",
-      heartbeatIntervalMs: typeof interval === "number" ? interval : 0,
+      "spectrum.fusor.ws.project_id":
+        typeof frame.projectId === "string" ? frame.projectId : "",
+      "spectrum.fusor.ws.heartbeat_interval_ms":
+        typeof interval === "number" ? interval : 0,
     });
   };
 
@@ -230,9 +233,11 @@ export function runFusorWsSession(
     try {
       event = toRawInboundEvent(eventFrame);
     } catch (error) {
-      log.warn("fusor ws: undecodable event frame; skipping", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      log.warn(
+        "fusor ws: undecodable event frame; skipping",
+        errorAttrs(error),
+        error
+      );
       return;
     }
     const sendReply = eventFrame.replyExpected
@@ -241,10 +246,11 @@ export function runFusorWsSession(
     tail = tail
       .then(() => options.onEvent(event, sendReply))
       .catch((error) => {
-        log.warn("fusor ws: event handler failed", {
-          eventId: event.eventId,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        log.warn(
+          "fusor ws: event handler failed",
+          { "spectrum.fusor.ws.event_id": event.eventId, ...errorAttrs(error) },
+          error
+        );
       });
   };
 
@@ -258,7 +264,11 @@ export function runFusorWsSession(
     } else {
       // Typed non-fatal notice (reply_unknown_event, frame_invalid, …)
       // — the stream keeps running; surface it for debugging.
-      log.warn("fusor ws: server notice", { code, message, reason });
+      log.warn("fusor ws: server notice", {
+        "spectrum.fusor.ws.notice_code": code,
+        "spectrum.fusor.ws.notice_message": message,
+        "spectrum.fusor.ws.notice_reason": reason,
+      });
     }
   };
 

--- a/packages/core/src/platform/build.ts
+++ b/packages/core/src/platform/build.ts
@@ -36,23 +36,6 @@ const platformLog = createLogger("spectrum.platform");
 
 export type { ProviderMessageRecord } from "./types";
 
-const ANSI_YELLOW = "\x1b[33m";
-const ANSI_RESET = "\x1b[0m";
-
-const supportsAnsiColor = (): boolean => {
-  if (typeof process === "undefined") {
-    return false;
-  }
-  if (process.env.NO_COLOR) {
-    return false;
-  }
-  const force = process.env.FORCE_COLOR;
-  if (force !== undefined) {
-    return force !== "" && force !== "0" && force !== "false";
-  }
-  return Boolean(process.stderr?.isTTY);
-};
-
 // Built-in content types whose provider `send` may return `void`/no id
 // because they're side-effects (typing indicator, edit, unsend), not new
 // messages. Reactions are NOT fire-and-forget: providers must return a
@@ -134,9 +117,13 @@ export const warnReservedAction = (
   name: string,
   platform: string
 ) => {
-  const body = `[spectrum-ts] ${platform} declared ${scope} action "${name}" which collides with a reserved ${scopeLabel(scope)} key; skipping.`;
-  console.warn(
-    supportsAnsiColor() ? `${ANSI_YELLOW}${body}${ANSI_RESET}` : body
+  platformLog.warn(
+    `${platform} declared ${scope} action "${name}" which collides with a reserved ${scopeLabel(scope)} key; skipping.`,
+    {
+      "spectrum.provider": platform,
+      "spectrum.reserved.scope": scope,
+      "spectrum.reserved.action": name,
+    }
   );
 };
 

--- a/packages/core/src/platform/define.ts
+++ b/packages/core/src/platform/define.ts
@@ -532,8 +532,8 @@ export function definePlatform(name: string, rawDef: unknown): unknown {
   const narrowSpace = (input: Space) => {
     if (input.__platform !== name) {
       platformLog.warn("space platform mismatch; narrowing skipped", {
-        expected: name,
-        actual: input.__platform,
+        "spectrum.platform.expected": name,
+        "spectrum.platform.actual": input.__platform,
       });
     }
     return input as PlatformSpace<Def>;
@@ -542,8 +542,8 @@ export function definePlatform(name: string, rawDef: unknown): unknown {
   const narrowMessage = (input: Message) => {
     if (input.platform !== name) {
       platformLog.warn("message platform mismatch; narrowing skipped", {
-        expected: name,
-        actual: input.platform,
+        "spectrum.platform.expected": name,
+        "spectrum.platform.actual": input.platform,
       });
     }
     return input as PlatformMessage<Def>;

--- a/packages/core/src/spectrum.ts
+++ b/packages/core/src/spectrum.ts
@@ -1,6 +1,8 @@
 import {
   createLogger,
+  type LogLevel,
   type OtelHandle,
+  setLogLevel,
   setupOtel,
   withSpan,
 } from "@photon-ai/otel";
@@ -47,7 +49,7 @@ import {
   mergeStreams,
   stream,
 } from "./utils/stream";
-import { contentAttrs, senderAttrs } from "./utils/telemetry";
+import { contentAttrs, errorAttrs, senderAttrs } from "./utils/telemetry";
 import {
   type DeserializeContext,
   deserializeSpectrumMessage,
@@ -146,6 +148,15 @@ export interface SpectrumOptions {
    * @default false
    */
   flattenGroups?: boolean;
+
+  /**
+   * Minimum severity emitted by the SDK's structured logger (to both the
+   * console and, when telemetry is on, OTLP). Applies process-wide. The
+   * `LOG_LEVEL` environment variable still takes precedence.
+   *
+   * @default "debug" in development, "info" otherwise (via `DEPLOYMENT_ENV`)
+   */
+  logLevel?: LogLevel;
 }
 
 // ---------------------------------------------------------------------------
@@ -155,6 +166,7 @@ export interface SpectrumOptions {
 const spectrumOptionsSchema = z
   .object({
     flattenGroups: z.boolean().optional(),
+    logLevel: z.enum(["debug", "info", "warn", "error", "silent"]).optional(),
   })
   .optional();
 
@@ -203,6 +215,14 @@ function bootstrapTelemetry(opts: {
     headers,
     resourceAttributes,
   });
+}
+
+// Apply an explicit log-level override (if any) before anything logs. Kept out
+// of Spectrum() so that factory stays under the cognitive-complexity cap.
+function applyLogLevel(level: LogLevel | undefined): void {
+  if (level) {
+    setLogLevel(level);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -261,6 +281,10 @@ export async function Spectrum<
     webhookSecret,
   } = options;
   const flattenGroups = runtimeOptions?.flattenGroups ?? false;
+  // Honor an explicit log-level override before anything logs. Applies even
+  // when telemetry is off (the console logger respects it too); the LOG_LEVEL
+  // env var still wins inside @photon-ai/otel.
+  applyLogLevel(runtimeOptions?.logLevel);
   // The per-webhook signing secret for native Spectrum webhooks. Explicit option
   // wins; otherwise fall back to the env var so deployments can inject it.
   const resolvedWebhookSecret =
@@ -597,7 +621,10 @@ export async function Spectrum<
           if (!eventQueue) {
             lifecycleLog.warn(
               `spectrum: fusorEvent("${channel}", …) names a channel not declared in "${name}".events; dropping`,
-              { platform: name, channel }
+              {
+                "spectrum.lifecycle.platform": name,
+                "spectrum.lifecycle.channel": channel,
+              }
             );
             return;
           }
@@ -627,9 +654,9 @@ export async function Spectrum<
     .join(",");
 
   lifecycleLog.info("Spectrum started", {
-    providerCount: providers.length,
-    providers: providerNames,
-    telemetry: telemetry === true,
+    "spectrum.lifecycle.provider_count": providers.length,
+    "spectrum.lifecycle.providers": providerNames,
+    "spectrum.lifecycle.telemetry": telemetry === true,
   });
 
   // Advisory, fire-and-forget: in cloud mode, compare the project's enabled
@@ -655,7 +682,7 @@ export async function Spectrum<
             hint
               ? `spectrum: project has "${platform}" enabled but no matching provider is registered — ${hint}`
               : `spectrum: project has "${platform}" enabled but no matching provider is registered`,
-            { platform }
+            { "spectrum.lifecycle.platform": platform }
           );
         }
       })
@@ -822,7 +849,7 @@ export async function Spectrum<
     ]);
     if (streamTimedOut) {
       lifecycleLog.warn("stream close timed out; proceeding to teardown", {
-        timeoutMs: STREAM_CLOSE_TIMEOUT_MS,
+        "spectrum.lifecycle.stream_close_timeout_ms": STREAM_CLOSE_TIMEOUT_MS,
       });
     }
 
@@ -836,7 +863,7 @@ export async function Spectrum<
         await fusorStartPromise.catch(ignoreCleanupError);
       }
       await fusorCore.close().catch((error) => {
-        lifecycleLog.warn("fusor core close failed", { error });
+        lifecycleLog.warn("fusor core close failed", errorAttrs(error), error);
       });
       fusorCloseMs = Math.round(performance.now() - fusorCloseStart);
       closeFusorSources();
@@ -877,10 +904,10 @@ export async function Spectrum<
     eventBroadcasters.clear();
     platformStates.clear();
     lifecycleLog.info("Spectrum stopped", {
-      providers: providerNames,
-      streamCloseMs,
-      fusorCloseMs,
-      clientCloseMs,
+      "spectrum.lifecycle.providers": providerNames,
+      "spectrum.lifecycle.stream_close_ms": streamCloseMs,
+      "spectrum.lifecycle.fusor_close_ms": fusorCloseMs,
+      "spectrum.lifecycle.client_close_ms": clientCloseMs,
     });
     if (otelHandle) {
       await otelHandle.shutdown();
@@ -979,13 +1006,14 @@ export async function Spectrum<
           await handler(space, message);
         } catch (error) {
           lifecycleLog.error(
-            `spectrum.webhook: handler threw (async), ${error}`,
+            "spectrum.webhook: handler threw (async)",
             {
-              eventId: context.eventId,
-              platform: context.platform,
-              messageId: message.id,
-              error: error instanceof Error ? error.message : String(error),
-            }
+              "spectrum.webhook.event_id": context.eventId,
+              "spectrum.webhook.platform": context.platform,
+              "spectrum.webhook.message_id": message.id,
+              ...errorAttrs(error),
+            },
+            error
           );
         }
       }
@@ -999,9 +1027,11 @@ export async function Spectrum<
     try {
       return RawInboundEvent.decode(bodyBytes);
     } catch (error) {
-      lifecycleLog.warn("spectrum.webhook: undecodable RawInboundEvent body", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      lifecycleLog.warn(
+        "spectrum.webhook: undecodable RawInboundEvent body",
+        errorAttrs(error),
+        error
+      );
       return null;
     }
   };
@@ -1051,12 +1081,13 @@ export async function Spectrum<
       deliverWebhookMessages(collected, runtime, handler, event).catch(
         (error) => {
           lifecycleLog.error(
-            `spectrum.webhook: delivery failed (async), ${error}`,
+            "spectrum.webhook: delivery failed (async)",
             {
-              eventId: event.eventId,
-              platform: event.platform,
-              error: error instanceof Error ? error.message : String(error),
-            }
+              "spectrum.webhook.event_id": event.eventId,
+              "spectrum.webhook.platform": event.platform,
+              ...errorAttrs(error),
+            },
+            error
           );
         }
       );
@@ -1164,7 +1195,8 @@ export async function Spectrum<
   ): Promise<WebhookRawResult> => {
     if (!resolvedWebhookSecret) {
       lifecycleLog.error(
-        "spectrum.webhook: received a signed Spectrum webhook but no webhookSecret is configured (set Spectrum({ webhookSecret }) or SPECTRUM_WEBHOOK_SECRET)"
+        "spectrum.webhook: received a signed Spectrum webhook but no webhookSecret is configured (set Spectrum({ webhookSecret }) or SPECTRUM_WEBHOOK_SECRET)",
+        { "spectrum.webhook.reason": "missing-secret" }
       );
       return webhookText(500, "webhook secret not configured");
     }
@@ -1187,7 +1219,9 @@ export async function Spectrum<
       envelope = slimEnvelopeSchema.parse(parsed);
     } catch (error) {
       lifecycleLog.warn(
-        `spectrum.webhook: malformed Spectrum webhook payload, ${error}`
+        "spectrum.webhook: malformed Spectrum webhook payload",
+        errorAttrs(error),
+        error
       );
       return webhookText(400, "malformed payload");
     }
@@ -1206,7 +1240,7 @@ export async function Spectrum<
     if (!runtime) {
       lifecycleLog.warn(
         `spectrum.webhook: no provider configured for platform "${platform}"; acknowledging without delivery`,
-        { platform }
+        { "spectrum.webhook.platform": platform }
       );
       return webhookText(200, "ok");
     }
@@ -1215,12 +1249,13 @@ export async function Spectrum<
     deliverWebhookMessages([record], runtime, handler, { platform }).catch(
       (error) => {
         lifecycleLog.error(
-          `spectrum.webhook: Spectrum delivery failed (async), ${error}`,
+          "spectrum.webhook: Spectrum delivery failed (async)",
           {
-            platform,
-            messageId: record.id,
-            error: error instanceof Error ? error.message : String(error),
-          }
+            "spectrum.webhook.platform": platform,
+            "spectrum.webhook.message_id": record.id,
+            ...errorAttrs(error),
+          },
+          error
         );
       }
     );

--- a/packages/core/src/utils/resumable-stream.ts
+++ b/packages/core/src/utils/resumable-stream.ts
@@ -1,5 +1,6 @@
-import { createLogger } from "@photon-ai/otel";
+import { createLogger, type LogAttrs } from "@photon-ai/otel";
 import { type ManagedStream, stream } from "./stream";
+import { errorAttrs } from "./telemetry";
 
 export const CATCH_UP_PAGE_SIZE = 100;
 export const MAX_BUFFERED_LIVE_EVENTS = 1000;
@@ -11,6 +12,8 @@ export const RECONNECT_MAX_DELAY_MS = 30_000;
 export const PERSISTENT_FAILURE_ERROR_THRESHOLD = 5;
 
 const log = createLogger("spectrum.stream");
+
+type StreamPhase = "catch-up" | "live";
 
 export interface CloseableAsyncIterable<T> extends AsyncIterable<T> {
   close?: () => Promise<void> | void;
@@ -90,9 +93,6 @@ const ignoreCleanupError = () => undefined;
 const jitterDelay = (delayMs: number): number =>
   delayMs * (0.5 + Math.random() * 0.5);
 
-const errorMessage = (error: unknown): string =>
-  error instanceof Error ? error.message : String(error);
-
 // Classifies only rejections raised by `source` itself: errors thrown by the
 // consuming for-await body exit a `yield*` through return(), not this catch,
 // so a processMissed/live error can never masquerade as a cursor rejection.
@@ -155,13 +155,30 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
     let sleepTimer: ReturnType<typeof setTimeout> | undefined;
     let wakeSleep: (() => void) | undefined;
     const deliveredSinceCursor = new Set<string>();
+    // Stable id so concurrent streams (and one stream's reconnect storm) are
+    // distinguishable in logs and traces.
+    const streamId =
+      globalThis.crypto?.randomUUID?.() ??
+      `s_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+
+    const baseStreamAttrs = (phase: StreamPhase): LogAttrs => ({
+      "spectrum.stream.id": streamId,
+      "spectrum.stream.label": label,
+      "spectrum.stream.phase": phase,
+      "spectrum.stream.has_cursor": lastCursor !== undefined,
+      "spectrum.stream.cursor": lastCursor,
+    });
 
     const noteRecovery = () => {
       retryDelayMs = initialRetryDelayMs;
       if (failedAttempts === 0) {
         return;
       }
-      log.info("stream recovered", { attempts: failedAttempts, label });
+      log.info("stream recovered", {
+        "spectrum.stream.id": streamId,
+        "spectrum.stream.label": label,
+        "spectrum.stream.attempt": failedAttempts,
+      });
       failedAttempts = 0;
     };
 
@@ -230,35 +247,46 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
       return delay;
     };
 
-    const handleFailure = (error: unknown): number => {
+    const failureKind = (error: unknown): string => {
+      if (error instanceof CursorRejectedError) {
+        return "cursor-rejected";
+      }
+      if (failedAttempts >= PERSISTENT_FAILURE_ERROR_THRESHOLD) {
+        return "persistent";
+      }
+      return "transient";
+    };
+
+    const handleFailure = (error: unknown, phase: StreamPhase): number => {
       failedAttempts += 1;
       const delayMs = nextRetryDelay();
+      // Capture cursor/phase state before the cursor-rejected branch clears it,
+      // so the log shows which cursor was rejected. Unwrap CursorRejectedError
+      // to surface the underlying server error in `spectrum.error.*`.
+      const attrs: LogAttrs = {
+        ...baseStreamAttrs(phase),
+        "spectrum.stream.attempt": failedAttempts,
+        "spectrum.stream.delay_ms": delayMs,
+        "spectrum.stream.failure_kind": failureKind(error),
+        ...errorAttrs(
+          error instanceof CursorRejectedError ? error.cause : error
+        ),
+      };
       if (error instanceof CursorRejectedError) {
         lastCursor = undefined;
         deliveredSinceCursor.clear();
         log.warn(
           "resume cursor rejected; accepting event gap and resuming live",
-          {
-            attempt: failedAttempts,
-            delayMs,
-            error: errorMessage(error.cause),
-            label,
-          }
+          attrs,
+          error
         );
         return delayMs;
       }
-      const attrs = {
-        attempt: failedAttempts,
-        delayMs,
-        error: errorMessage(error),
-        hasCursor: lastCursor !== undefined,
-        label,
-      };
       if (failedAttempts >= PERSISTENT_FAILURE_ERROR_THRESHOLD) {
         log.error("stream persistently failing; still retrying", attrs, error);
         return delayMs;
       }
-      log.warn("stream interrupted; reconnecting", attrs);
+      log.warn("stream interrupted; reconnecting", attrs, error);
       return delayMs;
     };
 
@@ -399,6 +427,7 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
 
     const run = async () => {
       while (!closed) {
+        const phase: StreamPhase = lastCursor ? "catch-up" : "live";
         try {
           if (lastCursor) {
             await catchUpThenConsumeLive(lastCursor);
@@ -411,7 +440,7 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
           if (closed) {
             break;
           }
-          await sleep(handleFailure(error));
+          await sleep(handleFailure(error, phase));
         }
       }
       end();
@@ -421,7 +450,11 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
     // should be unreachable — if it ever fires, fail loudly instead of dying
     // in silence.
     const pump = run().catch((error) => {
-      log.error("resumable stream loop crashed", { label }, error);
+      log.error(
+        "resumable stream loop crashed",
+        { "spectrum.stream.id": streamId, "spectrum.stream.label": label },
+        error
+      );
       if (!closed) {
         end(error);
       }

--- a/packages/core/src/utils/telemetry.ts
+++ b/packages/core/src/utils/telemetry.ts
@@ -1,4 +1,4 @@
-import type { LogAttrs } from "@photon-ai/otel";
+import { type LogAttrs, sanitizeErrorMessage } from "@photon-ai/otel";
 import type { Content } from "../content/types";
 import { classifyIdentifier } from "./identifier";
 
@@ -128,5 +128,60 @@ export function senderAttrs(sender: { id?: unknown } | undefined): LogAttrs {
   return {
     "spectrum.message.sender.id": identifier,
     "spectrum.message.sender.kind": kind,
+  };
+}
+
+const attrCode = (value: unknown): string | number | undefined => {
+  if (typeof value === "string" || typeof value === "number") {
+    return value;
+  }
+  return;
+};
+
+const causeType = (cause: unknown): string | undefined => {
+  if (cause === undefined) {
+    return;
+  }
+  return cause instanceof Error ? cause.name : typeof cause;
+};
+
+const causeMessage = (cause: unknown): string | undefined => {
+  if (cause === undefined) {
+    return;
+  }
+  const raw = cause instanceof Error ? cause.message : String(cause);
+  return sanitizeErrorMessage(raw);
+};
+
+/**
+ * Structured attributes for an unknown thrown value: its type, sanitized
+ * message, `code`/`status` when present, and one level of `cause`. Enough to
+ * debug from a log line or span without leaking PII or dumping a raw `Error`
+ * (which stringifies to "[object Object]" inside an attrs object). The stack is
+ * intentionally omitted — pass the `Error` as the logger's 3rd argument (or
+ * wrap with `withSpan`) so it lands on the OTLP record's `exception.*` fields.
+ */
+export function errorAttrs(
+  error: unknown,
+  prefix = "spectrum.error"
+): LogAttrs {
+  if (!(error instanceof Error)) {
+    return {
+      [`${prefix}.type`]: typeof error,
+      [`${prefix}.message`]: sanitizeErrorMessage(String(error)),
+    };
+  }
+  const { code, status, cause } = error as Error & {
+    cause?: unknown;
+    code?: unknown;
+    status?: unknown;
+  };
+  return {
+    [`${prefix}.type`]: error.name,
+    [`${prefix}.message`]: sanitizeErrorMessage(error.message),
+    [`${prefix}.code`]: attrCode(code),
+    [`${prefix}.status`]: attrCode(status),
+    [`${prefix}.cause.type`]: causeType(cause),
+    [`${prefix}.cause.message`]: causeMessage(cause),
   };
 }

--- a/packages/core/test/utils/telemetry.test.ts
+++ b/packages/core/test/utils/telemetry.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { errorAttrs } from "@/utils/telemetry";
+
+describe("errorAttrs", () => {
+  it("captures the error type and message", () => {
+    const attrs = errorAttrs(new TypeError("boom"));
+    expect(attrs["spectrum.error.type"]).toBe("TypeError");
+    expect(attrs["spectrum.error.message"]).toBe("boom");
+  });
+
+  it("uses a custom error class name as the type", () => {
+    class CursorRejectedError extends Error {
+      constructor() {
+        super("rejected");
+        this.name = "CursorRejectedError";
+      }
+    }
+    expect(errorAttrs(new CursorRejectedError())["spectrum.error.type"]).toBe(
+      "CursorRejectedError"
+    );
+  });
+
+  it("includes code and status when present", () => {
+    const err = Object.assign(new Error("nope"), {
+      code: "ECONNREFUSED",
+      status: 503,
+    });
+    const attrs = errorAttrs(err);
+    expect(attrs["spectrum.error.code"]).toBe("ECONNREFUSED");
+    expect(attrs["spectrum.error.status"]).toBe(503);
+  });
+
+  it("omits code/status when they are not primitives", () => {
+    const err = Object.assign(new Error("nope"), { code: { nested: true } });
+    const attrs = errorAttrs(err);
+    expect(attrs["spectrum.error.code"]).toBeUndefined();
+  });
+
+  it("unwraps one level of an Error cause", () => {
+    const cause = new RangeError("bad cursor");
+    const attrs = errorAttrs(new Error("wrapped", { cause }));
+    expect(attrs["spectrum.error.cause.type"]).toBe("RangeError");
+    expect(attrs["spectrum.error.cause.message"]).toBe("bad cursor");
+  });
+
+  it("reports a non-Error cause by its typeof", () => {
+    const attrs = errorAttrs(new Error("wrapped", { cause: "stringy" }));
+    expect(attrs["spectrum.error.cause.type"]).toBe("string");
+    expect(attrs["spectrum.error.cause.message"]).toBe("stringy");
+  });
+
+  it("leaves cause keys undefined when there is no cause", () => {
+    const attrs = errorAttrs(new Error("lonely"));
+    expect(attrs["spectrum.error.cause.type"]).toBeUndefined();
+    expect(attrs["spectrum.error.cause.message"]).toBeUndefined();
+  });
+
+  it("handles non-Error throws", () => {
+    const attrs = errorAttrs("just a string");
+    expect(attrs["spectrum.error.type"]).toBe("string");
+    expect(attrs["spectrum.error.message"]).toBe("just a string");
+  });
+
+  it("scrubs PII (email and phone) from the message", () => {
+    const attrs = errorAttrs(
+      new Error("failed for foo.bar@example.com / +13315553374")
+    );
+    const message = attrs["spectrum.error.message"] as string;
+    expect(message).not.toContain("foo.bar@example.com");
+    expect(message).not.toContain("3315553374");
+  });
+
+  it("honors a custom attribute prefix", () => {
+    const attrs = errorAttrs(new Error("x"), "spectrum.fusor.error");
+    expect(attrs["spectrum.fusor.error.type"]).toBe("Error");
+    expect(attrs["spectrum.error.type"]).toBeUndefined();
+  });
+});

--- a/packages/imessage/package.json
+++ b/packages/imessage/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@photon-ai/advanced-imessage": "^0.11.0",
     "@photon-ai/imessage-kit": "^3.0.0",
-    "@photon-ai/otel": "^0.1.1",
+    "@photon-ai/otel": "^1.0.0",
     "lru-cache": "^11.0.0",
     "marked": "^18.0.5",
     "zod": "^4.2.1"

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -4,7 +4,10 @@ import {
   type DedicatedTokenData,
   type SharedTokenData,
 } from "@spectrum-ts/core";
+import { createLogger, errorAttrs } from "@spectrum-ts/core/authoring";
 import { type RemoteClient, SHARED_PHONE } from "./types";
+
+const log = createLogger("spectrum.imessage.auth");
 
 const RENEWAL_RATIO = 0.8;
 const EXPIRY_BUFFER_MS = 30_000;
@@ -32,6 +35,7 @@ export async function createCloudClients(
   let tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
   let disposed = false;
   let renewalTimer: ReturnType<typeof setTimeout> | undefined;
+  let refreshFailures = 0;
 
   // The instanceId stays paired with each entry in this closure so renewal
   // can rewrite `entry.phone` in place without leaking instanceId onto the
@@ -42,6 +46,28 @@ export async function createCloudClients(
     for (const { entry, instanceId } of records) {
       entry.phone = requirePhone(data, instanceId);
     }
+  };
+
+  const onRefreshSuccess = () => {
+    if (refreshFailures > 0) {
+      log.info("imessage token refresh recovered", {
+        "spectrum.imessage.auth.attempt": refreshFailures,
+      });
+      refreshFailures = 0;
+    }
+  };
+
+  const onRefreshFailure = (error: unknown) => {
+    refreshFailures += 1;
+    log.warn(
+      "imessage token refresh failed; retrying",
+      {
+        "spectrum.imessage.auth.attempt": refreshFailures,
+        "spectrum.imessage.auth.retry_in_ms": RETRY_DELAY_MS,
+        ...errorAttrs(error),
+      },
+      error
+    );
   };
 
   const scheduleRenewal = () => {
@@ -58,8 +84,10 @@ export async function createCloudClients(
         if (tokenData.type === "dedicated") {
           syncPhones(tokenData);
         }
+        onRefreshSuccess();
         scheduleRenewal();
-      } catch {
+      } catch (error) {
+        onRefreshFailure(error);
         renewalTimer = setTimeout(() => scheduleRenewal(), RETRY_DELAY_MS);
         renewalTimer?.unref?.();
       }

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -106,6 +106,7 @@ export async function createCloudClients(
     if (tokenData.type === "dedicated") {
       syncPhones(tokenData);
     }
+    onRefreshSuccess();
     scheduleRenewal();
   };
 

--- a/packages/imessage/src/remote/contact-share.ts
+++ b/packages/imessage/src/remote/contact-share.ts
@@ -1,6 +1,12 @@
 import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
-import { sanitizeErrorMessage } from "@photon-ai/otel";
+import {
+  createLogger,
+  errorAttrs,
+  sanitizeErrorMessage,
+} from "@spectrum-ts/core/authoring";
 import { LRUCache } from "lru-cache";
+
+const log = createLogger("spectrum.imessage.contact");
 
 const SHARE_TTL_MS = 24 * 60 * 60 * 1000;
 const MAX_TRACKED_CHATS = 10_000;
@@ -38,14 +44,18 @@ export class ContactShareTracker {
     client.chats
       .shareContactInfo(chatGuid)
       .then(() => {
-        console.info(
-          `[spectrum-ts][imessage][contact-share] shared contact info to ${safeChatGuid}`
-        );
+        log.info("shared contact card", {
+          "spectrum.imessage.contact.chat": safeChatGuid,
+        });
       })
       .catch((error: unknown) => {
         this.cache.delete(chatGuid);
-        console.warn(
-          `[spectrum-ts][imessage][contact-share] failed to share contact info to ${safeChatGuid}`,
+        log.warn(
+          "failed to share contact card",
+          {
+            "spectrum.imessage.contact.chat": safeChatGuid,
+            ...errorAttrs(error),
+          },
           error
         );
       });

--- a/packages/imessage/src/remote/inbound.ts
+++ b/packages/imessage/src/remote/inbound.ts
@@ -10,6 +10,8 @@ import {
   asCustom,
   asRichlink,
   asText,
+  createLogger,
+  errorAttrs,
   groupSchema,
 } from "@spectrum-ts/core/authoring";
 import { getMessageCache, type MessageCache } from "../cache";
@@ -25,6 +27,8 @@ import {
   parseChildId,
   toMessageGuid,
 } from "./ids";
+
+const log = createLogger("spectrum.imessage.inbound");
 
 const URL_BALLOON_BUNDLE_ID = "com.apple.messages.URLBalloonProvider";
 
@@ -114,9 +118,10 @@ const toVCardContent = async (
     const buf = await downloadPrimaryAttachment(client, info.guid);
     return asContact(fromVCard(buf.toString("utf8")));
   } catch (err) {
-    console.warn(
-      "[spectrum-ts][imessage] failed to parse vCard attachment; falling back to attachment content",
-      { error: err, guid: info.guid }
+    log.warn(
+      "failed to parse vCard attachment; falling back to attachment content",
+      { "spectrum.imessage.attachment.guid": info.guid, ...errorAttrs(err) },
+      err
     );
     return toAttachmentContent(client, info);
   }
@@ -155,9 +160,10 @@ const toRichlinkMessage = (
   try {
     return { ...base, id, content: asRichlink({ url }) };
   } catch (err) {
-    console.warn(
-      "[spectrum-ts][imessage] failed to convert message to rich link; falling back to text/custom content",
-      { error: err, message, url }
+    log.warn(
+      "failed to convert message to rich link; falling back to text/custom content",
+      { "spectrum.imessage.message.id": id, ...errorAttrs(err) },
+      err
     );
     return {
       ...base,

--- a/packages/imessage/src/remote/polls.ts
+++ b/packages/imessage/src/remote/polls.ts
@@ -6,10 +6,17 @@ import type {
   PollEvent,
 } from "@photon-ai/advanced-imessage";
 import type { PollChoice } from "@spectrum-ts/core";
-import { asPoll, asPollOption } from "@spectrum-ts/core/authoring";
+import {
+  asPoll,
+  asPollOption,
+  createLogger,
+  errorAttrs,
+} from "@spectrum-ts/core/authoring";
 import type { CachedPoll, PollCache } from "../cache";
 import type { IMessageMessage } from "../types";
 import { chatTypeFromGuid } from "./ids";
+
+const log = createLogger("spectrum.imessage.poll");
 
 type VotedPollEvent = PollEvent & {
   delta: Extract<PollChangeDelta, { type: "voted" }>;
@@ -76,7 +83,14 @@ export const cachePollEvent = (
       cache.set(event.pollMessageGuid, cached);
       return cached;
     } catch (e) {
-      console.error("[spectrum-ts][imessage][poll] failed to cache poll", e);
+      log.error(
+        "failed to cache poll",
+        {
+          "spectrum.imessage.poll.guid": event.pollMessageGuid,
+          ...errorAttrs(e),
+        },
+        e
+      );
     }
   }
 };
@@ -91,7 +105,14 @@ const fetchPollInfo = async (
     cachePollInfo(cache, info);
     return info;
   } catch (e) {
-    console.error("[spectrum-ts][imessage][poll] failed to fetch poll", e);
+    log.error(
+      "failed to fetch poll",
+      {
+        "spectrum.imessage.poll.guid": event.pollMessageGuid,
+        ...errorAttrs(e),
+      },
+      e
+    );
     return;
   }
 };
@@ -110,7 +131,14 @@ const resolvePoll = async (
     const info = await client.polls.get(event.pollMessageGuid);
     return cachePollInfo(cache, info);
   } catch (e) {
-    console.error("[spectrum-ts][imessage][poll] failed to resolve poll", e);
+    log.error(
+      "failed to resolve poll",
+      {
+        "spectrum.imessage.poll.guid": event.pollMessageGuid,
+        ...errorAttrs(e),
+      },
+      e
+    );
     return;
   }
 };

--- a/packages/slack/src/auth.ts
+++ b/packages/slack/src/auth.ts
@@ -130,6 +130,7 @@ export async function createCloudClients(
       return;
     }
     await refreshTokens();
+    onRefreshSuccess();
     scheduleRenewal();
   };
 

--- a/packages/slack/src/auth.ts
+++ b/packages/slack/src/auth.ts
@@ -5,6 +5,9 @@ import {
   type TokenProvider,
 } from "@photon-ai/slack";
 import { cloud, type SlackTokenData } from "@spectrum-ts/core";
+import { createLogger, errorAttrs } from "@spectrum-ts/core/authoring";
+
+const log = createLogger("spectrum.slack.auth");
 
 const RENEWAL_RATIO = 0.8;
 const EXPIRY_BUFFER_MS = 30_000;
@@ -44,6 +47,7 @@ export async function createCloudClients(
   let tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
   let disposed = false;
   let renewalTimer: ReturnType<typeof setTimeout> | undefined;
+  let refreshFailures = 0;
 
   const clearRenewalTimer = () => {
     if (renewalTimer !== undefined) {
@@ -57,6 +61,28 @@ export async function createCloudClients(
     tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
   };
 
+  const onRefreshSuccess = () => {
+    if (refreshFailures > 0) {
+      log.info("slack token refresh recovered", {
+        "spectrum.slack.auth.attempt": refreshFailures,
+      });
+      refreshFailures = 0;
+    }
+  };
+
+  const onRefreshFailure = (error: unknown) => {
+    refreshFailures += 1;
+    log.warn(
+      "slack token refresh failed; retrying",
+      {
+        "spectrum.slack.auth.attempt": refreshFailures,
+        "spectrum.slack.auth.retry_in_ms": RETRY_DELAY_MS,
+        ...errorAttrs(error),
+      },
+      error
+    );
+  };
+
   const scheduleRetry = () => {
     if (disposed) {
       return;
@@ -68,12 +94,10 @@ export async function createCloudClients(
       }
       try {
         await refreshTokens();
+        onRefreshSuccess();
         scheduleRenewal();
       } catch (retryErr) {
-        console.warn(
-          `[spectrum-ts] Slack token refresh failed; retrying in ${RETRY_DELAY_MS}ms.`,
-          retryErr
-        );
+        onRefreshFailure(retryErr);
         scheduleRetry();
       }
     }, RETRY_DELAY_MS);
@@ -91,12 +115,10 @@ export async function createCloudClients(
     renewalTimer = setTimeout(async () => {
       try {
         await refreshTokens();
+        onRefreshSuccess();
         scheduleRenewal();
       } catch (err) {
-        console.warn(
-          `[spectrum-ts] Slack token refresh failed; retrying in ${RETRY_DELAY_MS}ms.`,
-          err
-        );
+        onRefreshFailure(err);
         scheduleRetry();
       }
     }, renewInMs);

--- a/packages/whatsapp-business/src/auth.ts
+++ b/packages/whatsapp-business/src/auth.ts
@@ -6,6 +6,10 @@ import {
   type WhatsAppEvent,
 } from "@photon-ai/whatsapp-business";
 import { cloud, stream } from "@spectrum-ts/core";
+import { createLogger, errorAttrs } from "@spectrum-ts/core/authoring";
+
+const log = createLogger("spectrum.whatsapp.auth");
+const streamLog = createLogger("spectrum.whatsapp.stream");
 
 const RENEWAL_RATIO = 0.8;
 const EXPIRY_BUFFER_MS = 30_000;
@@ -42,6 +46,7 @@ export async function createCloudClients(
   let tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
   let disposed = false;
   let renewalTimer: ReturnType<typeof setTimeout> | undefined;
+  let refreshFailures = 0;
 
   const lines = new Map<string, LineState>();
 
@@ -75,6 +80,28 @@ export async function createCloudClients(
     }
   };
 
+  const onRefreshSuccess = () => {
+    if (refreshFailures > 0) {
+      log.info("whatsapp token refresh recovered", {
+        "spectrum.whatsapp.auth.attempt": refreshFailures,
+      });
+      refreshFailures = 0;
+    }
+  };
+
+  const onRefreshFailure = (error: unknown) => {
+    refreshFailures += 1;
+    log.warn(
+      "whatsapp token refresh failed; retrying",
+      {
+        "spectrum.whatsapp.auth.attempt": refreshFailures,
+        "spectrum.whatsapp.auth.retry_in_ms": RETRY_DELAY_MS,
+        ...errorAttrs(error),
+      },
+      error
+    );
+  };
+
   const clearRenewalTimer = () => {
     if (renewalTimer !== undefined) {
       clearTimeout(renewalTimer);
@@ -93,12 +120,10 @@ export async function createCloudClients(
     renewalTimer = setTimeout(async () => {
       try {
         await refreshTokens();
+        onRefreshSuccess();
         scheduleRenewal();
       } catch (err) {
-        console.warn(
-          `[spectrum-ts] WhatsApp Business token refresh failed; retrying in ${RETRY_DELAY_MS}ms.`,
-          err
-        );
+        onRefreshFailure(err);
         clearRenewalTimer();
         renewalTimer = setTimeout(() => scheduleRenewal(), RETRY_DELAY_MS);
         renewalTimer?.unref?.();
@@ -222,7 +247,15 @@ const pumpOnce = async (ctx: ResubscribeContext): Promise<boolean> => {
       await ctx.emit(event);
     }
     return true;
-  } catch {
+  } catch (error) {
+    streamLog.warn(
+      "whatsapp event stream interrupted; resubscribing",
+      {
+        "spectrum.whatsapp.resubscribe_in_ms": RESUBSCRIBE_BACKOFF_MS,
+        ...errorAttrs(error),
+      },
+      error
+    );
     return false;
   } finally {
     ctx.setActive(undefined);

--- a/packages/whatsapp-business/src/auth.ts
+++ b/packages/whatsapp-business/src/auth.ts
@@ -137,6 +137,7 @@ export async function createCloudClients(
       return;
     }
     await refreshTokens();
+    onRefreshSuccess();
     scheduleRenewal();
   };
 


### PR DESCRIPTION
## Summary

ENG-1631. Replaces ad-hoc `console.*` logging with the structured `@photon-ai/otel` logger across `core`, fusor, iMessage, Slack, and WhatsApp, so every record carries namespaced `spectrum.*` attributes and flows through the same console + OTLP pipeline (the line you read in a terminal is the one you query in your observability tool).

- **New `errorAttrs(error)` helper** (`packages/core/src/utils/telemetry.ts`) — turns any thrown value into PII-sanitized, namespaced attributes `spectrum.error.{type,message,code,status,cause.*}`. Messages are scrubbed via `sanitizeErrorMessage`; the stack is intentionally omitted (pass the raw `Error` as the logger's 3rd arg so it lands on the record's `exception.*` fields). Avoids the `{ error }` → `[object Object]` footgun.
- **Every raw `console.warn/error/info` is gone** — fusor auth/ws/core, iMessage contact-share/inbound/polls, Slack auth, WhatsApp auth now log through `createLogger("spectrum.<area>")`. The hand-rolled ANSI-color helper in `platform/build.ts` is removed in favor of `platformLog.warn`.
- **Attribute keys namespaced** to the `spectrum.<area>.<field>` convention (e.g. `platform` → `spectrum.fusor.platform`, `eventId` → `spectrum.webhook.event_id`).
- **New `logLevel` option** on `SpectrumOptions` (`debug | info | warn | error | silent`), applied before anything logs via `applyLogLevel`. The `LOG_LEVEL` env var still takes precedence.
- **Token-refresh resilience signal** — fusor/imessage/slack/whatsapp refresh loops now track consecutive failures: `warn` with an attempt count + retry delay on each failure, `info` once on recovery. WhatsApp's previously-silent stream-resubscribe `catch` now logs too.
- **`resumableOrderedStream` retry logs** gain a stable `spectrum.stream.id`, a `phase` (catch-up/live), and a `failure_kind` classification (cursor-rejected / persistent / transient); `CursorRejectedError` is unwrapped so the underlying server error surfaces in `spectrum.error.*`.
- **`@spectrum-ts/core/authoring` re-exports the logging surface** (`createLogger`, `setLogLevel`, `errorAttrs`, `sanitizeEmail/Phone/ErrorMessage`, and the `LogAttrs`/`LogLevel`/`PhotonLogger` types) so providers stop depending on `@photon-ai/otel` directly.
- **Dependency bump** — `@photon-ai/otel` `^0.1.1` → `^1.0.0` (transitive OpenTelemetry SDK packages `0.216.0` → `0.218.0`).

## Usage

```ts
import { createLogger, errorAttrs } from "@spectrum-ts/core/authoring";

const log = createLogger("spectrum.myprovider");

try {
  // …
} catch (error) {
  // structured fields + the Error itself (for the stack) — never a raw { error }
  log.warn("send failed; retrying", { ...errorAttrs(error) }, error);
}

// quiet the SDK programmatically (LOG_LEVEL env still wins):
await Spectrum({
  providers: [/* … */],
  options: { logLevel: "warn" },
});
```

`errorAttrs(error)` yields `spectrum.error.{type,message,code,status,cause.*}`. Override the prefix for provider-scoped errors: `errorAttrs(error, "spectrum.fusor.error")`.

## Changes

| File | Change |
| --- | --- |
| `packages/core/src/utils/telemetry.ts` | Add `errorAttrs()` + `attrCode`/`causeType`/`causeMessage` helpers |
| `packages/core/test/utils/telemetry.test.ts` | New — 9 cases covering type/message, custom class, code/status, non-primitive code, cause unwrapping, non-Error throws, PII scrubbing, custom prefix |
| `packages/core/src/authoring.ts` | Re-export the logging surface (`createLogger`, `setLogLevel`, sanitizers, `errorAttrs`, types) |
| `packages/core/src/spectrum.ts` | Add `logLevel` option + `applyLogLevel`; namespace all lifecycle/webhook attrs; route async webhook errors through `errorAttrs` |
| `packages/core/src/utils/resumable-stream.ts` | Stream id, phase, `failureKind`, structured failure attrs; drop local `errorMessage` |
| `packages/core/src/fusor/{auth,core,websocket}.ts` | Replace `console.warn`; namespace attrs; refresh failure/recovery tracking |
| `packages/core/src/platform/{build,define}.ts` | Remove ANSI helper → `platformLog.warn`; namespace mismatch attrs |
| `packages/imessage/src/{auth,remote/contact-share,remote/inbound,remote/polls}.ts` | `console.*` → `createLogger`; `errorAttrs`; refresh tracking |
| `packages/slack/src/auth.ts` | `console.warn` → logger; refresh failure/recovery tracking |
| `packages/whatsapp-business/src/auth.ts` | `console.warn` → logger; refresh tracking; log previously-silent stream resubscribe |
| `packages/{core,imessage}/package.json`, `bun.lock` | `@photon-ai/otel` `^0.1.1` → `^1.0.0` |

## Test plan

- [ ] `bun test` (new `telemetry.test.ts` passes; no regressions in core)
- [ ] `bun x ultracite check`
- [ ] `tsc --noEmit` across affected packages
- [ ] Spot-check log output: a raw thrown value renders namespaced fields (not `[object Object]`), and `Spectrum({ options: { logLevel: "warn" } })` suppresses `info`/`debug` while `LOG_LEVEL` still overrides it

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/139"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784421002&installation_id=127326493&pr_number=139&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F139&signature=d4a34aedc0b0c81e1a5217e29892c26aebffc3ab7b5e13d844205a32e74c2283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `logLevel` configuration option to control runtime log verbosity.
  * Exposed provider-facing structured logging utilities and error/PII sanitizers for better observability.
* **Improvements**
  * Enhanced structured logging for token refresh, WebSocket connections, webhook delivery, and stream reconnects with sanitized error telemetry and richer context (e.g., attempt counts).
* **Chores**
  * Updated the telemetry dependency to v1.0.0.
* **Tests**
  * Added tests for telemetry error-attribute generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->