### PR TITLE
fix(imessage): recover from persistent auth-rejection reconnect loop (ENG-1689)

### DIFF
--- a/packages/core/src/utils/resumable-stream.ts
+++ b/packages/core/src/utils/resumable-stream.ts
@@ -51,6 +51,16 @@ export interface ResumableOrderedStreamOptions<TLive, TMissed, TOutput> {
   maxRetryDelayMs?: number;
   processLive: (event: TLive) => Promise<ResumableStreamItem<TOutput>>;
   processMissed: (event: TMissed) => Promise<ResumableStreamItem<TOutput>>;
+  /**
+   * Invoked when reconnects have failed persistently (the consecutive-failure
+   * count has reached a multiple of `PERSISTENT_FAILURE_ERROR_THRESHOLD`) to
+   * rebuild state a plain reconnect cannot refresh — e.g. re-mint an auth token
+   * the server rejects after a restart. Runs between the failure and the next
+   * retry, throttled to once per threshold window, and resets once the stream
+   * recovers. Errors thrown are logged and swallowed; the reconnect loop
+   * continues either way, so a recover that itself fails is harmless.
+   */
+  recover?: (error: unknown, failureCount: number) => Promise<void> | void;
   subscribeLive: (cursor?: string) => CloseableAsyncIterable<TLive>;
 }
 
@@ -150,6 +160,10 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
     let activeLive: CloseableAsyncIterable<TLive> | undefined;
     let closed = false;
     let failedAttempts = 0;
+    // The `failedAttempts` value at which `recover` last ran, so the hook fires
+    // at most once per `PERSISTENT_FAILURE_ERROR_THRESHOLD` window instead of on
+    // every retry. Reset on recovery so a later outage triggers it again.
+    let lastRecoverAttempt = 0;
     let lastCursor: string | undefined;
     let retryDelayMs = initialRetryDelayMs;
     let sleepTimer: ReturnType<typeof setTimeout> | undefined;
@@ -171,6 +185,7 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
 
     const noteRecovery = () => {
       retryDelayMs = initialRetryDelayMs;
+      lastRecoverAttempt = 0;
       if (failedAttempts === 0) {
         return;
       }
@@ -288,6 +303,40 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
       }
       log.warn("stream interrupted; reconnecting", attrs, error);
       return delayMs;
+    };
+
+    // Once reconnects fail persistently, give the caller a chance to rebuild
+    // state a plain retry cannot fix (e.g. re-mint a rejected auth token).
+    // Throttled to once per threshold window via `lastRecoverAttempt`; a hook
+    // that throws is logged and ignored so it can never wedge the loop.
+    const maybeRecover = async (error: unknown): Promise<void> => {
+      if (
+        !options.recover ||
+        failedAttempts < PERSISTENT_FAILURE_ERROR_THRESHOLD ||
+        failedAttempts - lastRecoverAttempt < PERSISTENT_FAILURE_ERROR_THRESHOLD
+      ) {
+        return;
+      }
+      lastRecoverAttempt = failedAttempts;
+      try {
+        await options.recover(error, failedAttempts);
+        log.info("stream recover hook ran", {
+          "spectrum.stream.id": streamId,
+          "spectrum.stream.label": label,
+          "spectrum.stream.attempt": failedAttempts,
+        });
+      } catch (recoverError) {
+        log.warn(
+          "stream recover hook failed",
+          {
+            "spectrum.stream.id": streamId,
+            "spectrum.stream.label": label,
+            "spectrum.stream.attempt": failedAttempts,
+            ...errorAttrs(recoverError),
+          },
+          recoverError
+        );
+      }
     };
 
     const consumeLive = async (): Promise<void> => {
@@ -440,7 +489,9 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
           if (closed) {
             break;
           }
-          await sleep(handleFailure(error, phase));
+          const delayMs = handleFailure(error, phase);
+          await maybeRecover(error);
+          await sleep(delayMs);
         }
       }
       end();

