### PR TITLE
docs: add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,3 +121,17 @@ Biome's linter will catch most issues automatically. Focus your attention on:
 ---
 
 Most formatting and common issues are automatically fixed by Biome. Run `bun x ultracite fix` before committing to ensure compliance.
+
+---
+
+## Cursor Cloud specific instructions
+
+This is a **Bun workspaces + Turbo monorepo** that publishes the `spectrum-ts` SDK and its provider packages. It is a **library, not a deployable service** — there are no servers, databases, or background daemons to run. The full validation loop is in-process. Standard commands live in `CONTRIBUTING.md` (`bun run check` / `typecheck` / `test` / `build`) and `package.json` scripts; use those rather than reinventing them.
+
+Runtime: Bun (pinned to `.bun-version`, currently 1.3.14) is the package manager and test runner. Node 24 is also installed and made the default `node` (see build gotcha below).
+
+Non-obvious gotchas:
+
+- **Build/dev require Node ≥ 24.11.1, not the pre-installed Node 22.** The `tsdown` build tool runs via a `#!/usr/bin/env node` shebang, and its `auto` config loader only loads the `tsdown.config.ts` files natively on Node ≥ 24.11.1. On older Node it falls back to the optional `unrun` package (not installed) and the build fails with `Failed to import module "unrun"`. Node 24 is installed via nvm and prepended onto `PATH` in `~/.bashrc` ahead of the pre-installed `/exec-daemon` Node 22, so `bun run build` and `bun run dev` work as documented. If you ever see the `unrun` error, run `node --version` — it must report v24.x. (Alternatively `bun run --bun build` forces the bin under Bun and also works.)
+- **`bun run dev` needs `--concurrency` ≥ 11.** There are 10 persistent watch tasks and Turbo's default concurrency is 10, so plain `bun run dev` aborts with `Invalid task configuration`. Run `bun run dev --concurrency=12`.
+- **Example app (`bun run examples/basic/index.ts`)** uses the Terminal provider, which downloads a `tuichat` binary on first run (needs network the first time; set `TUICHAT_BINARY`/`TUICHAT_VERSION` to skip). In a non-TTY shell it runs in plain readline mode and reads inbound messages from stdin, so you can drive it by piping lines in; it reacts with 👀 and echoes each message back.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for the `spectrum-ts` Bun + Turbo monorepo and documents the non-obvious gotchas discovered during setup in `AGENTS.md` under `## Cursor Cloud specific instructions`.

This is a **library monorepo** (no servers/databases). The full validation loop runs in-process.

## Environment setup performed

- Installed **Bun 1.3.14** (matches `.bun-version`) and ran `bun install` (resolves all `@photon-ai/*` scoped deps).
- Installed **Node 24** via nvm and made it the default `node` on `PATH` (one-off `~/.bashrc` edit, not committed). This is required because `tsdown`'s `tsdown` bin runs via a `#!/usr/bin/env node` shebang and its `auto` config loader only loads `tsdown.config.ts` natively on Node ≥ 24.11.1; the pre-installed Node 22 otherwise fails the build with `Failed to import module "unrun"`.

## Update script

`bun install` — minimal dependency refresh on VM startup (Bun/Node persist in the snapshot).

## Verification

- ✅ `bun run check` (ultracite lint/format — 245 files)
- ✅ `bun run typecheck` (11 packages)
- ✅ `bun run test` (189 tests, 18 turbo tasks)
- ✅ `bun run build --force` (10 packages, real `tsdown` run under Node 24)
- ✅ `bun run dev --concurrency=12` (watch mode starts for all packages)
- ✅ Hello-world: `bun run examples/basic/index.ts` — agent received a message, reacted 👀, and echoed a reply through the Terminal provider:

[example_app_run.log](https://cursor.com/artifacts/c/art-1b38ca52-a85c-4f61-aa04-c20c5ac0fe30)

## Notes documented in AGENTS.md

- Build/dev require Node ≥ 24.11.1 (the `unrun` gotcha).
- `bun run dev` needs `--concurrency` ≥ 11 (10 persistent tasks vs Turbo default of 10).
- Example app downloads a `tuichat` binary on first run and reads stdin in non-TTY mode.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d60ec3c-90e5-491a-96d0-5d6695539db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d60ec3c-90e5-491a-96d0-5d6695539db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784934165&installation_id=127326493&pr_number=152&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F152&signature=1152a0b12f602d34ba88bb4abcba31bfd071fe61cde8e027f78c5450b50c945b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->