### PR TITLE
feat(whatsapp-business): log live-stream reconnects

### DIFF
--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -26,6 +26,7 @@ import {
   asPollOption,
   asReaction,
   asText,
+  createLogger,
   type ProviderMessageRecord,
   tracedFetch,
 } from "@spectrum-ts/core/authoring";
@@ -483,11 +484,27 @@ const contactToWa = (contact: Contact): ContactCardInput => {
   return card;
 };
 
+const streamLog = createLogger("spectrum.whatsapp.stream");
+
 const clientStream = (
   client: WhatsAppClient
 ): ManagedStream<WhatsAppMessage> => {
   const eventStream = client.events
-    .subscribe()
+    .subscribe({
+      // The client heals disconnects AND silently stalled streams on its own
+      // (its stallTimeoutMs converts missed heartbeats into a reconnect with
+      // cursor gap-fill). That recovery is invisible from out here, so
+      // surface each attempt for operators — without this a stalled stream
+      // heals with zero log evidence and a flapping upstream is
+      // indistinguishable from a healthy one.
+      reconnect: {
+        onReconnect: (attempt) => {
+          streamLog.warn("whatsapp live stream reconnecting", {
+            "spectrum.whatsapp.reconnect_attempt": attempt,
+          });
+        },
+      },
+    })
     .filter(
       (e): e is Extract<typeof e, { type: "message" }> => e.type === "message"
     );


### PR DESCRIPTION
The @photon-ai/whatsapp-business client self-heals disconnects — and, from 0.1.2, silently stalled streams via its stall timeout — replaying missed events from the cursor. That recovery is invisible above the client: a stream that stalls and recovers leaves zero log evidence. Surface each reconnect attempt through the existing spectrum.whatsapp.stream logger so operators can see and alert on flapping upstreams. Compatible with the currently-published 0.1.1.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/167"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785550948&installation_id=127326493&pr_number=167&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F167&signature=64f8ffe1334f404fefa8776124a6464d3dc0daccbfbcf1f49726b27cbcbce5c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WhatsApp stream handling so reconnect events are tracked more reliably.
  * Added clearer warning-level logging during stream reconnections to help surface connection issues sooner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->