### PR TITLE
feat(imessage): support spaces in local mode

### DIFF
--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -470,16 +470,23 @@ export const imessage = definePlatform("iMessage", {
     schema: spaceSchema,
     params: spaceParamsSchema,
     create: async ({ input, client }) => {
-      if (isLocal(client)) {
-        throw UnsupportedError.action(
-          "space.create",
-          "iMessage (local mode)",
-          "local mode only supports replying to existing messages"
-        );
-      }
-
       if (input.users.length === 0) {
         throw new Error("iMessage space creation requires at least one user");
+      }
+
+      if (isLocal(client)) {
+        if (input.users.length > 1) {
+          throw UnsupportedError.action(
+            "space.create",
+            "iMessage (local mode)",
+            "local mode cannot create group chats — use space.get(chatGuid) for an existing group"
+          );
+        }
+        return {
+          id: dmChatGuid(input.users[0]?.id ?? ""),
+          type: "dm" as const,
+          phone: "",
+        };
       }
 
       if (client.length === 0) {
@@ -519,11 +526,11 @@ export const imessage = definePlatform("iMessage", {
     },
     get: async ({ input, client }) => {
       if (isLocal(client)) {
-        throw UnsupportedError.action(
-          "space.get",
-          "iMessage (local mode)",
-          "local mode only supports replying to existing messages"
-        );
+        return {
+          id: input.id,
+          type: chatTypeFromGuid(input.id),
+          phone: "",
+        };
       }
 
       if (client.length === 0) {

--- a/packages/imessage/test/space.test.ts
+++ b/packages/imessage/test/space.test.ts
@@ -7,7 +7,7 @@ import { SHARED_PHONE } from "@/types";
 
 const SHARED_GROUP_ERROR = /shared mode cannot create group chats/;
 const MULTI_CLIENT_ERROR = /params\.phone.*\+15550100, \+15550111/;
-const LOCAL_MODE_ERROR = /local mode/;
+const LOCAL_GROUP_ERROR = /local mode cannot create group chats/;
 
 const def = imessage.config({}).__definition;
 
@@ -43,6 +43,32 @@ const clients = (
   entries.map(([phone, onCreate]) => ({ phone, client: fakeRemote(onCreate) }));
 
 describe("imessage space.create", () => {
+  it("local mode: builds a deterministic DM guid without a remote API", async () => {
+    const localClient = Object.create(IMessageSDK.prototype) as IMessageSDK;
+    await expect(
+      def.space.create({
+        ...ctx,
+        client: localClient,
+        input: { users: [{ id: "+15550123" }] },
+      })
+    ).resolves.toEqual({
+      id: "any;-;+15550123",
+      type: "dm",
+      phone: "",
+    });
+  });
+
+  it("local mode: cannot create group chats from addresses", async () => {
+    const localClient = Object.create(IMessageSDK.prototype) as IMessageSDK;
+    await expect(
+      def.space.create({
+        ...ctx,
+        client: localClient,
+        input: { users: [{ id: "a@x.com" }, { id: "b@x.com" }] },
+      })
+    ).rejects.toThrow(LOCAL_GROUP_ERROR);
+  });
+
   it("shared mode: builds the deterministic DM guid without an API call", async () => {
     const client = clients([[SHARED_PHONE]]);
     await expect(
@@ -173,10 +199,33 @@ describe("imessage space.get", () => {
     ).rejects.toThrow(MULTI_CLIENT_ERROR);
   });
 
-  it("is unsupported in local mode", async () => {
+  it("local mode: constructs the space offline, deriving dm type from the guid shape", async () => {
     const localClient = Object.create(IMessageSDK.prototype) as IMessageSDK;
     await expect(
-      def.space.get?.({ ...ctx, client: localClient, input: { id: "any;-;x" } })
-    ).rejects.toThrow(LOCAL_MODE_ERROR);
+      def.space.get?.({
+        ...ctx,
+        client: localClient,
+        input: { id: "any;-;+15550123" },
+      })
+    ).resolves.toEqual({
+      id: "any;-;+15550123",
+      type: "dm",
+      phone: "",
+    });
+  });
+
+  it("local mode: derives group type from the `;+;` guid separator", async () => {
+    const localClient = Object.create(IMessageSDK.prototype) as IMessageSDK;
+    await expect(
+      def.space.get?.({
+        ...ctx,
+        client: localClient,
+        input: { id: "iMessage;+;chat42" },
+      })
+    ).resolves.toEqual({
+      id: "iMessage;+;chat42",
+      type: "group",
+      phone: "",
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Allow iMessage local mode to create deterministic DM spaces for single-recipient sends
- Allow iMessage local mode to hydrate spaces offline from known chat ids via `space.get(id)`
- Keep local group creation from multiple addresses unsupported, with a clearer error directing callers to `space.get(chatGuid)`
- Add local-mode coverage to the existing iMessage space tests

Closes #146.

## Test plan

- [x] `bun run fix` — 236 files checked, no fixes applied
- [x] `bun run typecheck` — 8/8 Turbo tasks passed
- [x] `bun run test` — 15/15 Turbo tasks passed
- [x] `bun run build` — 7/7 Turbo tasks passed, including Node smoke imports
