### PR TITLE
fix(imessage): drop enableDataDetection that broke link sends on Business dedicated lines

### DIFF
--- a/packages/imessage/src/remote/markdown.ts
+++ b/packages/imessage/src/remote/markdown.ts
@@ -70,15 +70,12 @@ const STYLE_ORDER: readonly InlineStyle[] = ["bold", "italic", "strikethrough"];
 // block separator. Offsets are assigned only in `finalize`, after the full
 // span sequence (including trim) is fixed — they can never be invalidated.
 interface StyledSpan {
-  /** Set on spans produced by link/image rendering — drives `hasLinks`. */
-  readonly link?: boolean;
   readonly styles: readonly InlineStyle[];
   readonly text: string;
 }
 
 export interface IMessageRenderedMarkdown {
   readonly formatting: readonly TextFormatInput[];
-  readonly hasLinks: boolean;
   readonly text: string;
 }
 
@@ -90,9 +87,6 @@ const withStyle = (spans: StyledSpan[], style: InlineStyle): StyledSpan[] =>
       ? span
       : { ...span, styles: [...span.styles, style] }
   );
-
-const asLink = (spans: StyledSpan[]): StyledSpan[] =>
-  spans.map((span) => ({ ...span, link: true }));
 
 const spanText = (spans: readonly StyledSpan[]): string => {
   let out = "";
@@ -162,12 +156,12 @@ const renderLink = (token: Tokens.Link): StyledSpan[] => {
   // A bare autolink lexes with its label equal to its href — render the
   // url alone instead of doubling it as "url (url)".
   if (token.text === token.href) {
-    return [{ text: token.href, styles: [], link: true }];
+    return [{ text: token.href, styles: [] }];
   }
   // The label keeps its inline styling; the " (url)" suffix stays unstyled.
   return [
-    ...asLink(renderInlineTokens(token.tokens)),
-    { text: ` (${token.href})`, styles: [], link: true },
+    ...renderInlineTokens(token.tokens),
+    { text: ` (${token.href})`, styles: [] },
   ];
 };
 
@@ -175,7 +169,6 @@ const renderImage = (token: Tokens.Image): StyledSpan[] => [
   {
     text: token.text ? `${token.text} (${token.href})` : token.href,
     styles: [],
-    link: true,
   },
 ];
 
@@ -351,7 +344,6 @@ const trimSpans = (spans: StyledSpan[]): StyledSpan[] => {
 // closes it. Unstyled separator/prefix spans therefore bound every range.
 const finalize = (spans: StyledSpan[]): IMessageRenderedMarkdown => {
   let text = "";
-  let hasLinks = false;
   const open = new Map<InlineStyle, number>();
   const ranges: { type: InlineStyle; start: number; length: number }[] = [];
 
@@ -367,7 +359,6 @@ const finalize = (spans: StyledSpan[]): IMessageRenderedMarkdown => {
     if (!span.text) {
       continue;
     }
-    hasLinks ||= span.link === true;
     const offset = text.length;
     for (const style of STYLE_ORDER) {
       if (span.styles.includes(style)) {
@@ -389,7 +380,7 @@ const finalize = (spans: StyledSpan[]): IMessageRenderedMarkdown => {
       a.start - b.start ||
       STYLE_ORDER.indexOf(a.type) - STYLE_ORDER.indexOf(b.type)
   );
-  return { text, formatting: ranges, hasLinks };
+  return { text, formatting: ranges };
 };
 
 /**
@@ -399,8 +390,7 @@ const finalize = (spans: StyledSpan[]): IMessageRenderedMarkdown => {
  * bullets, `label (url)` links); inline emphasis becomes native
  * bold/italic/strikethrough ranges instead of being stripped, headings
  * render as bold, and code maps to Unicode mathematical monospace
- * characters. `hasLinks` reports whether any link or image put a URL into
- * the text, so the sender can enable Apple's data-detector pass.
+ * characters.
  */
 export const markdownToIMessageText = (
   markdown: string

--- a/packages/imessage/src/remote/send.ts
+++ b/packages/imessage/src/remote/send.ts
@@ -94,11 +94,6 @@ const formattingOption = (
 ): Pick<SendOptions, "formatting"> =>
   formatting.length > 0 ? { formatting } : {};
 
-const dataDetectionOption = (
-  hasLinks: boolean
-): Pick<SendOptions, "enableDataDetection"> =>
-  hasLinks ? { enableDataDetection: true } : {};
-
 // Markdown that renders to nothing (e.g. a whitespace-only source) throws
 // UnsupportedError so the pipeline's downgrade path handles it exactly like
 // platforms without native markdown support.
@@ -217,7 +212,6 @@ const sendContent = async (
           {
             ...effectOption(effect),
             ...formattingOption(rendered.formatting),
-            ...dataDetectionOption(rendered.hasLinks),
           },
           replyTo
         )
@@ -308,7 +302,6 @@ const resolvePart = async (
     case "text":
       return { text: content.text };
     case "markdown": {
-      // `MessagePart` has no data-detection flag, so `hasLinks` is dropped.
       const rendered = renderMarkdown(content.markdown);
       return { text: rendered.text, ...formattingOption(rendered.formatting) };
     }

--- a/packages/imessage/test/remote/markdown.test.ts
+++ b/packages/imessage/test/remote/markdown.test.ts
@@ -6,7 +6,6 @@ describe("markdownToIMessageText", () => {
     expect(markdownToIMessageText("hello")).toEqual({
       text: "hello",
       formatting: [],
-      hasLinks: false,
     });
   });
 
@@ -14,7 +13,6 @@ describe("markdownToIMessageText", () => {
     expect(markdownToIMessageText("a **b** c")).toEqual({
       text: "a b c",
       formatting: [{ type: "bold", start: 2, length: 1 }],
-      hasLinks: false,
     });
   });
 
@@ -29,7 +27,6 @@ describe("markdownToIMessageText", () => {
     expect(markdownToIMessageText("🎉 **x**")).toEqual({
       text: "🎉 x",
       formatting: [{ type: "bold", start: 3, length: 1 }],
-      hasLinks: false,
     });
   });
 
@@ -47,7 +44,6 @@ describe("markdownToIMessageText", () => {
         { type: "bold", start: 0, length: 12 },
         { type: "italic", start: 5, length: 2 },
       ],
-      hasLinks: false,
     });
   });
 
@@ -59,7 +55,6 @@ describe("markdownToIMessageText", () => {
         { type: "bold", start: 0, length: 3 },
         { type: "italic", start: 2, length: 1 },
       ],
-      hasLinks: false,
     });
   });
 
@@ -70,7 +65,6 @@ describe("markdownToIMessageText", () => {
         { type: "bold", start: 0, length: 1 },
         { type: "bold", start: 3, length: 1 },
       ],
-      hasLinks: false,
     });
   });
 
