### PR TITLE
fix(imessage): scope contact-card auto-share per line (ENG-1682)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Learn more at **https://photon.codes**.
 
 ## Getting Started
 
-The fastest way to ship is with **Spectrum Cloud** — hosted infrastructure for platforms like iMessage, with credentials ready in minutes.
+The fastest way to ship is with **Spectrum Cloud** — hosted infrastructure for  like iMessage, with credentials ready in minutes.
 
 1. Sign up at **[app.photon.codes](https://app.photon.codes)** to get your project ID and secret.
 2. Install the SDK (`spectrum-ts` is batteries-included — the runtime plus

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Learn more at **https://photon.codes**.
 
 ## Getting Started
 
-The fastest way to ship is with **Spectrum Cloud** — hosted infrastructure for  like iMessage, with credentials ready in minutes.
+The fastest way to ship is with **Spectrum Cloud** — hosted infrastructure for platforms like iMessage, with credentials ready in minutes.
 
 1. Sign up at **[app.photon.codes](https://app.photon.codes)** to get your project ID and secret.
 2. Install the SDK (`spectrum-ts` is batteries-included — the runtime plus

--- a/packages/imessage/src/remote/contact-share.ts
+++ b/packages/imessage/src/remote/contact-share.ts
@@ -12,9 +12,12 @@ const SHARE_TTL_MS = 24 * 60 * 60 * 1000;
 const MAX_TRACKED_CHATS = 10_000;
 
 /**
- * Tracks which chats this bot has already proactively pushed its contact card
- * to, so `im.chats.shareContactInfo` is fired at most once per chat per 24h
- * per iMessage provider instance.
+ * Tracks which chats this bot's line has already proactively pushed its contact
+ * card to, so `im.chats.shareContactInfo` is fired at most once per chat per
+ * line per 24h. One tracker is created per `AdvancedIMessage` client (see
+ * `getContactShareTracker`), so the dedupe is naturally scoped to the line: a
+ * DM `chatGuid` encodes the peer, not the receiving bot line, so the same guid
+ * arriving on a different line shares independently.
  *
  * Backed by `lru-cache` for TTL + bounded memory. `ttlAutopurge: false`
  * keeps eviction lazy (on access) — there is no background timer to leak
@@ -27,6 +30,12 @@ export class ContactShareTracker {
     ttlAutopurge: false,
   });
 
+  private readonly client: AdvancedIMessage;
+
+  constructor(client: AdvancedIMessage) {
+    this.client = client;
+  }
+
   /**
    * Best-effort share. The cache is set eagerly so that a burst of inbound
    * messages for the same chat coalesces to a single API call. On failure the
@@ -34,14 +43,14 @@ export class ContactShareTracker {
    * permanently mute the feature for a chat. Never awaits and never throws:
    * the receive stream must not crash on share failures.
    */
-  maybeShare(client: AdvancedIMessage, chatGuid: string): void {
+  maybeShare(chatGuid: string): void {
     if (this.cache.has(chatGuid)) {
       return;
     }
     this.cache.set(chatGuid, true);
     // chatGuid embeds the peer's phone/email for DMs — scrub it before logging.
     const safeChatGuid = sanitizeErrorMessage(chatGuid);
-    client.chats
+    this.client.chats
       .shareContactInfo(chatGuid)
       .then(() => {
         log.info("shared contact card", {
@@ -62,19 +71,23 @@ export class ContactShareTracker {
   }
 }
 
-const trackers = new WeakMap<object, ContactShareTracker>();
+const trackers = new WeakMap<AdvancedIMessage, ContactShareTracker>();
 
 /**
- * Returns a per-owner tracker. Mirrors `getMessageCache`/`getPollCache` in
- * ../cache.ts — keyed by an object (the `RemoteClient[]` array for remote
- * mode), so each iMessage provider instance has its own tracker and multiple
- * providers don't share state accidentally.
+ * Returns a per-line tracker. Mirrors `getMessageCache` in ../cache.ts — keyed
+ * by the individual `AdvancedIMessage` client, so each line has its own dedupe
+ * state and multiple lines/providers don't share state accidentally. The
+ * WeakMap holds the client weakly, so a torn-down line's tracker is collected
+ * with its client (the tracker's own reference back to the client doesn't pin
+ * it — the entry is a collectible cycle).
  */
-export const getContactShareTracker = (owner: object): ContactShareTracker => {
-  let tracker = trackers.get(owner);
+export const getContactShareTracker = (
+  client: AdvancedIMessage
+): ContactShareTracker => {
+  let tracker = trackers.get(client);
   if (!tracker) {
-    tracker = new ContactShareTracker();
-    trackers.set(owner, tracker);
+    tracker = new ContactShareTracker(client);
+    trackers.set(client, tracker);
   }
   return tracker;
 };

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -259,22 +259,23 @@ export const messages = (
   projectConfig?: ProjectData | undefined
 ): ManagedStream<IMessageMessage> => {
   const pollCache = getPollCache(clients);
-  // When the project profile opts in to iMessage sync, push the bot's
-  // contact card to any chat we receive a new message in (24h dedupe per
-  // chat, fire-and-forget). The tracker is per `clients` array — same key
-  // shape as `getPollCache` — so multi-Spectrum setups don't cross-pollute.
+  // When the project profile opts in to iMessage sync, push the bot's contact
+  // card to any chat we receive a new message in (24h dedupe per chat per line,
+  // fire-and-forget). The tracker is keyed per `entry.client` — same shape as
+  // `getMessageCache` — so each line dedupes independently (a DM guid encodes
+  // the peer, not the line) and multi-Spectrum setups don't cross-pollute.
   const shareEnabled = projectConfig?.profile?.imessageSynced === true;
-  const tracker = shareEnabled ? getContactShareTracker(clients) : undefined;
   return mergeStreams(
-    clients.map((entry) =>
-      clientStream(
+    clients.map((entry) => {
+      const tracker = shareEnabled
+        ? getContactShareTracker(entry.client)
+        : undefined;
+      return clientStream(
         entry.client,
         pollCache,
         entry.phone,
-        tracker
-          ? (chatGuid) => tracker.maybeShare(entry.client, chatGuid)
-          : undefined
-      )
-    )
+        tracker ? (chatGuid) => tracker.maybeShare(chatGuid) : undefined
+      );
+    })
   );
 };

--- a/packages/imessage/test/remote/contact-share.test.ts
+++ b/packages/imessage/test/remote/contact-share.test.ts
@@ -17,11 +17,11 @@ describe("ContactShareTracker", () => {
   it("shares once per chat across repeated inbound messages", async () => {
     const share = mock((_: string) => Promise.resolve());
     const client = makeClient(share);
-    const tracker = new ContactShareTracker();
+    const tracker = new ContactShareTracker(client);
 
-    tracker.maybeShare(client, "chat-A");
-    tracker.maybeShare(client, "chat-A");
-    tracker.maybeShare(client, "chat-A");
+    tracker.maybeShare("chat-A");
+    tracker.maybeShare("chat-A");
+    tracker.maybeShare("chat-A");
     await flush();
 
     expect(share).toHaveBeenCalledTimes(1);
@@ -35,13 +35,13 @@ describe("ContactShareTracker", () => {
     });
     const share = mock((_: string) => sharePromise);
     const client = makeClient(share);
-    const tracker = new ContactShareTracker();
+    const tracker = new ContactShareTracker(client);
 
     // Five concurrent inbound messages for the same chat — only the first
     // should kick off the share; the rest should see the cached entry and
     // skip even though the in-flight promise hasn't resolved yet.
     for (let i = 0; i < 5; i++) {
-      tracker.maybeShare(client, "chat-burst");
+      tracker.maybeShare("chat-burst");
     }
     expect(share).toHaveBeenCalledTimes(1);
 
@@ -53,11 +53,11 @@ describe("ContactShareTracker", () => {
   it("shares for distinct chats independently", async () => {
     const share = mock((_: string) => Promise.resolve());
     const client = makeClient(share);
-    const tracker = new ContactShareTracker();
+    const tracker = new ContactShareTracker(client);
 
-    tracker.maybeShare(client, "chat-A");
-    tracker.maybeShare(client, "chat-B");
-    tracker.maybeShare(client, "chat-A");
+    tracker.maybeShare("chat-A");
+    tracker.maybeShare("chat-B");
+    tracker.maybeShare("chat-A");
     await flush();
 
     expect(share).toHaveBeenCalledTimes(2);
@@ -76,20 +76,20 @@ describe("ContactShareTracker", () => {
         : Promise.resolve();
     });
     const client = makeClient(share);
-    const tracker = new ContactShareTracker();
+    const tracker = new ContactShareTracker(client);
 
-    tracker.maybeShare(client, "chat-retry");
+    tracker.maybeShare("chat-retry");
     await flush();
     expect(share).toHaveBeenCalledTimes(1);
 
     // After failure the cache entry should be evicted, so the next inbound
     // tries again rather than silently muting the chat.
-    tracker.maybeShare(client, "chat-retry");
+    tracker.maybeShare("chat-retry");
     await flush();
     expect(share).toHaveBeenCalledTimes(2);
 
     // The retry succeeded — subsequent inbounds within the window are deduped.
-    tracker.maybeShare(client, "chat-retry");
+    tracker.maybeShare("chat-retry");
     await flush();
     expect(share).toHaveBeenCalledTimes(2);
   });
@@ -97,25 +97,43 @@ describe("ContactShareTracker", () => {
   it("never throws synchronously even when shareContactInfo rejects", async () => {
     const share = mock((_: string) => Promise.reject(new Error("boom")));
     const client = makeClient(share);
-    const tracker = new ContactShareTracker();
+    const tracker = new ContactShareTracker(client);
 
-    expect(() => tracker.maybeShare(client, "chat-throw")).not.toThrow();
+    expect(() => tracker.maybeShare("chat-throw")).not.toThrow();
     await flush();
     expect(share).toHaveBeenCalledTimes(1);
   });
 });
 
 describe("getContactShareTracker", () => {
-  it("returns the same tracker for the same owner", () => {
-    const owner = {};
-    const a = getContactShareTracker(owner);
-    const b = getContactShareTracker(owner);
+  const noopClient = () => makeClient(() => Promise.resolve());
+
+  it("returns the same tracker for the same client", () => {
+    const client = noopClient();
+    const a = getContactShareTracker(client);
+    const b = getContactShareTracker(client);
     expect(a).toBe(b);
   });
 
-  it("returns distinct trackers for distinct owners", () => {
-    const a = getContactShareTracker({});
-    const b = getContactShareTracker({});
+  it("returns distinct trackers for distinct clients", () => {
+    const a = getContactShareTracker(noopClient());
+    const b = getContactShareTracker(noopClient());
     expect(a).not.toBe(b);
+  });
+
+  it("shares per line — distinct clients dedupe the same chat independently", async () => {
+    const shareA = mock((_: string) => Promise.resolve());
+    const shareB = mock((_: string) => Promise.resolve());
+    const trackerA = getContactShareTracker(makeClient(shareA));
+    const trackerB = getContactShareTracker(makeClient(shareB));
+
+    // Same DM chat guid (encodes the peer) arriving on two different lines.
+    trackerA.maybeShare("any;-;+15550123");
+    trackerB.maybeShare("any;-;+15550123");
+    trackerA.maybeShare("any;-;+15550123"); // dup on line A — deduped
+    await flush();
+
+    expect(shareA).toHaveBeenCalledTimes(1);
+    expect(shareB).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- Scopes the proactive contact-card share (`ContactShareTracker`) **per line** instead of per provider instance, so every line auto-shares its own profile when a user enters a chat.
- `ContactShareTracker` now holds a reference to its `AdvancedIMessage` client (set in the constructor); `maybeShare(chatGuid)` drops the old `client` parameter.
- `getContactShareTracker` is keyed by the `AdvancedIMessage` instance (via a `WeakMap`) rather than a generic `object`, so each line gets its own dedupe state — mirroring `getMessageCache` in `../cache.ts`.
- In `stream.ts`, the tracker is resolved per `entry.client` inside `clients.map(...)` rather than once for the shared `clients` array.

## Why

Resolves **ENG-1682** ("profile is not automatically shared when the user enters"). When the project profile opts into iMessage sync (`imessageSynced`), the bot proactively pushes its contact card to any chat it receives a message in (24h dedupe, fire-and-forget).

Previously the tracker was created **once per `clients` array** (the whole provider instance) and deduped on `chatGuid` alone. But for a DM, the `chatGuid` encodes the **peer**, not the receiving bot line. With more than one line, the same DM `chatGuid` arriving on line B would hit the dedupe entry that line A had already set — so line B was silently skipped and **never shared its own contact card**. A user entering a conversation with line B never saw line B's profile.

Scoping the tracker per line makes the dedupe independent per line: two lines receiving the same DM `chatGuid` each share their own card exactly once per chat per 24h. The `WeakMap` holds the client weakly, so a torn-down line's tracker is collected with its client (the tracker's back-reference to the client doesn't pin it — it's a collectible cycle).

## Changes

| File | Change |
|---|---|
| `packages/imessage/src/remote/contact-share.ts` | `ContactShareTracker` takes its `AdvancedIMessage` client in the constructor; `maybeShare(chatGuid)` drops the `client` param and calls `this.client.chats.shareContactInfo`. `getContactShareTracker` is keyed by `AdvancedIMessage` (`WeakMap<AdvancedIMessage, …>`) instead of a generic `object`. Doc comments updated to explain per-line scoping and the collectible-cycle weak reference. |
| `packages/imessage/src/remote/stream.ts` | Resolve the tracker per `entry.client` inside `clients.map(...)` instead of once for the whole `clients` array; share callback is now `(chatGuid) => tracker.maybeShare(chatGuid)`. Comment updated to describe per-line dedupe. |
| `packages/imessage/test/remote/contact-share.test.ts` | Updated all `new ContactShareTracker(client)` / `maybeShare(chatGuid)` call sites; renamed the `owner` cases to `client`; **new** case: "shares per line — distinct clients dedupe the same chat independently" (same DM guid on two lines → each shares once). |
| `README.md` | Restore the word "platforms", accidentally dropped from the Getting Started blurb on this branch ("hosted infrastructure for  like iMessage" → "…for platforms like iMessage"). Separate commit. |

## Test plan

- [x] `bun test test/remote/contact-share.test.ts` — **8 pass, 0 fail**
- [ ] `turbo typecheck --filter=@spectrum-ts/imessage`
- [ ] `bun x ultracite check`
- [ ] Manual: with two lines and `imessageSynced` enabled, a DM `chatGuid` arriving on each line auto-shares **both** lines' contact cards (one per line), instead of only the first

## README

A prior edit on this branch had deleted "platforms" from the Getting Started section, leaving "hosted infrastructure for  like iMessage" with broken grammar and a double space. Restored the original wording in a dedicated commit (`docs: restore accidentally dropped "platforms" in README Getting Started`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784860306&installation_id=127326493&pr_number=145&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F145&signature=5a22cc540b2a2bff6119f83bf89ec3584627039ad00b895483cb84824be76115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact-sharing deduplication to operate independently per client line, reducing interference between simultaneous clients.
  * Enhanced retry behavior: failed contact shares now clear their cache entry, allowing reliable retries on subsequent attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->