### PR TITLE
fix(imessage): retry transient outbound RPCs with idempotency keys (ENG-1690)

### DIFF
--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -119,6 +119,12 @@ export async function createCloudClients(
         phone: SHARED_PHONE,
         client: createClient({
           address,
+          // Auto-retry transient unary failures so a brief server blip during
+          // an outbound action (send/react/reply) doesn't surface as an
+          // uncaught error. `autoIdempotency` attaches an x-idempotency-key to
+          // mutating RPCs so the retry can't double-apply.
+          autoIdempotency: true,
+          retry: true,
           tls: true,
           token: async () => {
             await refreshIfNeeded();
@@ -147,6 +153,8 @@ export async function createCloudClients(
       phone: requirePhone(dedicated, instanceId),
       client: createClient({
         address: `${instanceId}.imsg.photon.codes:443`,
+        autoIdempotency: true,
+        retry: true,
         tls: true,
         token: async () => {
           await refreshIfNeeded();

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -431,6 +431,11 @@ export const imessage = definePlatform("iMessage", {
           phone: e.phone,
           client: createClient({
             address: e.address,
+            // Auto-retry transient unary failures (idempotency-keyed so retries
+            // can't double-apply) so a server blip during an outbound action
+            // doesn't crash the app.
+            autoIdempotency: true,
+            retry: true,
             tls: true,
             token: e.token,
           }),


### PR DESCRIPTION
## Problem
A transient `ConnectionError: [upstream] Connection dropped` (grpc-14 UNAVAILABLE, `retryable:false`) on a **unary outbound RPC** (`SetReaction`, `SendTextMessage`, reply, typing) was unhandled and crashed the whole process (`exited with code 1`) when it propagated out of the user's `for await (const [space, message] of app.messages)` loop. Observed live on `message.react("👀")` → `reactToMessage` → `remote.messages.setReaction`.

Root cause: spectrum-ts built the SDK client with **neither** `retry` nor `autoIdempotency`, so nothing absorbed the blip — and the SDK's retry middleware only retries when the server tags `x-retryable:true`, which it won't do for a mutating RPC without an idempotency key.

## Fix
Enable `retry: true` + `autoIdempotency: true` on all three `createClient` paths (`auth.ts` shared + dedicated, `index.ts` explicit). `SetReaction` etc. are in the SDK's `MUTATING_METHODS`, so `autoIdempotency` attaches an `x-idempotency-key` and `retry` then auto-retries transient unary failures the server marks retryable.

Safe + forward-compatible: streaming RPCs are never auto-retried (won't touch the subscribe streams), and with no server idempotency support today this is effectively a no-op until the server honors the key.

## Verification
`tsc --noEmit` clean (imessage) · `ultracite check` clean · 86/86 imessage tests pass.

## Notes / depends on
- The crash is only fully prevented once the server honors `x-idempotency-key` + returns `x-retryable` for transient upstream drops — tracked in **ENG-1693**. Until then, apps should `try/catch` outbound calls in their message loop (a one-off blip shouldn't kill the bot).

Part of ENG-1688. Closes ENG-1690.

https://claude.ai/code/session_01AFkXpowryHpuBtqEgMMFaC

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784877878&installation_id=127326493&pr_number=148&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F148&signature=14f677626f93193c53813a03cbb932509e0f7fb804da52df7f5b239c728a4bcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->