### PR TITLE
refactor(richlink): make richlink outbound-only, drop inbound handling & metadata fetching

### DIFF
--- a/docs/native-webhook.md
+++ b/docs/native-webhook.md
@@ -6,6 +6,10 @@ endpoint — Spectrum's own message model (`text`, `attachment`, `contact`,
 with an HMAC. This is the webhook documented at
 <https://photon.codes/docs/webhooks>.
 
+A received link arrives as `text`: `richlink` is outbound-only, so an inbound URL
+is normalized to its URL string and deserialized as plain `text` rather than a
+`richlink` payload.
+
 It's a different wire format from the [Fusor webhook](./fusor.md#webhook-mode--appwebhook),
 which relays a **raw** provider request inside a protobuf envelope. You don't pick
 one: **`app.webhook()` handles both**, auto-detecting per request and handing your

--- a/docs/native-webhook.md
+++ b/docs/native-webhook.md
@@ -2,7 +2,7 @@
 
 Spectrum Cloud can **POST already-normalized, signed JSON** to your HTTPS
 endpoint — Spectrum's own message model (`text`, `attachment`, `contact`,
-`richlink`, `reaction`, `group`), with raw bytes and SDK methods stripped, signed
+`reaction`, `group`), with raw bytes and SDK methods stripped, signed
 with an HMAC. This is the webhook documented at
 <https://photon.codes/docs/webhooks>.
 

--- a/packages/core/src/content/richlink.ts
+++ b/packages/core/src/content/richlink.ts
@@ -1,90 +1,25 @@
 import z from "zod";
-import { bufferToStream, readSchema, streamSchema } from "../utils/io";
-import {
-  fetchImage,
-  fetchLinkMetadata,
-  type LinkMetadata,
-} from "../utils/link-metadata";
 import type { ContentBuilder } from "./types";
 
-const richlinkCoverSchema = z.object({
-  mimeType: z.string().min(1).optional(),
-  read: readSchema,
-  stream: streamSchema,
-});
-
-const optionalStringAccessor = z.function({
-  input: [],
-  output: z.promise(z.string().min(1).optional()),
-});
-
-const coverAccessor = z.function({
-  input: [],
-  output: z.promise(richlinkCoverSchema.optional()),
-});
-
+/**
+ * A URL the platform should render as a rich link preview.
+ *
+ * Outbound-only by design: inbound messages always surface as `text` content —
+ * a URL received from a platform arrives as plain text, never as `richlink`, so
+ * no metadata is fetched on the inbound path. On outbound, each platform asks
+ * its native client to render the preview (remote iMessage: `enableLinkPreview`;
+ * Telegram: auto-unfurls the bare URL), so the framework carries only the URL
+ * and fetches nothing itself.
+ */
 export const richlinkSchema = z.object({
   type: z.literal("richlink"),
   url: z.url(),
-  title: optionalStringAccessor,
-  summary: optionalStringAccessor,
-  cover: coverAccessor,
 });
 
 export type Richlink = z.infer<typeof richlinkSchema>;
-export type RichlinkCover = z.infer<typeof richlinkCoverSchema>;
 