--- a/packages/core/src/utils/resumable-stream.ts
+++ b/packages/core/src/utils/resumable-stream.ts
@@ -61,6 +61,8 @@ export interface ResumableOrderedStreamOptions<TLive, TMissed, TOutput> {
    * continues either way, so a recover that itself fails is harmless.
    */
   recover?: (error: unknown, failureCount: number) => Promise<void> | void;
+  /** Cap on how long a `recover` hook may run before it is abandoned; injectable for tests. */
+  recoverTimeoutMs?: number;
   subscribeLive: (cursor?: string) => CloseableAsyncIterable<TLive>;
 }
 
@@ -97,6 +99,34 @@ const closeIterable = async <T>(
 };
 
 const ignoreCleanupError = () => undefined;
+
+// A recover hook (e.g. an auth-token re-mint) that never settles must not
+// freeze the reconnect loop or leave close() waiting on the pump forever. Cap
+// it; on timeout the abandoned result is ignored and the loop proceeds.
+const RECOVER_TIMEOUT_MS = 30_000;
+
+const runWithTimeout = async (
+  work: Promise<void>,
+  timeoutMs: number,
+  onTimeout: () => Error
+): Promise<void> => {
+  // Swallow a late rejection from the abandoned work so it can't surface as an
+  // unhandled rejection once we stop awaiting it.
+  work.catch(ignoreCleanupError);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      work,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => reject(onTimeout()), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+};
 
 // Equal jitter: a near-zero random draw must not defeat backoff during an
 // outage, so the floor is half the nominal delay.
@@ -155,6 +185,7 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
       options.initialRetryDelayMs ?? RECONNECT_INITIAL_DELAY_MS;
     const maxRetryDelayMs = options.maxRetryDelayMs ?? RECONNECT_MAX_DELAY_MS;
     const jitter = options.jitter ?? jitterDelay;
+    const recoverTimeoutMs = options.recoverTimeoutMs ?? RECOVER_TIMEOUT_MS;
     const label = options.label;
 
     let activeLive: CloseableAsyncIterable<TLive> | undefined;
