### PR TITLE
fix: preserve interleaved imessage inbound parts

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -10,9 +10,9 @@
     }
   },
   "files": {
-    // docs-site/ holds Mintlify .vel templates + a generated nav.json fragment
+    // docs/ holds Mintlify .vel templates + a generated nav.json fragment
     // pulled by the photon-hq/docs aggregator; it isn't spectrum-ts source.
-    "includes": ["!!bun.lock", "!!docs-site"]
+    "includes": ["!!bun.lock", "!!docs"]
   },
   "overrides": [
     {

--- a/bun.lock
+++ b/bun.lock
@@ -4,13 +4,16 @@
   "workspaces": {
     "": {
       "name": "specturm-ts",
+      "dependencies": {
+        "@photon-ai/otel": "^3.1.0",
+      },
       "devDependencies": {
-        "@arethetypeswrong/cli": "^0.18.2",
-        "@biomejs/biome": "^2.4.12",
-        "@types/node": "^26.0.0",
-        "clean-publish": "^7.0.0",
-        "publint": "^0.3.14",
-        "turbo": "^2",
+        "@arethetypeswrong/cli": "^0.18.4",
+        "@biomejs/biome": "^2.5.1",
+        "@types/node": "^26.0.1",
+        "clean-publish": "^7.1.0",
+        "publint": "^0.3.21",
+        "turbo": "^2.10.0",
         "ultracite": "7.8.3",
       },
     },
@@ -24,7 +27,7 @@
       "name": "@spectrum-ts/core",
       "version": "8.0.0",
       "dependencies": {
-        "@photon-ai/otel": "^1.0.0",
+        "@photon-ai/otel": "^3.1.0",
         "@photon-ai/proto": "^0.2.4",
         "@repeaterjs/repeater": "^3.0.6",
         "marked": "^18.0.5",
@@ -120,7 +123,7 @@
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.12.0",
         "@photon-ai/imessage-kit": "^3.0.0",
-        "@photon-ai/otel": "^1.0.0",
+        "@photon-ai/otel": "^3.1.0",
         "lru-cache": "^11.0.0",
         "marked": "^18.0.5",
         "zod": "^4.2.1",
@@ -157,12 +160,12 @@
       "name": "spectrum-ts",
       "version": "8.0.0",
       "dependencies": {
-        "@spectrum-ts/core": "6.1.1",
-        "@spectrum-ts/imessage": "6.1.1",
-        "@spectrum-ts/slack": "6.1.1",
-        "@spectrum-ts/telegram": "6.1.1",
-        "@spectrum-ts/terminal": "6.1.1",
-        "@spectrum-ts/whatsapp-business": "6.1.1",
+        "@spectrum-ts/core": "8.0.0",
+        "@spectrum-ts/imessage": "8.0.0",
+        "@spectrum-ts/slack": "8.0.0",
+        "@spectrum-ts/telegram": "8.0.0",
+        "@spectrum-ts/terminal": "8.0.0",
+        "@spectrum-ts/whatsapp-business": "8.0.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -241,9 +244,9 @@
   "packages": {
     "@andrewbranch/untar.js": ["@andrewbranch/untar.js@1.0.3", "", {}, "sha512-Jh15/qVmrLGhkKJBdXlK1+9tY4lZruYjsgkDFj08ZmDiWVBLJcqkok7Z0/R0In+i1rScBpJlSvrTS2Lm41Pbnw=="],
 
-    "@arethetypeswrong/cli": ["@arethetypeswrong/cli@0.18.3", "", { "dependencies": { "@arethetypeswrong/core": "0.18.3", "chalk": "^4.1.2", "cli-table3": "^0.6.3", "commander": "^10.0.1", "marked": "^9.1.2", "marked-terminal": "^7.1.0", "semver": "^7.5.4" }, "bin": { "attw": "./dist/index.js" } }, "sha512-GeAlc+lUD4gKHD/LDQNvQY30FfQ+xAXg2inbQKUjFZgTOdI5ygEweaOnGHGBPSKXSLGQC7VLhpXu9zMnYk/4sQ=="],
+    "@arethetypeswrong/cli": ["@arethetypeswrong/cli@0.18.4", "", { "dependencies": { "@arethetypeswrong/core": "0.18.4", "chalk": "^4.1.2", "cli-table3": "^0.6.3", "commander": "^10.0.1", "marked": "^9.1.2", "marked-terminal": "^7.1.0", "semver": "^7.5.4" }, "bin": { "attw": "./dist/index.js" } }, "sha512-kNWo6LTzGAuLYPpJ7Sgo63whSUeeSuKMlYx6IBgzs4ONEG807gW4hSSENvpeCHzO2H2wIzG5EFl0OKBbqGBAyA=="],
 
-    "@arethetypeswrong/core": ["@arethetypeswrong/core@0.18.3", "", { "dependencies": { "@andrewbranch/untar.js": "^1.0.3", "@loaderkit/resolve": "^1.0.2", "cjs-module-lexer": "^1.2.3", "fflate": "^0.8.3", "lru-cache": "^11.0.1", "semver": "^7.5.4", "typescript": "5.6.1-rc", "validate-npm-package-name": "^5.0.0" } }, "sha512-sWBB/tdIktaT5xMq0Dz6CJyqcf6oMNdmiKiuPU1lWoJLTL6gjRSsksBuSgqot21hylkklBQY1wiSu+PkZhW7sw=="],
+    "@arethetypeswrong/core": ["@arethetypeswrong/core@0.18.4", "", { "dependencies": { "@andrewbranch/untar.js": "^1.0.3", "@loaderkit/resolve": "^1.0.2", "cjs-module-lexer": "^1.2.3", "fflate": "^0.8.3", "lru-cache": "^11.0.1", "semver": "^7.5.4", "typescript": "5.6.1-rc", "validate-npm-package-name": "^5.0.0" } }, "sha512-M5F0ePyN6h2Z6XxRiyIPqjGbltotXLjR0CKA0uKspsDu0QmgTNYvRb4RSQPMUs2ZXZHCCYpbaZbFbYOXLxCjUA=="],
 
     "@babel/generator": ["@babel/generator@8.0.0-rc.6", "", { "dependencies": { "@babel/parser": "^8.0.0-rc.6", "@babel/types": "^8.0.0-rc.6", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-6mIzgVK8DgEzvIapoQwhXTMnnkuE4STQmVv9H03i/tZ2ml8oev3TRvZJgTenK2Bsq0YWNtzOrFdTyNzCMFtjJQ=="],
 
@@ -255,23 +258,23 @@
 
     "@babel/types": ["@babel/types@8.0.0-rc.6", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.6", "@babel/helper-validator-identifier": "^8.0.0-rc.6" } }, "sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.12", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.12", "@biomejs/cli-darwin-x64": "2.4.12", "@biomejs/cli-linux-arm64": "2.4.12", "@biomejs/cli-linux-arm64-musl": "2.4.12", "@biomejs/cli-linux-x64": "2.4.12", "@biomejs/cli-linux-x64-musl": "2.4.12", "@biomejs/cli-win32-arm64": "2.4.12", "@biomejs/cli-win32-x64": "2.4.12" }, "bin": { "biome": "bin/biome" } }, "sha512-Rro7adQl3NLq/zJCIL98eElXKI8eEiBtoeu5TbXF/U3qbjuSc7Jb5rjUbeHHcquDWeSf3HnGP7XI5qGrlRk/pA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.1", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.1", "@biomejs/cli-darwin-x64": "2.5.1", "@biomejs/cli-linux-arm64": "2.5.1", "@biomejs/cli-linux-arm64-musl": "2.5.1", "@biomejs/cli-linux-x64": "2.5.1", "@biomejs/cli-linux-x64-musl": "2.5.1", "@biomejs/cli-win32-arm64": "2.5.1", "@biomejs/cli-win32-x64": "2.5.1" }, "bin": { "biome": "bin/biome" } }, "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-BnMU4Pc3ciEVteVpZ0BK33MLr7X57F5w1dwDLDn+/iy/yTrA4Q/N2yftidFtsA4vrDh0FMXDpacNV/Tl3fbmng=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-x9uJ0bI1rJsWICp3VH8w/5PnAVD3A7SqzDpbrfoUQX1QyWrK5jSU4fRLo/wSgGeplCivbxBRKmt5Xq4/nWvq8A=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-tOwuCuZZtKi1jVzbk/5nXmIsziOB6yqN8c9r9QM0EJYPU6DpQWf11uBOSCfFKKM4H3d9ZoarvlgMfbcuD051Pw=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-FhfpkAAlKL6kwvcVap0Hgp4AhZmtd3YImg0kK1jd7C/aSoh4SfsB2f++yG1rU0lr8Y5MCFJrcSkmssiL9Xnnig=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-8pFeAnLU9QdW9jCIslB/v82bI0lhBmz2ZAKc8pVMFPO0t0wAHsoEkrUQUbMkIorTRIjbqyNZHA3lEXavsPWYSw=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.12", "", { "os": "linux", "cpu": "x64" }, "sha512-dwTIgZrGutzhkQCuvHynCkyW6hJxUuyZqKKO0YNfaS2GUoRO+tOvxXZqZB6SkWAOdfZTzwaw8IEdUnIkHKHoew=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-B0DLnx0vA9ya/3v7XyCaP+/lCpnbWbMOfUFFve+xb5OxyYvdHaS55YsSddr228Y+JAFk58agCuZTsqNiw2a6ig=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.12", "", { "os": "win32", "cpu": "x64" }, "sha512-yMckRzTyZ83hkk8iDFWswqSdU8tvZxspJKnYNh7JZr/zhZNOlzH13k4ecboU6MurKExCe2HUkH75pGI/O2JwGA=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
@@ -385,6 +388,10 @@
 
     "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw=="],
 
+    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.219.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.219.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-X5t7I8GyIO9rmGHwoedZLREpQqrF1WW2nxzNNym6HOKpFiE+rvqV3ngC0xcZVO2YwIGf3KKmRdWrYwdwz3H9RQ=="],
+
+    "@opentelemetry/instrumentation-undici": ["@opentelemetry/instrumentation-undici@0.29.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.219.0", "@opentelemetry/semantic-conventions": "^1.24.0" }, "peerDependencies": { "@opentelemetry/api": "^1.7.0" } }, "sha512-SnA+0XgGc595jtnwFVfWy7Vgfr5hle4D5YKIlm0U4z8aK9YoCZVUn1xAkVZ2evaJyykiDF50FBzr1XZ0uj8CPA=="],
+
     "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-transformer": "0.218.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-ZwqpkNL5W7RyGJPDZ9g06DvKp8KFTWPJPN12anpMQYSKpTSU0z3EIZuPq9vPGpS8siFyOqDYDAuCwlNO9FqgbA=="],
 
     "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-logs": "0.218.0", "@opentelemetry/sdk-metrics": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CFaKH87WAzjuJ4awowTTLzUvMfaRfiOFG5+qm5S5ncyalRtN4ecQ+YmuANJSCrVPuvZFEkUgKhBPBndxi3rHsQ=="],
@@ -409,7 +416,7 @@
 
     "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-GGDETlRbrPXP5eaRvswaead7MCBGQkm8f7d3aVbx8+rXhB4GEyPiw7Q1/yz5ix53rmxqKRevWywOfG7n+kZDBw=="],
 
-    "@photon-ai/otel": ["@photon-ai/otel@1.0.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/api-logs": "^0.218.0", "@opentelemetry/context-async-hooks": "^2.7.1", "@opentelemetry/exporter-logs-otlp-http": "^0.218.0", "@opentelemetry/exporter-trace-otlp-http": "^0.218.0", "@opentelemetry/resources": "^2.7.1", "@opentelemetry/sdk-logs": "^0.218.0", "@opentelemetry/sdk-trace-base": "^2.7.1" }, "peerDependencies": { "typescript": "^5 || ^6.0.0" } }, "sha512-5fACVHN7BtGS+phglVAxun5QLckNUSS4p750oCxR//m9JNVzFQMoLFWfC6DnWBP/W0/+B2yP75+3NMVLodEJEg=="],
+    "@photon-ai/otel": ["@photon-ai/otel@3.1.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/api-logs": "^0.218.0", "@opentelemetry/context-async-hooks": "^2.7.1", "@opentelemetry/core": "^2.7.1", "@opentelemetry/exporter-logs-otlp-http": "^0.218.0", "@opentelemetry/exporter-trace-otlp-http": "^0.218.0", "@opentelemetry/resources": "^2.7.1", "@opentelemetry/sdk-logs": "^0.218.0", "@opentelemetry/sdk-trace-base": "^2.7.1", "@opentelemetry/semantic-conventions": "^1.41.1" }, "optionalDependencies": { "@opentelemetry/instrumentation": "^0.219.0", "@opentelemetry/instrumentation-undici": "^0.29.0" }, "peerDependencies": { "typescript": "^5 || ^6.0.0" } }, "sha512-8PvN7o3rySHlMk6+a/5X/F5/w1RqGJkFuvcdaSinhdXYCsuO24AALSFV0g8KY4jNtVDs7L3I6v6QsL7WxZECjw=="],
 
     "@photon-ai/proto": ["@photon-ai/proto@0.2.4", "", { "dependencies": { "@bufbuild/protobuf": "^2.12.0", "nice-grpc-common": "^2.0.3" } }, "sha512-DQANEp0gHvtwqpMGEF0ufa0hs1nniRdsSuo0Q/TG6GoL1WjC5tp59tHFSLUeIm6fvnAuRjREsGzURz3+/69g7g=="],
 
