### PR TITLE
fix: preserve imessage inbound replies

### DIFF
--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -45,6 +45,7 @@ export { asMarkdown } from "./content/markdown";
 export { asPoll, asPollOption } from "./content/poll";
 export { asReaction, reactionSchema } from "./content/reaction";
 export { asRead } from "./content/read";
+export { asReply, replySchema } from "./content/reply";
 export { asRichlink } from "./content/richlink";
 export { asText } from "./content/text";
 export { asVoice } from "./content/voice";

--- a/packages/core/src/platform/build.ts
+++ b/packages/core/src/platform/build.ts
@@ -469,8 +469,8 @@ const rawDirection = (
  * record can carry its own `direction` when the provider knows better than the
  * wrapping context, which matters for inbound reactions targeting outbound
  * messages.
- * Recursion through `wrapNestedContent` handles reaction targets and group
- * items, which providers return as nested raw records.
+ * Recursion through `wrapNestedContent` handles reaction/reply targets and
+ * group items, which providers return as nested raw records.
  */
 export function wrapProviderMessage(
   raw: ProviderMessageRecord,
@@ -523,6 +523,22 @@ const wrapNestedContent = (
       };
     }
     return content;
+  }
+  if (content.type === "reply") {
+    const wrappedInner = wrapNestedContent(
+      content.content,
+      ctx,
+      direction
+    ) as typeof content.content;
+    const target = content.target as unknown;
+    if (isRawProviderRecord(target)) {
+      return {
+        ...content,
+        content: wrappedInner,
+        target: wrapProviderMessage(target, ctx, "inbound"),
+      };
+    }
+    return { ...content, content: wrappedInner };
   }
   if (content.type === "edit") {
     const target = content.target as unknown;

--- a/packages/core/src/webhook/deserialize.ts
+++ b/packages/core/src/webhook/deserialize.ts
@@ -66,9 +66,9 @@ const asOptionalDate = (value: unknown): Date | undefined =>
  * message with no resolvable platform) — the caller acknowledges it (200)
  * rather than failing, since neither is fixed by a retry.
  *
