### PR TITLE
feat(core,imessage): make user.schema authoritative for the typed sender shape

### DIFF
--- a/packages/core/src/platform/types.ts
+++ b/packages/core/src/platform/types.ts
@@ -634,12 +634,24 @@ type SchemaSpaceOf<Def extends AnyPlatformDef> = InferOptionalSchema<
 type ResolvedUserOf<Def extends AnyPlatformDef> = AwaitedReturn<
   Def["user"]["resolve"]
 >;
+type SchemaUserOf<Def extends AnyPlatformDef> = InferOptionalSchema<
+  Def["user"]["schema"]
+>;
 
 type SpaceShapeOf<Def extends AnyPlatformDef> = [SchemaSpaceOf<Def>] extends [
   never,
 ]
   ? ResolvedSpaceOf<Def>
   : SchemaSpaceOf<Def>;
+
+// Mirrors `SpaceShapeOf`: a declared `user.schema` is authoritative for the
+// app-facing sender shape; without one we fall back to `user.resolve`'s
+// return type so providers that declare no schema are unaffected.
+type UserShapeOf<Def extends AnyPlatformDef> = [SchemaUserOf<Def>] extends [
+  never,
+]
+  ? ResolvedUserOf<Def>
+  : SchemaUserOf<Def>;
 
 // When a provider declares no `space.params`, `definePlatform`'s
 // `_SpaceParamsSchema` has no inference candidate and falls back to its
@@ -811,7 +823,7 @@ export type PlatformMessage<Def extends AnyPlatformDef> = Omit<
   MessageActionMethods<Def>;
 
 export type PlatformUser<Def extends AnyPlatformDef> = Omit<
-  ResolvedUserOf<Def>,
+  UserShapeOf<Def>,
   keyof User
 > &
   User;

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -95,6 +95,7 @@ import {
   SHARED_PHONE,
   spaceParamsSchema,
   spaceSchema,
+  userSchema,
 } from "./types";
 
 const isPollContent = (content: { type: string }): boolean =>
@@ -456,6 +457,7 @@ export const imessage = definePlatform("iMessage", {
   },
 
   user: {
+    schema: userSchema,
     resolve: async ({ input }) => ({ id: input.userID }),
   },
 


### PR DESCRIPTION
## Summary

- Introduces `UserShapeOf<Def>` in core, mirroring the existing `SpaceShapeOf`: a declared `user.schema` is now authoritative for the app-facing sender/user shape, falling back to `user.resolve`'s return type when no schema is declared.
- `PlatformUser` now derives from `UserShapeOf` instead of `ResolvedUserOf`, so a provider's declared `user.schema` fields surface on the typed sender — with **no change** for providers that declare no schema.
- Wires `schema: userSchema` into the iMessage platform's `user` definition so the `address` / `country` / `service` fields (added in #143) actually appear on the typed sender ref.

## Why

Resolves ENG-1655 ("iMessage space should include channel"). #143 populated `address`/`country`/`service` on iMessage sender refs at runtime and extended `userSchema`, but because the type system derived `PlatformUser` purely from `user.resolve`'s return type — and iMessage's `resolve` returns only `{ id }` — those fields were invisible at the type level. Apps could not read `sender.service` (the iMessage / SMS / RCS "channel") with type safety.

This completes the feature by making the declared schema authoritative for the user shape, exactly as `space.schema` already works for spaces.

## Usage

```ts
// iMessage sender refs are now typed with the channel/service fields:
const sender = message.sender;
sender.id;       // cross-provider identity key (the address)
sender.address;  // string | undefined
sender.country;  // string | undefined
sender.service;  // "iMessage" | "SMS" | "RCS" | "unknown" | undefined

if (sender.service === "SMS") {
  // branch on green-bubble (SMS/RCS) vs blue-bubble (iMessage)
}
```

## Changes

| File | Change |
|------|--------|
| `packages/core/src/platform/types.ts` | Adds `SchemaUserOf` and `UserShapeOf` type utilities (mirroring `SchemaSpaceOf`/`SpaceShapeOf`); `PlatformUser` now derives its non-`User` shape from `UserShapeOf` instead of `ResolvedUserOf` |
| `packages/imessage/src/index.ts` | Declares `schema: userSchema` on the iMessage `user` definition (imports `userSchema` from `./types`) |

## Test plan

- [x] `bun run typecheck` passes for `@spectrum-ts/core` and `@spectrum-ts/imessage`
- [ ] iMessage `sender` is typed with optional `address` / `country` / `service`
- [ ] Providers that declare no `user.schema` still derive from `user.resolve` (no type change)
- [ ] `bun x ultracite check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/144"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784608728&installation_id=127326493&pr_number=144&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F144&signature=852f86ecf6442fe5e1c43c1d7d645eb1b214b0d75f037be20cf93ea73f455ef6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how user types are defined across platforms to prioritize schema-based definitions
  * Enhanced user input validation for platform integrations including iMessage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->