### PR TITLE
refactor: extract framework webhook adapters into standalone packages (ENG-1683)

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -20,9 +20,6 @@
         "packages/core/src/fusor/index.ts",
         "packages/spectrum-ts/src/index.ts",
         "packages/spectrum-ts/src/authoring.ts",
-        "packages/spectrum-ts/src/elysia.ts",
-        "packages/spectrum-ts/src/express.ts",
-        "packages/spectrum-ts/src/hono.ts",
         "packages/spectrum-ts/src/providers/**"
       ],
       "linter": {

--- a/bun.lock
+++ b/bun.lock
@@ -35,29 +35,68 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
-        "@types/express": "^5",
         "@types/mime-types": "^3.0.1",
         "@types/vcf": "^2.0.7",
-        "elysia": "^1",
-        "express": "^5",
-        "hono": "^4",
         "hotscript": "^1.0.13",
         "tsdown": "^0.22.2",
         "unicode-emoji-json": "^0.9.0",
       },
       "peerDependencies": {
-        "elysia": "^1",
-        "express": "^4 || ^5",
         "ffmpeg-static": "^5",
-        "hono": "^4",
         "typescript": "^5 || ^6.0.0",
       },
       "optionalPeers": [
-        "elysia",
-        "express",
         "ffmpeg-static",
-        "hono",
       ],