@@ -78,15 +72,13 @@ describe("markdownToIMessageText", () => {
     expect(markdownToIMessageText("# Title\n\nbody")).toEqual({
       text: "Title\n\nbody",
       formatting: [{ type: "bold", start: 0, length: 5 }],
-      hasLinks: false,
     });
   });
 
-  it("renders links as label (url) and reports hasLinks", () => {
+  it("renders links as label (url)", () => {
     expect(markdownToIMessageText("[docs](https://d.test)")).toEqual({
       text: "docs (https://d.test)",
       formatting: [],
-      hasLinks: true,
     });
   });
 
@@ -94,7 +86,6 @@ describe("markdownToIMessageText", () => {
     expect(markdownToIMessageText("[**a**](https://d.test)")).toEqual({
       text: "a (https://d.test)",
       formatting: [{ type: "bold", start: 0, length: 1 }],
-      hasLinks: true,
     });
   });
 
@@ -102,7 +93,6 @@ describe("markdownToIMessageText", () => {
     expect(markdownToIMessageText("see https://bare.example")).toEqual({
       text: "see https://bare.example",
       formatting: [],
-      hasLinks: true,
     });
   });
 
@@ -110,7 +100,6 @@ describe("markdownToIMessageText", () => {
     expect(markdownToIMessageText("![chart](https://i.test/p.png)")).toEqual({
       text: "chart (https://i.test/p.png)",
       formatting: [],
-      hasLinks: true,
     });
   });
 
@@ -118,7 +107,6 @@ describe("markdownToIMessageText", () => {
     expect(markdownToIMessageText("`npm install spectrum-ts`")).toEqual({
       text: "𝚗𝚙𝚖 𝚒𝚗𝚜𝚝𝚊𝚕𝚕 𝚜𝚙𝚎𝚌𝚝𝚛𝚞𝚖-𝚝𝚜",
       formatting: [],
-      hasLinks: false,
     });
   });
 
@@ -135,7 +123,6 @@ describe("markdownToIMessageText", () => {
     expect(markdownToIMessageText("`ab` **c**")).toEqual({
       text: "𝚊𝚋 c",
       formatting: [{ type: "bold", start: 5, length: 1 }],
-      hasLinks: false,
     });
   });
 
@@ -143,7 +130,6 @@ describe("markdownToIMessageText", () => {
     expect(markdownToIMessageText("- **a**\n- b")).toEqual({
       text: "• a\n• b",
       formatting: [{ type: "bold", start: 2, length: 1 }],
-      hasLinks: false,
     });
   });
 
@@ -165,7 +151,6 @@ describe("markdownToIMessageText", () => {
     expect(markdownToIMessageText("> **q**")).toEqual({
       text: "> q",
       formatting: [{ type: "bold", start: 2, length: 1 }],
-      hasLinks: false,
     });
   });
 
@@ -179,7 +164,6 @@ describe("markdownToIMessageText", () => {
     ).toEqual({
       text: "h1 | h2\na | b",
       formatting: [{ type: "bold", start: 8, length: 1 }],
-      hasLinks: false,
     });
   });
 
@@ -191,7 +175,6 @@ describe("markdownToIMessageText", () => {
     expect(markdownToIMessageText("<u>under</u> ok")).toEqual({
       text: "<u>under</u> ok",
       formatting: [],
-      hasLinks: false,
     });
   });
 
@@ -199,7 +182,6 @@ describe("markdownToIMessageText", () => {
     expect(markdownToIMessageText("**line one\nline two**")).toEqual({
       text: "line one\nline two",
       formatting: [{ type: "bold", start: 0, length: 17 }],
-      hasLinks: false,
     });
   });
 
@@ -207,7 +189,6 @@ describe("markdownToIMessageText", () => {
     expect(markdownToIMessageText("\n\n# A")).toEqual({
       text: "A",
       formatting: [{ type: "bold", start: 0, length: 1 }],
-      hasLinks: false,
     });
   });
 
@@ -215,7 +196,6 @@ describe("markdownToIMessageText", () => {
     expect(markdownToIMessageText("   ")).toEqual({
       text: "",
       formatting: [],
-      hasLinks: false,
     });
   });
 });

