### PR TITLE
feat(imessage): surface address, country, and service on sender refs

### DIFF
--- a/packages/imessage/src/local/inbound.ts
+++ b/packages/imessage/src/local/inbound.ts
@@ -72,7 +72,11 @@ export const toMessages = async (
   }
 
   const base: Omit<IMessageMessage, "id" | "content"> = {
-    sender: { id: message.participant ?? "" },
+    // Local mode exposes only the participant address; no service/country.
+    sender: {
+      id: message.participant ?? "",
+      ...(message.participant ? { address: message.participant } : {}),
+    },
     // Local mode has no concept of "which-of-my-phones"; phone is empty.
     space: {
       id: chatId,

--- a/packages/imessage/src/remote/inbound.ts
+++ b/packages/imessage/src/remote/inbound.ts
@@ -1,7 +1,9 @@
 import {
   type AdvancedIMessage,
+  type ChatServiceType,
   type MessageEvent,
   NotFoundError,
+  type SingleServiceAddressInfo,
 } from "@photon-ai/advanced-imessage";
 import { type Content, fromVCard, type Group } from "@spectrum-ts/core";
 import {
@@ -55,8 +57,25 @@ const resolveChatGuid = (
   return first ?? "";
 };
 
-const resolveSenderId = (message: AppleMessage): string =>
-  message.sender?.address ?? "";
+/**
+ * Normalize an Apple address (`message.sender` or an event `actor`) into the
+ * spectrum sender ref. `id` stays the cross-provider identity key (the
+ * address); `address`/`country`/`service` are surfaced when present so apps
+ * can tell iMessage from SMS/RCS. Empty fields are omitted.
+ */
+export const toSenderRef = (
+  addr: SingleServiceAddressInfo | undefined
+): {
+  id: string;
+  address?: string;
+  country?: string;
+  service?: ChatServiceType;
+} => ({
+  id: addr?.address ?? "",
+  ...(addr?.address ? { address: addr.address } : {}),
+  ...(addr?.country ? { country: addr.country } : {}),
+  ...(addr?.service ? { service: addr.service } : {}),
+});
 
 type RawProviderMessage = Pick<IMessageMessage, "content" | "id">;
 
@@ -87,7 +106,7 @@ export const buildMessageBase = (
   const chat = resolveChatGuid(message, chatGuidHint);
   return {
     direction: message.isFromMe ? "outbound" : "inbound",
-    sender: { id: resolveSenderId(message) },
+    sender: toSenderRef(message.sender),
     space: {
       id: chat,
       type: chatTypeFromGuid(chat),

--- a/packages/imessage/src/remote/polls.ts
+++ b/packages/imessage/src/remote/polls.ts
@@ -15,6 +15,7 @@ import {
 import type { CachedPoll, PollCache } from "../cache";
 import type { IMessageMessage } from "../types";
 import { chatTypeFromGuid } from "./ids";
+import { toSenderRef } from "./inbound";
 
 const log = createLogger("spectrum.imessage.poll");
 
@@ -38,7 +39,7 @@ interface PollOptionMessageInput {
   optionId: string;
   phone: string;
   selected: boolean;
-  senderAddress: string;
+  sender: ReturnType<typeof toSenderRef>;
 }
 
 const isVotedPollEvent = (event: PollEvent): event is VotedPollEvent =>
@@ -154,8 +155,8 @@ const buildPollOptionMessage = (
   const eventTime = input.event.occurredAt.getTime();
 
   return {
-    id: `${input.event.pollMessageGuid}:${input.senderAddress}:${input.optionId}:${action}:${eventTime}`,
-    sender: { id: input.senderAddress },
+    id: `${input.event.pollMessageGuid}:${input.sender.id}:${input.optionId}:${action}:${eventTime}`,
+    sender: input.sender,
     space: {
       id: input.chatGuid,
       type: chatTypeFromGuid(input.chatGuid),
@@ -188,9 +189,9 @@ const toPollOptionMessage = async (
   event: VotedPollEvent | UnvotedPollEvent,
   phone: string
 ): Promise<IMessageMessage[]> => {
-  const senderAddress = event.actor?.address;
+  const sender = toSenderRef(event.actor);
   const optionId = event.delta.optionIdentifier;
-  if (!(senderAddress && optionId)) {
+  if (!(sender.id && optionId)) {
     return [];
   }
 
@@ -213,7 +214,7 @@ const toPollOptionMessage = async (
     optionId,
     phone,
     selected: event.delta.type === "voted",
-    senderAddress,
+    sender,
   });
 
   return message ? [message] : [];

--- a/packages/imessage/src/remote/reactions.ts
+++ b/packages/imessage/src/remote/reactions.ts
@@ -15,6 +15,7 @@ import {
   cacheMessage,
   isIMessageMessage,
   rebuildFromAppleMessage,
+  toSenderRef,
 } from "./inbound";
 
 type ReactionAddedEvent = Extract<
@@ -93,8 +94,7 @@ export const toReactionMessages = async (
   if (!emoji) {
     return [];
   }
-  const senderAddress = event.actor?.address;
-  if (!senderAddress) {
+  if (!event.actor?.address) {
     return [];
   }
   const resolved = await resolveReactionTarget(
@@ -116,7 +116,7 @@ export const toReactionMessages = async (
 
   return [
     {
-      sender: { id: senderAddress },
+      sender: toSenderRef(event.actor),
       space: {
         id: event.chatGuid,
         type: chatTypeFromGuid(event.chatGuid),

--- a/packages/imessage/src/types.ts
+++ b/packages/imessage/src/types.ts
@@ -34,7 +34,19 @@ export const configSchema = z.union([
   }),
 ]);
 
-export const userSchema = z.object({});
+/**
+ * iMessage sender identity. `id` is the cross-provider key (the address);
+ * `address`/`country`/`service` mirror the SDK's `SingleServiceAddressInfo`,
+ * letting apps tell iMessage from SMS/RCS. All optional — local mode and
+ * actor-less events can't always supply them.
+ */
+const SERVICE_VALUES = ["iMessage", "SMS", "RCS", "unknown"] as const;
+
+export const userSchema = z.object({
+  address: z.string().optional(),
+  country: z.string().optional(),
+  service: z.enum(SERVICE_VALUES).optional(),
+});
 
 export const spaceSchema = z.object({
   id: z.string(),

--- a/packages/imessage/test/remote/inbound.test.ts
+++ b/packages/imessage/test/remote/inbound.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import type {
+  AdvancedIMessage,
+  MessageEvent,
+} from "@photon-ai/advanced-imessage";
+import { MessageCache } from "@/cache";
+import { toInboundMessages } from "@/remote/inbound";
+
+type ReceivedEvent = Extract<MessageEvent, { type: "message.received" }>;
+
+const RECEIVED_AT = new Date(1_700_000_000_000);
+
+// A plain text message never touches the client (no attachment download), so a
+// bare stub is enough to exercise the sender-normalization path.
+const client = {} as unknown as AdvancedIMessage;
+
+const receivedEvent = (sender?: Record<string, unknown>): ReceivedEvent =>
+  ({
+    type: "message.received",
+    sequence: 1,
+    chatGuid: "s1",
+    isFromMe: false,
+    occurredAt: RECEIVED_AT,
+    message: {
+      guid: "msg-guid",
+      chatGuids: ["s1"],
+      content: { attachments: [], formatting: [], mentions: [], text: "hi" },
+      dateCreated: RECEIVED_AT,
+      isFromMe: false,
+      sender,
+    },
+  }) as unknown as ReceivedEvent;
+
+const inboundSender = async (sender?: Record<string, unknown>) => {
+  const messages = await toInboundMessages(
+    client,
+    new MessageCache(),
+    receivedEvent(sender),
+    "+15550000000"
+  );
+  return messages[0]?.sender;
+};
+
+describe("iMessage remote toInboundMessages sender", () => {
+  it("surfaces address, country, and service from an iMessage sender", async () => {
+    expect(
+      await inboundSender({
+        address: "+15551234567",
+        country: "us",
+        service: "iMessage",
+      })
+    ).toEqual({
+      id: "+15551234567",
+      address: "+15551234567",
+      country: "us",
+      service: "iMessage",
+    });
+  });
+
+  it("reports the SMS service for green-bubble senders and omits absent country", async () => {
+    expect(
+      await inboundSender({ address: "+15551234567", service: "SMS" })
+    ).toEqual({
+      id: "+15551234567",
+      address: "+15551234567",
+      service: "SMS",
+    });
+  });
+
+  it("falls back to an empty id when the sender is absent", async () => {
+    expect(await inboundSender(undefined)).toEqual({ id: "" });
+  });
+});

--- a/packages/imessage/test/remote/reactions.test.ts
+++ b/packages/imessage/test/remote/reactions.test.ts
@@ -146,6 +146,33 @@ describe("iMessage remote toReactionMessages", () => {
     }
   });
 
+  it("carries the actor's address, country, and service onto the reaction sender", async () => {
+    const get = mock((_message: string) => Promise.resolve(sdkMessage()));
+    const remote = {
+      messages: { get },
+    } as unknown as AdvancedIMessage;
+
+    const messages = await toReactionMessages(
+      remote,
+      new MessageCache(),
+      reactionEvent({
+        actor: {
+          address: "+15557654321",
+          country: "ca",
+          service: "iMessage",
+        },
+      } as Partial<Extract<MessageEvent, { type: "message.reactionAdded" }>>),
+      "+15551234567"
+    );
+
+    expect(messages[0]?.sender).toEqual({
+      id: "+15557654321",
+      address: "+15557654321",
+      country: "ca",
+      service: "iMessage",
+    });
+  });
+
   it("resolves tapbacks on a just-sent streamText message from the outbound cache", async () => {
     const sent = sdkMessage({ guid: "outbound-stream-guid" });
     const sendText = mock((_chat: string, _text: string) =>


### PR DESCRIPTION
## Summary

- Surfaces the underlying Apple address, country, and service (`iMessage` / `SMS` / `RCS` / `unknown`) on iMessage sender refs so apps can tell an iMessage (blue-bubble) sender from SMS/RCS (green-bubble).
- `sender.id` stays the cross-provider identity key (the address); `address`/`country`/`service` are additive, optional fields mirroring the SDK's `SingleServiceAddressInfo`. Empty fields are omitted.
- Introduces a single `toSenderRef()` normalizer in `remote/inbound.ts` and reuses it across inbound messages, poll votes, and reactions — replacing the three ad-hoc `{ id: address }` constructions.
- Extends `userSchema` with optional `address`, `country`, and `service` fields.
- Local mode surfaces `address` only (no service/country available from the local DB).

## Why

Resolves ENG-1655. The spectrum sender ref previously collapsed to just an `id`, dropping the channel/service distinction that the advanced-imessage SDK provides. Apps that need to branch on whether a message arrived over iMessage vs SMS/RCS now have that information on the sender.

## Changes

| File | Change |
|------|--------|
| `src/remote/inbound.ts` | New exported `toSenderRef()` normalizer; `buildMessageBase` uses it instead of the old `resolveSenderId` |
| `src/remote/polls.ts` | Poll-option messages thread a full sender ref (`sender`) instead of a bare `senderAddress`; message id keyed off `sender.id` |
| `src/remote/reactions.ts` | Reaction sender built via `toSenderRef(event.actor)` |
| `src/local/inbound.ts` | Local sender surfaces `address` when the participant is present |
| `src/types.ts` | `userSchema` gains optional `address`/`country`/`service`; `service` enum = `iMessage` / `SMS` / `RCS` / `unknown` |
| `test/remote/inbound.test.ts` | New: covers iMessage sender, SMS green-bubble (omitted country), and absent-sender fallback |
| `test/remote/reactions.test.ts` | New case: actor address/country/service carried onto the reaction sender |

## Test plan

- [ ] `bun test packages/imessage` passes
- [ ] iMessage sender surfaces `address`, `country`, `service`
- [ ] SMS sender reports `service: "SMS"` and omits absent `country`
- [ ] Absent sender falls back to `{ id: "" }`
- [ ] Reaction sender carries the actor's `address`/`country`/`service`
- [ ] `bun x ultracite check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784600288&installation_id=127326493&pr_number=143&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F143&signature=6510fd10868e12be77460919657df14d5674a7f9804854c918db278799cb263c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced sender information capture across all message types—direct messages, reactions, and polls now include sender address, country, and service type (iMessage, SMS, RCS) when available.
  * Improved sender data normalization for consistent handling across local and remote messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->