+    },
+    "packages/elysia": {
+      "name": "@spectrum-ts/elysia",
+      "version": "6.1.1",
+      "devDependencies": {
+        "@spectrum-ts/core": "workspace:*",
+        "@spectrum-ts/test-support": "workspace:*",
+        "@types/bun": "latest",
+        "elysia": "^1",
+        "tsdown": "^0.22.2",
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^6.0.0",
+        "elysia": "^1",
+        "typescript": "^5 || ^6.0.0",
+      },
+    },
+    "packages/express": {
+      "name": "@spectrum-ts/express",
+      "version": "6.1.1",
+      "devDependencies": {
+        "@spectrum-ts/core": "workspace:*",
+        "@spectrum-ts/test-support": "workspace:*",
+        "@types/bun": "latest",
+        "@types/express": "^5",
+        "express": "^5",
+        "tsdown": "^0.22.2",
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^6.0.0",
+        "express": "^4 || ^5",
+        "typescript": "^5 || ^6.0.0",
+      },
+    },
+    "packages/hono": {
+      "name": "@spectrum-ts/hono",
+      "version": "6.1.1",
+      "devDependencies": {
+        "@spectrum-ts/core": "workspace:*",
+        "@spectrum-ts/test-support": "workspace:*",
+        "@types/bun": "latest",
+        "hono": "^4",
+        "tsdown": "^0.22.2",
+      },
+      "peerDependencies": {
+        "@spectrum-ts/core": "^6.0.0",
+        "hono": "^4",
+        "typescript": "^5 || ^6.0.0",
+      },
     },
     "packages/imessage": {
       "name": "@spectrum-ts/imessage",
@@ -102,12 +141,15 @@
       "name": "spectrum-ts",
       "version": "6.1.1",
       "dependencies": {
-        "@spectrum-ts/core": "5.0.0",
-        "@spectrum-ts/imessage": "5.0.0",
-        "@spectrum-ts/slack": "5.0.0",
-        "@spectrum-ts/telegram": "5.0.0",
-        "@spectrum-ts/terminal": "5.0.0",
-        "@spectrum-ts/whatsapp-business": "5.0.0",
+        "@spectrum-ts/core": "6.1.1",
+        "@spectrum-ts/elysia": "6.1.1",
+        "@spectrum-ts/express": "6.1.1",
+        "@spectrum-ts/hono": "6.1.1",
+        "@spectrum-ts/imessage": "6.1.1",
+        "@spectrum-ts/slack": "6.1.1",
+        "@spectrum-ts/telegram": "6.1.1",
+        "@spectrum-ts/terminal": "6.1.1",
+        "@spectrum-ts/whatsapp-business": "6.1.1",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -416,7 +458,13 @@
 
     "@spectrum-ts/core": ["@spectrum-ts/core@workspace:packages/core"],
 
+    "@spectrum-ts/elysia": ["@spectrum-ts/elysia@workspace:packages/elysia"],
+
     "@spectrum-ts/example-basic": ["@spectrum-ts/example-basic@workspace:examples/basic"],
+
+    "@spectrum-ts/express": ["@spectrum-ts/express@workspace:packages/express"],
+
+    "@spectrum-ts/hono": ["@spectrum-ts/hono@workspace:packages/hono"],
 
     "@spectrum-ts/imessage": ["@spectrum-ts/imessage@workspace:packages/imessage"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -142,9 +142,6 @@
       "version": "6.1.1",
       "dependencies": {
         "@spectrum-ts/core": "6.1.1",
-        "@spectrum-ts/elysia": "6.1.1",
-        "@spectrum-ts/express": "6.1.1",
-        "@spectrum-ts/hono": "6.1.1",
         "@spectrum-ts/imessage": "6.1.1",
         "@spectrum-ts/slack": "6.1.1",
         "@spectrum-ts/telegram": "6.1.1",

--- a/docs/elysia.md
+++ b/docs/elysia.md
@@ -1,6 +1,6 @@
 # ElysiaJS plugin
 
-`spectrum-ts/elysia` is a first-party [ElysiaJS](https://elysiajs.com) plugin that
+`@spectrum-ts/elysia` is a first-party [ElysiaJS](https://elysiajs.com) plugin that
 mounts a Spectrum webhook endpoint in a single `.use()`. It wraps
 [`app.webhook()`](./fusor.md#webhook-mode--appwebhook), so it handles **both**
 webhook formats — the [native Spectrum webhook](./native-webhook.md) (HMAC-signed
@@ -25,10 +25,12 @@ leaves the body untouched, then forwards the raw `Request` straight to
 ## Install
 
 ```bash
-bun add elysia spectrum-ts
+bun add spectrum-ts @spectrum-ts/elysia elysia
 ```
 
-`elysia` is an optional peer dependency — you only need it if you use this subpath.
+`spectrum-ts` provides `Spectrum` (and your providers); `@spectrum-ts/elysia` is the
+plugin; `elysia` is its required peer dependency. (Using `@spectrum-ts/core`
+directly instead of the metapackage? Swap it in for `spectrum-ts`.)
 
 ## Usage
 
@@ -36,7 +38,7 @@ bun add elysia spectrum-ts
 import { Elysia } from "elysia";
 import { Spectrum } from "spectrum-ts";
 import { imessage } from "spectrum-ts/providers/imessage";
-import { spectrum } from "spectrum-ts/elysia";
+import { spectrum } from "@spectrum-ts/elysia";
 
 const app = await Spectrum({
   projectId: process.env.PROJECT_ID,
@@ -73,5 +75,5 @@ semantics — is exactly [what `app.webhook()` does](./native-webhook.md#what-th
 
 ## Reference
 
-- Plugin source — `src/elysia.ts`
-- `app.webhook(request, handler)` — `src/spectrum.ts`
+- Plugin source — `@spectrum-ts/elysia` (`packages/elysia/src/index.ts`)
+- `app.webhook(request, handler)` — `@spectrum-ts/core` (`packages/core/src/spectrum.ts`)

--- a/docs/express.md
+++ b/docs/express.md
@@ -1,6 +1,6 @@
 # Express plugin
 
-`spectrum-ts/express` is a first-party [Express](https://expressjs.com) plugin
+`@spectrum-ts/express` is a first-party [Express](https://expressjs.com) plugin
 that mounts a Spectrum webhook endpoint in a single `.use()`. It wraps
 [`app.webhook()`](./fusor.md#webhook-mode--appwebhook), so it handles **both**
 webhook formats — the [native Spectrum webhook](./native-webhook.md) (HMAC-signed
@@ -42,10 +42,12 @@ response writing — behind one `app.use()`.
 ## Install
 
 ```bash
-bun add express spectrum-ts
+bun add spectrum-ts @spectrum-ts/express express
 ```
 
-`express` is an optional peer dependency — you only need it if you use this subpath.
+`spectrum-ts` provides `Spectrum` (and your providers); `@spectrum-ts/express` is
+the plugin; `express` is its required peer dependency. (Using `@spectrum-ts/core`
+directly instead of the metapackage? Swap it in for `spectrum-ts`.)
 
 ## Usage
 
@@ -53,7 +55,7 @@ bun add express spectrum-ts
 import express from "express";
 import { Spectrum } from "spectrum-ts";
 import { imessage } from "spectrum-ts/providers/imessage";
-import { spectrum } from "spectrum-ts/express";
+import { spectrum } from "@spectrum-ts/express";
 
 const app = await Spectrum({
   projectId: process.env.PROJECT_ID,
@@ -99,5 +101,5 @@ semantics — is exactly [what `app.webhook()` does](./native-webhook.md#what-th
 
 ## Reference
 
-- Plugin source — `src/express.ts`
-- `app.webhook(request, handler)` — `src/spectrum.ts`
+- Plugin source — `@spectrum-ts/express` (`packages/express/src/index.ts`)
+- `app.webhook(request, handler)` — `@spectrum-ts/core` (`packages/core/src/spectrum.ts`)

--- a/docs/fusor.md
+++ b/docs/fusor.md
@@ -178,7 +178,7 @@ The reply Hono sends is the platform ack, produced by the pipeline — not
 whatever your handler does. `space.send(...)` posts a *new* message back to the
 platform out-of-band; it is not the HTTP response.
 
-> 🔌 Prefer the first-party **[`spectrum-ts/hono`](./hono.md)** plugin to mount
+> 🔌 Prefer the first-party **[`@spectrum-ts/hono`](./hono.md)** plugin to mount
 > this endpoint in one `app.route(...)`.
 
 **Bun.serve / Next.js App Router / Cloudflare Workers** — native `Request` →
@@ -211,14 +211,14 @@ app.post(
 );
 ```
 
-> 🔌 Prefer the first-party **[`spectrum-ts/express`](./express.md)** plugin — it
+> 🔌 Prefer the first-party **[`@spectrum-ts/express`](./express.md)** plugin — it
 > bundles `express.raw` and the response writing behind one `app.use(...)`.
 
 **ElysiaJS** — use the first-party plugin (it handles the raw-body parsing for
 you); see **[ElysiaJS plugin](./elysia.md)**:
 
 ```typescript
-import { spectrum } from "spectrum-ts/elysia";
+import { spectrum } from "@spectrum-ts/elysia";
 
 new Elysia().use(
   spectrum({

--- a/docs/hono.md
+++ b/docs/hono.md
@@ -1,6 +1,6 @@
 # Hono plugin
 
-`spectrum-ts/hono` is a first-party [Hono](https://hono.dev) plugin that mounts a
+`@spectrum-ts/hono` is a first-party [Hono](https://hono.dev) plugin that mounts a
 Spectrum webhook endpoint in a single `.route()`. It wraps
 [`app.webhook()`](./fusor.md#webhook-mode--appwebhook), so it handles **both**
 webhook formats — the [native Spectrum webhook](./native-webhook.md) (HMAC-signed
@@ -32,10 +32,12 @@ returns a mountable Hono sub-app, so you compose it with `app.route(...)`.
 ## Install
 
 ```bash
-bun add hono spectrum-ts
+bun add spectrum-ts @spectrum-ts/hono hono
 ```
 
-`hono` is an optional peer dependency — you only need it if you use this subpath.
+`spectrum-ts` provides `Spectrum` (and your providers); `@spectrum-ts/hono` is the
+plugin; `hono` is its required peer dependency. (Using `@spectrum-ts/core` directly
+instead of the metapackage? Swap it in for `spectrum-ts`.)
 
 ## Usage
 
@@ -43,7 +45,7 @@ bun add hono spectrum-ts
 import { Hono } from "hono";
 import { Spectrum } from "spectrum-ts";
 import { imessage } from "spectrum-ts/providers/imessage";
-import { spectrum } from "spectrum-ts/hono";
+import { spectrum } from "@spectrum-ts/hono";
 
 const app = await Spectrum({
   projectId: process.env.PROJECT_ID,
@@ -81,5 +83,5 @@ semantics — is exactly [what `app.webhook()` does](./native-webhook.md#what-th
 
 ## Reference
 
-- Plugin source — `src/hono.ts`
-- `app.webhook(request, handler)` — `src/spectrum.ts`
+- Plugin source — `@spectrum-ts/hono` (`packages/hono/src/index.ts`)
+- `app.webhook(request, handler)` — `@spectrum-ts/core` (`packages/core/src/spectrum.ts`)

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -1,0 +1,197 @@
+# The provider manifest (`generate-manifest.ts`)
+
+`scripts/generate-manifest.ts` (in the `spectrum-ts` package) emits
+**`dist/manifest.json`** — a small, public description of every provider package
+in the workspace. External tooling reads it so that **adding a provider package is
+all you need to do**: downstream scaffolders like `create-spectrum-app` pick the
+new provider up automatically, with no second list to keep in sync.
+
+The generator's job is half code-gen, half guardrail. It derives each entry from
+the provider's hand-written `package.json#spectrum` metadata, then **validates that
+metadata against the provider's own source** so the published surface can't quietly
+drift away from what the code actually exports.
+
+## The artifact
+
+Each entry is a `ManifestEntry`, sorted by `key`:
+
+```json
+[
+  {
+    "key": "imessage",
+    "import": "imessage",
+    "path": "@spectrum-ts/imessage",
+    "label": "iMessage"
+  },
+  {
+    "key": "telegram",
+    "import": "telegram",
+    "path": "@spectrum-ts/telegram",
+    "label": "telegram"
+  }
+]
+```
+
+| Field | Source | Meaning |
+|---|---|---|
+| `key` | `package.json#spectrum.key` | Short, stable routing slug for the provider (lowercase). |
+| `import` | `package.json#spectrum.import` | The named export consumers `import { … }` — must equal the `export const` name in `src/index.ts`. |
+| `path` | the package's `name` field | The npm package a consumer adds to their dependencies and imports from. |
+| `label` | `package.json#spectrum.label` | The platform name passed to `definePlatform(<label>, …)` — the platform identifier. |
+
+> `key` and `label` are independent. For fusor providers they coincide (Telegram:
+> `key` and `label` are both `"telegram"`, because the `definePlatform` name doubles
+> as the routing key — see the [platform identifier invariant](./fusor.md)). For
+> others they differ (iMessage: `key` `"imessage"`, `label` `"iMessage"`).
+
+## When it runs
+
+It's the last step of the `spectrum-ts` package's `build`:
+
+```jsonc
+// packages/spectrum-ts/package.json
+"build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js && bun scripts/generate-manifest.ts"
+```
+
+You can also run it on its own:
+
+```bash
+cd packages/spectrum-ts
+bun run generate:manifest   # → bun scripts/generate-manifest.ts
+```
+
+It performs **pure source reads** — it never touches any provider's build output,
+only their `package.json` and `src/*.ts`. That's deliberate: it has no dependency
+on provider `dist/`, so it can run early in the task graph without waiting on other
+packages to build. `dist/manifest.json` is a build artifact (gitignored) and is
+regenerated on every build.
+
+## How it builds the manifest
+
+`buildManifest()` walks every **sibling** directory of the `spectrum-ts` package
+(i.e. all of `packages/*`) and decides, per directory, whether it's a provider:
+
+1. **Read `package.json`.** No file, or unparseable → skip silently (not every
+   directory is a package).
+2. **Filter.** Skip unless the package has a `spectrum` field, is **not** `private`,
+   and has a `name`. (This is why `@spectrum-ts/core`, the `spectrum-ts`
+   meta-package, and the private `test-support` package are all absent — none carry
+   a `spectrum` field.)
+3. **Require complete metadata.** A `spectrum` field present but missing any of
+   `key` / `import` / `label` is a hard error, not a skip.
+4. **Validate against source** (see below).
+5. **Emit** `{ key, import, path: pkg.name, label }`.
+
+Finally it **sorts by `key`** (`localeCompare`) so the file diff is stable across
+machines and filesystem orderings, ensures `dist/` exists (`mkdir … { recursive:
+true }` — a no-op when tsup already made it), and writes pretty-printed JSON with a
+trailing newline. If **no** provider packages were found at all, it throws rather
+than writing an empty manifest.
+
+## The guardrail: validating against source
+
+This is the part that keeps the hand-written `spectrum` metadata honest.
+`validateAgainstSource()` reads the provider's `src/index.ts` and matches it against:
+
+```
+export const <import> = definePlatform(<label>, …)
+```
+
+via this regex (anchored per-line, so the export must be top-level):
+
+```ts
+/^export\s+const\s+(\w+)\s*=\s*definePlatform\(\s*(?:"([^"]+)"|(\w+))/m
+```
+
+It then cross-checks two things, throwing a precise error on any mismatch:
+
+- **`import` ↔ exported name.** The `export const <name>` must equal
+  `spectrum.import`.
+- **`label` ↔ `definePlatform` name.** The first argument to `definePlatform` must
+  equal `spectrum.label`.
+
+The `definePlatform` name argument comes in **two shapes**, and the regex captures
+both:
+
+| Shape | Example | How `label` is resolved |
+|---|---|---|
+| String literal | `export const imessage = definePlatform("iMessage", { … })` | Taken inline from the matched `"…"`. |
+| Shared const | `export const telegram = definePlatform(TELEGRAM_PLATFORM, { … })` | The matched identifier is resolved by `resolvePlatformLabel()`. |
+
+Fusor providers use the shared-const shape on purpose: the platform name is the
+single source of truth for the routing key, so it lives in one exported const
+(`export const TELEGRAM_PLATFORM = "telegram"` in `src/config.ts`) that
+`definePlatform`, `fusor()`, and event routing all reference. When the generator
+sees an identifier instead of a literal, `resolvePlatformLabel()` scans the
+provider's `src/*.ts` files for a matching `const <name> = "…"` (double-quoted) and
+uses that string. If the const can't be found, it throws.
+
+### The three places that must agree
+
+For a provider to make it into the manifest, these must line up — the generator
+fails the build otherwise. For Telegram (the shared-const shape):
+
+```ts
+// package.json#spectrum
+{ "import": "telegram", "label": "telegram" }
+//             │              │
+//             │              └──────────────┐  must equal definePlatform's name…
+//             └──────────────┐              │
+// src/index.ts               ▼              ▼
+export const telegram = definePlatform(TELEGRAM_PLATFORM, { … });
+//           └─ must equal `import`         │  …resolved from:
+// src/config.ts                            ▼
+export const TELEGRAM_PLATFORM = "telegram";
+```
+
+## Failure modes
+
+Every error names the offending package so the build log points straight at the fix.
+
+| Thrown when | Message (abbreviated) |
+|---|---|
+| `spectrum` field is missing `key`, `import`, or `label` | `…#spectrum must define key, import, and label.` |
+| `src/index.ts` has no matching `export const … = definePlatform(…)` | `…does not match the expected … pattern. If you intentionally renamed the call, update generate-manifest.ts.` |
+| Exported name ≠ `spectrum.import` | `…spectrum.import is "X" but src/index.ts exports \`Y\`.` |
+| Shared-const label can't be found in `src/*.ts` | `Provider source references platform-name constant "X" but no \`const X = "…"\` was found…` |
+| Resolved label ≠ `spectrum.label` | `…spectrum.label is "X" but definePlatform uses "Y".` |
+| No provider packages found at all | `No provider packages with a package.json#spectrum field found under …` |
+
+## Adding a provider
+
+Because the manifest is derived, you don't edit it. To have a new provider appear
+in `manifest.json` (and thus in downstream scaffolders):
+
+1. Give the package a **public** `package.json` (no `"private": true`) with a `name`.
+2. Add a `spectrum` field:
+
+   ```jsonc
+   "spectrum": {
+     "key": "myplatform",
+     "import": "myplatform",
+     "label": "MyPlatform"
+   }
+   ```
+
+3. Export the platform from `src/index.ts` so it matches the contract:
+
+   ```ts
+   export const myplatform = definePlatform("MyPlatform", { /* … */ });
+   ```
+
+   (or use a shared `const MYPLATFORM_PLATFORM = "MyPlatform"` for the fusor shape.)
+
+The next build picks it up. If anything is inconsistent, the build **fails loudly**
+with one of the messages above rather than shipping a wrong manifest.
+
+> If you intentionally change the `definePlatform` call shape (e.g. wrap it, or
+> rename it), the validating regex in `generate-manifest.ts` must be updated to
+> match — the error message for that case says so explicitly.
+
+## Reference
+
+- Generator — `packages/spectrum-ts/scripts/generate-manifest.ts`
+- Output — `packages/spectrum-ts/dist/manifest.json` (gitignored build artifact)
+- Build wiring — `packages/spectrum-ts/package.json` (`build`, `generate:manifest`)
+- `definePlatform(name, def)` — `packages/core/src/platform/define.ts`
+- Provider metadata — each provider's `package.json#spectrum` + `src/index.ts`

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -93,7 +93,7 @@ than writing an empty manifest.
 This is the part that keeps the hand-written `spectrum` metadata honest.
 `validateAgainstSource()` reads the provider's `src/index.ts` and matches it against:
 
-```
+```text
 export const <import> = definePlatform(<label>, …)
 ```
 

--- a/docs/native-webhook.md
+++ b/docs/native-webhook.md
@@ -79,9 +79,9 @@ app.post(
 > `express.raw(...)` — never `req.json()`.
 
 > 🔌 **First-party plugins** mount the endpoint for you in one call, with the
-> raw-body handling already correct: **[`spectrum-ts/hono`](./hono.md)**,
-> **[`spectrum-ts/express`](./express.md)**, and
-> **[`spectrum-ts/elysia`](./elysia.md)** (Elysia auto-parses JSON bodies, so the
+> raw-body handling already correct: **[`@spectrum-ts/hono`](./hono.md)**,
+> **[`@spectrum-ts/express`](./express.md)**, and
+> **[`@spectrum-ts/elysia`](./elysia.md)** (Elysia auto-parses JSON bodies, so the
 > plugin disables parsing on its route and forwards the raw request).
 
 ## What the SDK does for you

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,21 +28,6 @@
       "bun": "./src/authoring.ts",
       "types": "./src/authoring.ts",
       "default": "./dist/authoring.js"
-    },
-    "./elysia": {
-      "bun": "./src/elysia.ts",
-      "types": "./src/elysia.ts",
-      "default": "./dist/elysia.js"
-    },
-    "./express": {
-      "bun": "./src/express.ts",
-      "types": "./src/express.ts",
-      "default": "./dist/express.js"
-    },
-    "./hono": {
-      "bun": "./src/hono.ts",
-      "types": "./src/hono.ts",
-      "default": "./dist/hono.js"
     }
   },
   "publishConfig": {
@@ -55,18 +40,6 @@
       "./authoring": {
         "types": "./dist/authoring.d.ts",
         "default": "./dist/authoring.js"
-      },
-      "./elysia": {
-        "types": "./dist/elysia.d.ts",
-        "default": "./dist/elysia.js"
-      },
-      "./express": {
-        "types": "./dist/express.d.ts",
-        "default": "./dist/express.js"
-      },
-      "./hono": {
-        "types": "./dist/hono.d.ts",
-        "default": "./dist/hono.js"
       }
     }
   },
@@ -91,34 +64,18 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "@types/express": "^5",
     "@types/mime-types": "^3.0.1",
     "@types/vcf": "^2.0.7",
-    "elysia": "^1",
-    "express": "^5",
-    "hono": "^4",
     "hotscript": "^1.0.13",
     "tsdown": "^0.22.2",
     "unicode-emoji-json": "^0.9.0"
   },
   "peerDependencies": {
-    "elysia": "^1",
-    "express": "^4 || ^5",
     "ffmpeg-static": "^5",
-    "hono": "^4",
     "typescript": "^5 || ^6.0.0"
   },
   "peerDependenciesMeta": {
-    "elysia": {
-      "optional": true
-    },
-    "express": {
-      "optional": true
-    },
     "ffmpeg-static": {
-      "optional": true
-    },
-    "hono": {
       "optional": true
     }
   },

--- a/packages/elysia/README.md
+++ b/packages/elysia/README.md
@@ -1,0 +1,39 @@
+# @spectrum-ts/elysia
+
+[ElysiaJS](https://elysiajs.com) webhook adapter for [spectrum-ts](https://github.com/photon-hq/spectrum-ts).
+
+## Install
+
+```sh
+bun add spectrum-ts @spectrum-ts/elysia elysia
+```
+
+## Use
+
+```ts
+import { Spectrum } from "spectrum-ts";
+import { spectrum } from "@spectrum-ts/elysia";
+import { Elysia } from "elysia";
+
+const app = await Spectrum({
+  webhookSecret: process.env.SPECTRUM_WEBHOOK_SECRET,
+});
+
+new Elysia()
+  .use(
+    spectrum({
+      app,
+      onMessage: async (space, message) => {
+        if (message.content.type === "text") {
+          await space.send(`echo: ${message.content.text}`);
+        }
+      },
+    })
+  )
+  .listen(3000);
+```
+
+> Using the batteries-included `spectrum-ts` metapackage? Import from
+> `spectrum-ts/elysia` instead — it re-exports this package.
+
+See the [spectrum-ts documentation](https://photon.codes/spectrum) for the full guide.

--- a/packages/elysia/README.md
+++ b/packages/elysia/README.md
@@ -33,7 +33,4 @@ new Elysia()
   .listen(3000);
 ```
 
-> Using the batteries-included `spectrum-ts` metapackage? Import from
-> `spectrum-ts/elysia` instead — it re-exports this package.
-
 See the [spectrum-ts documentation](https://photon.codes/spectrum) for the full guide.

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@spectrum-ts/elysia",
+  "version": "6.1.1",
+  "description": "ElysiaJS webhook adapter for spectrum-ts.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/photon-hq/spectrum-ts.git",
+    "directory": "packages/elysia"
+  },
+  "homepage": "https://photon.codes/spectrum",
+  "bugs": {
+    "url": "https://github.com/photon-hq/spectrum-ts/issues"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js",
+    "dev": "tsdown --watch",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@spectrum-ts/core": "^6.0.0",
+    "elysia": "^1",
+    "typescript": "^5 || ^6.0.0"
+  },
+  "devDependencies": {
+    "@spectrum-ts/core": "workspace:*",
+    "@spectrum-ts/test-support": "workspace:*",
+    "@types/bun": "latest",
+    "elysia": "^1",
+    "tsdown": "^0.22.2"
+  },
+  "license": "MIT"
+}

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -51,7 +51,7 @@ export interface SpectrumPluginOptions {
  * ```ts
  * import { Elysia } from "elysia";
  * import { Spectrum } from "spectrum-ts";
- * import { spectrum } from "spectrum-ts/elysia";
+ * import { spectrum } from "@spectrum-ts/elysia";
  *
  * const app = await Spectrum({ ...,  webhookSecret: process.env.SPECTRUM_WEBHOOK_SECRET });
  *

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -14,8 +14,8 @@
 // `app.webhook()`'s behavior (native + fusor detection, signature verification,
 // fire-and-forget dispatch) for free.
 
+import type { WebhookHandler } from "@spectrum-ts/core";
 import { Elysia } from "elysia";
-import type { WebhookHandler } from "./fusor";
 
 /**
  * The minimal structural surface of a Spectrum instance the plugin needs. Kept
@@ -77,6 +77,4 @@ export function spectrum(options: SpectrumPluginOptions) {
   );
 }
 
-export type { WebhookHandler } from "./fusor";
-export type { Message } from "./types/message";
-export type { Space } from "./types/space";
+export type { Message, Space, WebhookHandler } from "@spectrum-ts/core";

--- a/packages/elysia/test/elysia.test.ts
+++ b/packages/elysia/test/elysia.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { type Message, Spectrum } from "@spectrum-ts/core";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
   baseConfig,
@@ -11,10 +12,8 @@ import {
   signSpectrum,
   textEnvelope,
 } from "@spectrum-ts/test-support/webhook";
-import { Hono } from "hono";
-import { spectrum } from "@/hono";
-import { Spectrum } from "@/spectrum";
-import type { Message } from "@/types/message";
+import { Elysia } from "elysia";
+import { spectrum } from "@/index";
 
 stubCloud();
 
@@ -39,16 +38,15 @@ const post = (signed: SignedSpectrumWebhook, url = DEFAULT_URL) =>
     body: signed.body,
   });
 
-describe("spectrum (hono plugin)", () => {
-  it("verifies and delivers a signed webhook (raw body survives Hono)", async () => {
+describe("spectrum (elysia plugin)", () => {
+  it("verifies and delivers a signed webhook (raw body survives Elysia parsing)", async () => {
     const app = await makeApp();
     try {
       const received: Message[] = [];
       const { promise: finished, resolve: done } =
         Promise.withResolvers<void>();
 
-      const hono = new Hono().route(
-        "/",
+      const elysia = new Elysia().use(
         spectrum({
           app,
           onMessage: (_space, message) => {
@@ -59,11 +57,11 @@ describe("spectrum (hono plugin)", () => {
       );
 
       const signed = signSpectrum(textEnvelope(PLATFORM, "hello there"));
-      const response = await hono.request(post(signed));
+      const response = await elysia.handle(post(signed));
       await finished;
 
       // A valid signature only verifies if the exact wire bytes reached the SDK
-      // — so a 200 here proves Hono never consumed or re-encoded the body.
+      // — so a 200 here proves Elysia never consumed or re-encoded the body.
       expect(response.status).toBe(200);
       expect(received).toHaveLength(1);
       expect(received[0]?.content).toEqual({
@@ -79,8 +77,7 @@ describe("spectrum (hono plugin)", () => {
     const app = await makeApp();
     try {
       let called = false;
-      const hono = new Hono().route(
-        "/",
+      const elysia = new Elysia().use(
         spectrum({
           app,
           onMessage: () => {
@@ -92,7 +89,7 @@ describe("spectrum (hono plugin)", () => {
       const signed = signSpectrum(textEnvelope(PLATFORM, "hi"), {
         secret: "the-wrong-secret",
       });
-      const response = await hono.request(post(signed));
+      const response = await elysia.handle(post(signed));
       await flush();
 
       expect(response.status).toBe(401);
@@ -107,8 +104,7 @@ describe("spectrum (hono plugin)", () => {
     try {
       const { promise: finished, resolve: done } =
         Promise.withResolvers<void>();
-      const hono = new Hono().route(
-        "/",
+      const elysia = new Elysia().use(
         spectrum({
           app,
           path: "/hooks/spectrum",
@@ -117,7 +113,7 @@ describe("spectrum (hono plugin)", () => {
       );
 
       const signed = signSpectrum(textEnvelope(PLATFORM, "custom path"));
-      const response = await hono.request(
+      const response = await elysia.handle(
         post(signed, "https://example.com/hooks/spectrum")
       );
       await finished;

--- a/packages/elysia/tsconfig.json
+++ b/packages/elysia/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "test"],
+  "compilerOptions": {
+    "strictNullChecks": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/packages/elysia/tsdown.config.ts
+++ b/packages/elysia/tsdown.config.ts
@@ -1,14 +1,10 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: {
-    index: "src/index.ts",
-    authoring: "src/authoring.ts",
-  },
+  entry: { index: "src/index.ts" },
   format: "esm",
   fixedExtension: false,
   dts: true,
   clean: true,
   platform: "node",
-  external: ["ffmpeg-static"],
 });

--- a/packages/elysia/turbo.json
+++ b/packages/elysia/turbo.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tags": ["adapter"]
+}

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -1,0 +1,40 @@
+# @spectrum-ts/express
+
+[Express](https://expressjs.com) webhook adapter for [spectrum-ts](https://github.com/photon-hq/spectrum-ts).
+
+## Install
+
+```sh
+bun add spectrum-ts @spectrum-ts/express express
+```
+
+## Use
+
+```ts
+import { Spectrum } from "spectrum-ts";
+import { spectrum } from "@spectrum-ts/express";
+import express from "express";
+
+const app = await Spectrum({
+  webhookSecret: process.env.SPECTRUM_WEBHOOK_SECRET,
+});
+
+const server = express();
+// Mount before any global express.json() — the plugin needs the raw body.
+server.use(
+  spectrum({
+    app,
+    onMessage: async (space, message) => {
+      if (message.content.type === "text") {
+        await space.send(`echo: ${message.content.text}`);
+      }
+    },
+  })
+);
+server.listen(3000);
+```
+
+> Using the batteries-included `spectrum-ts` metapackage? Import from
+> `spectrum-ts/express` instead — it re-exports this package.
+
+See the [spectrum-ts documentation](https://photon.codes/spectrum) for the full guide.

--- a/packages/express/README.md
+++ b/packages/express/README.md
@@ -34,7 +34,4 @@ server.use(
 server.listen(3000);
 ```
 
-> Using the batteries-included `spectrum-ts` metapackage? Import from
-> `spectrum-ts/express` instead — it re-exports this package.
-
 See the [spectrum-ts documentation](https://photon.codes/spectrum) for the full guide.

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@spectrum-ts/express",
+  "version": "6.1.1",
+  "description": "Express webhook adapter for spectrum-ts.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/photon-hq/spectrum-ts.git",
+    "directory": "packages/express"
+  },
+  "homepage": "https://photon.codes/spectrum",
+  "bugs": {
+    "url": "https://github.com/photon-hq/spectrum-ts/issues"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js",
+    "dev": "tsdown --watch",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@spectrum-ts/core": "^6.0.0",
+    "express": "^4 || ^5",
+    "typescript": "^5 || ^6.0.0"
+  },
+  "devDependencies": {
+    "@spectrum-ts/core": "workspace:*",
+    "@spectrum-ts/test-support": "workspace:*",
+    "@types/bun": "latest",
+    "@types/express": "^5",
+    "express": "^5",
+    "tsdown": "^0.22.2"
+  },
+  "license": "MIT"
+}

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -66,7 +66,7 @@ export interface SpectrumPluginOptions {
  * ```ts
  * import express from "express";
  * import { Spectrum } from "spectrum-ts";
- * import { spectrum } from "spectrum-ts/express";
+ * import { spectrum } from "@spectrum-ts/express";
  *
  * const app = await Spectrum({ ...,  webhookSecret: process.env.SPECTRUM_WEBHOOK_SECRET });
  *

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -19,8 +19,8 @@
 // `app.use(spectrum(...))` — the route, the raw-body parser, and the response
 // writing are all owned by the plugin.
 
+import type { WebhookHandler } from "@spectrum-ts/core";
 import express, { type Router } from "express";
-import type { WebhookHandler } from "./fusor";
 
 /**
  * The minimal structural surface of a Spectrum instance the plugin needs. Kept
@@ -97,6 +97,4 @@ export function spectrum(options: SpectrumPluginOptions): Router {
   return router;
 }
 
-export type { WebhookHandler } from "./fusor";
-export type { Message } from "./types/message";
-export type { Space } from "./types/space";
+export type { Message, Space, WebhookHandler } from "@spectrum-ts/core";

--- a/packages/express/test/express.test.ts
+++ b/packages/express/test/express.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { AddressInfo } from "node:net";
+import { type Message, Spectrum } from "@spectrum-ts/core";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
   baseConfig,
@@ -13,9 +14,7 @@ import {
   textEnvelope,
 } from "@spectrum-ts/test-support/webhook";
 import express from "express";
-import { spectrum } from "@/express";
-import { Spectrum } from "@/spectrum";
-import type { Message } from "@/types/message";
+import { spectrum } from "@/index";
 
 stubCloud();
 

--- a/packages/express/tsconfig.json
+++ b/packages/express/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "test"],
+  "compilerOptions": {
+    "strictNullChecks": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/packages/express/tsdown.config.ts
+++ b/packages/express/tsdown.config.ts
@@ -1,14 +1,10 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: {
-    index: "src/index.ts",
-    authoring: "src/authoring.ts",
-  },
+  entry: { index: "src/index.ts" },
   format: "esm",
   fixedExtension: false,
   dts: true,
   clean: true,
   platform: "node",
-  external: ["ffmpeg-static"],
 });

--- a/packages/express/turbo.json
+++ b/packages/express/turbo.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tags": ["adapter"]
+}

--- a/packages/hono/README.md
+++ b/packages/hono/README.md
@@ -32,7 +32,4 @@ const server = new Hono().route(
 );
 ```
 
-> Using the batteries-included `spectrum-ts` metapackage? Import from
-> `spectrum-ts/hono` instead — it re-exports this package.
-
 See the [spectrum-ts documentation](https://photon.codes/spectrum) for the full guide.

--- a/packages/hono/README.md
+++ b/packages/hono/README.md
@@ -1,0 +1,38 @@
+# @spectrum-ts/hono
+
+[Hono](https://hono.dev) webhook adapter for [spectrum-ts](https://github.com/photon-hq/spectrum-ts).
+
+## Install
+
+```sh
+bun add spectrum-ts @spectrum-ts/hono hono
+```
+
+## Use
+
+```ts
+import { Spectrum } from "spectrum-ts";
+import { spectrum } from "@spectrum-ts/hono";
+import { Hono } from "hono";
+
+const app = await Spectrum({
+  webhookSecret: process.env.SPECTRUM_WEBHOOK_SECRET,
+});
+
+const server = new Hono().route(
+  "/",
+  spectrum({
+    app,
+    onMessage: async (space, message) => {
+      if (message.content.type === "text") {
+        await space.send(`echo: ${message.content.text}`);
+      }
+    },
+  })
+);
+```
+
+> Using the batteries-included `spectrum-ts` metapackage? Import from
+> `spectrum-ts/hono` instead — it re-exports this package.
+
+See the [spectrum-ts documentation](https://photon.codes/spectrum) for the full guide.

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@spectrum-ts/hono",
+  "version": "6.1.1",
+  "description": "Hono webhook adapter for spectrum-ts.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/photon-hq/spectrum-ts.git",
+    "directory": "packages/hono"
+  },
+  "homepage": "https://photon.codes/spectrum",
+  "bugs": {
+    "url": "https://github.com/photon-hq/spectrum-ts/issues"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "bun": "./src/index.ts",
+      "types": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    }
+  },
+  "scripts": {
+    "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js",
+    "dev": "tsdown --watch",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@spectrum-ts/core": "^6.0.0",
+    "hono": "^4",
+    "typescript": "^5 || ^6.0.0"
+  },
+  "devDependencies": {
+    "@spectrum-ts/core": "workspace:*",
+    "@spectrum-ts/test-support": "workspace:*",
+    "@types/bun": "latest",
+    "hono": "^4",
+    "tsdown": "^0.22.2"
+  },
+  "license": "MIT"
+}

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -52,7 +52,7 @@ export interface SpectrumPluginOptions {
  * ```ts
  * import { Hono } from "hono";
  * import { Spectrum } from "spectrum-ts";
- * import { spectrum } from "spectrum-ts/hono";
+ * import { spectrum } from "@spectrum-ts/hono";
  *
  * const app = await Spectrum({ ...,  webhookSecret: process.env.SPECTRUM_WEBHOOK_SECRET });
  *

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -15,8 +15,8 @@
 // composes it with `app.route("/", spectrum(...))` — the direct analog of
 // Elysia's `.use(spectrum(...))`.
 
+import type { WebhookHandler } from "@spectrum-ts/core";
 import { Hono } from "hono";
-import type { WebhookHandler } from "./fusor";
 
 /**
  * The minimal structural surface of a Spectrum instance the plugin needs. Kept
@@ -70,6 +70,4 @@ export function spectrum(options: SpectrumPluginOptions) {
   return new Hono().post(path, (c) => app.webhook(c.req.raw, onMessage));
 }
 
-export type { WebhookHandler } from "./fusor";
-export type { Message } from "./types/message";
-export type { Space } from "./types/space";
+export type { Message, Space, WebhookHandler } from "@spectrum-ts/core";

--- a/packages/hono/test/hono.test.ts
+++ b/packages/hono/test/hono.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { type Message, Spectrum } from "@spectrum-ts/core";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
   baseConfig,
@@ -11,10 +12,8 @@ import {
   signSpectrum,
   textEnvelope,
 } from "@spectrum-ts/test-support/webhook";
-import { Elysia } from "elysia";
-import { spectrum } from "@/elysia";
-import { Spectrum } from "@/spectrum";
-import type { Message } from "@/types/message";
+import { Hono } from "hono";
+import { spectrum } from "@/index";
 
 stubCloud();
 
@@ -39,15 +38,16 @@ const post = (signed: SignedSpectrumWebhook, url = DEFAULT_URL) =>
     body: signed.body,
   });
 
-describe("spectrum (elysia plugin)", () => {
-  it("verifies and delivers a signed webhook (raw body survives Elysia parsing)", async () => {
+describe("spectrum (hono plugin)", () => {
+  it("verifies and delivers a signed webhook (raw body survives Hono)", async () => {
     const app = await makeApp();
     try {
       const received: Message[] = [];
       const { promise: finished, resolve: done } =
         Promise.withResolvers<void>();
 
-      const elysia = new Elysia().use(
+      const hono = new Hono().route(
+        "/",
         spectrum({
           app,
           onMessage: (_space, message) => {
@@ -58,11 +58,11 @@ describe("spectrum (elysia plugin)", () => {
       );
 
       const signed = signSpectrum(textEnvelope(PLATFORM, "hello there"));
-      const response = await elysia.handle(post(signed));
+      const response = await hono.request(post(signed));
       await finished;
 
       // A valid signature only verifies if the exact wire bytes reached the SDK
-      // — so a 200 here proves Elysia never consumed or re-encoded the body.
+      // — so a 200 here proves Hono never consumed or re-encoded the body.
       expect(response.status).toBe(200);
       expect(received).toHaveLength(1);
       expect(received[0]?.content).toEqual({
@@ -78,7 +78,8 @@ describe("spectrum (elysia plugin)", () => {
     const app = await makeApp();
     try {
       let called = false;
-      const elysia = new Elysia().use(
+      const hono = new Hono().route(
+        "/",
         spectrum({
           app,
           onMessage: () => {
@@ -90,7 +91,7 @@ describe("spectrum (elysia plugin)", () => {
       const signed = signSpectrum(textEnvelope(PLATFORM, "hi"), {
         secret: "the-wrong-secret",
       });
-      const response = await elysia.handle(post(signed));
+      const response = await hono.request(post(signed));
       await flush();
 
       expect(response.status).toBe(401);
@@ -105,7 +106,8 @@ describe("spectrum (elysia plugin)", () => {
     try {
       const { promise: finished, resolve: done } =
         Promise.withResolvers<void>();
-      const elysia = new Elysia().use(
+      const hono = new Hono().route(
+        "/",
         spectrum({
           app,
           path: "/hooks/spectrum",
@@ -114,7 +116,7 @@ describe("spectrum (elysia plugin)", () => {
       );
 
       const signed = signSpectrum(textEnvelope(PLATFORM, "custom path"));
-      const response = await elysia.handle(
+      const response = await hono.request(
         post(signed, "https://example.com/hooks/spectrum")
       );
       await finished;

--- a/packages/hono/tsconfig.json
+++ b/packages/hono/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["src", "test"],
+  "compilerOptions": {
+    "strictNullChecks": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}

--- a/packages/hono/tsdown.config.ts
+++ b/packages/hono/tsdown.config.ts
@@ -1,14 +1,10 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: {
-    index: "src/index.ts",
-    authoring: "src/authoring.ts",
-  },
+  entry: { index: "src/index.ts" },
   format: "esm",
   fixedExtension: false,
   dts: true,
   clean: true,
   platform: "node",
-  external: ["ffmpeg-static"],
 });

--- a/packages/hono/turbo.json
+++ b/packages/hono/turbo.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tags": ["adapter"]
+}

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -99,6 +99,9 @@
   },
   "dependencies": {
     "@spectrum-ts/core": "6.1.1",
+    "@spectrum-ts/elysia": "6.1.1",
+    "@spectrum-ts/express": "6.1.1",
+    "@spectrum-ts/hono": "6.1.1",
     "@spectrum-ts/imessage": "6.1.1",
     "@spectrum-ts/slack": "6.1.1",
     "@spectrum-ts/telegram": "6.1.1",

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -29,21 +29,6 @@
       "types": "./src/authoring.ts",
       "default": "./dist/authoring.js"
     },
-    "./elysia": {
-      "bun": "./src/elysia.ts",
-      "types": "./src/elysia.ts",
-      "default": "./dist/elysia.js"
-    },
-    "./express": {
-      "bun": "./src/express.ts",
-      "types": "./src/express.ts",
-      "default": "./dist/express.js"
-    },
-    "./hono": {
-      "bun": "./src/hono.ts",
-      "types": "./src/hono.ts",
-      "default": "./dist/hono.js"
-    },
     "./providers": {
       "bun": "./src/providers/index.ts",
       "types": "./src/providers/index.ts",
@@ -67,18 +52,6 @@
         "types": "./dist/authoring.d.ts",
         "default": "./dist/authoring.js"
       },
-      "./elysia": {
-        "types": "./dist/elysia.d.ts",
-        "default": "./dist/elysia.js"
-      },
-      "./express": {
-        "types": "./dist/express.d.ts",
-        "default": "./dist/express.js"
-      },
-      "./hono": {
-        "types": "./dist/hono.d.ts",
-        "default": "./dist/hono.js"
-      },
       "./providers": {
         "types": "./dist/providers/index.d.ts",
         "default": "./dist/providers/index.js"
@@ -99,9 +72,6 @@
   },
   "dependencies": {
     "@spectrum-ts/core": "6.1.1",
-    "@spectrum-ts/elysia": "6.1.1",
-    "@spectrum-ts/express": "6.1.1",
-    "@spectrum-ts/hono": "6.1.1",
     "@spectrum-ts/imessage": "6.1.1",
     "@spectrum-ts/slack": "6.1.1",
     "@spectrum-ts/telegram": "6.1.1",

--- a/packages/spectrum-ts/src/elysia.ts
+++ b/packages/spectrum-ts/src/elysia.ts
@@ -1,3 +1,3 @@
-// Re-export of the runtime's ElysiaJS webhook plugin so the
+// Re-export of the standalone `@spectrum-ts/elysia` adapter so the
 // `spectrum-ts/elysia` import path works through the metapackage.
-export * from "@spectrum-ts/core/elysia";
+export * from "@spectrum-ts/elysia";

--- a/packages/spectrum-ts/src/elysia.ts
+++ b/packages/spectrum-ts/src/elysia.ts
@@ -1,3 +1,0 @@
-// Re-export of the standalone `@spectrum-ts/elysia` adapter so the
-// `spectrum-ts/elysia` import path works through the metapackage.
-export * from "@spectrum-ts/elysia";

--- a/packages/spectrum-ts/src/express.ts
+++ b/packages/spectrum-ts/src/express.ts
@@ -1,3 +1,0 @@
-// Re-export of the standalone `@spectrum-ts/express` adapter so the
-// `spectrum-ts/express` import path works through the metapackage.
-export * from "@spectrum-ts/express";

--- a/packages/spectrum-ts/src/express.ts
+++ b/packages/spectrum-ts/src/express.ts
@@ -1,3 +1,3 @@
-// Re-export of the runtime's Express webhook router so the
+// Re-export of the standalone `@spectrum-ts/express` adapter so the
 // `spectrum-ts/express` import path works through the metapackage.
-export * from "@spectrum-ts/core/express";
+export * from "@spectrum-ts/express";

--- a/packages/spectrum-ts/src/hono.ts
+++ b/packages/spectrum-ts/src/hono.ts
@@ -1,3 +1,0 @@
-// Re-export of the standalone `@spectrum-ts/hono` adapter so the
-// `spectrum-ts/hono` import path works through the metapackage.
-export * from "@spectrum-ts/hono";

--- a/packages/spectrum-ts/src/hono.ts
+++ b/packages/spectrum-ts/src/hono.ts
@@ -1,3 +1,3 @@
-// Re-export of the runtime's Hono webhook handler so the
+// Re-export of the standalone `@spectrum-ts/hono` adapter so the
 // `spectrum-ts/hono` import path works through the metapackage.
-export * from "@spectrum-ts/core/hono";
+export * from "@spectrum-ts/hono";

--- a/packages/spectrum-ts/tsdown.config.ts
+++ b/packages/spectrum-ts/tsdown.config.ts
@@ -4,9 +4,6 @@ export default defineConfig({
   entry: {
     index: "src/index.ts",
     authoring: "src/authoring.ts",
-    elysia: "src/elysia.ts",
-    express: "src/express.ts",
-    hono: "src/hono.ts",
     "providers/index": "src/providers/index.ts",
     "providers/imessage/index": "src/providers/imessage/index.ts",
     "providers/slack/index": "src/providers/slack/index.ts",


### PR DESCRIPTION
## Summary

- Extracts the Elysia, Express, and Hono webhook adapters out of `@spectrum-ts/core` into three standalone published packages: **`@spectrum-ts/elysia`**, **`@spectrum-ts/express`**, **`@spectrum-ts/hono`**.
- Removes the `spectrum-ts/{elysia,express,hono}` metapackage subpath re-exports and the matching `@spectrum-ts/core/{elysia,express,hono}` subpaths.
- Each adapter now takes `@spectrum-ts/core` as a peer dependency and imports `Message` / `Space` / `WebhookHandler` from the package root (`@spectrum-ts/core`) instead of relative `./fusor`, `./types/*` paths.
- Drops `elysia`, `express`, `hono` (and `@types/express`) from core's dev/peer deps and `peerDependenciesMeta` — **core no longer carries any web-framework dependency**.

## Why

ENG-1683 ("scope out adapters like ElysiaJS"). The adapters were optional peer-dependency subpaths bolted onto core. That coupled core's dependency surface to three web frameworks, meant every framework bump touched core, and forced consumers to pull the framework types in through core. Splitting each into its own package:

- keeps `@spectrum-ts/core` framework-agnostic;
- lets each adapter version, release, and document independently (own `README`, own focused install);
- makes the dependency explicit — you add the adapter you actually use.

## Migration (breaking for adapter consumers)

Import from the standalone package, and install it explicitly:

```diff
- import { spectrum } from "spectrum-ts/elysia";
+ import { spectrum } from "@spectrum-ts/elysia";
```

```diff
- bun add elysia spectrum-ts
+ bun add spectrum-ts @spectrum-ts/elysia elysia
```

The `@spectrum-ts/core/{elysia,express,hono}` subpaths are also gone — import the standalone package instead. `elysia` / `express` / `hono` are now **required** peers of their adapter package (previously optional peers of core). The docs (`docs/{elysia,express,hono,fusor,native-webhook}.md`) are updated to the new paths.

## Changes

| Area | Change |
|---|---|
| **`packages/elysia/**`** (new) | `@spectrum-ts/elysia` — `package.json`, `README.md`, `tsconfig.json`, `tsdown.config.ts`, `turbo.json` (tagged `["adapter"]`). Plugin source moved `core/src/elysia.ts` → `src/index.ts`; test moved `core/test/webhook/elysia.test.ts` → `test/elysia.test.ts`. |
| **`packages/express/**`** (new) | `@spectrum-ts/express` — same package shape; source + test relocated from core. |
| **`packages/hono/**`** (new) | `@spectrum-ts/hono` — same package shape; source + test relocated from core. |
| Adapter `src/index.ts` (×3) | Import `WebhookHandler` from `@spectrum-ts/core` (was `./fusor`); re-export `Message, Space, WebhookHandler` from `@spectrum-ts/core` (was `./types/message`, `./types/space`, `./fusor`); doc-comment import paths updated to `@spectrum-ts/*`. |
| Adapter tests (×3) | Import `Spectrum` + `Message` from `@spectrum-ts/core` and the plugin from `@/index` (was `@/spectrum`, `@/types/message`, `@/{elysia,express,hono}`). |
| `packages/core/package.json` | Drop `./elysia`, `./express`, `./hono` from `exports` and `publishConfig.exports`; remove `elysia` / `express` / `hono` / `@types/express` from dev + peer deps; remove their `peerDependenciesMeta.optional` entries. |
| `packages/core/tsdown.config.ts` | Drop the three adapter entries; remove `elysia`/`express`/`hono` from `external` (only `ffmpeg-static` remains). |
| `packages/spectrum-ts/package.json` | Drop `./elysia`, `./express`, `./hono` subpath exports (+ `publishConfig`). |
| `packages/spectrum-ts/src/{elysia,express,hono}.ts` | Deleted — the metapackage re-export shims for `@spectrum-ts/core/*`. |
| `packages/spectrum-ts/tsdown.config.ts` | Drop the three adapter entries. |
| `biome.jsonc` | Remove the three deleted metapackage files from the override globs. |
| `bun.lock` | Register the three new workspace packages; refresh resolution. |
| `docs/{elysia,express,hono,fusor,native-webhook}.md` | Update import paths `spectrum-ts/x` → `@spectrum-ts/x`, install lines, and reference sections. |
| `docs/manifest.md` (new) | Documents the `generate-manifest.ts` provider-manifest generator (artifact shape, validation guardrail, how to add a provider). |

## Test plan

- [x] `turbo typecheck` — `@spectrum-ts/core`, `@spectrum-ts/elysia`, `@spectrum-ts/express`, `@spectrum-ts/hono` all clean
- [x] Adapter suites pass after the move — elysia **3/3**, express **3/3**, hono **3/3**
- [x] `ultracite check` clean across the changed packages (118 files, no fixes)
- [ ] `turbo build` (incl. `smoke-import`) green before publishing the three new packages

Closes ENG-1683.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784929716&installation_id=127326493&pr_number=151&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F151&signature=e20fc5eacca6cd3682962d3dd2c05a18485a874b686d1506f0aff07a1c1f880a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `./authoring` public entrypoint for the core package.
  * Added/standardized Elysia, Express, and Hono adapter packages (`@spectrum-ts/*`) with dedicated READMEs and build metadata.
  * Added a new manifest documentation page describing provider discovery/generation.

* **Documentation**
  * Updated adapter and plugin docs to use the correct scoped package names and current entrypoints.
  * Added/updated reference links to point at the monorepo package locations.

* **Bug Fixes**
  * Corrected routing-plugin and link names in docs to match the current package surface.

* **Breaking Changes**
  * Removed older `spectrum-ts/*` metapackage re-export paths in favor of adapter imports via `@spectrum-ts/*`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->