@@ -511,17 +518,17 @@
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.9.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-P8foouaP+y/p+hhEGBoZpzMbpVvUMwPjDpcy6wN7EYfvvyISD1USuV27qWkczecihwuPJzQ1lDBuL8ERcavTyg=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-EwvHThXzpY0KGd1/NAmuewI5D+aVa3Rl/OlxE36yfjUKb/+ySrfJrSlEFt8aD1OXwnnaHnQnPKHFndor0Zxlsg=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-SIzEkvtNdzdI50FJDaIQ6kQGqgSSdFPcdn0wqmmONN6iGKjy6hsT+EH99GP65FsfV7DLZTh2NmtTIRl2kdoz5Q=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9d2fTyyG0lf5Wq1bwJA9qUaeecViMkLcdctWaMMmCkxZ/JqypmqOwK3W6vmejeKVgkr06gSoiX8bD+xN5Jpxcg=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.9.3", "", { "os": "linux", "cpu": "x64" }, "sha512-pLRwFmcHHNBvsCySLS6OFabr/07kDT2pxEt/k6eBf/3asiVQZKJ7Rk88AafQx2aYA641qek4RsXvYO3JYpiBug=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.10.0", "", { "os": "linux", "cpu": "x64" }, "sha512-sZBtjMuufitanjzi6UssoUpJMnnPlLMcdcJj3m3ptNsSq31Xh7MnjhwA5nWvLDTfEFg8GPcbYFXMo8vSdKRfqQ=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.9.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-gy6ApUroC2Nzv+qjGtE/uPNkhHAFU4c8God+zd5Aiv9L9uBgHlxVJpHT3XWl5xwlJZ2KWuMrlHTaS5kmNB+q1Q=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vkq/Z8R+1DQ+kifWFa810IjRy2NNBVvha3cg9sWA3nFh6nnGrHSMnnJKrzH7c/No9kq4Jb55Ru44YKsCSBgrKg=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.9.3", "", { "os": "win32", "cpu": "x64" }, "sha512-d0YelTX6hAsB7kIEtGB3PzIzSfAg3yDoUlHwuwJc3adBXUsyUIs0YLG+1NNtuhcDOUGnWQeKUoJ2pGWvbpRj7w=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.10.0", "", { "os": "win32", "cpu": "x64" }, "sha512-CRUEguLWxFQHptYZS7HjPhNhAFawfea07iR+xAQ5e4klgLrPCMdexBkXwSCwOxqTFknJ7RZFN3gOaADsw+Gttg=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.9.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-/08CwpKJl3oRY8nOlh2YgilZVJDHsr60XTNxRhuDeuFXONpUZ5X+Nv65izbG/xBew9qxcJFbDX9/sAmAX+ITcQ=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-dVHGaf9F8twzgibcBqKoADT/LLqf9++jDb+hq/LPWWaOmRpp4M+/pVOm7vy4z9D++xg8eaxWLT0+wQxFwhYu9A=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
@@ -543,7 +550,7 @@
 
     "@types/mime-types": ["@types/mime-types@3.0.1", "", {}, "sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ=="],
 
-    "@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
+    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
 
     "@types/qs": ["@types/qs@6.15.1", "", {}, "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw=="],
 
@@ -560,6 +567,10 @@
     "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
+
+    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -629,7 +640,7 @@
 
     "cjs-module-lexer": ["cjs-module-lexer@1.4.3", "", {}, "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="],
 
-    "clean-publish": ["clean-publish@7.0.1", "", { "dependencies": { "lilconfig": "^3.1.3", "picomatch": "^4.0.4", "tinyexec": "^1.1.1", "tinyglobby": "^0.2.16" }, "bin": { "clean-publish": "clean-publish.js", "clear-package-json": "clear-package-json.js" } }, "sha512-Fr4c1dg6kEG4juBo2IMbft0w8inX0QTsbkRWIy5R0jZGWswQIpgOW0yfqV7bmyxn1F1eQtm9VBy5VDyB3go8WQ=="],
+    "clean-publish": ["clean-publish@7.1.0", "", { "dependencies": { "lilconfig": "^3.1.3", "picomatch": "^4.0.4", "tinyexec": "^1.1.2", "tinyglobby": "^0.2.16" }, "bin": { "clean-publish": "clean-publish.js", "clear-package-json": "clear-package-json.js" } }, "sha512-fnsFHW6fIq7Sr5Pf9YUsxB1up5pEA13DHg4Q/bZdphWssmIUuKV7G5Kaq2Q0X6UsCFm//uFbONOWTi7m4DvMTg=="],
 
     "cli-highlight": ["cli-highlight@2.1.11", "", { "dependencies": { "chalk": "^4.0.0", "highlight.js": "^10.7.1", "mz": "^2.4.0", "parse5": "^5.1.1", "parse5-htmlparser2-tree-adapter": "^6.0.0", "yargs": "^16.0.0" }, "bin": { "highlight": "bin/highlight" } }, "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg=="],
 