-const memoize = <T>(factory: () => Promise<T>): (() => Promise<T>) => {
-  let cached: Promise<T> | undefined;
-  return () => {
-    cached ??= factory();
-    return cached;
-  };
-};
-
-const buildCover = (
-  image: NonNullable<LinkMetadata["image"]>
-): RichlinkCover => {
-  const read = memoize(() =>
-    fetchImage(image.url)
-      .then((r) => r.data)
-      .catch(() => Buffer.alloc(0))
-  );
-  return {
-    mimeType: image.mimeType,
-    read,
-    stream: async () => bufferToStream(await read()),
-  };
-};
-
-/**
- * Construct a `richlink` content value.
- *
- * Accessors (`title`, `summary`, `cover`) are async and lazy: the first call
- * issues a single network request to the URL; subsequent calls share the
- * cached result. Network / parse failures resolve to `undefined` and are
- * cached — no retries. Callers who only need `title` / `summary` never
- * trigger an image download; calling `cover.read()` triggers one additional
- * request to fetch the image bytes.
- */
-export const asRichlink = (input: { url: string }): Richlink => {
-  const getMetadata = memoize(() => fetchLinkMetadata(input.url));
-  const getCover = memoize(async (): Promise<RichlinkCover | undefined> => {
-    const { image } = await getMetadata();
-    return image ? buildCover(image) : undefined;
-  });
-
-  const title = async () => (await getMetadata()).title;
-  const summary = async () => (await getMetadata()).summary;
-
-  return richlinkSchema.parse({
-    type: "richlink",
-    url: input.url,
-    title,
-    summary,
-    cover: getCover,
-  });
-};
+export const asRichlink = (input: { url: string }): Richlink =>
+  richlinkSchema.parse({ type: "richlink", url: input.url });
 
 export function richlink(url: string): ContentBuilder {
   return {

--- a/packages/core/src/webhook/deserialize.ts
+++ b/packages/core/src/webhook/deserialize.ts
@@ -5,7 +5,6 @@ import {
   type ContactPhone,
 } from "../content/contact";
 import { asCustom } from "../content/custom";
-import { asRichlink } from "../content/richlink";
 import type { Content } from "../content/types";
 import type { ProviderMessageRecord } from "../platform/build";
 import { UnsupportedError } from "../utils/errors";
@@ -126,7 +125,8 @@ const mapContent = (
     case "text":
       return { type: "text", text: asString(raw.text) };
     case "richlink":
-      return asRichlink({ url: asString(raw.url) });
+      // Outbound-only content type; inbound URLs always surface as text.
+      return { type: "text", text: asString(raw.url) };
     case "contact":
       return deserializeContact(raw);
     case "reaction":

--- a/packages/core/test/webhook/deserialize.test.ts
+++ b/packages/core/test/webhook/deserialize.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { Attachment } from "@/content/attachment";
 import type { Reaction } from "@/content/reaction";
-import type { Richlink } from "@/content/richlink";
 import {
   type DeserializeContext,
   deserializeSpectrumMessage,
@@ -136,16 +135,15 @@ describe("deserializeSpectrumMessage", () => {
     expect(content.items[1]?.id).toBe("g1");
   });
 
-  it("maps a richlink with lazy accessors", () => {
+  it("surfaces an inbound richlink as plain text (outbound-only type)", () => {
     const { record } = deserialize({
       type: "richlink",
       url: "https://example.com/post",
     });
-    const content = record.content as Richlink;
-    expect(content.type).toBe("richlink");
-    expect(content.url).toBe("https://example.com/post");
-    expect(typeof content.title).toBe("function");
-    expect(typeof content.cover).toBe("function");
+    expect(record.content).toEqual({
+      type: "text",
+      text: "https://example.com/post",
+    });
   });
 
   it("maps a contact's name and phones", () => {

--- a/packages/imessage/src/remote/inbound.ts
+++ b/packages/imessage/src/remote/inbound.ts
@@ -10,7 +10,6 @@ import {
   asAttachment,
   asContact,
   asCustom,
-  asRichlink,
   asText,
   createLogger,
   errorAttrs,
@@ -32,15 +31,10 @@ import {
 
 const log = createLogger("spectrum.imessage.inbound");
 
-const URL_BALLOON_BUNDLE_ID = "com.apple.messages.URLBalloonProvider";
-
 export type ReceivedEvent = Extract<MessageEvent, { type: "message.received" }>;
 export type AppleMessage = ReceivedEvent["message"];
 type AppleAttachment = AppleMessage["content"]["attachments"][number];
 export type RemoteMessageBase = Omit<IMessageMessage, "id" | "content">;
-
-const getBalloonBundleId = (message: AppleMessage): string | undefined =>
-  message.content.balloonBundleId;
 
 const messageAttachments = (
   message: AppleMessage
@@ -170,28 +164,6 @@ const buildAttachmentMessage = async (
   return msg;
 };
 
-const toRichlinkMessage = (
-  message: AppleMessage,
-  base: RemoteMessageBase,
-  id: string
-): IMessageMessage => {
-  const url = message.content.text ?? "";
-  try {
-    return { ...base, id, content: asRichlink({ url }) };
-  } catch (err) {
-    log.warn(
-      "failed to convert message to rich link; falling back to text/custom content",
-      { "spectrum.imessage.message.id": id, ...errorAttrs(err) },
-      err
-    );
-    return {
-      ...base,
-      id,
-      content: url ? asText(url) : asCustom(message),
-    };
-  }
-};
-
 export const rebuildFromAppleMessage = async (
   client: AdvancedIMessage,
   message: AppleMessage,
@@ -237,10 +209,6 @@ export const rebuildFromAppleMessage = async (
     };
   }
 
-  if (getBalloonBundleId(message) === URL_BALLOON_BUNDLE_ID) {
-    return toRichlinkMessage(message, base, messageGuidStr);
-  }
-
   const text = message.content.text;
   return {
     ...base,
@@ -276,12 +244,6 @@ export const toInboundMessages = async (
     phone
   );
   const messageGuidStr = event.message.guid as string;
-
-  if (getBalloonBundleId(event.message) === URL_BALLOON_BUNDLE_ID) {
-    const msg = toRichlinkMessage(event.message, base, messageGuidStr);
-    cacheMessage(cache, msg);
-    return [msg];
-  }
 
   const attachments = messageAttachments(event.message);
 

--- a/packages/imessage/test/remote/inbound.test.ts
+++ b/packages/imessage/test/remote/inbound.test.ts
@@ -14,7 +14,10 @@ const RECEIVED_AT = new Date(1_700_000_000_000);
 // bare stub is enough to exercise the sender-normalization path.
 const client = {} as unknown as AdvancedIMessage;
 
-const receivedEvent = (sender?: Record<string, unknown>): ReceivedEvent =>
+const receivedEvent = (
+  sender?: Record<string, unknown>,
+  content?: Record<string, unknown>
+): ReceivedEvent =>
   ({
     type: "message.received",
     sequence: 1,
@@ -24,7 +27,13 @@ const receivedEvent = (sender?: Record<string, unknown>): ReceivedEvent =>
     message: {
       guid: "msg-guid",
       chatGuids: ["s1"],
-      content: { attachments: [], formatting: [], mentions: [], text: "hi" },
+      content: {
+        attachments: [],
+        formatting: [],
+        mentions: [],
+        text: "hi",
+        ...content,
+      },
       dateCreated: RECEIVED_AT,
       isFromMe: false,
       sender,
@@ -69,5 +78,26 @@ describe("iMessage remote toInboundMessages sender", () => {
 
   it("falls back to an empty id when the sender is absent", async () => {
     expect(await inboundSender(undefined)).toEqual({ id: "" });
+  });
+});
+
+describe("iMessage remote toInboundMessages content", () => {
+  it("surfaces a URL balloon as plain text rather than a rich link", async () => {
+    const [message] = await toInboundMessages(
+      client,
+      new MessageCache(),
+      receivedEvent(
+        { address: "+15551234567" },
+        {
+          text: "https://example.com/post",
+          balloonBundleId: "com.apple.messages.URLBalloonProvider",
+        }
+      ),
+      "+15550000000"
+    );
+    expect(message?.content).toEqual({
+      type: "text",
+      text: "https://example.com/post",
+    });
   });
 });


### PR DESCRIPTION
## Summary

ENG-1737. Makes `richlink` an **outbound-only** content type (like `markdown`) and removes all inbound rich-link handling. A URL received from any platform now surfaces as plain `text`, and the framework no longer fetches link metadata on the inbound path — receiving a message issues zero network requests for previews.

- **`richlink` is now just `{ type, url }`.** The lazy async accessors (`title`, `summary`, `cover`) and the metadata/image-fetch machinery behind them are gone; `asRichlink` is a pure constructor. **Breaking** change to the `Richlink` type → major release.
- **Inbound URLs surface as `text`.** The webhook deserializer maps an inbound `richlink` envelope to `text` (the URL), and the remote-iMessage inbound path no longer converts a URL balloon (`com.apple.messages.URLBalloonProvider`) into a `richlink` — it flows through the normal text path.
- **No inbound network calls.** Nothing on the receive path fetches Open Graph metadata or cover images anymore.

`link-metadata.ts` is intentionally kept — the `app` content type still uses it on the outbound path.

## Behavior change

| | Before | After |
|---|---|---|
| Receive a URL (any platform) | `richlink` w/ lazy `title`/`summary`/`cover` (network fetch on access) | plain `text` with the URL |
| Native webhook `richlink` arm | reconstructed `richlink` | `text` |
| iMessage URL balloon | `richlink` | `text` |
| `Richlink` type | `{ type, url, title, summary, cover }` | `{ type, url }` |
| Send `richlink(url)` | unchanged — platform renders the preview natively | unchanged |

## Changes

| File | Change |
|---|---|
| `packages/core/src/content/richlink.ts` | Strip `Richlink` to `{ type, url }`; remove the lazy `title`/`summary`/`cover` accessors, `buildCover`/`memoize`, and the `link-metadata`/`io` imports. `asRichlink` is now a one-line constructor; the doc comment explains the outbound-only design. |
| `packages/core/src/webhook/deserialize.ts` | Inbound `richlink` envelope arm now returns `{ type: "text", text: url }` instead of `asRichlink(...)`; drop the `asRichlink` import. |
| `packages/core/test/webhook/deserialize.test.ts` | Replace the "lazy accessors" case with one asserting an inbound `richlink` surfaces as plain `text`. |
| `packages/imessage/src/remote/inbound.ts` | Remove `toRichlinkMessage`, `getBalloonBundleId`, and `URL_BALLOON_BUNDLE_ID`; the balloon check is dropped from both `rebuildFromAppleMessage` and `toInboundMessages`, so URL balloons fall through to the text path. |
| `packages/imessage/test/remote/inbound.test.ts` | Extend the event helper with a `content` override; add a case asserting a URL balloon surfaces as plain `text`. |
| `docs/native-webhook.md` | Drop `richlink` from the normalized-JSON content-type list. |

## Test plan

- [x] `bun test packages/core/test/webhook/deserialize.test.ts` — 11 pass (inbound richlink → text)
- [x] `bun test packages/imessage/test/remote/inbound.test.ts` — 4 pass (URL balloon → text)
- [ ] `turbo typecheck`
- [ ] `bun x ultracite check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785037167&installation_id=127326493&pr_number=155&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F155&signature=ca82e3f29c82c7da74b6673ef9244c0f52fa1607728b96005fe747076e0b617b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Incoming webhook rich-link deliveries and iMessage URL balloon content are now shown as plain text URL strings (instead of rich-link previews).
  * Improved consistency of URL-based message content across different message sources.
* **Documentation**
  * Updated webhook documentation to reflect the current normalized payload fields for rich-link content.
* **Tests**
  * Adjusted and added coverage to verify rich-link/URL balloon inputs surface as plain text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->