- * Reaction targets and group items are emitted as **raw nested records**; the
- * `wrapProviderMessage`/`wrapNestedContent` pipeline turns them into fully-built
- * Messages, exactly as a provider's own `messages` handler would.
+ * Reaction/reply targets and group items are emitted as **raw nested records**;
+ * the `wrapProviderMessage`/`wrapNestedContent` pipeline turns them into
+ * fully-built Messages, exactly as a provider's own `messages` handler would.
  */
 export function deserializeSpectrumMessage(
   envelope: SlimEnvelope,
@@ -131,6 +131,8 @@ const mapContent = (
       return deserializeContact(raw);
     case "reaction":
       return deserializeReaction(raw, spaceRef);
+    case "reply":
+      return deserializeReply(raw, platform, spaceRef, ctx);
     case "group":
       return deserializeGroup(raw, platform, spaceRef, ctx);
     case "attachment":
@@ -174,6 +176,20 @@ const deserializeReaction = (
   ({
     type: "reaction",
     emoji: asString(raw.emoji),
+    target: buildTargetRecord(raw.target, spaceRef),
+  }) as unknown as Content;
+
+const deserializeReply = (
+  raw: Record<string, unknown>,
+  platform: string,
+  spaceRef: SpaceRef,
+  ctx: DeserializeContext
+): Content =>
+  ({
+    type: "reply",
+    content: isRecord(raw.content)
+      ? deserializeContent(raw.content as SlimContent, platform, spaceRef, ctx)
+      : asCustom(raw.content),
     target: buildTargetRecord(raw.target, spaceRef),
   }) as unknown as Content;
 

--- a/packages/core/test/core/send-reaction.test.ts
+++ b/packages/core/test/core/send-reaction.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@spectrum-ts/test-support/platform";
 import z from "zod";
 import { asReaction, reaction } from "@/content/reaction";
+import { asReply } from "@/content/reply";
 import type { Content } from "@/content/types";
 import { definePlatform } from "@/platform/define";
 import type { ProviderMessage, ProviderMessageRecord } from "@/platform/types";
@@ -233,6 +234,110 @@ describe("inbound reaction target direction", () => {
       if (message.content.type === "reaction") {
         expect(message.content.target.direction).toBe("inbound");
       }
+    } finally {
+      await app.stop();
+    }
+  });
+});
+
+describe("inbound reply target wrapping", () => {
+  const makeInboundReplyProvider = (
+    name: string,
+    target: ProviderMessageRecord,
+    content: Content = { type: "text", text: "answer" }
+  ) => {
+    const queue = makeQueue<ProviderMessage<{ id: string }, { id: string }>>();
+    queue.push({
+      id: "reply-1",
+      content: asReply({
+        content: content as Parameters<typeof asReply>[0]["content"],
+        target: target as unknown as Message,
+      }),
+      sender: { id: "u1" },
+      space: { id: "s1" },
+      timestamp: REACTION_TIMESTAMP,
+    });
+    queue.close();
+    return definePlatform(name, {
+      config: z.object({}),
+      lifecycle: {
+        createClient: () => Promise.resolve({}),
+      },
+      user: { resolve: ({ input }) => Promise.resolve({ id: input.userID }) },
+      space: {
+        create: ({ input }) =>
+          Promise.resolve({ id: input.users[0]?.id ?? "s1" }),
+      },
+      messages: () => queue.iter,
+      send: () => Promise.resolve(undefined),
+    });
+  };
+
+  it("wraps a raw reply target into a Message", async () => {
+    const provider = makeInboundReplyProvider("reply-target-wrap", {
+      id: "question-1",
+      content: { type: "text", text: "question" },
+      space: { id: "s1" },
+      timestamp: new Date(0),
+    });
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [, message] = await firstMessage(app);
+
+      expect(message.content.type).toBe("reply");
+      if (message.content.type === "reply") {
+        expect(message.content.target.id).toBe("question-1");
+        expect(message.content.target.direction).toBe("inbound");
+        expect(typeof message.content.target.reply).toBe("function");
+      }
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("wraps raw group items inside a reply", async () => {
+    const provider = makeInboundReplyProvider(
+      "reply-inner-group-wrap",
+      {
+        id: "question-1",
+        content: { type: "text", text: "question" },
+        space: { id: "s1" },
+        timestamp: new Date(0),
+      },
+      {
+        type: "group",
+        items: [
+          {
+            id: "reply-part-1",
+            content: { type: "text", text: "answer part" },
+            space: { id: "s1" },
+            timestamp: new Date(1),
+          } as unknown as Message,
+        ],
+      }
+    );
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [, message] = await firstMessage(app);
+
+      expect(message.content.type).toBe("reply");
+      if (message.content.type !== "reply") {
+        throw new Error("expected reply content");
+      }
+      expect(message.content.content.type).toBe("group");
+      if (message.content.content.type !== "group") {
+        throw new Error("expected group reply content");
+      }
+      const [item] = message.content.content.items;
+      expect(item?.id).toBe("reply-part-1");
+      expect(item?.platform).toBe("reply-inner-group-wrap");
+      expect(typeof item?.reply).toBe("function");
     } finally {
       await app.stop();
     }

--- a/packages/core/test/webhook/deserialize.test.ts
+++ b/packages/core/test/webhook/deserialize.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { Attachment } from "@/content/attachment";
 import type { Reaction } from "@/content/reaction";
+import type { Reply } from "@/content/reply";
 import {
   type DeserializeContext,
   deserializeSpectrumMessage,
@@ -106,6 +107,30 @@ describe("deserializeSpectrumMessage", () => {
     expect(target.id).toBe("target-1");
     expect(target.content).toEqual({ type: "text", text: "earlier message" });
     // A raw record (no methods) so wrapNestedContent wraps it into a Message.
+    expect((target as { react?: unknown }).react).toBeUndefined();
+  });
+
+  it("maps a reply to inner content and a raw text target", () => {
+    const { record } = deserialize({
+      type: "reply",
+      content: { type: "text", text: "answer" },
+      target: {
+        id: "target-1",
+        platform: PLATFORM,
+        timestamp: "2026-06-12T09:59:00.000Z",
+        sender: { id: "u2", platform: PLATFORM },
+        contentPreview: "question",
+      },
+    });
+    const content = record.content as unknown as Reply;
+    expect(content.type).toBe("reply");
+    expect(content.content).toEqual({ type: "text", text: "answer" });
+    const target = content.target as unknown as {
+      id: string;
+      content: { type: string; text: string };
+    };
+    expect(target.id).toBe("target-1");
+    expect(target.content).toEqual({ type: "text", text: "question" });
     expect((target as { react?: unknown }).react).toBeUndefined();
   });
 

--- a/packages/imessage/src/local/inbound.ts
+++ b/packages/imessage/src/local/inbound.ts
@@ -3,8 +3,13 @@ import type {
   IMessageSDK,
   Message as LocalIMessage,
 } from "@photon-ai/imessage-kit";
-import { type ManagedStream, stream } from "@spectrum-ts/core";
-import { asText } from "@spectrum-ts/core/authoring";
+import { type Content, type ManagedStream, stream } from "@spectrum-ts/core";
+import {
+  asCustom,
+  asReply,
+  asText,
+  type ProviderMessageRecord,
+} from "@spectrum-ts/core/authoring";
 import {
   ATTACHMENT_PLACEHOLDER,
   hasUsableTextPart,
@@ -23,6 +28,43 @@ const hasAttachmentPlaceholder = (message: LocalIMessage): boolean =>
 const isPendingAttachmentJoin = (message: LocalIMessage): boolean =>
   message.attachments.length === 0 &&
   (message.hasAttachments || hasAttachmentPlaceholder(message));
+
+const replyTargetId = (message: LocalIMessage): string | undefined =>
+  message.threadRootMessageId ?? undefined;
+
+const stubReplyTarget = (
+  space: IMessageMessage["space"],
+  targetId: string
+): ProviderMessageRecord => ({
+  id: targetId,
+  content: asCustom({ imessage_type: "reply-target", stub: true }),
+  space,
+});
+
+const asProviderReply = (
+  content: Content,
+  target: ProviderMessageRecord
+): Content =>
+  asReply({
+    content: content as Parameters<typeof asReply>[0]["content"],
+    target: target as unknown as Parameters<typeof asReply>[0]["target"],
+  });
+
+const wrapReply = (
+  messages: IMessageMessage[],
+  targetId: string | undefined
+): IMessageMessage[] => {
+  if (!targetId) {
+    return messages;
+  }
+  return messages.map((message) => ({
+    ...message,
+    content: asProviderReply(
+      message.content,
+      stubReplyTarget(message.space, targetId)
+    ),
+  }));
+};
 
 const refetchUntilAttachmentsSettle = async (
   client: IMessageSDK,
@@ -90,16 +132,18 @@ export const toMessages = async (
     },
     timestamp: message.createdAt,
   };
+  const targetId = replyTargetId(message);
 
   if (message.attachments.length > 0) {
     if (!hasUsableTextPart(message.text)) {
-      return Promise.all(
+      const messages = await Promise.all(
         message.attachments.map(async (att) => ({
           ...base,
           id: `${message.id}:${att.id}`,
           content: await localAttachmentContent(att),
         }))
       );
+      return wrapReply(messages, targetId);
     }
 
     const parts = toOrderedParts(message.text, message.attachments);
@@ -128,16 +172,19 @@ export const toMessages = async (
       );
     }
 
-    return messages;
+    return wrapReply(messages, targetId);
   }
 
-  return [
-    {
-      ...base,
-      id: message.id,
-      content: { type: "text", text: message.text ?? "" },
-    },
-  ];
+  return wrapReply(
+    [
+      {
+        ...base,
+        id: message.id,
+        content: { type: "text", text: message.text ?? "" },
+      },
+    ],
+    targetId
+  );
 };
 
 export const messages = (client: IMessageSDK): ManagedStream<IMessageMessage> =>

--- a/packages/imessage/src/remote/inbound.ts
+++ b/packages/imessage/src/remote/inbound.ts
@@ -78,6 +78,7 @@ type RawProviderMessage = Pick<IMessageMessage, "content" | "id">;
 interface BuildContentOptions {
   cache?: MessageCache;
   phone: string;
+  visitedReplyGuids?: ReadonlySet<string>;
 }
 
 export const isIMessageMessage = (value: unknown): value is IMessageMessage => {
@@ -297,7 +298,10 @@ const resolveReplyTarget = async (
   currentGuid: string,
   options: BuildContentOptions
 ): Promise<RawProviderMessage> => {
-  if (targetGuid === currentGuid) {
+  if (
+    targetGuid === currentGuid ||
+    options.visitedReplyGuids?.has(targetGuid)
+  ) {
     return stubReplyTarget(base, targetGuid);
   }
 
@@ -307,19 +311,33 @@ const resolveReplyTarget = async (
   }
 
   try {
+    const visitedReplyGuids = new Set(options.visitedReplyGuids);
+    visitedReplyGuids.add(currentGuid);
     const fetched = await client.messages.get(toMessageGuid(targetGuid));
     const rebuilt = await rebuildFromAppleMessage(
       client,
       fetched,
       options.phone,
       base.space.id,
-      options.cache
+      options.cache,
+      visitedReplyGuids
     );
     if (options.cache) {
       cacheMessage(options.cache, rebuilt);
     }
     return rebuilt;
-  } catch {
+  } catch (err) {
+    if (!(err instanceof NotFoundError)) {
+      log.warn(
+        "failed to resolve iMessage reply target; falling back to stub target",
+        {
+          "spectrum.imessage.message.guid": currentGuid,
+          "spectrum.imessage.reply.target_guid": targetGuid,
+          ...errorAttrs(err),
+        },
+        err
+      );
+    }
     return stubReplyTarget(base, targetGuid);
   }
 };
@@ -372,7 +390,8 @@ export const rebuildFromAppleMessage = async (
   message: AppleMessage,
   phone: string,
   chatGuidHint?: string,
-  cache?: MessageCache
+  cache?: MessageCache,
+  visitedReplyGuids?: ReadonlySet<string>
 ): Promise<IMessageMessage> => {
   const messageGuidStr = message.guid as string;
   const timestamp = message.dateCreated ?? new Date();
@@ -380,6 +399,7 @@ export const rebuildFromAppleMessage = async (
   return buildContentMessage(client, base, message, messageGuidStr, {
     cache,
     phone,
+    visitedReplyGuids,
   });
 };
 

--- a/packages/imessage/src/remote/inbound.ts
+++ b/packages/imessage/src/remote/inbound.ts
@@ -10,10 +10,12 @@ import {
   asAttachment,
   asContact,
   asCustom,
+  asReply,
   asText,
   createLogger,
   errorAttrs,
   groupSchema,
+  type ProviderMessageRecord,
 } from "@spectrum-ts/core/authoring";
 import { getMessageCache, type MessageCache } from "../cache";
 import { type OrderedPart, toOrderedParts } from "../shared/inbound-parts";
@@ -73,6 +75,10 @@ export const toSenderRef = (
 });
 
 type RawProviderMessage = Pick<IMessageMessage, "content" | "id">;
+interface BuildContentOptions {
+  cache?: MessageCache;
+  phone: string;
+}
 
 export const isIMessageMessage = (value: unknown): value is IMessageMessage => {
   if (typeof value !== "object" || value === null) {
@@ -91,6 +97,15 @@ export const isIMessageMessage = (value: unknown): value is IMessageMessage => {
 
 const asProviderGroup = (items: readonly RawProviderMessage[]): Group =>
   groupSchema.parse({ type: "group", items });
+
+const asProviderReply = (
+  content: Content,
+  target: RawProviderMessage
+): Content =>
+  asReply({
+    content: content as Parameters<typeof asReply>[0]["content"],
+    target: target as unknown as Parameters<typeof asReply>[0]["target"],
+  });
 
 export const buildMessageBase = (
   message: AppleMessage,
@@ -203,7 +218,7 @@ const buildOrderedPartMessage = async (
         parentId
       );
 
-const buildContentMessage = async (
+const buildUnwrappedContentMessage = async (
   client: AdvancedIMessage,
   base: RemoteMessageBase,
   message: AppleMessage,
@@ -263,16 +278,109 @@ const buildContentMessage = async (
   };
 };
 
+const replyTargetGuid = (message: AppleMessage): string | undefined =>
+  message.replyTargetGuid ?? message.threadOriginatorGuid;
+
+const stubReplyTarget = (
+  base: RemoteMessageBase,
+  targetGuid: string
+): ProviderMessageRecord => ({
+  id: targetGuid,
+  content: asCustom({ imessage_type: "reply-target", stub: true }),
+  space: base.space,
+});
+
+const resolveReplyTarget = async (
+  client: AdvancedIMessage,
+  base: RemoteMessageBase,
+  targetGuid: string,
+  currentGuid: string,
+  options: BuildContentOptions
+): Promise<RawProviderMessage> => {
+  if (targetGuid === currentGuid) {
+    return stubReplyTarget(base, targetGuid);
+  }
+
+  const cached = options.cache?.get(targetGuid);
+  if (cached) {
+    return cached;
+  }
+
+  try {
+    const fetched = await client.messages.get(toMessageGuid(targetGuid));
+    const rebuilt = await rebuildFromAppleMessage(
+      client,
+      fetched,
+      options.phone,
+      base.space.id,
+      options.cache
+    );
+    if (options.cache) {
+      cacheMessage(options.cache, rebuilt);
+    }
+    return rebuilt;
+  } catch {
+    return stubReplyTarget(base, targetGuid);
+  }
+};
+
+const buildContentMessage = async (
+  client: AdvancedIMessage,
+  base: RemoteMessageBase,
+  message: AppleMessage,
+  messageGuidStr: string,
+  options: BuildContentOptions
+): Promise<IMessageMessage> => {
+  const msg = await buildUnwrappedContentMessage(
+    client,
+    base,
+    message,
+    messageGuidStr
+  );
+  const targetGuid = replyTargetGuid(message);
+  if (!targetGuid) {
+    return msg;
+  }
+  const target = await resolveReplyTarget(
+    client,
+    base,
+    targetGuid,
+    messageGuidStr,
+    options
+  );
+  return {
+    ...msg,
+    content: asProviderReply(msg.content, target),
+  };
+};
+
+const messageGroupContent = (message: IMessageMessage): Group | undefined => {
+  if (message.content.type === "group") {
+    return message.content;
+  }
+  if (
+    message.content.type === "reply" &&
+    message.content.content.type === "group"
+  ) {
+    return message.content.content;
+  }
+  return;
+};
+
 export const rebuildFromAppleMessage = async (
   client: AdvancedIMessage,
   message: AppleMessage,
   phone: string,
-  chatGuidHint?: string
+  chatGuidHint?: string,
+  cache?: MessageCache
 ): Promise<IMessageMessage> => {
   const messageGuidStr = message.guid as string;
   const timestamp = message.dateCreated ?? new Date();
   const base = buildMessageBase(message, chatGuidHint, timestamp, phone);
-  return buildContentMessage(client, base, message, messageGuidStr);
+  return buildContentMessage(client, base, message, messageGuidStr, {
+    cache,
+    phone,
+  });
 };
 
 export const cacheMessage = (
@@ -280,8 +388,9 @@ export const cacheMessage = (
   message: IMessageMessage
 ): void => {
   cache.set(message.id, message);
-  if (message.content.type === "group") {
-    for (const item of message.content.items) {
+  const group = messageGroupContent(message);
+  if (group) {
+    for (const item of group.items) {
       if (isIMessageMessage(item)) {
         cache.set(item.id, item);
       }
@@ -306,7 +415,8 @@ export const toInboundMessages = async (
     client,
     base,
     event.message,
-    messageGuidStr
+    messageGuidStr,
+    { cache, phone }
   );
   cacheMessage(cache, msg);
   return [msg];
@@ -334,13 +444,15 @@ export const getMessage = async (
         remote,
         fetched,
         phone,
-        spaceId
+        spaceId,
+        cache
       );
       cacheMessage(cache, parent);
-      if (parent.content.type !== "group") {
+      const group = messageGroupContent(parent);
+      if (!group) {
         return;
       }
-      const item = parent.content.items[childRef.partIndex];
+      const item = group.items[childRef.partIndex];
       return isIMessageMessage(item) ? item : undefined;
     } catch (err) {
       if (err instanceof NotFoundError) {
@@ -356,7 +468,8 @@ export const getMessage = async (
       remote,
       fetched,
       phone,
-      spaceId
+      spaceId,
+      cache
     );
     cacheMessage(cache, rebuilt);
     return rebuilt;

--- a/packages/imessage/test/local/inbound.test.ts
+++ b/packages/imessage/test/local/inbound.test.ts
@@ -74,6 +74,36 @@ describe("iMessage local toMessages", () => {
     ]);
   });
 
+  it("wraps plain text replies with the thread root target", async () => {
+    const [message] = await toMessages(
+      localMessage({
+        text: "reply text",
+        threadRootMessageId: "target-message",
+      } as Partial<LocalIMessage>)
+    );
+
+    expect(message?.content.type).toBe("reply");
+    if (message?.content.type !== "reply") {
+      throw new Error("expected reply content");
+    }
+    expect(message.content.content).toEqual({
+      text: "reply text",
+      type: "text",
+    });
+    expect(message.content.target.id).toBe("target-message");
+  });
+
+  it("does not treat replyToMessageId alone as a public reply target", async () => {
+    const [message] = await toMessages(
+      localMessage({
+        replyToMessageId: "diagnostic-message",
+        text: "plain text",
+      } as Partial<LocalIMessage>)
+    );
+
+    expect(message?.content).toEqual({ text: "plain text", type: "text" });
+  });
+
   it("keeps a single attachment without text as a single attachment message", async () => {
     const messages = await toMessages(
       localMessage({
@@ -95,6 +125,28 @@ describe("iMessage local toMessages", () => {
         partIndex: undefined,
       },
     ]);
+  });
+
+  it("wraps attachment replies without changing the local message id", async () => {
+    const [message] = await toMessages(
+      localMessage({
+        attachments: [attachment("att-0", "IMG_9151.png", "image/png")],
+        hasAttachments: true,
+        text: undefined,
+        threadRootMessageId: "target-message",
+      } as Partial<LocalIMessage>)
+    );
+
+    expect(message?.id).toBe("msg-1:att-0");
+    expect(message?.content.type).toBe("reply");
+    if (message?.content.type !== "reply") {
+      throw new Error("expected reply content");
+    }
+    expect(message.content.target.id).toBe("target-message");
+    expect(message.content.content.type).toBe("attachment");
+    if (message.content.content.type === "attachment") {
+      expect(message.content.content.id).toBe("att-0");
+    }
   });
 
   it("keeps multiple attachments without usable text as attachment messages", async () => {
@@ -198,6 +250,43 @@ describe("iMessage local toMessages", () => {
         partIndex: 6,
       },
     ]);
+  });
+
+  it("wraps each local interleaved reply part without changing order", async () => {
+    const messages = await toMessages(
+      localMessage({
+        attachments: [
+          attachment("att-0", "IMG_9151.png", "image/png"),
+          attachment("att-1", "central.log", "application/octet-stream"),
+        ],
+        hasAttachments: true,
+        text: `before ${ATTACHMENT_PLACEHOLDER} after ${ATTACHMENT_PLACEHOLDER}`,
+        threadRootMessageId: "target-message",
+      } as Partial<LocalIMessage>)
+    );
+
+    expect(messages).toHaveLength(4);
+    expect(messages.map((message) => message.content.type)).toEqual([
+      "reply",
+      "reply",
+      "reply",
+      "reply",
+    ]);
+    const inners = messages.map((message) =>
+      message.content.type === "reply" ? message.content.content.type : "none"
+    );
+    expect(inners).toEqual(["text", "attachment", "text", "attachment"]);
+    expect(
+      messages.map((message) =>
+        message.content.type === "reply" ? message.content.target.id : ""
+      )
+    ).toEqual([
+      "target-message",
+      "target-message",
+      "target-message",
+      "target-message",
+    ]);
+    expect(messages.map((message) => message.partIndex)).toEqual([0, 1, 2, 3]);
   });
 
   it("keeps attachment indexes stable when text has no placeholder", async () => {

--- a/packages/imessage/test/remote/inbound.test.ts
+++ b/packages/imessage/test/remote/inbound.test.ts
@@ -25,7 +25,8 @@ const client = {} as unknown as AdvancedIMessage;
 
 const receivedEvent = (
   sender?: Record<string, unknown>,
-  content?: Record<string, unknown>
+  content?: Record<string, unknown>,
+  messageOverrides?: Record<string, unknown>
 ): ReceivedEvent =>
   ({
     type: "message.received",
@@ -46,6 +47,7 @@ const receivedEvent = (
       dateCreated: RECEIVED_AT,
       isFromMe: false,
       sender,
+      ...messageOverrides,
     },
   }) as unknown as ReceivedEvent;
 
@@ -173,6 +175,137 @@ describe("iMessage remote toInboundMessages content", () => {
     expect(message?.content).toEqual({
       type: "text",
       text: "https://example.com/post",
+    });
+  });
+
+  it("wraps text replies with the canonical reply target", async () => {
+    const [message] = await toInboundMessages(
+      client,
+      new MessageCache(),
+      receivedEvent(
+        { address: "+15551234567" },
+        { text: "reply text" },
+        {
+          replyTargetGuid: "target-guid",
+          replyToGuid: "ignored-reply-to",
+          threadOriginatorGuid: "thread-guid",
+        }
+      ),
+      "+15550000000"
+    );
+
+    expect(message?.content.type).toBe("reply");
+    if (message?.content.type !== "reply") {
+      throw new Error("expected reply content");
+    }
+    expect(message.content.content).toEqual({
+      type: "text",
+      text: "reply text",
+    });
+    expect(message.content.target.id).toBe("target-guid");
+  });
+
+  it("falls back to threadOriginatorGuid for inbound replies", async () => {
+    const [message] = await toInboundMessages(
+      client,
+      new MessageCache(),
+      receivedEvent(
+        { address: "+15551234567" },
+        { text: "reply text" },
+        { threadOriginatorGuid: "thread-guid" }
+      ),
+      "+15550000000"
+    );
+
+    expect(message?.content.type).toBe("reply");
+    if (message?.content.type !== "reply") {
+      throw new Error("expected reply content");
+    }
+    expect(message.content.target.id).toBe("thread-guid");
+  });
+
+  it("does not treat replyToGuid alone as a public reply target", async () => {
+    const [message] = await toInboundMessages(
+      client,
+      new MessageCache(),
+      receivedEvent(
+        { address: "+15551234567" },
+        { text: "plain text" },
+        { replyToGuid: "diagnostic-guid" }
+      ),
+      "+15550000000"
+    );
+
+    expect(message?.content).toEqual({ type: "text", text: "plain text" });
+  });
+
+  it("resolves reply targets from the message cache", async () => {
+    const cache = new MessageCache();
+    cache.set("target-guid", {
+      content: { type: "text", text: "cached target" },
+      id: "target-guid",
+      space: { id: "s1", phone: "+15550000000", type: "dm" },
+      timestamp: RECEIVED_AT,
+    } as Awaited<ReturnType<typeof toInboundMessages>>[number]);
+
+    const [message] = await toInboundMessages(
+      client,
+      cache,
+      receivedEvent(
+        { address: "+15551234567" },
+        { text: "reply text" },
+        { replyTargetGuid: "target-guid" }
+      ),
+      "+15550000000"
+    );
+
+    expect(message?.content.type).toBe("reply");
+    if (message?.content.type !== "reply") {
+      throw new Error("expected reply content");
+    }
+    expect(message.content.target.content).toEqual({
+      type: "text",
+      text: "cached target",
+    });
+  });
+
+  it("resolves reply targets from the remote client when absent from cache", async () => {
+    const remote = {
+      messages: {
+        get: async (guid: string) => ({
+          chatGuids: ["s1"],
+          content: {
+            attachments: [],
+            formatting: [],
+            mentions: [],
+            text: `target ${guid}`,
+          },
+          dateCreated: RECEIVED_AT,
+          guid,
+          isFromMe: false,
+          sender: { address: "+15557654321" },
+        }),
+      },
+    } as unknown as AdvancedIMessage;
+
+    const [message] = await toInboundMessages(
+      remote,
+      new MessageCache(),
+      receivedEvent(
+        { address: "+15551234567" },
+        { text: "reply text" },
+        { replyTargetGuid: "target-guid" }
+      ),
+      "+15550000000"
+    );
+
+    expect(message?.content.type).toBe("reply");
+    if (message?.content.type !== "reply") {
+      throw new Error("expected reply content");
+    }
+    expect(message.content.target.content).toEqual({
+      type: "text",
+      text: "target target-guid",
     });
   });
 
@@ -346,6 +479,73 @@ describe("iMessage remote toInboundMessages content", () => {
       { id: "att-0", partIndex: 1, type: "attachment" },
       { partIndex: 2, text: "after", type: "text" },
     ]);
+  });
+
+  it("wraps a single inbound attachment reply", async () => {
+    const [message] = await toInboundMessages(
+      client,
+      new MessageCache(),
+      receivedEvent(
+        { address: "+15551234567" },
+        {
+          attachments: [attachment("att-0", "IMG_9151.png", "image/png")],
+          text: undefined,
+        },
+        { replyTargetGuid: "target-guid" }
+      ),
+      "+15550000000"
+    );
+
+    expect(message?.content.type).toBe("reply");
+    if (message?.content.type !== "reply") {
+      throw new Error("expected reply content");
+    }
+    expect(message.content.target.id).toBe("target-guid");
+    expect(message.content.content.type).toBe("attachment");
+    if (message.content.content.type === "attachment") {
+      expect(message.content.content.id).toBe("att-0");
+    }
+  });
+
+  it("wraps interleaved inbound reply content without changing part order", async () => {
+    const cache = new MessageCache();
+    const [message] = await toInboundMessages(
+      client,
+      cache,
+      receivedEvent(
+        { address: "+15551234567" },
+        {
+          attachments: [
+            attachment("att-0", "IMG_9151.png", "image/png"),
+            attachment("att-1", "central.log", "application/octet-stream"),
+          ],
+          text: `before ${ATTACHMENT_PLACEHOLDER} middle ${ATTACHMENT_PLACEHOLDER} after`,
+        },
+        { replyTargetGuid: "target-guid" }
+      ),
+      "+15550000000"
+    );
+
+    expect(message?.content.type).toBe("reply");
+    if (message?.content.type !== "reply") {
+      throw new Error("expected reply content");
+    }
+    expect(message.content.content.type).toBe("group");
+    if (message.content.content.type !== "group") {
+      throw new Error("expected grouped reply content");
+    }
+    expect(message.content.content.items.map(summarizeCaptionItem)).toEqual([
+      { partIndex: 0, text: "before", type: "text" },
+      { id: "att-0", partIndex: 1, type: "attachment" },
+      { partIndex: 2, text: "middle", type: "text" },
+      { id: "att-1", partIndex: 3, type: "attachment" },
+      { partIndex: 4, text: "after", type: "text" },
+    ]);
+    expect(cache.get("p:1/msg-guid")?.content.type).toBe("attachment");
+    expect(cache.get("p:4/msg-guid")?.content).toEqual({
+      type: "text",
+      text: "after",
+    });
   });
 
   it("keeps attachment indexes stable when text has no placeholder", async () => {

--- a/packages/imessage/test/remote/inbound.test.ts
+++ b/packages/imessage/test/remote/inbound.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import type {
-  AdvancedIMessage,
-  MessageEvent,
+import {
+  type AdvancedIMessage,
+  type MessageEvent,
+  NotFoundError,
 } from "@photon-ai/advanced-imessage";
 import { MessageCache } from "@/cache";
 import { toInboundMessages } from "@/remote/inbound";
@@ -19,9 +20,17 @@ type GroupItem = Extract<
 const RECEIVED_AT = new Date(1_700_000_000_000);
 const ATTACHMENT_PLACEHOLDER = "\uFFFC";
 
-// A plain text message never touches the client (no attachment download), so a
-// bare stub is enough to exercise the sender-normalization path.
-const client = {} as unknown as AdvancedIMessage;
+const client = {
+  messages: {
+    get: async () => {
+      throw new NotFoundError("not found", {
+        code: "messageNotFound",
+        grpcCode: 5,
+        retryable: false,
+      });
+    },
+  },
+} as unknown as AdvancedIMessage;
 
 const receivedEvent = (
   sender?: Record<string, unknown>,
@@ -306,6 +315,60 @@ describe("iMessage remote toInboundMessages content", () => {
     expect(message.content.target.content).toEqual({
       type: "text",
       text: "target target-guid",
+    });
+  });
+
+  it("uses a stub target for cyclic reply target chains", async () => {
+    const fetchedGuids: string[] = [];
+    const remote = {
+      messages: {
+        get: async (guid: string) => {
+          fetchedGuids.push(guid);
+          return {
+            chatGuids: ["s1"],
+            content: {
+              attachments: [],
+              formatting: [],
+              mentions: [],
+              text: "target reply",
+            },
+            dateCreated: RECEIVED_AT,
+            guid,
+            isFromMe: false,
+            replyTargetGuid: "msg-guid",
+            sender: { address: "+15557654321" },
+          };
+        },
+      },
+    } as unknown as AdvancedIMessage;
+
+    const [message] = await toInboundMessages(
+      remote,
+      new MessageCache(),
+      receivedEvent(
+        { address: "+15551234567" },
+        { text: "reply text" },
+        { replyTargetGuid: "target-guid" }
+      ),
+      "+15550000000"
+    );
+
+    expect(fetchedGuids).toEqual(["target-guid"]);
+    expect(message?.content.type).toBe("reply");
+    if (message?.content.type !== "reply") {
+      throw new Error("expected reply content");
+    }
+    expect(message.content.target.content.type).toBe("reply");
+    if (message.content.target.content.type !== "reply") {
+      throw new Error("expected nested reply content");
+    }
+    expect(message.content.target.content.target.id).toBe("msg-guid");
+    expect(message.content.target.content.target.content).toEqual({
+      raw: {
+        imessage_type: "reply-target",
+        stub: true,
+      },
+      type: "custom",
     });
   });
 


### PR DESCRIPTION
## Summary
- preserve inbound iMessage reply relationships using Spectrum reply content
- resolve remote reply targets from cache/client with a stub fallback
- add local and remote inbound reply coverage plus core reply wrapping/deserialize coverage

## Tests
- bun run check
- bun run typecheck
- bun run test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785565895&installation_id=127326493&pr_number=168&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F168&signature=cc810d05447fd1be7cf1e0d95532f078e65b0c7c737978986080a6857185464b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for `reply` content in inbound message handling, including nested replies, reply targets, and reply content with attachments.
  * Improved preservation of threading context when rebuilding or receiving messages, including correct grouping and part ordering.

* **Bug Fixes**
  * Fixed reply-target wrapping to resolve thread references more reliably, including cases where reply targets are missing or unavailable.
  * Improved reply deserialization so reply content and target fields map consistently, with better handling of cached rebuilds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->