--- a/packages/imessage/test/remote/send-markdown.test.ts
+++ b/packages/imessage/test/remote/send-markdown.test.ts
@@ -77,7 +77,7 @@ describe("send (markdown)", () => {
     expect(record.space).toEqual({ id: "chat" });
   });
 
-  it("omits formatting and data detection for unstyled, link-free markdown", async () => {
+  it("omits formatting for unstyled markdown", async () => {
     const { remote, sendText } = makeRemote();
 
     await send(remote, "chat", asMarkdown("just words"));
@@ -85,7 +85,7 @@ describe("send (markdown)", () => {
     expect(sendText.mock.calls[0]).toEqual(["chat", "just words", {}]);
   });
 
-  it("enables data detection when the markdown contains links", async () => {
+  it("sends link-bearing markdown as plain text (no data detection)", async () => {
     const { remote, sendText } = makeRemote();
 
     await send(remote, "chat", asMarkdown("[docs](https://d.test)"));
@@ -93,7 +93,7 @@ describe("send (markdown)", () => {
     expect(sendText.mock.calls[0]).toEqual([
       "chat",
       "docs (https://d.test)",
-      { enableDataDetection: true },
+      {},
     ]);
   });
 


### PR DESCRIPTION
## Summary

ENG-1739 (fixes #154). On **Business dedicated lines** (Photon's "IMAgentKit" send path), any `text`/`markdown` reply containing a link was **silently dropped**: `sendText` rejects `enableDataDetection` with `FAILED_PRECONDITION`, yet Spectrum set that flag unconditionally whenever the rendered markdown contained a URL. Link-bearing replies (chart links, "open in app", citations) went missing in production on dedicated numbers while shared-pool lines worked, making it easy to miss in testing.

This removes the data-detection plumbing entirely:

- **Root cause.** `dataDetectionOption(rendered.hasLinks)` spread `{ enableDataDetection: true }` into the markdown `sendText` call whenever a link rendered. The IMAgentKit path rejects that option, so the send failed with no user-visible error. (The `richlink` path was already fine — it uses `enableLinkPreview`, which IMAgentKit *does* accept.)
- **Fix.** Drop the flag outright rather than capability-gate or catch-and-retry. There is no caller-facing data-detection toggle to preserve, and links still render as `label (url)` plain text — iMessage's client-side detection keeps URLs tappable. The `richlink` content type (native preview via `enableLinkPreview`) is unchanged.
- **Cleanup.** `hasLinks` is removed from the internal `IMessageRenderedMarkdown` type, along with the `StyledSpan.link` tracking and `asLink` helper that fed it. These are **not** part of the package's public exports (`markdownToIMessageText`/`IMessageRenderedMarkdown` are not re-exported from `index.ts`), so this is **not** a public API change — no major bump required.

## Behavior change

| | Before | After |
|---|---|---|
| Link-bearing `text`/`markdown` on a Business dedicated line (IMAgentKit) | `FAILED_PRECONDITION`, reply silently dropped | sends as `label (url)` plain text |
| Link-bearing `markdown` on a shared-pool line | `sendText(…, { enableDataDetection: true })` | no data-detection flag; plain text |
| `richlink(url)` send | `enableLinkPreview: true` | unchanged |
| `IMessageRenderedMarkdown` (internal) | `{ text, formatting, hasLinks }` | `{ text, formatting }` |

## Changes

| File | Change |
|---|---|
| `packages/imessage/src/remote/markdown.ts` | Remove `StyledSpan.link`, the `asLink` helper, and `hasLinks` from both `IMessageRenderedMarkdown` and `finalize`. `renderLink`/`renderImage` no longer tag spans as links. Drop the data-detector note from the doc comment. |
| `packages/imessage/src/remote/send.ts` | Remove `dataDetectionOption` and stop spreading `enableDataDetection` into the markdown `sendText` call. |
| `packages/imessage/test/remote/markdown.test.ts` | Drop `hasLinks` from every expectation; rename the link case to "renders links as label (url)". |
| `packages/imessage/test/remote/send-markdown.test.ts` | Rework the two data-detection cases to assert no `enableDataDetection` flag is sent for link-bearing markdown. |

## Test plan

- [x] `bun test` (imessage package) — 88 pass, 0 fail
- [x] `bun run typecheck` (imessage package) — clean
- [x] `bun x ultracite check` on the changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785040279&installation_id=127326493&pr_number=156&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F156&signature=7ebe50601e095cfae9d340c92ba86341da0fd61d424ee8c2b4a63c6ace548e94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Markdown messages now send without automatically enabling link/data detection.
  * Markdown rendering now returns a simpler result with just text and formatting, with no link-tracking field.
  * Link and image content is still rendered correctly, but no longer adds extra link metadata to the output.
* **Tests**
  * Updated markdown rendering and sending tests to match the new output shape and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->