@@ -319,7 +350,14 @@ export const resumableOrderedStream = <TLive, TMissed, TOutput>(
       }
       lastRecoverAttempt = failedAttempts;
       try {
-        await options.recover(error, failedAttempts);
+        await runWithTimeout(
+          Promise.resolve(options.recover(error, failedAttempts)),
+          recoverTimeoutMs,
+          () =>
+            new Error(
+              `recover hook did not settle within ${recoverTimeoutMs}ms`
+            )
+        );
         log.info("stream recover hook ran", {
           "spectrum.stream.id": streamId,
           "spectrum.stream.label": label,

--- a/packages/core/test/utils/resumable-stream.test.ts
+++ b/packages/core/test/utils/resumable-stream.test.ts
@@ -85,6 +85,7 @@ interface FixtureConfig {
   ) => CloseableAsyncIterable<Item>;
   maxRetryDelayMs?: number;
   processMissed?: (event: Item) => Promise<Item>;
+  recover?: (error: unknown, failureCount: number) => Promise<void> | void;
 }
 
 const buildStream = (config: FixtureConfig) => {
@@ -113,6 +114,7 @@ const buildStream = (config: FixtureConfig) => {
     maxRetryDelayMs: config.maxRetryDelayMs ?? 8,
     processLive: (event) => Promise.resolve(event),
     processMissed: config.processMissed ?? ((event) => Promise.resolve(event)),
+    recover: config.recover,
     subscribeLive: (cursor) => {
       liveCalls.push(cursor);
       return config.live(liveCalls.length, cursor);
@@ -402,6 +404,47 @@ describe("resumableOrderedStream", () => {
     expect(fx.liveCalls).toEqual([undefined, "1"]);
     expect(fx.fetchCalls).toEqual(["1"]);
     expect(fx.delays).toEqual([1]);
+    await fx.close();
+    expect(await fx.ended).toBe("done");
+  });
+
+  it("runs recover once at the persistent-failure threshold and resumes after it heals", async () => {
+    let healed = false;
+    const recoverAt: number[] = [];
+    const fx = buildStream({
+      // Reject every reconnect (server rejecting a stale token) until recover
+      // "re-mints" it; then the next reconnect succeeds.
+      live: () =>
+        healed
+          ? liveSession([item("1", "ok")], "pending")
+          : liveSession([], "throw", () => new Error("Invalid credentials")),
+      recover: (_error, failureCount) => {
+        recoverAt.push(failureCount);
+        healed = true;
+      },
+    });
+
+    await waitUntil(() => fx.received.includes("ok"));
+    // Fired exactly once, at the threshold — not on every prior failure.
+    expect(recoverAt).toEqual([PERSISTENT_FAILURE_ERROR_THRESHOLD]);
+    await fx.close();
+    expect(await fx.ended).toBe("done");
+  });
+
+  it("throttles recover to once per threshold window while failures persist", async () => {
+    const recoverAt: number[] = [];
+    const fx = buildStream({
+      live: () =>
+        liveSession([], "throw", () => new Error("Invalid credentials")),
+      recover: (_error, failureCount) => {
+        recoverAt.push(failureCount);
+      },
+    });
+
+    await waitUntil(() => recoverAt.length >= 2);
+    // Never before the threshold; re-armed exactly one window later.
+    expect(recoverAt[0]).toBe(PERSISTENT_FAILURE_ERROR_THRESHOLD);
+    expect(recoverAt[1]).toBe(PERSISTENT_FAILURE_ERROR_THRESHOLD * 2);
     await fx.close();
     expect(await fx.ended).toBe("done");
   });

--- a/packages/core/test/utils/resumable-stream.test.ts
+++ b/packages/core/test/utils/resumable-stream.test.ts
@@ -86,6 +86,7 @@ interface FixtureConfig {
   maxRetryDelayMs?: number;
   processMissed?: (event: Item) => Promise<Item>;
   recover?: (error: unknown, failureCount: number) => Promise<void> | void;
+  recoverTimeoutMs?: number;
 }
 
 const buildStream = (config: FixtureConfig) => {
@@ -115,6 +116,7 @@ const buildStream = (config: FixtureConfig) => {
     processLive: (event) => Promise.resolve(event),
     processMissed: config.processMissed ?? ((event) => Promise.resolve(event)),
     recover: config.recover,
+    recoverTimeoutMs: config.recoverTimeoutMs,
     subscribeLive: (cursor) => {
       liveCalls.push(cursor);
       return config.live(liveCalls.length, cursor);
@@ -445,6 +447,29 @@ describe("resumableOrderedStream", () => {
     // Never before the threshold; re-armed exactly one window later.
     expect(recoverAt[0]).toBe(PERSISTENT_FAILURE_ERROR_THRESHOLD);
     expect(recoverAt[1]).toBe(PERSISTENT_FAILURE_ERROR_THRESHOLD * 2);
+    await fx.close();
+    expect(await fx.ended).toBe("done");
+  });
+
+  it("does not let a hung recover hook freeze the reconnect loop", async () => {
+    let recoverCalls = 0;
+    const fx = buildStream({
+      recoverTimeoutMs: 5,
+      live: () =>
+        liveSession([], "throw", () => new Error("Invalid credentials")),
+      // Never settles — must time out instead of blocking retries / close().
+      recover: () =>
+        new Promise<void>(() => {
+          recoverCalls += 1;
+        }),
+    });
+
+    // The loop keeps making new live attempts past the first recover (so the
+    // hung hook did not park the loop), and close() still resolves.
+    await waitUntil(
+      () => fx.liveCalls.length >= PERSISTENT_FAILURE_ERROR_THRESHOLD + 3
+    );
+    expect(recoverCalls).toBeGreaterThanOrEqual(1);
     await fx.close();
     expect(await fx.ended).toBe("done");
   });

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -112,13 +112,22 @@ export async function createCloudClients(
     const ttlMs = tokenData.expiresIn * 1000;
     const renewInMs = Math.max(ttlMs * RENEWAL_RATIO, 5000);
 
-    renewalTimer = setTimeout(() => {
+    const runScheduledRefresh = () => {
       coalescedRefresh().catch((error) => {
         onRefreshFailure(error);
-        renewalTimer = setTimeout(() => scheduleRenewal(), RETRY_DELAY_MS);
+        if (disposed) {
+          return;
+        }
+        // Retry the refresh itself after RETRY_DELAY_MS. Re-running
+        // scheduleRenewal would instead wait another full renewal window (80%
+        // of TTL), leaving the token stale/expired during an outage. On
+        // success, refreshNow() re-arms the next renewal.
+        renewalTimer = setTimeout(runScheduledRefresh, RETRY_DELAY_MS);
         renewalTimer?.unref?.();
       });
-    }, renewInMs);
+    };
+
+    renewalTimer = setTimeout(runScheduledRefresh, renewInMs);
     renewalTimer?.unref?.();
   };
 

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -12,9 +12,14 @@ const log = createLogger("spectrum.imessage.auth");
 const RENEWAL_RATIO = 0.8;
 const EXPIRY_BUFFER_MS = 30_000;
 const RETRY_DELAY_MS = 30_000;
+// Floor between forced re-mints so a stream reconnect storm can't hammer the
+// cloud token endpoint — well below any token TTL, just enough to coalesce the
+// message + poll streams asking at nearly the same instant.
+const FORCE_REFRESH_MIN_INTERVAL_MS = 5000;
 
 interface CloudAuth {
   dispose: () => void;
+  forceRefresh: () => Promise<void>;
 }
 
 const cloudAuthState = new WeakMap<RemoteClient[], CloudAuth>();
@@ -36,6 +41,8 @@ export async function createCloudClients(
   let disposed = false;
   let renewalTimer: ReturnType<typeof setTimeout> | undefined;
   let refreshFailures = 0;
+  let refreshInFlight: Promise<void> | undefined;
+  let lastRefreshAt = Date.now();
 
   // The instanceId stays paired with each entry in this closure so renewal
   // can rewrite `entry.phone` in place without leaking instanceId onto the
@@ -70,27 +77,47 @@ export async function createCloudClients(
     );
   };
 
+  const refreshNow = async (): Promise<void> => {
+    tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
+    tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
+    lastRefreshAt = Date.now();
+    if (tokenData.type === "dedicated") {
+      syncPhones(tokenData);
+    }
+    onRefreshSuccess();
+    scheduleRenewal();
+  };
+
+  // Coalesce concurrent re-mints: the message + poll streams and the renewal
+  // timer can all ask at once, but only one issueImessageTokens call should run.
+  const coalescedRefresh = (): Promise<void> => {
+    if (!refreshInFlight) {
+      refreshInFlight = refreshNow().finally(() => {
+        refreshInFlight = undefined;
+      });
+    }
+    return refreshInFlight;
+  };
+
   const scheduleRenewal = () => {
     if (disposed) {
       return;
     }
+    // Clear any prior timer first — refreshNow()/forceRefresh() can re-arm the
+    // schedule, and leaving the old timer running would leak overlapping renewals.
+    if (renewalTimer !== undefined) {
+      clearTimeout(renewalTimer);
+      renewalTimer = undefined;
+    }
     const ttlMs = tokenData.expiresIn * 1000;
     const renewInMs = Math.max(ttlMs * RENEWAL_RATIO, 5000);
 
-    renewalTimer = setTimeout(async () => {
-      try {
-        tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
-        tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
-        if (tokenData.type === "dedicated") {
-          syncPhones(tokenData);
-        }
-        onRefreshSuccess();
-        scheduleRenewal();
-      } catch (error) {
+    renewalTimer = setTimeout(() => {
+      coalescedRefresh().catch((error) => {
         onRefreshFailure(error);
         renewalTimer = setTimeout(() => scheduleRenewal(), RETRY_DELAY_MS);
         renewalTimer?.unref?.();
-      }
+      });
     }, renewInMs);
     renewalTimer?.unref?.();
   };
@@ -101,14 +128,28 @@ export async function createCloudClients(
     if (Date.now() < tokenExpiresAt - EXPIRY_BUFFER_MS) {
       return;
     }
-    tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
-    tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
-    if (tokenData.type === "dedicated") {
-      syncPhones(tokenData);
-    }
-    onRefreshSuccess();
-    scheduleRenewal();
+    await coalescedRefresh();
   };
+
+  // Re-mint unconditionally — wired to the stream recover hook so a token the
+  // server rejects after a restart (UNAUTHENTICATED / "Invalid credentials",
+  // not yet near expiry) is replaced. The per-RPC token function then hands the
+  // fresh token to the next reconnect without recreating the gRPC channel.
+  const forceRefresh = async (): Promise<void> => {
+    if (Date.now() - lastRefreshAt < FORCE_REFRESH_MIN_INTERVAL_MS) {
+      return;
+    }
+    await coalescedRefresh();
+  };
+
+  const dispose = () => {
+    disposed = true;
+    if (renewalTimer !== undefined) {
+      clearTimeout(renewalTimer);
+      renewalTimer = undefined;
+    }
+  };
+  const cloudAuth: CloudAuth = { dispose, forceRefresh };
 
   if (tokenData.type === "shared") {
     const address =
@@ -128,15 +169,7 @@ export async function createCloudClients(
       },
     ];
 
-    cloudAuthState.set(entries, {
-      dispose: () => {
-        disposed = true;
-        if (renewalTimer !== undefined) {
-          clearTimeout(renewalTimer);
-          renewalTimer = undefined;
-        }
-      },
-    });
+    cloudAuthState.set(entries, cloudAuth);
 
     return entries;
   }
@@ -159,15 +192,7 @@ export async function createCloudClients(
   }
   const entries = records.map((r) => r.entry);
 
-  cloudAuthState.set(entries, {
-    dispose: () => {
-      disposed = true;
-      if (renewalTimer !== undefined) {
-        clearTimeout(renewalTimer);
-        renewalTimer = undefined;
-      }
-    },
-  });
+  cloudAuthState.set(entries, cloudAuth);
 
   return entries;
 }
@@ -178,4 +203,16 @@ export async function disposeCloudAuth(clients: RemoteClient[]): Promise<void> {
     auth.dispose();
     cloudAuthState.delete(clients);
   }
+}
+
+/**
+ * The recover hook for a cloud-backed client array: forces a token re-mint so a
+ * persistently-failing stream (server rejecting an unexpired token after a
+ * restart) gets a fresh bearer on its next reconnect. Returns undefined for
+ * explicitly-configured (static-token) clients, which have nothing to re-mint.
+ */
+export function getCloudRecover(
+  clients: RemoteClient[]
+): (() => Promise<void>) | undefined {
+  return cloudAuthState.get(clients)?.forceRefresh;
 }

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -16,6 +16,7 @@ import {
   type ResumableStreamItem,
   resumableOrderedStream,
 } from "@spectrum-ts/core/authoring";
+import { getCloudRecover } from "../auth";
 import { getMessageCache, getPollCache, type PollCache } from "../cache";
 import {
   type IMessageMessage,
@@ -202,12 +203,14 @@ const withClose = <T extends MessageEvent | PollEvent>(
 const messageStream = (
   client: AdvancedIMessage,
   phone: string,
-  onInbound?: OnInboundMessage
+  onInbound?: OnInboundMessage,
+  recover?: () => Promise<void>
 ): ManagedStream<IMessageMessage> =>
   resumableOrderedStream<MessageEvent, MessageCatchUpEvent, IMessageMessage>({
     fetchMissed: (cursor) => catchUpEvents(client, cursor, isMessageEvent),
     isCursorRejectedError: isCursorRejectedIMessageError,
     label: streamLabel("messages", phone),
+    recover,
     processLive: (event) =>
       toMessageItem(client, event, phone, String(event.sequence), onInbound),
     processMissed: (event) =>
@@ -227,12 +230,14 @@ const messageStream = (
 const pollStream = (
   client: AdvancedIMessage,
   pollCache: PollCache,
-  phone: string
+  phone: string,
+  recover?: () => Promise<void>
 ): ManagedStream<IMessageMessage> =>
   resumableOrderedStream<PollEvent, PollCatchUpEvent, IMessageMessage>({
     fetchMissed: (cursor) => catchUpEvents(client, cursor, isPollEvent),
     isCursorRejectedError: isCursorRejectedIMessageError,
     label: streamLabel("polls", phone),
+    recover,
     processLive: (event) =>
       toPollItem(client, pollCache, event, phone, String(event.sequence)),
     processMissed: (event) =>
@@ -247,11 +252,12 @@ const clientStream = (
   client: AdvancedIMessage,
   pollCache: PollCache,
   phone: string,
-  onInbound?: OnInboundMessage
+  onInbound?: OnInboundMessage,
+  recover?: () => Promise<void>
 ): ManagedStream<IMessageMessage> =>
   mergeStreams([
-    messageStream(client, phone, onInbound),
-    pollStream(client, pollCache, phone),
+    messageStream(client, phone, onInbound, recover),
+    pollStream(client, pollCache, phone, recover),
   ]);
 
 export const messages = (
@@ -265,6 +271,10 @@ export const messages = (
   // shape as `getPollCache` — so multi-Spectrum setups don't cross-pollute.
   const shareEnabled = projectConfig?.profile?.imessageSynced === true;
   const tracker = shareEnabled ? getContactShareTracker(clients) : undefined;
+  // Cloud clients can re-mint a rejected token; explicit/static-token clients
+  // return undefined (nothing to refresh). Shared across this client array's
+  // streams so the message + poll loops coalesce onto one re-mint.
+  const recover = getCloudRecover(clients);
   return mergeStreams(
     clients.map((entry) =>
       clientStream(
@@ -273,7 +283,8 @@ export const messages = (
         entry.phone,
         tracker
           ? (chatGuid) => tracker.maybeShare(entry.client, chatGuid)
-          : undefined
+          : undefined,
+        recover
       )
     )
   );


### PR DESCRIPTION
## Problem
After a `spectrum-imessage` server restart, every stream reconnect is rejected with `IMessageError: Invalid credentials` and `resumableOrderedStream` retries it forever at the 30s backoff cap. Production SigNoz: `attempt: 9797`, `delayMs: 30000`, **zero recoveries**, across real `hermes-agent` sidecars — both `imessage.messages:shared` and `imessage.polls:shared`. The only recovery today is a full process restart, which re-runs `createCloudClients` (fresh token).

## Fix
- **`packages/core/src/utils/resumable-stream.ts`**: new optional `recover(error, failureCount)` hook. Invoked between a failure and the backoff sleep once the consecutive-failure count reaches a multiple of `PERSISTENT_FAILURE_ERROR_THRESHOLD` — throttled via `lastRecoverAttempt`, reset on `noteRecovery`. A recover that throws is logged and ignored, so it can never wedge the loop.
- **`packages/imessage/src/auth.ts`**: factored token refresh into a coalesced `refreshNow`/`coalescedRefresh`; added `forceRefresh()` (re-mint regardless of expiry, 5s min-interval guard) exposed via `getCloudRecover(clients)`. Also fixed a latent renewal-timer leak (`scheduleRenewal` now clears the prior timer).
- **`packages/imessage/src/remote/stream.ts`**: threads `recover = getCloudRecover(clients)` into the message + poll streams (cloud only; `undefined` for static-token clients).

Since gRPC bearer auth is per-RPC metadata, re-minting the token is enough — the existing client hands the fresh bearer to the next reconnect; **no channel rebuild needed**.

## Verification
`tsc --noEmit` clean (core + imessage) · `ultracite check` clean · 197/197 core tests pass, incl. 2 new recover tests (fires once at threshold then heals; throttled re-arm while failing).

## Notes
- Pairs with **ENG-1693** (server-side RCA of *why* a valid bearer is rejected after restart). If RCA shows a fresh connection is also required, the `recover` hook is generic enough to additionally rebuild the channel.
- Also strips the throwaway `[debug-instrumentation]` logging the investigation added to these two files.

Part of ENG-1688. Closes ENG-1689.

https://claude.ai/code/session_01AFkXpowryHpuBtqEgMMFaC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/147"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784877684&installation_id=127326493&pr_number=147&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F147&signature=610af41a3b3a6beca31b5d70e6f8c7d07516e0de012a8840f21c87aa83280698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable stream recovery hook for persistently failing reconnects, including a timeout limit so recovery can’t stall reconnection.
  * Enabled cloud-backed recovery for iMessage message and poll streams.
  * Coordinated cloud token renewal via a single-flight refresh flow.
  * Added a helper to access cloud recovery capabilities for eligible clients.

* **Bug Fixes**
  * Prevented overlapping cloud token refresh requests during renewals.
  * Throttled recovery so it runs at most once per persistent-failure window.

* **Tests**
  * Extended resumable stream tests to validate recovery throttling and timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->