### PR TITLE
feat(core): add universal `app` content type with lazy URL + layout

### DIFF
--- a/packages/core/src/content/app.ts
+++ b/packages/core/src/content/app.ts
@@ -1,0 +1,185 @@
+import z from "zod";
+import {
+  fetchImage,
+  fetchLinkMetadata,
+  type LinkMetadata,
+} from "../utils/link-metadata";
+import type { ContentBuilder } from "./types";
+
+/**
+ * Visible layout of an app card. Mirrors Apple's `MSMessageTemplateLayout`
+ * (the iMessage mini-app surface) — the iMessage provider renders it natively;
+ * other platforms ignore it and fall back to the bare URL. At least one of
+ * `caption`, `subcaption`, `trailingCaption`, `trailingSubcaption`, or `image`
+ * must be set so the bubble is not empty — `summary` is the fallback text shown
+ * on surfaces that cannot render the card and is not a visible slot on its own.
+ * `image` and `imageTitle` must be set together; `imageSubtitle` requires
+ * `image`.
+ */
+export const appLayoutSchema = z
+  .object({
+    caption: z.string().nonempty().optional(),
+    subcaption: z.string().nonempty().optional(),
+    trailingCaption: z.string().nonempty().optional(),
+    trailingSubcaption: z.string().nonempty().optional(),
+    image: z.instanceof(Uint8Array).optional(),
+    imageTitle: z.string().nonempty().optional(),
+    imageSubtitle: z.string().nonempty().optional(),
+    summary: z.string().nonempty().optional(),
+  })
+  .refine(
+    (layout) =>
+      layout.caption !== undefined ||
+      layout.subcaption !== undefined ||
+      layout.trailingCaption !== undefined ||
+      layout.trailingSubcaption !== undefined ||
+      layout.image !== undefined,
+    {
+      message:
+        "layout must set at least one of caption, subcaption, trailingCaption, trailingSubcaption, image",
+    }
+  )
+  .refine(
+    (layout) =>
+      (layout.image === undefined) === (layout.imageTitle === undefined),
+    {
+      message: "layout.image and layout.imageTitle must be set together",
+      path: ["imageTitle"],
+    }
+  )
+  .refine(
+    (layout) =>
+      layout.imageSubtitle === undefined || layout.image !== undefined,
+    {
+      message: "layout.imageSubtitle requires layout.image",
+      path: ["imageSubtitle"],
+    }
+  );
+
+export type AppLayout = z.infer<typeof appLayoutSchema>;
+
+// Both accessors are lazy and async: the layout is parsed from the URL's link
+// metadata, so callers who never read it never issue the network request.
+const urlAccessor = z.function({ input: [], output: z.promise(z.url()) });
+const layoutAccessor = z.function({
+  input: [],
+  output: z.promise(appLayoutSchema),
+});
+
+export const appSchema = z.object({
+  type: z.literal("app"),
+  url: urlAccessor,
+  layout: layoutAccessor,
+});
+
+export type App = z.infer<typeof appSchema>;
+
+/**
+ * The only thing a caller supplies: the URL. It is itself consumable — pass a
+ * string, a promise, or a thunk (sync or async). The thunk form lets the URL be
+ * computed at send time (e.g. minting a signed link).
+ */
+export type AppUrl =
+  | string
+  | Promise<string>
+  | (() => string | Promise<string>);
+
+const memoize = <T>(factory: () => Promise<T>): (() => Promise<T>) => {
+  let cached: Promise<T> | undefined;
+  return () => {
+    cached ??= factory();
+    return cached;
+  };
+};
+
+const resolveUrl = (url: AppUrl): (() => Promise<string>) =>
+  memoize(async () => (typeof url === "function" ? await url() : await url));
+
+const WWW_PREFIX = /^www\./;
+
+// The bare site host, without a leading `www.` — the fallback "website name"
+// when the page exposes no `og:site_name`.
+const siteHost = (url: string): string => {
+  try {
+    return new URL(url).host.replace(WWW_PREFIX, "");
+  } catch {
+    return url;
+  }
+};
+
+// The mini-app card's image slot is wire-encoded as JPEG (`imageJpeg`), but
+// og:images are overwhelmingly PNG/WebP and there is no in-process transcoder.
+// Route the image through the weserv.nl proxy, which re-encodes any source to a
+// width-bounded JPEG. The bytes are verified to actually be JPEG before use.
+const JPEG_PROXY = "https://wsrv.nl/";
+const MAX_IMAGE_WIDTH = 1200;
+const toJpegUrl = (imageUrl: string): string =>
+  `${JPEG_PROXY}?url=${encodeURIComponent(imageUrl)}&output=jpg&w=${MAX_IMAGE_WIDTH}`;
+
+const isJpeg = (bytes: Uint8Array): boolean =>
+  bytes.length > 2 && bytes[0] === 0xff && bytes[1] === 0xd8;
+
+const buildLayout = (
+  metadata: LinkMetadata,
+  url: string,
+  image: Uint8Array | undefined
+): AppLayout => {
+  // The prominent name is the page title (e.g. "7-Eleven … | DoorDash"),
+  // falling back to the site name and then the host so the card is never empty.
+  const title = metadata.title ?? metadata.siteName ?? siteHost(url);
+  if (image) {
+    // `imageTitle` is mandatory whenever `image` is set — use the site name as
+    // the banner overlay (falling back to the title when there is no
+    // `og:site_name`). `summary` is the fallback shown where the card can't
+    // render.
+    return appLayoutSchema.parse({
+      caption: title,
+      subcaption: metadata.summary,
+      image,
+      imageTitle: metadata.siteName ?? title,
+      summary: title,
+    });
+  }
+  return appLayoutSchema.parse({
+    caption: title,
+    subcaption: metadata.summary,
+    summary: title,
+  });
+};
+
+/**
+ * Construct an `app` content value.
+ *
+ * `url` is stored as a lazy accessor; `layout` is derived from the URL's Open
+ * Graph / link metadata (title → caption, og:site_name → image overlay,
+ * description → subcaption, og:image → JPEG-transcoded image) using the same
+ * machinery as `richlink`. A single metadata fetch is shared and memoized
+ * across `url()` / `layout()`; fetch / parse failures resolve to a host-only
+ * caption (no throw, no retry).
+ */
+export const asApp = (url: AppUrl): App => {
+  const getUrl = resolveUrl(url);
+  const getMetadata = memoize(async () => fetchLinkMetadata(await getUrl()));
+  const getLayout = memoize(async (): Promise<AppLayout> => {
+    const resolvedUrl = await getUrl();
+    const metadata = await getMetadata();
+    let image: Uint8Array | undefined;
+    if (metadata.image) {
+      try {
+        const bytes = (await fetchImage(toJpegUrl(metadata.image.url))).data;
+        image = isJpeg(bytes) ? bytes : undefined;
+      } catch {
+        image = undefined;
+      }
+    }
+    return buildLayout(metadata, resolvedUrl, image);
+  });
+
+  return appSchema.parse({ type: "app", url: getUrl, layout: getLayout });
+};
+
+export function app(url: AppUrl): ContentBuilder {
+  return {
+    build: async () => asApp(url),
+  };
+}