@@ -807,6 +818,8 @@
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
+    "import-in-the-middle": ["import-in-the-middle@3.2.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-vR2B6HKIhaBjcZr2bLpFiJ1VbzOlRQ7aby4/gw5WPIzToLjqpfWw3VJ4sk1uDchoOODEirvO2jyrSPtUSL5CrQ=="],
+
     "import-without-cache": ["import-without-cache@0.4.0", "", {}, "sha512-NkJQA7oZ4YHQhd2+H3BoRFKF3d/XNsiKpHZCQEMH9pDX27hQQLsTyOocyRgaIVtf8gHX3Nt3LPkR4e5EdtPAGQ=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
@@ -864,6 +877,8 @@
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
+
+    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
     "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
 
@@ -963,6 +978,8 @@
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
+
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
     "ret": ["ret@0.5.0", "", {}, "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw=="],
@@ -1051,9 +1068,9 @@
 
     "thread-stream": ["thread-stream@4.2.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ=="],
 
-    "tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
-    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "toad-cache": ["toad-cache@3.7.1", "", {}, "sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ=="],
 
@@ -1073,7 +1090,7 @@
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
-    "turbo": ["turbo@2.9.3", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.3", "@turbo/darwin-arm64": "2.9.3", "@turbo/linux-64": "2.9.3", "@turbo/linux-arm64": "2.9.3", "@turbo/windows-64": "2.9.3", "@turbo/windows-arm64": "2.9.3" }, "bin": { "turbo": "bin/turbo" } }, "sha512-J/VUvsGRykPb9R8Kh8dHVBOqioDexLk9BhLCU/ZybRR+HN9UR3cURdazFvNgMDt9zPP8TF6K73Z+tplfmi0PqQ=="],
+    "turbo": ["turbo@2.10.0", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.0", "@turbo/darwin-arm64": "2.10.0", "@turbo/linux-64": "2.10.0", "@turbo/linux-arm64": "2.10.0", "@turbo/windows-64": "2.10.0", "@turbo/windows-arm64": "2.10.0" }, "bin": { "turbo": "bin/turbo" } }, "sha512-o016H9PPtuH2deb3mh3Vci3Avfi9UYgM/RONQisY7HnloupP0IFSbFS3gFYJgFJP8nwBrByHWFQIDa8T2zIXPw=="],
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
@@ -1133,6 +1150,8 @@
 
     "@grpc/proto-loader/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
+    "@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.219.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg=="],
+
     "@photon-ai/slack/nice-grpc": ["nice-grpc@2.1.15", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.5.0", "nice-grpc-common": "^2.0.3" } }, "sha512-agPIt7dtQASnN5p1X3c2S5amDhWRWRT0Jp62trmpMBKSbkm87l8bG2slqxSthlrGa4AnRPG8+lFf4y8nn+Pogw=="],
 
     "@photon-ai/whatsapp-business/nice-grpc": ["nice-grpc@2.1.15", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.5.0", "nice-grpc-common": "^2.0.3" } }, "sha512-agPIt7dtQASnN5p1X3c2S5amDhWRWRT0Jp62trmpMBKSbkm87l8bG2slqxSthlrGa4AnRPG8+lFf4y8nn+Pogw=="],
@@ -1163,6 +1182,8 @@
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
+    "import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
+
     "light-my-request/process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
 
     "marked-terminal/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
@@ -1171,6 +1192,8 @@
 
     "node-abi/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
+    "nypm/tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
+
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "protobufjs/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
@@ -1178,10 +1201,6 @@
     "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
-
-    "tsdown/tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
-
-    "tsdown/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "tsx/get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
     },
     "packages/core": {
       "name": "@spectrum-ts/core",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "dependencies": {
         "@photon-ai/otel": "^3.1.0",
         "@photon-ai/proto": "^0.2.4",
@@ -54,7 +54,7 @@
     },
     "packages/elysia": {
       "name": "@spectrum-ts/elysia",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "devDependencies": {
         "@spectrum-ts/core": "workspace:*",
         "@spectrum-ts/test-support": "workspace:*",
@@ -70,7 +70,7 @@
     },
     "packages/express": {
       "name": "@spectrum-ts/express",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "devDependencies": {
         "@spectrum-ts/core": "workspace:*",
         "@spectrum-ts/test-support": "workspace:*",
@@ -87,7 +87,7 @@
     },
     "packages/fastify": {
       "name": "@spectrum-ts/fastify",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "devDependencies": {
         "@spectrum-ts/core": "workspace:*",
         "@spectrum-ts/test-support": "workspace:*",
@@ -103,7 +103,7 @@
     },
     "packages/hono": {
       "name": "@spectrum-ts/hono",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "devDependencies": {
         "@spectrum-ts/core": "workspace:*",
         "@spectrum-ts/test-support": "workspace:*",
@@ -119,7 +119,7 @@
     },
     "packages/imessage": {
       "name": "@spectrum-ts/imessage",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "dependencies": {
         "@photon-ai/advanced-imessage": "^0.12.0",
         "@photon-ai/imessage-kit": "^3.0.0",
@@ -141,7 +141,7 @@
     },
     "packages/slack": {
       "name": "@spectrum-ts/slack",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "dependencies": {
         "@photon-ai/slack": "^0.2.0",
         "zod": "^4.2.1",
@@ -158,7 +158,7 @@
     },
     "packages/spectrum-ts": {
       "name": "spectrum-ts",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "dependencies": {
         "@spectrum-ts/core": "8.0.0",
         "@spectrum-ts/imessage": "8.0.0",
@@ -174,7 +174,7 @@
     },
     "packages/telegram": {
       "name": "@spectrum-ts/telegram",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "dependencies": {
         "@photon-ai/telegram-ts": "10.0.0",
         "marked": "^18.0.5",
@@ -192,7 +192,7 @@
     },
     "packages/terminal": {
       "name": "@spectrum-ts/terminal",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "dependencies": {
         "zod": "^4.2.1",
       },
@@ -223,7 +223,7 @@
     },
     "packages/whatsapp-business": {
       "name": "@spectrum-ts/whatsapp-business",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "dependencies": {
         "@photon-ai/whatsapp-business": "^0.1.1",
         "mime-types": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.18.2",
-    "@biomejs/biome": "^2.4.12",
-    "@types/node": "^26.0.0",
-    "clean-publish": "^7.0.0",
-    "publint": "^0.3.14",
-    "turbo": "^2",
+    "@arethetypeswrong/cli": "^0.18.4",
+    "@biomejs/biome": "^2.5.1",
+    "@types/node": "^26.0.1",
+    "clean-publish": "^7.1.0",
+    "publint": "^0.3.21",
+    "turbo": "^2.10.0",
     "ultracite": "7.8.3"
   },
   "packageManager": "bun@1.3.14",
@@ -21,5 +21,8 @@
   "workspaces": [
     "packages/*",
     "examples/*"
-  ]
+  ],
+  "dependencies": {
+    "@photon-ai/otel": "^3.1.0"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,7 +53,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@photon-ai/otel": "^1.0.0",
+    "@photon-ai/otel": "^3.1.0",
     "@photon-ai/proto": "^0.2.4",
     "@repeaterjs/repeater": "^3.0.6",
     "marked": "^18.0.5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-ts/core",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "The spectrum-ts runtime — Spectrum, content builders, fusor, and the provider authoring API.",
   "repository": {
     "type": "git",

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -28,9 +28,11 @@ export {
   type LogAttrs,
   type LogLevel,
   type PhotonLogger,
+  type SanitizeUrlOptions,
   sanitizeEmail,
   sanitizeErrorMessage,
   sanitizePhone,
+  sanitizeUrl,
   setLogLevel,
 } from "@photon-ai/otel";
 // Content factories, schemas, and the inbound-record type (from `content/`).
@@ -49,6 +51,10 @@ export { asVoice } from "./content/voice";
 export type { ProviderMessageRecord } from "./platform/types";
 // Generic translation helpers (from `utils/`).
 export { ensureM4a } from "./utils/audio";
+// Outbound-HTTP tracing — wrap a provider's own fetch so its requests get a
+// CLIENT span tagged `peer.service`, without ever touching globalThis.fetch.
+// Pair `redactUrl` with `sanitizeUrl` to strip secrets from the recorded URL.
+export { tracedFetch } from "./utils/instrumented-fetch";
 export { renderInlineTokens } from "./utils/markdown";
 export {
   buildPhotoAction,

--- a/packages/core/src/spectrum.ts
+++ b/packages/core/src/spectrum.ts
@@ -214,6 +214,15 @@ function bootstrapTelemetry(opts: {
     endpoint: PHOTON_OTEL_ENDPOINT,
     headers,
     resourceAttributes,
+    // Never monkeypatch the consumer's global fetch: it would wrap their own
+    // unrelated outbound requests in spans and inject trace headers into them.
+    // Spectrum only traces its own operations via withSpan / tracedFetch.
+    instrumentFetch: false,
+    // Scoped mode: build our OTLP providers but hold them privately instead of
+    // registering them as the process-global tracer/logger providers, so a
+    // consumer's own OpenTelemetry is never clobbered (global registration is
+    // first-writer-wins). withSpan / createLogger / tracedFetch resolve them.
+    register: false,
   });
 }
 

--- a/packages/core/src/utils/cloud.ts
+++ b/packages/core/src/utils/cloud.ts
@@ -1,3 +1,5 @@
+import { tracedFetch } from "./instrumented-fetch";
+
 export const SPECTRUM_CLOUD_URL =
   process.env.SPECTRUM_CLOUD_URL ?? "https://spectrum.photon.codes";
 
@@ -119,8 +121,12 @@ interface ErrorBody {
   succeed: false;
 }
 
+// Spectrum's calls to its own cloud API, traced as CLIENT spans. The URL
+// carries no secret (Basic auth lives in init.headers), so no redaction needed.
+const cloudFetch = tracedFetch("spectrum-cloud");
+
 const request = async <T>(path: string, init?: RequestInit): Promise<T> => {
-  const response = await fetch(`${SPECTRUM_CLOUD_URL}${path}`, init);
+  const response = await cloudFetch(`${SPECTRUM_CLOUD_URL}${path}`, init);
 
   if (!response.ok) {
     const body = await response.text().catch(() => "");

--- a/packages/core/src/utils/instrumented-fetch.ts
+++ b/packages/core/src/utils/instrumented-fetch.ts
@@ -1,0 +1,33 @@
+import {
+  createInstrumentedFetch,
+  type FetchSpanOptions,
+} from "@photon-ai/otel";
+
+/**
+ * Build a fetch that traces spectrum's OWN outbound HTTP: each request through
+ * the returned fetch emits a CLIENT span (tagged with `peer.service`) and
+ * carries W3C trace context downstream. It never mutates `globalThis.fetch`, so
+ * a consumer's unrelated requests stay untouched.
+ *
+ * The base delegates to `globalThis.fetch` at call time — deliberately NOT
+ * `createInstrumentedFetch(globalThis.fetch, …)`, which would capture the
+ * original and bypass a test's `spyOn(globalThis, "fetch")`. When telemetry is
+ * off (no `setupOtel`), the tracer is a no-op and this is a transparent
+ * pass-through. Create one per module: `const tf = tracedFetch("…")`.
+ *
+ * Pass `redactUrl` to strip secrets from a request URL before it is recorded as
+ * the span's `url.full` (e.g. a token in the path or query); the real request
+ * still uses the original URL. Pair with `sanitizeUrl` for semconv-style query
+ * redaction.
+ */
+export const tracedFetch = (
+  peerService: string,
+  options?: Pick<FetchSpanOptions, "ignore" | "redactUrl">
+): typeof fetch =>
+  createInstrumentedFetch(
+    // Cast: the delegating lambda lacks fetch's `preconnect` static (which the
+    // instrumentation never calls), so it isn't structurally `typeof fetch`.
+    ((input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) =>
+      globalThis.fetch(input, init)) as typeof fetch,
+    { attributes: { "peer.service": peerService }, ...options }
+  );

--- a/packages/core/src/utils/io.ts
+++ b/packages/core/src/utils/io.ts
@@ -1,4 +1,6 @@
+import { sanitizeUrl } from "@photon-ai/otel";
 import z from "zod";
+import { tracedFetch } from "./instrumented-fetch";
 
 export const readSchema = z.function({
   input: [],
@@ -25,6 +27,11 @@ export interface FetchedBytes {
 
 const DEFAULT_FETCH_TIMEOUT_MS = 10_000;
 
+// Spectrum's own media/URL downloads, traced as CLIENT spans. sanitizeUrl
+// scrubs presigned-URL secrets from the recorded url.full (the real request
+// still uses the original URL).
+const mediaFetch = tracedFetch("media", { redactUrl: sanitizeUrl });
+
 /**
  * Fetch URL bytes into memory — never touches the filesystem, so callers
  * remain safe in read-only environments. Returns the response's Content-Type
@@ -40,7 +47,7 @@ export const fetchUrlBytes = async (
     options?.timeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS
   );
   try {
-    const res = await fetch(url, {
+    const res = await mediaFetch(url, {
       signal: controller.signal,
       headers: options?.headers,
     });

--- a/packages/core/test/utils/instrumented-fetch.test.ts
+++ b/packages/core/test/utils/instrumented-fetch.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { tracedFetch } from "@/utils/instrumented-fetch";
+
+describe("tracedFetch", () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  it("delegates to a globalThis.fetch spy installed AFTER the wrapper is built", async () => {
+    // Build the wrapper first — mirrors creation at module-eval time, before a
+    // test installs its fetch mock. Capturing globalThis.fetch here instead of
+    // delegating would silently bypass the spy.
+    const tf = tracedFetch("test-peer");
+    const spy = spyOn(globalThis, "fetch").mockImplementation(
+      (async () =>
+        new Response("ok", { status: 200 })) as unknown as typeof fetch
+    );
+
+    const res = await tf("https://example.test/thing");
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(await res.text()).toBe("ok");
+  });
+
+  it("forwards method, headers, and signal to the delegated fetch", async () => {
+    const tf = tracedFetch("test-peer");
+    let seenInit: RequestInit | undefined;
+    spyOn(globalThis, "fetch").mockImplementation((async (
+      _input: unknown,
+      init?: RequestInit
+    ) => {
+      seenInit = init;
+      return new Response("ok");
+    }) as unknown as typeof fetch);
+
+    const controller = new AbortController();
+    await tf("https://example.test/x", {
+      method: "POST",
+      headers: { "x-test": "1" },
+      signal: controller.signal,
+    });
+
+    expect(seenInit?.method).toBe("POST");
+    // The wrapper merges headers into a Headers object (and would inject
+    // traceparent when telemetry is on), so read via the Headers API.
+    expect(new Headers(seenInit?.headers).get("x-test")).toBe("1");
+    expect(seenInit?.signal).toBe(controller.signal);
+  });
+});

--- a/packages/core/test/utils/otel-scoped.test.ts
+++ b/packages/core/test/utils/otel-scoped.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { trace } from "@opentelemetry/api";
+import { setupOtel } from "@photon-ai/otel";
+
+// Regression guard for the client-facing-SDK conflict fix: scoped mode
+// (register: false) must NOT register spectrum's providers as the process-global
+// tracer/logger providers, or it would clobber a consumer's own OpenTelemetry
+// (global registration is first-writer-wins and silently drops the loser).
+describe("setupOtel scoped mode (register: false)", () => {
+  it("leaves the global tracer provider untouched", () => {
+    const globalBefore = trace.getTracerProvider();
+
+    const handle = setupOtel({
+      serviceName: "spectrum-ts-test",
+      register: false,
+    });
+
+    // The global provider is the same object as before the call...
+    expect(trace.getTracerProvider()).toBe(globalBefore);
+    // ...and spectrum's private provider is held separately, not registered.
+    expect(handle.tracerProvider).not.toBe(trace.getTracerProvider());
+  });
+});

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-ts/elysia",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "ElysiaJS webhook adapter for spectrum-ts.",
   "repository": {
     "type": "git",

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-ts/express",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Express webhook adapter for spectrum-ts.",
   "repository": {
     "type": "git",

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-ts/fastify",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Fastify webhook adapter for spectrum-ts.",
   "repository": {
     "type": "git",

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-ts/hono",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Hono webhook adapter for spectrum-ts.",
   "repository": {
     "type": "git",

--- a/packages/imessage/package.json
+++ b/packages/imessage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-ts/imessage",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "iMessage provider for spectrum-ts — local and remote (advanced) modes.",
   "repository": {
     "type": "git",

--- a/packages/imessage/package.json
+++ b/packages/imessage/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@photon-ai/advanced-imessage": "^0.12.0",
     "@photon-ai/imessage-kit": "^3.0.0",
-    "@photon-ai/otel": "^1.0.0",
+    "@photon-ai/otel": "^3.1.0",
     "lru-cache": "^11.0.0",
     "marked": "^18.0.5",
     "zod": "^4.2.1"

--- a/packages/imessage/src/local/inbound.ts
+++ b/packages/imessage/src/local/inbound.ts
@@ -4,10 +4,15 @@ import type {
   Message as LocalIMessage,
 } from "@photon-ai/imessage-kit";
 import { type ManagedStream, stream } from "@spectrum-ts/core";
+import { asText } from "@spectrum-ts/core/authoring";
+import {
+  ATTACHMENT_PLACEHOLDER,
+  hasUsableTextPart,
+  toOrderedParts,
+} from "../shared/inbound-parts";
 import type { IMessageMessage } from "../types";
 import { localAttachmentContent } from "./attachments";
 
-const ATTACHMENT_PLACEHOLDER = "\uFFFC";
 const ATTACHMENT_JOIN_RETRY_DELAY_MS = 250;
 const ATTACHMENT_JOIN_RETRY_LIMIT = 8;
 const ATTACHMENT_JOIN_FETCH_LIMIT = 10;
@@ -87,13 +92,43 @@ export const toMessages = async (
   };
 
   if (message.attachments.length > 0) {
-    return Promise.all(
-      message.attachments.map(async (att) => ({
-        ...base,
-        id: `${message.id}:${att.id}`,
-        content: await localAttachmentContent(att),
-      }))
-    );
+    if (!hasUsableTextPart(message.text)) {
+      return Promise.all(
+        message.attachments.map(async (att) => ({
+          ...base,
+          id: `${message.id}:${att.id}`,
+          content: await localAttachmentContent(att),
+        }))
+      );
+    }
+
+    const parts = toOrderedParts(message.text, message.attachments);
+    const messages: IMessageMessage[] = [];
+
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (!part) {
+        continue;
+      }
+
+      messages.push(
+        part.type === "text"
+          ? {
+              ...base,
+              id: `${message.id}:text:${i}`,
+              content: asText(part.text),
+              partIndex: i,
+            }
+          : {
+              ...base,
+              id: `${message.id}:${part.attachment.id}`,
+              content: await localAttachmentContent(part.attachment),
+              partIndex: i,
+            }
+      );
+    }
+
+    return messages;
   }
 
   return [

--- a/packages/imessage/src/remote/inbound.ts
+++ b/packages/imessage/src/remote/inbound.ts
@@ -16,6 +16,7 @@ import {
   groupSchema,
 } from "@spectrum-ts/core/authoring";
 import { getMessageCache, type MessageCache } from "../cache";
+import { type OrderedPart, toOrderedParts } from "../shared/inbound-parts";
 import { isVCardAttachment } from "../shared/vcard";
 import type { IMessageMessage } from "../types";
 import {
@@ -164,6 +165,104 @@ const buildAttachmentMessage = async (
   return msg;
 };
 
+const buildTextMessage = (
+  base: RemoteMessageBase,
+  text: string,
+  id: string,
+  partIndex: number,
+  parentId?: string
+): IMessageMessage => {
+  const msg: IMessageMessage = {
+    ...base,
+    id,
+    content: asText(text),
+    partIndex,
+  };
+  if (parentId !== undefined) {
+    msg.parentId = parentId;
+  }
+  return msg;
+};
+
+const buildOrderedPartMessage = async (
+  client: AdvancedIMessage,
+  base: RemoteMessageBase,
+  part: OrderedPart<AppleAttachment>,
+  id: string,
+  partIndex: number,
+  parentId?: string
+): Promise<IMessageMessage> =>
+  part.type === "text"
+    ? buildTextMessage(base, part.text, id, partIndex, parentId)
+    : await buildAttachmentMessage(
+        client,
+        base,
+        part.attachment,
+        id,
+        partIndex,
+        parentId
+      );
+
+const buildContentMessage = async (
+  client: AdvancedIMessage,
+  base: RemoteMessageBase,
+  message: AppleMessage,
+  messageGuidStr: string
+): Promise<IMessageMessage> => {
+  const attachments = messageAttachments(message);
+
+  if (attachments.length === 0) {
+    const text = message.content.text;
+    return {
+      ...base,
+      id: messageGuidStr,
+      content: text ? asText(text) : asCustom(message),
+    };
+  }
+
+  const parts = toOrderedParts(message.content.text, attachments);
+
+  if (parts.length === 0) {
+    return {
+      ...base,
+      id: messageGuidStr,
+      content: asCustom(message),
+    };
+  }
+
+  if (parts.length === 1) {
+    const part = parts[0];
+    if (!part) {
+      throw new Error("Unreachable: parts.length === 1 but no element");
+    }
+    return buildOrderedPartMessage(client, base, part, messageGuidStr, 0);
+  }
+
+  const items: IMessageMessage[] = [];
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    if (!part) {
+      continue;
+    }
+    items.push(
+      await buildOrderedPartMessage(
+        client,
+        base,
+        part,
+        formatChildId(i, messageGuidStr),
+        i,
+        messageGuidStr
+      )
+    );
+  }
+
+  return {
+    ...base,
+    id: messageGuidStr,
+    content: asProviderGroup(items),
+  };
+};
+
 export const rebuildFromAppleMessage = async (
   client: AdvancedIMessage,
   message: AppleMessage,
@@ -173,48 +272,7 @@ export const rebuildFromAppleMessage = async (
   const messageGuidStr = message.guid as string;
   const timestamp = message.dateCreated ?? new Date();
   const base = buildMessageBase(message, chatGuidHint, timestamp, phone);
-
-  const attachments = messageAttachments(message);
-
-  if (attachments.length === 1) {
-    const info = attachments[0];
-    if (!info) {
-      throw new Error("Unreachable: attachments.length === 1 but no element");
-    }
-    return buildAttachmentMessage(client, base, info, messageGuidStr, 0);
-  }
-
-  if (attachments.length > 1) {
-    const items: IMessageMessage[] = [];
-    for (let i = 0; i < attachments.length; i++) {
-      const info = attachments[i];
-      if (!info) {
-        continue;
-      }
-      items.push(
-        await buildAttachmentMessage(
-          client,
-          base,
-          info,
-          formatChildId(i, messageGuidStr),
-          i,
-          messageGuidStr
-        )
-      );
-    }
-    return {
-      ...base,
-      id: messageGuidStr,
-      content: asProviderGroup(items),
-    };
-  }
-
-  const text = message.content.text;
-  return {
-    ...base,
-    id: messageGuidStr,
-    content: text ? asText(text) : asCustom(message),
-  };
+  return buildContentMessage(client, base, message, messageGuidStr);
 };
 
 export const cacheMessage = (
@@ -244,58 +302,12 @@ export const toInboundMessages = async (
     phone
   );
   const messageGuidStr = event.message.guid as string;
-
-  const attachments = messageAttachments(event.message);
-
-  if (attachments.length === 1) {
-    const info = attachments[0];
-    if (!info) {
-      throw new Error("Unreachable: attachments.length === 1 but no element");
-    }
-    const msg = await buildAttachmentMessage(
-      client,
-      base,
-      info,
-      messageGuidStr,
-      0
-    );
-    cacheMessage(cache, msg);
-    return [msg];
-  }
-
-  if (attachments.length > 1) {
-    const items: IMessageMessage[] = [];
-    for (let i = 0; i < attachments.length; i++) {
-      const info = attachments[i];
-      if (!info) {
-        continue;
-      }
-      items.push(
-        await buildAttachmentMessage(
-          client,
-          base,
-          info,
-          formatChildId(i, messageGuidStr),
-          i,
-          messageGuidStr
-        )
-      );
-    }
-    const parent: IMessageMessage = {
-      ...base,
-      id: messageGuidStr,
-      content: asProviderGroup(items),
-    };
-    cacheMessage(cache, parent);
-    return [parent];
-  }
-
-  const text = event.message.content.text;
-  const msg: IMessageMessage = {
-    ...base,
-    id: messageGuidStr,
-    content: text ? asText(text) : asCustom(event.message),
-  };
+  const msg = await buildContentMessage(
+    client,
+    base,
+    event.message,
+    messageGuidStr
+  );
   cacheMessage(cache, msg);
   return [msg];
 };

--- a/packages/imessage/src/shared/inbound-parts.ts
+++ b/packages/imessage/src/shared/inbound-parts.ts
@@ -1,0 +1,61 @@
+export const ATTACHMENT_PLACEHOLDER = "\uFFFC";
+
+export type OrderedPart<TAttachment extends object> =
+  | { readonly text: string; readonly type: "text" }
+  | { readonly attachment: TAttachment; readonly type: "attachment" };
+
+const addTextPart = <TAttachment extends object>(
+  parts: OrderedPart<TAttachment>[],
+  text: string | undefined
+): void => {
+  const trimmed = text?.trim();
+  if (trimmed) {
+    parts.push({ type: "text", text: trimmed });
+  }
+};
+
+export const hasUsableTextPart = (text: string | null | undefined): boolean =>
+  text?.split(ATTACHMENT_PLACEHOLDER).some((segment) => segment.trim()) ??
+  false;
+
+const addAttachmentParts = <TAttachment extends object>(
+  parts: OrderedPart<TAttachment>[],
+  attachments: readonly TAttachment[]
+): void => {
+  for (const attachment of attachments) {
+    if (attachment) {
+      parts.push({ type: "attachment", attachment });
+    }
+  }
+};
+
+export const toOrderedParts = <TAttachment extends object>(
+  text: string | null | undefined,
+  attachments: readonly TAttachment[]
+): readonly OrderedPart<TAttachment>[] => {
+  const parts: OrderedPart<TAttachment>[] = [];
+
+  if (!text) {
+    addAttachmentParts(parts, attachments);
+    return parts;
+  }
+
+  if (!text.includes(ATTACHMENT_PLACEHOLDER)) {
+    addAttachmentParts(parts, attachments);
+    addTextPart(parts, text);
+    return parts;
+  }
+
+  const textSegments = text.split(ATTACHMENT_PLACEHOLDER);
+  for (let i = 0; i < attachments.length; i++) {
+    addTextPart(parts, textSegments[i]);
+
+    const attachment = attachments[i];
+    if (attachment) {
+      parts.push({ type: "attachment", attachment });
+    }
+  }
+
+  addTextPart(parts, textSegments.slice(attachments.length).join(""));
+  return parts;
+};

--- a/packages/imessage/src/types.ts
+++ b/packages/imessage/src/types.ts
@@ -60,8 +60,9 @@ export const spaceParamsSchema = z.object({
 
 /**
  * iMessage-specific per-message metadata surfaced on `IMessageMessage`.
- * - `partIndex`: attachment index within a multi-part message (0 for bare
- *   or single-attachment messages; 0..N-1 for a group's sub-items).
+ * - `partIndex`: ordered part index within a multi-part message. Text and
+ *   attachment parts both consume an index (0 for bare or single-part
+ *   messages; 0..N-1 for a group's sub-items).
  * - `parentId`: guid of the parent message for a group sub-item. Undefined
  *   when the message itself is the parent.
  */

--- a/packages/imessage/test/local/inbound.test.ts
+++ b/packages/imessage/test/local/inbound.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from "bun:test";
+import type { Message as LocalIMessage } from "@photon-ai/imessage-kit";
+import { toMessages } from "@/local/inbound";
+
+const CREATED_AT = new Date(1_700_000_000_000);
+const ATTACHMENT_PLACEHOLDER = "\uFFFC";
+
+const attachment = (
+  id: string,
+  fileName: string,
+  mimeType: string,
+  sizeBytes = 123
+): LocalIMessage["attachments"][number] =>
+  ({
+    fileName,
+    id,
+    isFromMe: false,
+    isSticker: false,
+    localPath: undefined,
+    mimeType,
+    sizeBytes,
+    transferName: fileName,
+    transferStatus: "finished",
+    uti: undefined,
+  }) as unknown as LocalIMessage["attachments"][number];
+
+const localMessage = (overrides: Partial<LocalIMessage> = {}): LocalIMessage =>
+  ({
+    attachments: [],
+    chatId: "chat-1",
+    chatKind: "direct",
+    createdAt: CREATED_AT,
+    hasAttachments: false,
+    id: "msg-1",
+    kind: "text",
+    participant: "+15551234567",
+    reaction: null,
+    retractedAt: null,
+    text: "hi",
+    ...overrides,
+  }) as unknown as LocalIMessage;
+
+const summarize = (message: Awaited<ReturnType<typeof toMessages>>[number]) => {
+  if (message.content.type === "attachment") {
+    return {
+      content: {
+        id: message.content.id,
+        mimeType: message.content.mimeType,
+        name: message.content.name,
+        type: message.content.type,
+      },
+      id: message.id,
+      partIndex: (message as { partIndex?: number }).partIndex,
+    };
+  }
+
+  return {
+    content: message.content,
+    id: message.id,
+    partIndex: (message as { partIndex?: number }).partIndex,
+  };
+};
+
+describe("iMessage local toMessages", () => {
+  it("keeps plain text messages as text", async () => {
+    const messages = await toMessages(localMessage({ text: "plain text" }));
+
+    expect(messages.map(summarize)).toEqual([
+      {
+        content: { text: "plain text", type: "text" },
+        id: "msg-1",
+        partIndex: undefined,
+      },
+    ]);
+  });
+
+  it("keeps a single attachment without text as a single attachment message", async () => {
+    const messages = await toMessages(
+      localMessage({
+        attachments: [attachment("att-0", "IMG_9151.png", "image/png")],
+        hasAttachments: true,
+        text: undefined,
+      })
+    );
+
+    expect(messages.map(summarize)).toEqual([
+      {
+        content: {
+          id: "att-0",
+          mimeType: "image/png",
+          name: "IMG_9151.png",
+          type: "attachment",
+        },
+        id: "msg-1:att-0",
+        partIndex: undefined,
+      },
+    ]);
+  });
+
+  it("keeps multiple attachments without usable text as attachment messages", async () => {
+    const messages = await toMessages(
+      localMessage({
+        attachments: [
+          attachment("att-0", "IMG_9151.png", "image/png"),
+          attachment("att-1", "central.log", "application/octet-stream"),
+        ],
+        hasAttachments: true,
+        text: ` ${ATTACHMENT_PLACEHOLDER}\n${ATTACHMENT_PLACEHOLDER} `,
+      })
+    );
+
+    expect(messages.map(summarize)).toEqual([
+      {
+        content: {
+          id: "att-0",
+          mimeType: "image/png",
+          name: "IMG_9151.png",
+          type: "attachment",
+        },
+        id: "msg-1:att-0",
+        partIndex: undefined,
+      },
+      {
+        content: {
+          id: "att-1",
+          mimeType: "application/octet-stream",
+          name: "central.log",
+          type: "attachment",
+        },
+        id: "msg-1:att-1",
+        partIndex: undefined,
+      },
+    ]);
+  });
+
+  it("reconstructs interleaved text and attachments in placeholder order", async () => {
+    const messages = await toMessages(
+      localMessage({
+        attachments: [
+          attachment("att-0", "IMG_9151.png", "image/png"),
+          attachment("att-1", "central.log", "application/octet-stream"),
+          attachment("att-2", "IMG_8883.png", "image/png"),
+        ],
+        hasAttachments: true,
+        text: `Link, next image ${ATTACHMENT_PLACEHOLDER} image, next file ${ATTACHMENT_PLACEHOLDER} final image ${ATTACHMENT_PLACEHOLDER} final text`,
+      })
+    );
+
+    expect(messages.map(summarize)).toEqual([
+      {
+        content: { text: "Link, next image", type: "text" },
+        id: "msg-1:text:0",
+        partIndex: 0,
+      },
+      {
+        content: {
+          id: "att-0",
+          mimeType: "image/png",
+          name: "IMG_9151.png",
+          type: "attachment",
+        },
+        id: "msg-1:att-0",
+        partIndex: 1,
+      },
+      {
+        content: { text: "image, next file", type: "text" },
+        id: "msg-1:text:2",
+        partIndex: 2,
+      },
+      {
+        content: {
+          id: "att-1",
+          mimeType: "application/octet-stream",
+          name: "central.log",
+          type: "attachment",
+        },
+        id: "msg-1:att-1",
+        partIndex: 3,
+      },
+      {
+        content: { text: "final image", type: "text" },
+        id: "msg-1:text:4",
+        partIndex: 4,
+      },
+      {
+        content: {
+          id: "att-2",
+          mimeType: "image/png",
+          name: "IMG_8883.png",
+          type: "attachment",
+        },
+        id: "msg-1:att-2",
+        partIndex: 5,
+      },
+      {
+        content: { text: "final text", type: "text" },
+        id: "msg-1:text:6",
+        partIndex: 6,
+      },
+    ]);
+  });
+
+  it("keeps attachment indexes stable when text has no placeholder", async () => {
+    const messages = await toMessages(
+      localMessage({
+        attachments: [attachment("att-0", "IMG_9151.png", "image/png")],
+        hasAttachments: true,
+        text: "caption without placeholder",
+      })
+    );
+
+    expect(messages.map(summarize)).toEqual([
+      {
+        content: {
+          id: "att-0",
+          mimeType: "image/png",
+          name: "IMG_9151.png",
+          type: "attachment",
+        },
+        id: "msg-1:att-0",
+        partIndex: 0,
+      },
+      {
+        content: { text: "caption without placeholder", type: "text" },
+        id: "msg-1:text:1",
+        partIndex: 1,
+      },
+    ]);
+  });
+
+  it("drops pending attachment joins until attachments settle", async () => {
+    const messages = await toMessages(
+      localMessage({
+        attachments: [],
+        hasAttachments: true,
+        text: ATTACHMENT_PLACEHOLDER,
+      })
+    );
+
+    expect(messages).toEqual([]);
+  });
+});

--- a/packages/imessage/test/remote/inbound.test.ts
+++ b/packages/imessage/test/remote/inbound.test.ts
@@ -7,8 +7,17 @@ import { MessageCache } from "@/cache";
 import { toInboundMessages } from "@/remote/inbound";
 
 type ReceivedEvent = Extract<MessageEvent, { type: "message.received" }>;
+type AttachmentContent = Extract<
+  Awaited<ReturnType<typeof toInboundMessages>>[number]["content"],
+  { type: "attachment" }
+>;
+type GroupItem = Extract<
+  Awaited<ReturnType<typeof toInboundMessages>>[number]["content"],
+  { type: "group" }
+>["items"][number];
 
 const RECEIVED_AT = new Date(1_700_000_000_000);
+const ATTACHMENT_PLACEHOLDER = "\uFFFC";
 
 // A plain text message never touches the client (no attachment download), so a
 // bare stub is enough to exercise the sender-normalization path.
@@ -39,6 +48,57 @@ const receivedEvent = (
       sender,
     },
   }) as unknown as ReceivedEvent;
+
+const attachment = (
+  guid: string,
+  fileName: string,
+  mimeType: string,
+  totalBytes = 123
+) => ({
+  guid,
+  fileName,
+  mimeType,
+  totalBytes,
+});
+
+const summarizeGroupItem = (item: GroupItem) => {
+  if (item.content.type === "attachment") {
+    return {
+      content: {
+        id: item.content.id,
+        mimeType: item.content.mimeType,
+        name: item.content.name,
+        type: item.content.type,
+      },
+      id: item.id,
+      parentId: (item as { parentId?: string }).parentId,
+      partIndex: (item as { partIndex?: number }).partIndex,
+    };
+  }
+
+  return {
+    content: item.content,
+    id: item.id,
+    parentId: (item as { parentId?: string }).parentId,
+    partIndex: (item as { partIndex?: number }).partIndex,
+  };
+};
+
+const summarizeCaptionItem = (item: GroupItem) => {
+  if (item.content.type === "attachment") {
+    return {
+      id: item.content.id,
+      partIndex: (item as { partIndex?: number }).partIndex,
+      type: item.content.type,
+    };
+  }
+
+  return {
+    partIndex: (item as { partIndex?: number }).partIndex,
+    text: item.content.type === "text" ? item.content.text : undefined,
+    type: item.content.type,
+  };
+};
 
 const inboundSender = async (sender?: Record<string, unknown>) => {
   const messages = await toInboundMessages(
@@ -82,6 +142,21 @@ describe("iMessage remote toInboundMessages sender", () => {
 });
 
 describe("iMessage remote toInboundMessages content", () => {
+  it("keeps plain text messages as text", async () => {
+    const [message] = await toInboundMessages(
+      client,
+      new MessageCache(),
+      receivedEvent({ address: "+15551234567" }, { text: "plain text" }),
+      "+15550000000"
+    );
+
+    expect(message?.id).toBe("msg-guid");
+    expect(message?.content).toEqual({ type: "text", text: "plain text" });
+    expect((message as { partIndex?: number } | undefined)?.partIndex).toBe(
+      undefined
+    );
+  });
+
   it("surfaces a URL balloon as plain text rather than a rich link", async () => {
     const [message] = await toInboundMessages(
       client,
@@ -99,5 +174,202 @@ describe("iMessage remote toInboundMessages content", () => {
       type: "text",
       text: "https://example.com/post",
     });
+  });
+
+  it("keeps a single attachment without text as a single attachment message", async () => {
+    const [message] = await toInboundMessages(
+      client,
+      new MessageCache(),
+      receivedEvent(
+        { address: "+15551234567" },
+        {
+          attachments: [attachment("att-0", "IMG_9151.png", "image/png")],
+          text: undefined,
+        }
+      ),
+      "+15550000000"
+    );
+
+    expect(message?.id).toBe("msg-guid");
+    expect(message?.content.type).toBe("attachment");
+    if (message?.content.type === "attachment") {
+      expect(message.content.id).toBe("att-0");
+      expect(message.content.name).toBe("IMG_9151.png");
+    }
+    expect((message as { partIndex?: number } | undefined)?.partIndex).toBe(0);
+    expect((message as { parentId?: string } | undefined)?.parentId).toBe(
+      undefined
+    );
+  });
+
+  it("keeps multiple attachments without usable text as an attachment-only group", async () => {
+    const [message] = await toInboundMessages(
+      client,
+      new MessageCache(),
+      receivedEvent(
+        { address: "+15551234567" },
+        {
+          attachments: [
+            attachment("att-0", "IMG_9151.png", "image/png"),
+            attachment("att-1", "central.log", "application/octet-stream"),
+          ],
+          text: ` ${ATTACHMENT_PLACEHOLDER} \n${ATTACHMENT_PLACEHOLDER} `,
+        }
+      ),
+      "+15550000000"
+    );
+
+    expect(message?.content.type).toBe("group");
+    if (message?.content.type !== "group") {
+      throw new Error("expected attachment-only group");
+    }
+
+    expect(message.content.items.map(summarizeCaptionItem)).toEqual([
+      { id: "att-0", partIndex: 0, type: "attachment" },
+      { id: "att-1", partIndex: 1, type: "attachment" },
+    ]);
+  });
+
+  it("reconstructs interleaved text and attachments in placeholder order", async () => {
+    const cache = new MessageCache();
+    const [message] = await toInboundMessages(
+      client,
+      cache,
+      receivedEvent(
+        { address: "+15551234567" },
+        {
+          attachments: [
+            attachment("att-0", "IMG_9151.png", "image/png"),
+            attachment("att-1", "central.log", "application/octet-stream"),
+            attachment("att-2", "IMG_8883.png", "image/png"),
+          ],
+          text: `Link, next iamge ${ATTACHMENT_PLACEHOLDER} \n\nimage, next file${ATTACHMENT_PLACEHOLDER}final image ${ATTACHMENT_PLACEHOLDER}final text\n`,
+        }
+      ),
+      "+15550000000"
+    );
+
+    expect(message?.content.type).toBe("group");
+    if (message?.content.type !== "group") {
+      throw new Error("expected grouped interleaved content");
+    }
+
+    expect(message.content.items.map(summarizeGroupItem)).toEqual([
+      {
+        content: { type: "text", text: "Link, next iamge" },
+        id: "p:0/msg-guid",
+        parentId: "msg-guid",
+        partIndex: 0,
+      },
+      {
+        content: {
+          id: "att-0",
+          mimeType: "image/png",
+          name: "IMG_9151.png",
+          type: "attachment",
+        },
+        id: "p:1/msg-guid",
+        parentId: "msg-guid",
+        partIndex: 1,
+      },
+      {
+        content: { type: "text", text: "image, next file" },
+        id: "p:2/msg-guid",
+        parentId: "msg-guid",
+        partIndex: 2,
+      },
+      {
+        content: {
+          id: "att-1",
+          mimeType: "application/octet-stream",
+          name: "central.log",
+          type: "attachment",
+        },
+        id: "p:3/msg-guid",
+        parentId: "msg-guid",
+        partIndex: 3,
+      },
+      {
+        content: { type: "text", text: "final image" },
+        id: "p:4/msg-guid",
+        parentId: "msg-guid",
+        partIndex: 4,
+      },
+      {
+        content: {
+          id: "att-2",
+          mimeType: "image/png",
+          name: "IMG_8883.png",
+          type: "attachment",
+        },
+        id: "p:5/msg-guid",
+        parentId: "msg-guid",
+        partIndex: 5,
+      },
+      {
+        content: { type: "text", text: "final text" },
+        id: "p:6/msg-guid",
+        parentId: "msg-guid",
+        partIndex: 6,
+      },
+    ]);
+    expect(cache.get("p:0/msg-guid")?.content).toEqual({
+      type: "text",
+      text: "Link, next iamge",
+    });
+    expect(
+      (cache.get("p:5/msg-guid")?.content as AttachmentContent | undefined)?.id
+    ).toBe("att-2");
+  });
+
+  it("keeps captions around a single attachment", async () => {
+    const [message] = await toInboundMessages(
+      client,
+      new MessageCache(),
+      receivedEvent(
+        { address: "+15551234567" },
+        {
+          attachments: [attachment("att-0", "IMG_9151.png", "image/png")],
+          text: `before ${ATTACHMENT_PLACEHOLDER} after`,
+        }
+      ),
+      "+15550000000"
+    );
+
+    expect(message?.content.type).toBe("group");
+    if (message?.content.type !== "group") {
+      throw new Error("expected grouped captioned attachment");
+    }
+
+    expect(message.content.items.map(summarizeCaptionItem)).toEqual([
+      { partIndex: 0, text: "before", type: "text" },
+      { id: "att-0", partIndex: 1, type: "attachment" },
+      { partIndex: 2, text: "after", type: "text" },
+    ]);
+  });
+
+  it("keeps attachment indexes stable when text has no placeholder", async () => {
+    const [message] = await toInboundMessages(
+      client,
+      new MessageCache(),
+      receivedEvent(
+        { address: "+15551234567" },
+        {
+          attachments: [attachment("att-0", "IMG_9151.png", "image/png")],
+          text: "caption without placeholder",
+        }
+      ),
+      "+15550000000"
+    );
+
+    expect(message?.content.type).toBe("group");
+    if (message?.content.type !== "group") {
+      throw new Error("expected grouped captioned attachment");
+    }
+
+    expect(message.content.items.map(summarizeCaptionItem)).toEqual([
+      { id: "att-0", partIndex: 0, type: "attachment" },
+      { partIndex: 1, text: "caption without placeholder", type: "text" },
+    ]);
   });
 });

--- a/packages/imessage/test/remote/reactions.test.ts
+++ b/packages/imessage/test/remote/reactions.test.ts
@@ -65,6 +65,23 @@ const sdkMessage = (overrides: Partial<SDKMessage> = {}): SDKMessage =>
     ...overrides,
   }) as unknown as SDKMessage;
 
+const attachment = (
+  guid: string,
+  fileName: string,
+  mimeType: string
+): SDKMessage["content"]["attachments"][number] =>
+  ({
+    fileName,
+    guid,
+    isHidden: false,
+    isOutgoing: false,
+    isSticker: false,
+    mimeType,
+    totalBytes: 123,
+    transferState: "finished",
+    uti: undefined,
+  }) as unknown as SDKMessage["content"]["attachments"][number];
+
 const reactionEvent = (
   overrides: Partial<
     Extract<MessageEvent, { type: "message.reactionAdded" }>
@@ -221,6 +238,55 @@ describe("iMessage remote toReactionMessages", () => {
         text: "hello",
         type: "text",
       });
+    }
+  });
+
+  it("resolves tapbacks to the ordered part inside an interleaved message", async () => {
+    const get = mock((_message: string) =>
+      Promise.resolve(
+        sdkMessage({
+          content: {
+            attachments: [
+              attachment("att-0", "IMG_9151.png", "image/png"),
+              attachment("att-1", "central.log", "application/octet-stream"),
+              attachment("att-2", "IMG_8883.png", "image/png"),
+            ],
+            formatting: [],
+            mentions: [],
+            text: "before \uFFFC middle \uFFFC after \uFFFC done",
+          },
+          isFromMe: false,
+          sender: { address: "+15550001111", service: "iMessage" },
+        })
+      )
+    );
+    const remote = {
+      messages: { get },
+    } as unknown as AdvancedIMessage;
+
+    const messages = await toReactionMessages(
+      remote,
+      new MessageCache(),
+      reactionEvent({ targetPartIndex: 5 }),
+      "+15551234567"
+    );
+
+    expect(messages).toHaveLength(1);
+    const message = messages[0];
+    expect(message?.id).toBe("msg-guid:reaction:1:5");
+    expect(message?.content.type).toBe("reaction");
+    if (message?.content.type !== "reaction") {
+      throw new Error("expected reaction content");
+    }
+
+    const targetMessage = message.content.target as unknown as IMessageMessage;
+    expect(targetMessage.id).toBe("p:5/msg-guid");
+    expect(targetMessage.parentId).toBe("msg-guid");
+    expect(targetMessage.partIndex).toBe(5);
+    expect(targetMessage.content.type).toBe("attachment");
+    if (targetMessage.content.type === "attachment") {
+      expect(targetMessage.content.id).toBe("att-2");
+      expect(targetMessage.content.name).toBe("IMG_8883.png");
     }
   });
 });

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-ts/slack",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Slack provider for spectrum-ts.",
   "repository": {
     "type": "git",

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectrum-ts",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Bring agents to any interface — unified messaging SDK for TypeScript. Batteries-included: the runtime plus every official provider.",
   "repository": {
     "type": "git",
@@ -71,12 +71,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@spectrum-ts/core": "8.0.0",
-    "@spectrum-ts/imessage": "8.0.0",
-    "@spectrum-ts/slack": "8.0.0",
-    "@spectrum-ts/telegram": "8.0.0",
-    "@spectrum-ts/terminal": "8.0.0",
-    "@spectrum-ts/whatsapp-business": "8.0.0"
+    "@spectrum-ts/core": "8.1.0",
+    "@spectrum-ts/imessage": "8.1.0",
+    "@spectrum-ts/slack": "8.1.0",
+    "@spectrum-ts/telegram": "8.1.0",
+    "@spectrum-ts/terminal": "8.1.0",
+    "@spectrum-ts/whatsapp-business": "8.1.0"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-ts/telegram",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Telegram provider for spectrum-ts.",
   "repository": {
     "type": "git",

--- a/packages/telegram/src/client.ts
+++ b/packages/telegram/src/client.ts
@@ -1,9 +1,26 @@
 import { createTelegramClient, getFile } from "@photon-ai/telegram-ts";
+import { tracedFetch } from "@spectrum-ts/core/authoring";
 import type { TelegramConfig } from "./config";
 import type { SentMessage, TelegramSendSpec } from "./types";
 
 const REQUEST_TIMEOUT_MS = 30_000;
 const TRAILING_SLASHES = /\/+$/;
+// The `/file/bot<token>` path segment of a Telegram file-download URL. Anchored
+// on `/file/` so a base whose host starts with `bot` (e.g. bot-proxy.example)
+// can't match the host instead of the token.
+const BOT_TOKEN_SEGMENT = /\/file\/bot[^/]+/;
+
+/**
+ * Mask the bot token embedded in a Telegram file URL path before it is recorded
+ * on a span (`/file/bot<token>/…` → `/file/bot<redacted>/…`). The real download
+ * still uses the true URL — only the span's `url.full` is masked.
+ */
+export const redactBotToken = (url: string): string =>
+  url.replace(BOT_TOKEN_SEGMENT, "/file/bot<redacted>");
+
+// Spectrum's Telegram media downloads, traced as CLIENT spans with the bot
+// token redacted from the recorded URL.
+const mediaFetch = tracedFetch("telegram", { redactUrl: redactBotToken });
 
 /**
  * A photon Bot API client (hey-api `Client`). Created per request — the
@@ -103,9 +120,12 @@ export const downloadFile = async (
     throw new Error(`Telegram getFile returned no file_path for ${fileId}`);
   }
   const base = config.baseUrl.replace(TRAILING_SLASHES, "");
-  const res = await fetch(`${base}/file/bot${config.botToken}/${filePath}`, {
-    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-  });
+  const res = await mediaFetch(
+    `${base}/file/bot${config.botToken}/${filePath}`,
+    {
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    }
+  );
   if (!res.ok) {
     throw new Error(
       `Telegram media download failed: ${res.status} ${res.statusText}`

--- a/packages/telegram/test/redact-url.test.ts
+++ b/packages/telegram/test/redact-url.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { redactBotToken } from "@/client";
+
+describe("redactBotToken", () => {
+  it("masks the bot token in a Telegram file URL path", () => {
+    const url =
+      "https://api.telegram.org/file/bot123456:AAH-secret_token/photos/file_1.jpg";
+    expect(redactBotToken(url)).toBe(
+      "https://api.telegram.org/file/bot<redacted>/photos/file_1.jpg"
+    );
+  });
+
+  it("never leaves the token in the redacted URL, for any base", () => {
+    const url =
+      "https://custom.example/file/bot987654:ZZ_top-secret/voice/v.ogg";
+    expect(redactBotToken(url)).not.toContain("987654:ZZ_top-secret");
+  });
+
+  it("redacts the token without mangling a bot-prefixed host", () => {
+    const url =
+      "https://bot-proxy.example/file/bot987654:ZZ_top-secret/voice/v.ogg";
+    expect(redactBotToken(url)).toBe(
+      "https://bot-proxy.example/file/bot<redacted>/voice/v.ogg"
+    );
+  });
+});

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-ts/terminal",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "Terminal (tuichat) provider for spectrum-ts — chat with your agent from the command line.",
   "repository": {
     "type": "git",

--- a/packages/whatsapp-business/package.json
+++ b/packages/whatsapp-business/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spectrum-ts/whatsapp-business",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "WhatsApp Business provider for spectrum-ts.",
   "repository": {
     "type": "git",

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -27,6 +27,7 @@ import {
   asReaction,
   asText,
   type ProviderMessageRecord,
+  tracedFetch,
 } from "@spectrum-ts/core/authoring";
 import { extension as mimeExtension } from "mime-types";
 import { pollOptionId, pollToInteractive } from "./poll";
@@ -322,12 +323,29 @@ const mapContent = (client: WhatsAppClient, msg: InboundMessage): Content => {
   }
 };
 
+// WhatsApp media URLs are signed (the download credential lives in the query
+// string), so drop the query from the recorded span URL — host + path are
+// enough to identify the download. The real request still uses the full URL.
+export const redactMediaUrl = (url: string): string => {
+  try {
+    const parsed = new URL(url);
+    parsed.search = "";
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+};
+
+const waMediaFetch = tracedFetch("whatsapp-business", {
+  redactUrl: redactMediaUrl,
+});
+
 const fetchMedia = async (
   client: WhatsAppClient,
   mediaId: string
 ): Promise<Response> => {
   const { url } = await client.media.getUrl(mediaId);
-  const response = await fetch(url);
+  const response = await waMediaFetch(url);
   if (!response.ok) {
     throw new Error(`Media download failed: ${response.status}`);
   }

--- a/packages/whatsapp-business/test/redact-url.test.ts
+++ b/packages/whatsapp-business/test/redact-url.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { redactMediaUrl } from "@/messages";
+
+describe("redactMediaUrl", () => {
+  it("drops the signed query string from a media URL", () => {
+    const url =
+      "https://lookaside.fbsbx.com/whatsapp_business/attachments/?mid=ABC&hash=SECRET_SIG";
+    expect(redactMediaUrl(url)).toBe(
+      "https://lookaside.fbsbx.com/whatsapp_business/attachments/"
+    );
+  });
+
+  it("never leaves signing material in the redacted URL", () => {
+    const redacted = redactMediaUrl(
+      "https://cdn.example/media/x?token=topsecret&exp=123"
+    );
+    expect(redacted).not.toContain("topsecret");
+    expect(redacted).not.toContain("token");
+  });
+
+  it("returns unparseable input unchanged", () => {
+    expect(redactMediaUrl("not a url")).toBe("not a url");
+  });
+});


### PR DESCRIPTION
## Summary
- Reconstruct iMessage inbound text and attachments from U+FFFC placeholders before building Spectrum content
- Preserve existing plain-text, attachment-only, and attachment-album behavior
- Add remote/local inbound regression coverage and ordered part reaction coverage

## Tests
- bunx ultracite check packages/imessage/src/shared/inbound-parts.ts packages/imessage/src/local/inbound.ts packages/imessage/src/remote/inbound.ts packages/imessage/src/types.ts packages/imessage/test/remote/inbound.test.ts packages/imessage/test/remote/reactions.test.ts packages/imessage/test/local/inbound.test.ts
- bun run --cwd packages/imessage typecheck
- bun run --cwd packages/imessage test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785422675&installation_id=127326493&pr_number=162&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F162&signature=87cb970bc02eb6deadf9a85631facd4d3e1e939f3ec56e21728002df4002f66b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iMessage content now preserves the original order of interleaved captions and attachments.
  * Reactions now target the correct text or attachment segment within multi-part messages.
* **Bug Fixes**
  * Improved handling of pending iMessage attachments by retrying until content is fully available.
  * Fixed placeholder-only caption cases and improved stability of part indexing/order.
* **Chores**
  * Added traced fetch instrumentation for cloud/media downloads, with redaction of sensitive URL details (e.g., tokens/credentials).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->