--- a/packages/core/src/content/types.ts
+++ b/packages/core/src/content/types.ts
@@ -1,4 +1,5 @@
 import z from "zod";
+import { appSchema } from "./app";
 import { attachmentSchema } from "./attachment";
 import { avatarSchema } from "./avatar";
 import { contactSchema } from "./contact";
@@ -35,6 +36,7 @@ const baseContentSchemas = [
   contactSchema,
   voiceSchema,
   richlinkSchema,
+  appSchema,
   reactionSchema,
   groupSchema,
   pollSchema,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,11 @@
 export {
+  type App,
+  type AppLayout,
+  type AppUrl,
+  app,
+  appLayoutSchema,
+} from "./content/app";
+export {
   type Attachment,
   type AttachmentInput,
   attachment,

--- a/packages/core/src/utils/link-metadata.ts
+++ b/packages/core/src/utils/link-metadata.ts
@@ -3,6 +3,7 @@ import { type FetchedBytes, fetchUrlBytes } from "./io";
 
 export interface LinkMetadata {
   image?: { mimeType?: string; url: string };
+  siteName?: string;
   summary?: string;
   title?: string;
 }
@@ -44,6 +45,7 @@ export const fetchLinkMetadata = async (url: string): Promise<LinkMetadata> => {
       ogTitle,
       ogDescription,
       ogImage,
+      ogSiteName,
       twitterTitle,
       twitterDescription,
       twitterImage,
@@ -52,6 +54,7 @@ export const fetchLinkMetadata = async (url: string): Promise<LinkMetadata> => {
     const title = cleanString(ogTitle) ?? cleanString(twitterTitle);
     const summary =
       cleanString(ogDescription) ?? cleanString(twitterDescription);
+    const siteName = cleanString(ogSiteName);
 
     const imageCandidate = ogImage?.[0] ?? twitterImage?.[0];
     const resolved = imageCandidate
@@ -69,7 +72,7 @@ export const fetchLinkMetadata = async (url: string): Promise<LinkMetadata> => {
           }
         : undefined;
 
-    return { title, summary, image };
+    return { title, summary, siteName, image };
   } catch {
     return {};
   }

--- a/packages/core/test/content/app.test.ts
+++ b/packages/core/test/content/app.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { LinkMetadata } from "@/utils/link-metadata";
+
+// `app`'s layout is parsed from the URL's link metadata, so stub the network
+// layer. Registering the module mock before importing `@/content/app` means
+// the builder closes over these mocks instead of `open-graph-scraper` / fetch.
+const DEFAULT_METADATA: LinkMetadata = {
+  siteName: "DoorDash",
+  title: "7-Eleven (527 Sutter Street)",
+  summary: "Convenience, delivered",
+  image: { url: "https://img.example/cover.png", mimeType: "image/png" },
+};
+
+// JPEG magic bytes (FF D8) — `app` keeps the image only if it is real JPEG.
+const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 1, 2, 3]);
+
+const fetchLinkMetadata = mock(
+  (_url: string): Promise<LinkMetadata> => Promise.resolve(DEFAULT_METADATA)
+);
+const fetchImage = mock((_url: string) =>
+  Promise.resolve({ data: JPEG_BYTES, mimeType: "image/jpeg" })
+);
+
+mock.module("@/utils/link-metadata", () => ({ fetchLinkMetadata, fetchImage }));
+
+const { app } = await import("@/content/app");
+
+const buildApp = async (url: Parameters<typeof app>[0]) => {
+  const content = await app(url).build();
+  if (content.type !== "app") {
+    throw new Error(`expected app content, got ${content.type}`);
+  }
+  return content;
+};
+
+describe("app content — consumable url", () => {
+  it("resolves a string url", async () => {
+    const content = await buildApp("https://example.com/store");
+    expect(content.type).toBe("app");
+    expect(await content.url()).toBe("https://example.com/store");
+  });
+
+  it("resolves a promise url", async () => {
+    const content = await buildApp(Promise.resolve("https://example.com/p"));
+    expect(await content.url()).toBe("https://example.com/p");
+  });
+
+  it("resolves a thunk url and memoizes it (called once)", async () => {
+    const thunk = mock(() => "https://example.com/x");
+    const content = await buildApp(thunk);
+    expect(await content.url()).toBe("https://example.com/x");
+    expect(await content.url()).toBe("https://example.com/x");
+    expect(thunk).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("app content — layout parsed from url", () => {
+  it("uses the page title as the caption, with site name overlaid on the banner", async () => {
+    fetchLinkMetadata.mockClear();
+    fetchImage.mockClear();
+    const content = await buildApp("https://example.com/store");
+    const layout = await content.layout();
+    expect(layout.caption).toBe("7-Eleven (527 Sutter Street)");
+    expect(layout.subcaption).toBe("Convenience, delivered");
+    expect(layout.imageTitle).toBe("DoorDash");
+    expect(layout.image).toEqual(JPEG_BYTES);
+  });
+
+  it("routes the og:image through the JPEG proxy", async () => {
+    fetchImage.mockClear();
+    const content = await buildApp("https://example.com/store");
+    await content.layout();
+    const requested = fetchImage.mock.calls[0]?.[0] as string;
+    expect(requested).toContain("wsrv.nl");
+    expect(requested).toContain("output=jpg");
+    expect(requested).toContain(
+      encodeURIComponent("https://img.example/cover.png")
+    );
+  });
+
+  it("drops the image when the proxy returns non-JPEG bytes", async () => {
+    // PNG magic bytes — not JPEG, so the card must not embed them.
+    fetchImage.mockResolvedValueOnce({
+      data: Buffer.from([0x89, 0x50, 0x4e, 0x47]),
+      mimeType: "image/png",
+    });
+    const content = await buildApp("https://example.com/store");
+    const layout = await content.layout();
+    expect(layout.image).toBeUndefined();
+    expect(layout.imageTitle).toBeUndefined();
+    expect(layout.caption).toBe("7-Eleven (527 Sutter Street)");
+  });
+
+  it("shares one memoized metadata fetch across url() and layout()", async () => {
+    fetchLinkMetadata.mockClear();
+    fetchImage.mockClear();
+    const content = await buildApp("https://example.com/store");
+    await content.url();
+    await content.layout();
+    await content.layout();
+    expect(fetchLinkMetadata).toHaveBeenCalledTimes(1);
+    expect(fetchImage).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the www-stripped host when the page has no metadata", async () => {
+    fetchLinkMetadata.mockResolvedValueOnce({});
+    const content = await buildApp("https://www.store.example.com/deep/path");
+    const layout = await content.layout();
+    expect(layout.caption).toBe("store.example.com");
+    expect(layout.subcaption).toBeUndefined();
+    expect(layout.image).toBeUndefined();
+    expect(layout.imageTitle).toBeUndefined();
+  });
+
+  it("omits the image (and imageTitle) when the image fetch fails", async () => {
+    fetchLinkMetadata.mockResolvedValueOnce({
+      title: "Title",
+      summary: "Summary",
+      image: { url: "https://img.example/broken.png" },
+    });
+    fetchImage.mockRejectedValueOnce(new Error("network down"));
+    const content = await buildApp("https://example.com/store");
+    const layout = await content.layout();
+    expect(layout.caption).toBe("Title");
+    expect(layout.subcaption).toBe("Summary");
+    expect(layout.image).toBeUndefined();
+    expect(layout.imageTitle).toBeUndefined();
+  });
+});

--- a/packages/imessage/src/content/customized-mini-app.ts
+++ b/packages/imessage/src/content/customized-mini-app.ts
@@ -1,54 +1,15 @@
-import type { Content, ContentBuilder } from "@spectrum-ts/core";
+import {
+  appLayoutSchema,
+  type Content,
+  type ContentBuilder,
+} from "@spectrum-ts/core";
 import z from "zod";
 
-/**
- * Visible layout of a mini-app card. Mirrors Apple's
- * `MSMessageTemplateLayout`. At least one of `caption`, `subcaption`,
- * `trailingCaption`, `trailingSubcaption`, or `image` must be set so the
- * bubble is not empty — `summary` is the fallback text shown on surfaces
- * that cannot render the card (notifications, lock screen) and is not a
- * visible slot on its own. `image` and `imageTitle` must be set together;
- * `imageSubtitle` requires `image`.
- */
-const layoutSchema = z
-  .object({
-    caption: z.string().nonempty().optional(),
-    subcaption: z.string().nonempty().optional(),
-    trailingCaption: z.string().nonempty().optional(),
-    trailingSubcaption: z.string().nonempty().optional(),
-    image: z.instanceof(Uint8Array).optional(),
-    imageTitle: z.string().nonempty().optional(),
-    imageSubtitle: z.string().nonempty().optional(),
-    summary: z.string().nonempty().optional(),
-  })
-  .refine(
-    (layout) =>
-      layout.caption !== undefined ||
-      layout.subcaption !== undefined ||
-      layout.trailingCaption !== undefined ||
-      layout.trailingSubcaption !== undefined ||
-      layout.image !== undefined,
-    {
-      message:
-        "layout must set at least one of caption, subcaption, trailingCaption, trailingSubcaption, image",
-    }
-  )
-  .refine(
-    (layout) =>
-      (layout.image === undefined) === (layout.imageTitle === undefined),
-    {
-      message: "layout.image and layout.imageTitle must be set together",
-      path: ["imageTitle"],
-    }
-  )
-  .refine(
-    (layout) =>
-      layout.imageSubtitle === undefined || layout.image !== undefined,
-    {
-      message: "layout.imageSubtitle requires layout.image",
-      path: ["imageSubtitle"],
-    }
-  );
+// The mini-app card layout is the universal `AppLayout` (promoted to
+// `@spectrum-ts/core` so the framework `app` content and this iMessage-only
+// primitive share one source of truth). It mirrors Apple's
+// `MSMessageTemplateLayout`.
+const layoutSchema = appLayoutSchema;
 
 /**
  * iMessage-only mini-app card content. Lives entirely under the iMessage

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -6,6 +6,7 @@ import {
 import { IMessageSDK } from "@photon-ai/imessage-kit";
 import { withSpan } from "@photon-ai/otel";
 import {
+  type App,
   type Attachment,
   type Avatar,
   type Content,
@@ -14,6 +15,7 @@ import {
   type Rename,
   type Space,
   type StreamText,
+  text,
   type Unsend,
   UnsupportedError,
 } from "@spectrum-ts/core";
@@ -74,6 +76,7 @@ import {
   unsendMessage as remoteUnsendMessage,
   unsendReaction as remoteUnsendReaction,
 } from "./remote/api";
+import { toSpectrumMiniApp } from "./remote/app";
 import { getRemoteAttachment } from "./remote/attachments";
 import {
   availablePhones,
@@ -229,6 +232,34 @@ const handleCustomizedMiniApp = async (
   );
 };
 
+/**
+ * Render the universal `app` content. On remote it becomes a native Spectrum
+ * mini-app card (fixed `SPECTRUM_MINI_APP` identity + the URL + the layout
+ * already parsed from the URL's link metadata). Local mode cannot send cards,
+ * so it degrades to the bare URL as a text message.
+ */
+const handleApp = async (
+  client: IMessageClient,
+  space: { id: string; phone: string; type: "dm" | "group" },
+  content: App
+): Promise<ProviderMessageRecord> => {
+  const url = await content.url();
+  if (isLocal(client)) {
+    return await localSend(client, space.id, await text(url).build());
+  }
+  const layout = await content.layout();
+  const remote = clientForPhone(client, space.phone);
+  return cacheRemoteOutbound(
+    remote,
+    space,
+    await remoteSendCustomizedMiniApp(
+      remote,
+      space.id,
+      toSpectrumMiniApp(url, layout)
+    )
+  );
+};
+
 const handleRead = async (
   client: IMessageClient,
   space: { id: string; phone: string }
@@ -344,6 +375,32 @@ const handleProviderControlSignal = async (
     return true;
   }
   return false;
+};
+
+/**
+ * Resolve the remote client for a `reply` / `reaction` whose target is another
+ * message. Both reject local mode and poll targets identically, so the guard
+ * lives here to keep the `send` dispatch flat. `action` labels the error and
+ * `pollNoun` is the plural used in the poll-unsupported message.
+ */
+const remoteForMessageTarget = (
+  client: IMessageClient,
+  space: { phone: string },
+  target: { content: { type: string } },
+  action: string,
+  pollNoun: string
+): AdvancedIMessage => {
+  if (isLocal(client)) {
+    throw UnsupportedError.action(action, "iMessage (local mode)");
+  }
+  if (isPollContent(target.content)) {
+    throw UnsupportedError.action(
+      action,
+      "iMessage",
+      `iMessage polls do not support ${pollNoun}`
+    );
+  }
+  return clientForPhone(client, space.phone);
 };
 
 export const imessage = definePlatform("iMessage", {
@@ -516,17 +573,13 @@ export const imessage = definePlatform("iMessage", {
 
   send: async ({ space, content, client }) => {
     if (content.type === "reply") {
-      if (isLocal(client)) {
-        throw UnsupportedError.action("reply", "iMessage (local mode)");
-      }
-      if (isPollContent(content.target.content)) {
-        throw UnsupportedError.action(
-          "reply",
-          "iMessage",
-          "iMessage polls do not support replies"
-        );
-      }
-      const remote = clientForPhone(client, space.phone);
+      const remote = remoteForMessageTarget(
+        client,
+        space,
+        content.target,
+        "reply",
+        "replies"
+      );
       return cacheRemoteOutbound(
         remote,
         space,
@@ -539,17 +592,13 @@ export const imessage = definePlatform("iMessage", {
       );
     }
     if (content.type === "reaction") {
-      if (isLocal(client)) {
-        throw UnsupportedError.action("react", "iMessage (local mode)");
-      }
-      if (isPollContent(content.target.content)) {
-        throw UnsupportedError.action(
-          "react",
-          "iMessage",
-          "iMessage polls do not support reactions"
-        );
-      }
-      const remote = clientForPhone(client, space.phone);
+      const remote = remoteForMessageTarget(
+        client,
+        space,
+        content.target,
+        "react",
+        "reactions"
+      );
       // `content.target` is statically typed as the generic `Message`, but
       // execution only reaches this iMessage `send` action when the target
       // came from the iMessage stream — hence the unknown-cast widen.
@@ -593,6 +642,9 @@ export const imessage = definePlatform("iMessage", {
       // chat, never a per-message cutoff.
       await handleRead(client, space);
       return;
+    }
+    if (content.type === "app") {
+      return await handleApp(client, space, content);
     }
     // iMessage-only fire-and-forget signals (`background`, `contactCard`) that
     // live outside the universal `Content` union — see the helper.

--- a/packages/imessage/src/remote/app.ts
+++ b/packages/imessage/src/remote/app.ts
@@ -1,0 +1,30 @@
+import type { AppLayout } from "@spectrum-ts/core";
+import {
+  asCustomizedMiniApp,
+  type CustomizedMiniApp,
+} from "../content/customized-mini-app";
+
+/**
+ * Fixed identity of Spectrum's own iMessage extension. The universal `app`
+ * content renders through this extension, so callers never supply (or even see)
+ * these constants — they pass only a URL and the card opens it inside the
+ * Spectrum mini app on tap. Callers shipping their *own* extension use the
+ * low-level `customizedMiniApp()` instead.
+ */
+export const SPECTRUM_MINI_APP = {
+  appName: "Spectrum",
+  extensionBundleId: "codes.photon.Spectrum.MessagesExtension",
+  teamId: "P8XT6232SL",
+  appStoreId: 6_777_616_651,
+} as const;
+
+/**
+ * Build the iMessage mini-app card for an `app` content: Spectrum's fixed
+ * identity plus the per-message `url` and the `layout` already derived from the
+ * URL's link metadata.
+ */
+export const toSpectrumMiniApp = (
+  url: string,
+  layout: AppLayout
+): CustomizedMiniApp =>
+  asCustomizedMiniApp({ ...SPECTRUM_MINI_APP, url, layout });

--- a/packages/imessage/test/remote/app.test.ts
+++ b/packages/imessage/test/remote/app.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, mock } from "bun:test";
+import type {
+  AdvancedIMessage,
+  Message as SDKMessage,
+} from "@photon-ai/advanced-imessage";
+import { IMessageSDK } from "@photon-ai/imessage-kit";
+import type { Content } from "@spectrum-ts/core";
+import { imessage } from "@/index";
+import { SPECTRUM_MINI_APP, toSpectrumMiniApp } from "@/remote/app";
+import { type RemoteClient, SHARED_PHONE } from "@/types";
+
+const SENT_DATE = new Date(1_700_000_000_000);
+
+// A minimal `app` content with stub accessors — keeps the dispatch test off the
+// network (the real `app()` would parse the layout from the URL).
+const appContent = (
+  url: string,
+  layout: Record<string, unknown> = { caption: "Store", subcaption: "Hi" }
+): Content =>
+  ({
+    type: "app",
+    url: () => Promise.resolve(url),
+    layout: () => Promise.resolve(layout),
+  }) as unknown as Content;
+
+const def = imessage.config({}).__definition;
+const ctx = { config: {} as never, store: undefined as never };
+
+const remoteClient = (
+  sendCustomizedMiniApp: (chat: string, content: unknown) => Promise<SDKMessage>
+): RemoteClient[] => [
+  {
+    phone: SHARED_PHONE,
+    client: {
+      messages: { sendCustomizedMiniApp },
+    } as unknown as AdvancedIMessage,
+  },
+];
+
+describe("toSpectrumMiniApp", () => {
+  it("merges Spectrum's fixed identity with the url and layout", () => {
+    const card = toSpectrumMiniApp("https://x.example/1", { caption: "C" });
+    expect(card).toMatchObject({
+      type: "customized-mini-app",
+      __platform: "iMessage",
+      ...SPECTRUM_MINI_APP,
+      url: "https://x.example/1",
+      layout: { caption: "C" },
+    });
+  });
+});
+
+describe("iMessage send: app dispatch", () => {
+  it("renders a Spectrum mini-app card on remote", async () => {
+    const sendCustomizedMiniApp = mock((_chat: string, _content: unknown) =>
+      Promise.resolve({
+        guid: "card-guid",
+        dateCreated: SENT_DATE,
+      } as unknown as SDKMessage)
+    );
+
+    const record = await def.send({
+      ...ctx,
+      client: remoteClient(sendCustomizedMiniApp),
+      space: { id: "any;-;+15550123", type: "dm", phone: SHARED_PHONE },
+      content: appContent("https://x.example/1"),
+    });
+
+    expect(sendCustomizedMiniApp).toHaveBeenCalledTimes(1);
+    const [chat, sent] = sendCustomizedMiniApp.mock.calls[0] ?? [];
+    expect(chat).toBe("any;-;+15550123");
+    expect(sent).toMatchObject({
+      ...SPECTRUM_MINI_APP,
+      url: "https://x.example/1",
+      layout: { caption: "Store", subcaption: "Hi" },
+    });
+    expect(record?.id).toBe("card-guid");
+    expect(record?.timestamp).toEqual(SENT_DATE);
+  });
+
+  it("degrades to a bare-url text message in local mode", async () => {
+    const send = mock((_: unknown) => Promise.resolve());
+    const localClient = Object.assign(Object.create(IMessageSDK.prototype), {
+      send,
+    }) as IMessageSDK;
+
+    await def.send({
+      ...ctx,
+      client: localClient,
+      space: { id: "any;-;x", type: "dm", phone: SHARED_PHONE },
+      content: appContent("https://x.example/2"),
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0]).toMatchObject({
+      to: "any;-;x",
+      text: "https://x.example/2",
+    });
+  });
+});

--- a/packages/slack/src/messages.ts
+++ b/packages/slack/src/messages.ts
@@ -353,6 +353,15 @@ const sendContent = async (
       });
       return toUploadRecord(result, space, content);
     }
+    case "app": {
+      // No mini-app surface on Slack — send the bare URL (Slack unfurls it).
+      const result = await team.messages.send({
+        channel: space.id,
+        text: await content.url(),
+        threadTs,
+      });
+      return toRecord(result, space, content);
+    }
     default:
       throw UnsupportedError.content(content.type);
   }

--- a/packages/telegram/src/outbound/message.ts
+++ b/packages/telegram/src/outbound/message.ts
@@ -102,6 +102,9 @@ export const buildSend = async (
     case "richlink":
       // Telegram auto-unfurls a bare URL in the message text.
       return { method: "sendMessage", params: { text: content.url } };
+    case "app":
+      // No mini-app surface on Telegram — send the bare URL (auto-unfurled).
+      return { method: "sendMessage", params: { text: await content.url() } };
     case "attachment":
       return await attachmentSpec(content);
     case "voice": {

--- a/packages/telegram/test/outbound/message.test.ts
+++ b/packages/telegram/test/outbound/message.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  app,
   attachment,
   type Content,
   contact,
@@ -50,6 +51,13 @@ describe("buildSend", () => {
 
   it("maps a richlink to sendMessage with the url (Telegram auto-unfurls)", async () => {
     expect(await buildSend(await richlink("https://x.test").build())).toEqual({
+      method: "sendMessage",
+      params: { text: "https://x.test" },
+    });
+  });
+
+  it("maps an app to sendMessage with the url (no mini-app surface)", async () => {
+    expect(await buildSend(await app("https://x.test").build())).toEqual({
       method: "sendMessage",
       params: { text: "https://x.test" },
     });

--- a/packages/terminal/src/index.ts
+++ b/packages/terminal/src/index.ts
@@ -455,6 +455,10 @@ async function spectrumToProtocol(
       vcard: await toVCard(content),
     };
   }
+  if (content.type === "app") {
+    // No mini-app surface in the terminal — render the bare URL as text.
+    return { type: "text", text: await content.url() };
+  }
   // Surface the failure as an UnsupportedError — the platform builder
   // catches those and warns+skips, so an agent sending e.g. `richlink` on
   // this provider gets a warning rather than an uncaught throw that

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -586,6 +586,13 @@ export const send = async (
       cachePoll(client, result.messageId, content);
       return toRecord(result, spaceId, content);
     }
+    case "app":
+      // No mini-app surface on WhatsApp — send the bare URL as text.
+      return toRecord(
+        await client.messages.send({ to: spaceId, text: await content.url() }),
+        spaceId,
+        content
+      );
     default:
       throw UnsupportedError.content(content.type);
   }
@@ -679,6 +686,17 @@ export const replyToMessage = async (
       cachePoll(client, result.messageId, content);
       return toRecord(result, spaceId, content);
     }
+    case "app":
+      // No mini-app surface on WhatsApp — send the bare URL as text.
+      return toRecord(
+        await client.messages.send({
+          to: spaceId,
+          replyTo: messageId,
+          text: await content.url(),
+        }),
+        spaceId,
+        content
+      );
     default:
       throw UnsupportedError.content(content.type);
   }


### PR DESCRIPTION
## Summary

ENG-1635. Adds a universal `app` content type to `@spectrum-ts/core`. The caller supplies only a URL; everything the card shows is derived from that URL's Open Graph / link metadata, so sending a rich app card is as little as `space.send(app(url))`.

On iMessage (remote) it renders as a **native Spectrum mini-app card** — the URL opens inside Spectrum's own Messages extension on tap. Every other surface has no mini-app affordance, so they degrade to the bare URL (which the platform unfurls): Slack, Telegram, WhatsApp Business, Terminal, and iMessage local mode.

- **`app(url)` content builder** (`packages/core/src/content/app.ts`). `url` is *consumable* — pass a string, a `Promise<string>`, or a thunk (sync or async). The thunk form lets the URL be minted at send time (e.g. a signed link).
- **Lazy, memoized accessors.** `url()` and `layout()` are both async. A single link-metadata fetch is shared across them and memoized, so a caller who never reads `layout()` never issues the network request, and reading it twice fetches once.
- **Layout derived from metadata** the same way as `richlink`: `title` → caption, `og:description` → subcaption, `og:site_name` → the image banner overlay (`imageTitle`), `og:image` → the card image. Fetch/parse failures resolve to a `www`-stripped, host-only caption — **no throw, no retry**.
- **JPEG transcode.** The mini-app image slot is wire-encoded as JPEG, but `og:image`s are overwhelmingly PNG/WebP. The image is routed through the `wsrv.nl` proxy (`output=jpg`, width-bounded to 1200px) and the returned bytes are verified to actually be JPEG (FF D8 magic) before use; anything else is dropped (`image` + `imageTitle` omitted together).
- **`AppLayout` promoted to core.** The layout schema (mirroring Apple's `MSMessageTemplateLayout`) now lives in `@spectrum-ts/core` as `appLayoutSchema`, and the iMessage-only `customizedMiniApp` primitive re-uses it instead of redefining a duplicate — one source of truth.
- **`og:site_name` plumbed through `link-metadata`** (`siteName` added to `LinkMetadata`).

## Usage

```ts
import { app } from "@spectrum-ts/core";

// Bare URL — caption/subcaption/image are parsed from the page metadata.
await space.send(app("https://doordash.com/store/7-eleven-527-sutter-st"));

// Mint the URL at send time (signed link, per-recipient token, …):
await space.send(app(async () => signStoreLink(store.id, recipient)));
```

On iMessage remote, the recipient sees a native card that opens the link inside the Spectrum mini app. Everywhere else they get the URL, unfurled by the platform.

## Changes

| File | Change |
|---|---|
| `packages/core/src/content/app.ts` | **New.** `app()` builder, `asApp`, `appSchema`, `appLayoutSchema`, `AppUrl`/`App`/`AppLayout` types; consumable+memoized URL, metadata→layout derivation, JPEG-proxy transcode. |
| `packages/core/src/content/types.ts` | Register `appSchema` in the universal `Content` union. |
| `packages/core/src/index.ts` | Export `app`, `appLayoutSchema`, and the `App`/`AppLayout`/`AppUrl` types. |
| `packages/core/src/utils/link-metadata.ts` | Add `siteName` to `LinkMetadata` (parsed from `og:site_name`). |
| `packages/core/test/content/app.test.ts` | **New.** 9 cases — consumable URL forms + memoization, metadata→layout mapping, JPEG-proxy routing, non-JPEG/failed-image drop, shared-fetch memoization, host-only fallback. |
| `packages/imessage/src/content/customized-mini-app.ts` | Re-use core's `appLayoutSchema` instead of a local duplicate. |
| `packages/imessage/src/remote/app.ts` | **New.** `SPECTRUM_MINI_APP` fixed identity + `toSpectrumMiniApp(url, layout)`. |
| `packages/imessage/src/index.ts` | `handleApp` — native card on remote, bare-URL text in local mode; extract `remoteForMessageTarget` to flatten reply/reaction dispatch. |
| `packages/imessage/test/remote/app.test.ts` | **New.** `toSpectrumMiniApp` merge + `send` dispatch (remote card / local degrade). |
| `packages/slack/src/messages.ts` | `app` → bare URL (Slack unfurls). |
| `packages/telegram/src/outbound/message.ts` | `app` → `sendMessage` with the URL (auto-unfurled). |
| `packages/telegram/test/outbound/message.test.ts` | Cover the `app` → `sendMessage` mapping. |
| `packages/terminal/src/index.ts` | `app` → bare-URL text. |
| `packages/whatsapp-business/src/messages.ts` | `app` → bare URL in both `send` and `replyToMessage`. |

## Test plan

- [x] `bun test packages/core/test/content/app.test.ts` — consumable URL, layout derivation, JPEG proxy, fallbacks
- [x] `bun test packages/imessage/test/remote/app.test.ts` — remote card + local degrade
- [x] `bun test packages/telegram/test/outbound/message.test.ts` — `app` → `sendMessage`
- [ ] `turbo typecheck` across affected packages
- [ ] `bun x ultracite check`
- [ ] Manual: `space.send(app(url))` renders a native Spectrum mini-app card on iMessage remote and a bare unfurled URL on Slack / Telegram / WhatsApp / terminal
- [ ] Manual: a page with no OG metadata yields a host-only caption and no image (no throw)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784426127&installation_id=127326493&pr_number=140&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F140&signature=b4b41f79ddfb6e26165002ee1da33d55bdc5d8d5dc6213dbc433498cc7f2991b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "app" content type for sharing mini-app cards with auto-extracted metadata (title, image, description) from URLs.
  * App cards now supported across iMessage, Slack, Telegram, WhatsApp Business, and Terminal.

* **Refactor**
  * Unified app layout validation across platforms for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->