### PR TITLE
test: switch to vitest and run the suite under both Node and Bun (ENG-1746)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false # read-only job, never pushes
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
@@ -47,6 +49,8 @@ jobs:
         runtime: [node, bun]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false # read-only job, never pushes
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,10 +20,15 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
+      # Pin the Node that `vitest run` (and the build) executes under.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
       - run: bun install --frozen-lockfile
       - run: bun run check # ultracite lint/format
       - run: bun run typecheck # per-package tsc --noEmit via turbo
-      - run: bun run test # turbo test -> per-package bun test
+      - run: bun run test:node # turbo -> per-package `vitest run` (Node)
+      - run: bun run test:bun # same suite under the Bun runtime
       - run: bun run build # turbo build -> tsdown + smoke-import (+ manifest in core)
       # Validate the exact artifacts we'd publish: clean-publish output passes
       # publint + attw, devDeps stripped, no workspace:/catalog: survivors.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,15 +20,13 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: .bun-version
-      # Pin the Node that `vitest run` (and the build) executes under.
+      # Pin the Node that the build's smoke-import executes under.
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
       - run: bun install --frozen-lockfile
       - run: bun run check # ultracite lint/format
       - run: bun run typecheck # per-package tsc --noEmit via turbo
-      - run: bun run test:node # turbo -> per-package `vitest run` (Node)
-      - run: bun run test:bun # same suite under the Bun runtime
       - run: bun run build # turbo build -> tsdown + smoke-import (+ manifest in core)
       # Validate the exact artifacts we'd publish: clean-publish output passes
       # publint + attw, devDeps stripped, no workspace:/catalog: survivors.
@@ -37,3 +35,26 @@ jobs:
       # undeclared cross-package imports. Non-blocking while experimental.
       - run: bun x turbo boundaries
         continue-on-error: true
+
+  # Run the same vitest suite under both runtimes as parallel matrix legs — bun
+  # and node diverge, so each is exercised independently.
+  test:
+    name: test (${{ matrix.runtime }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runtime: [node, bun]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version-file: .bun-version
+      # The node leg pins the Node that `vitest run` executes under; the bun leg
+      # forces bun via `bun --bun vitest run` and needs no Node setup.
+      - if: matrix.runtime == 'node'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+      - run: bun install --frozen-lockfile
+      - run: bun run test:${{ matrix.runtime }} # turbo -> per-package vitest run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,9 +126,9 @@ Most formatting and common issues are automatically fixed by Biome. Run `bun x u
 
 ## Cursor Cloud specific instructions
 
-This is a **Bun workspaces + Turbo monorepo** that publishes the `spectrum-ts` SDK and its provider packages. It is a **library, not a deployable service** — there are no servers, databases, or background daemons to run. The full validation loop is in-process. Standard commands live in `CONTRIBUTING.md` (`bun run check` / `typecheck` / `test` / `build`) and `package.json` scripts; use those rather than reinventing them.
+This is a **Bun workspaces + Turbo monorepo** that publishes the `spectrum-ts` SDK and its provider packages. It is a **library, not a deployable service** — there are no servers, databases, or background daemons to run. The full validation loop is in-process. Standard commands live in `CONTRIBUTING.md` (`bun run check` / `typecheck` / `test` / `test:node` / `test:bun` / `build`) and `package.json` scripts; use those rather than reinventing them.
 
-Runtime: Bun (pinned to `.bun-version`, currently 1.3.14) is the package manager and test runner. Node 24 is also installed and made the default `node` (see build gotcha below).
+Runtime: Bun (pinned to `.bun-version`, currently 1.3.14) is the package manager. Tests use Vitest and run under BOTH runtimes — `bun run test:node` (Node 24) and `bun run test:bun` (`bun --bun vitest run`); `bun run test` runs both. Node 24 is also installed and made the default `node` (see build gotcha below).
 
 Non-obvious gotchas:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,18 +48,20 @@ bun run examples/basic/index.ts
 ### Run tests
 
 ```bash
-bun run test            # whole suite (via Turbo)
+bun run test            # whole suite under BOTH runtimes (via Turbo)
+bun run test:node       # whole suite under Node only
+bun run test:bun        # whole suite under the Bun runtime only
 ```
 
 Or from inside a package directory:
 
 ```bash
-cd packages/core && bun test            # core suite
-cd packages/telegram && bun test        # one provider
-bun run test:watch                      # watch mode (core)
+cd packages/core && bun run test:node   # core suite (Node)
+cd packages/telegram && bun run test:bun # one provider (Bun runtime)
+bun run test:watch                      # watch mode (core, Node)
 ```
 
-Tests use [`bun:test`](https://bun.sh/docs/cli/test) and live in each package's `test/` directory, mirroring its `src/`. Core tests (`packages/core/test/{core,content,utils}/`) cover the SDK; each provider package carries its own tests (`packages/<platform>/test/`). Import the code under test through the package-local `@/*` alias (`@/spectrum` in core, `@/verify` in a provider) and shared fixtures from `@spectrum-ts/test-support/*`.
+Tests use [Vitest](https://vitest.dev) and run under both Node (`vitest run`) and the Bun runtime (`bun --bun vitest run`) so Bun/Node incompatibilities surface in CI. They live in each package's `test/` directory, mirroring its `src/`. Core tests (`packages/core/test/{core,content,utils}/`) cover the SDK; each provider package carries its own tests (`packages/<platform>/test/`). Import the code under test through the package-local `@/*` alias (`@/spectrum` in core, `@/verify` in a provider) and shared fixtures from `@spectrum-ts/test-support/*`.
 
 ### Lint and format
 

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
         "zod": "^4.2.1",
       },
       "devDependencies": {
+        "@opentelemetry/api": "^1.9.1",
         "@types/bun": "latest",
         "@types/mime-types": "^3.0.1",
         "@types/vcf": "^2.0.7",

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "publint": "^0.3.21",
         "turbo": "^2.10.0",
         "ultracite": "7.8.3",
+        "vitest": "^4.1.9",
       },
     },
     "examples/basic": {
@@ -40,9 +41,13 @@
         "@types/bun": "latest",
         "@types/mime-types": "^3.0.1",
         "@types/vcf": "^2.0.7",
+        "@types/ws": "^8",
+        "@vitest/coverage-v8": "^4.1.9",
         "hotscript": "^1.0.13",
         "tsdown": "^0.22.2",
         "unicode-emoji-json": "^0.9.0",
+        "vitest": "^4.1.9",
+        "ws": "^8.21.0",
       },
       "peerDependencies": {
         "ffmpeg-static": "^5",
@@ -61,6 +66,7 @@
         "@types/bun": "latest",
         "elysia": "^1",
         "tsdown": "^0.22.2",
+        "vitest": "^4.1.9",
       },
       "peerDependencies": {
         "@spectrum-ts/core": "^8.0.0",
@@ -78,6 +84,7 @@
         "@types/express": "^5",
         "express": "^5",
         "tsdown": "^0.22.2",
+        "vitest": "^4.1.9",
       },
       "peerDependencies": {
         "@spectrum-ts/core": "^8.0.0",
@@ -94,6 +101,7 @@
         "@types/bun": "latest",
         "fastify": "^5",
         "tsdown": "^0.22.2",
+        "vitest": "^4.1.9",
       },
       "peerDependencies": {
         "@spectrum-ts/core": "^8.0.0",
@@ -110,6 +118,7 @@
         "@types/bun": "latest",
         "hono": "^4",
         "tsdown": "^0.22.2",
+        "vitest": "^4.1.9",
       },
       "peerDependencies": {
         "@spectrum-ts/core": "^8.0.0",
@@ -133,6 +142,7 @@
         "@spectrum-ts/test-support": "workspace:*",
         "@types/bun": "latest",
         "tsdown": "^0.22.2",
+        "vitest": "^4.1.9",
       },
       "peerDependencies": {
         "@spectrum-ts/core": "^8.0.0",
@@ -148,8 +158,10 @@
       },
       "devDependencies": {
         "@spectrum-ts/core": "workspace:*",
+        "@spectrum-ts/test-support": "workspace:*",
         "@types/bun": "latest",
         "tsdown": "^0.22.2",
+        "vitest": "^4.1.9",
       },
       "peerDependencies": {
         "@spectrum-ts/core": "^8.0.0",
@@ -160,16 +172,18 @@
       "name": "spectrum-ts",
       "version": "8.2.1",
       "dependencies": {
-        "@spectrum-ts/core": "8.0.0",
-        "@spectrum-ts/imessage": "8.0.0",
-        "@spectrum-ts/slack": "8.0.0",
-        "@spectrum-ts/telegram": "8.0.0",
-        "@spectrum-ts/terminal": "8.0.0",
-        "@spectrum-ts/whatsapp-business": "8.0.0",
+        "@spectrum-ts/core": "8.2.1",
+        "@spectrum-ts/imessage": "8.2.1",
+        "@spectrum-ts/slack": "8.2.1",
+        "@spectrum-ts/telegram": "8.2.1",
+        "@spectrum-ts/terminal": "8.2.1",
+        "@spectrum-ts/whatsapp-business": "8.2.1",
       },
       "devDependencies": {
+        "@spectrum-ts/test-support": "workspace:*",
         "@types/bun": "latest",
         "tsdown": "^0.22.2",
+        "vitest": "^4.1.9",
       },
     },
     "packages/telegram": {
@@ -182,8 +196,10 @@
       },
       "devDependencies": {
         "@spectrum-ts/core": "workspace:*",
+        "@spectrum-ts/test-support": "workspace:*",
         "@types/bun": "latest",
         "tsdown": "^0.22.2",
+        "vitest": "^4.1.9",
       },
       "peerDependencies": {
         "@spectrum-ts/core": "^8.0.0",
@@ -198,8 +214,10 @@
       },
       "devDependencies": {
         "@spectrum-ts/core": "workspace:*",
+        "@spectrum-ts/test-support": "workspace:*",
         "@types/bun": "latest",
         "tsdown": "^0.22.2",
+        "vitest": "^4.1.9",
       },
       "peerDependencies": {
         "@spectrum-ts/core": "^8.0.0",
@@ -216,6 +234,7 @@
       "devDependencies": {
         "@spectrum-ts/core": "workspace:*",
         "@types/bun": "latest",
+        "vitest": "^4.1.9",
       },
       "peerDependencies": {
         "@spectrum-ts/core": "*",
@@ -231,9 +250,11 @@
       },
       "devDependencies": {
         "@spectrum-ts/core": "workspace:*",
+        "@spectrum-ts/test-support": "workspace:*",
         "@types/bun": "latest",
         "@types/mime-types": "^3.0.1",
         "tsdown": "^0.22.2",
+        "vitest": "^4.1.9",
       },
       "peerDependencies": {
         "@spectrum-ts/core": "^8.0.0",
@@ -250,13 +271,15 @@
 
     "@babel/generator": ["@babel/generator@8.0.0-rc.6", "", { "dependencies": { "@babel/parser": "^8.0.0-rc.6", "@babel/types": "^8.0.0-rc.6", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "@types/jsesc": "^2.5.0", "jsesc": "^3.0.2" } }, "sha512-6mIzgVK8DgEzvIapoQwhXTMnnkuE4STQmVv9H03i/tZ2ml8oev3TRvZJgTenK2Bsq0YWNtzOrFdTyNzCMFtjJQ=="],
 
-    "@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.6", "", {}, "sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g=="],
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
 
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@8.0.0-rc.6", "", {}, "sha512-nVJ+1JcCgntv8d78rRo++o2wuODT0Irknx2BF8Np4Ft2CRgjLqIs4qzSZ8b66yGbBdMWGmZBO9WEZv1hhNiSpg=="],
 
-    "@babel/parser": ["@babel/parser@8.0.0-rc.6", "", { "dependencies": { "@babel/types": "^8.0.0-rc.6" }, "bin": "./bin/babel-parser.js" }, "sha512-rOS8IpdO7mQELkTPlCsTgPejO0bFuZdEDCGQJouYbYf9e1FLTym7Fei2pEjq8q7MWbX0ravcd7QQYKs1TxOuog=="],
+    "@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
-    "@babel/types": ["@babel/types@8.0.0-rc.6", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.6", "@babel/helper-validator-identifier": "^8.0.0-rc.6" } }, "sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw=="],
+    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.5.1", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.1", "@biomejs/cli-darwin-x64": "2.5.1", "@biomejs/cli-linux-arm64": "2.5.1", "@biomejs/cli-linux-arm64-musl": "2.5.1", "@biomejs/cli-linux-x64": "2.5.1", "@biomejs/cli-linux-x64-musl": "2.5.1", "@biomejs/cli-win32-arm64": "2.5.1", "@biomejs/cli-win32-x64": "2.5.1" }, "bin": { "biome": "bin/biome" } }, "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q=="],
 
@@ -514,6 +537,8 @@
 
     "@spectrum-ts/whatsapp-business": ["@spectrum-ts/whatsapp-business@workspace:packages/whatsapp-business"],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
@@ -536,7 +561,11 @@
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -562,6 +591,24 @@
 
     "@types/vcf": ["@types/vcf@2.0.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-PFZg6Ix/hMvURL4JpExCU3jTVEzGrfW+3RYSca+hlGsmW+PQGScc/vH6czR7tAxF01TZTLK8i3tPKE1EYvBOkg=="],
 
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@4.1.9", "", { "dependencies": { "@bcoe/v8-coverage": "^1.0.2", "@vitest/utils": "4.1.9", "ast-v8-to-istanbul": "^1.0.0", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-reports": "^3.2.0", "magicast": "^0.5.2", "obug": "^2.1.1", "std-env": "^4.0.0-rc.1", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "@vitest/browser": "4.1.9", "vitest": "4.1.9" }, "optionalPeers": ["@vitest/browser"] }, "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
+
     "abort-controller-x": ["abort-controller-x@0.5.0", "", {}, "sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ=="],
 
     "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
@@ -586,7 +633,11 @@
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "ast-kit": ["ast-kit@3.0.0-beta.1", "", { "dependencies": { "@babel/parser": "^8.0.0-beta.4", "estree-walker": "^3.0.3", "pathe": "^2.0.3" } }, "sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw=="],
+
+    "ast-v8-to-istanbul": ["ast-v8-to-istanbul@1.0.4", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA=="],
 
     "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
@@ -624,6 +675,8 @@
 
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
     "char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
@@ -657,6 +710,8 @@
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
@@ -720,6 +775,8 @@
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
+    "es-module-lexer": ["es-module-lexer@2.3.0", "", {}, "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw=="],
+
     "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
@@ -735,6 +792,8 @@
     "exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
 
     "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
@@ -810,6 +869,8 @@
 
     "hotscript": ["hotscript@1.0.13", "", {}, "sha512-C++tTF1GqkGYecL+2S1wJTfoH6APGAsbb7PAWQ3iVIwgG/EFseAfEVOKFgAFq4yK3+6j1EjUD4UQ9dRJHX/sSQ=="],
 
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
@@ -834,6 +895,14 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
+    "js-tokens": ["js-tokens@10.0.0", "", {}, "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q=="],
+
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-schema-ref-resolver": ["json-schema-ref-resolver@3.0.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A=="],
@@ -844,6 +913,30 @@
 
     "light-my-request": ["light-my-request@6.6.0", "", { "dependencies": { "cookie": "^1.0.1", "process-warning": "^4.0.0", "set-cookie-parser": "^2.6.0" } }, "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A=="],
 
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
     "lodash.camelcase": ["lodash.camelcase@4.3.0", "", {}, "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="],
@@ -851,6 +944,12 @@
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.5.3", "", { "dependencies": { "@babel/parser": "^7.29.3", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
 
     "marked": ["marked@18.0.5", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
 
@@ -885,6 +984,8 @@
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
+    "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
@@ -945,6 +1046,8 @@
     "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
 
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
+
+    "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
 
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
@@ -1028,6 +1131,8 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
 
     "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
@@ -1038,11 +1143,17 @@
 
     "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
 
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
     "spectrum-ts": ["spectrum-ts@workspace:packages/spectrum-ts"],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1068,9 +1179,13 @@
 
     "thread-stream": ["thread-stream@4.2.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "toad-cache": ["toad-cache@3.7.1", "", {}, "sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ=="],
 
@@ -1120,15 +1235,23 @@
 
     "vcf": ["vcf@2.1.2", "", { "dependencies": { "camelcase": "^5.0.0", "foldline": "^1.1.0" } }, "sha512-oLYtZ+GJPjpKS950fw70+HavdP7ZO2Q+xMCMeCyiUKuXkJJJG1/wUjCKTagPryS1gApYjZOWW/khmdLsch8jxg=="],
 
+    "vite": ["vite@8.1.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.16", "rolldown": "~1.1.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA=="],
+
+    "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
+
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -1143,6 +1266,12 @@
     "@arethetypeswrong/cli/marked": ["marked@9.1.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q=="],
 
     "@arethetypeswrong/core/typescript": ["typescript@5.6.1-rc", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-E3b2+1zEFu84jB0YQi9BORDjz9+jGbwwy1Zi3G0LUNw7a7cePUrHMRNy8aPh53nXpkFGVHSxIZo5vKTfYaFiBQ=="],
+
+    "@babel/generator/@babel/parser": ["@babel/parser@8.0.0-rc.6", "", { "dependencies": { "@babel/types": "^8.0.0-rc.6" }, "bin": "./bin/babel-parser.js" }, "sha512-rOS8IpdO7mQELkTPlCsTgPejO0bFuZdEDCGQJouYbYf9e1FLTym7Fei2pEjq8q7MWbX0ravcd7QQYKs1TxOuog=="],
+
+    "@babel/generator/@babel/types": ["@babel/types@8.0.0-rc.6", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.6", "@babel/helper-validator-identifier": "^8.0.0-rc.6" } }, "sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw=="],
+
+    "@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
 
     "@fastify/proxy-addr/ipaddr.js": ["ipaddr.js@2.4.0", "", {}, "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ=="],
 
@@ -1165,6 +1294,8 @@
     "@types/serve-static/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/vcf/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "ast-kit/@babel/parser": ["@babel/parser@8.0.0-rc.6", "", { "dependencies": { "@babel/types": "^8.0.0-rc.6" }, "bin": "./bin/babel-parser.js" }, "sha512-rOS8IpdO7mQELkTPlCsTgPejO0bFuZdEDCGQJouYbYf9e1FLTym7Fei2pEjq8q7MWbX0ravcd7QQYKs1TxOuog=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
@@ -1196,6 +1327,8 @@
 
     "protobufjs/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
+    "rolldown-plugin-dts/@babel/parser": ["@babel/parser@8.0.0-rc.6", "", { "dependencies": { "@babel/types": "^8.0.0-rc.6" }, "bin": "./bin/babel-parser.js" }, "sha512-rOS8IpdO7mQELkTPlCsTgPejO0bFuZdEDCGQJouYbYf9e1FLTym7Fei2pEjq8q7MWbX0ravcd7QQYKs1TxOuog=="],
+
     "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
@@ -1206,7 +1339,11 @@
 
     "ultracite/commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
+    "vite/rolldown": ["rolldown@1.1.4", "", { "dependencies": { "@oxc-project/types": "=0.138.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.4", "@rolldown/binding-darwin-arm64": "1.1.4", "@rolldown/binding-darwin-x64": "1.1.4", "@rolldown/binding-freebsd-x64": "1.1.4", "@rolldown/binding-linux-arm-gnueabihf": "1.1.4", "@rolldown/binding-linux-arm64-gnu": "1.1.4", "@rolldown/binding-linux-arm64-musl": "1.1.4", "@rolldown/binding-linux-ppc64-gnu": "1.1.4", "@rolldown/binding-linux-s390x-gnu": "1.1.4", "@rolldown/binding-linux-x64-gnu": "1.1.4", "@rolldown/binding-linux-x64-musl": "1.1.4", "@rolldown/binding-openharmony-arm64": "1.1.4", "@rolldown/binding-wasm32-wasi": "1.1.4", "@rolldown/binding-win32-arm64-msvc": "1.1.4", "@rolldown/binding-win32-x64-msvc": "1.1.4" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA=="],
+
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "@babel/generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.6", "", {}, "sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g=="],
 
     "@grpc/proto-loader/protobufjs/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
@@ -1226,12 +1363,60 @@
 
     "@types/vcf/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
+    "ast-kit/@babel/parser/@babel/types": ["@babel/types@8.0.0-rc.6", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.6", "@babel/helper-validator-identifier": "^8.0.0-rc.6" } }, "sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw=="],
+
     "bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "cli-highlight/parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
 
     "protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
+    "rolldown-plugin-dts/@babel/parser/@babel/types": ["@babel/types@8.0.0-rc.6", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.6", "@babel/helper-validator-identifier": "^8.0.0-rc.6" } }, "sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw=="],
+
+    "vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
+
+    "vite/rolldown/@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.4", "", { "os": "android", "cpu": "arm64" }, "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw=="],
+
+    "vite/rolldown/@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ=="],
+
+    "vite/rolldown/@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg=="],
+
+    "vite/rolldown/@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ=="],
+
+    "vite/rolldown/@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.4", "", { "os": "linux", "cpu": "arm" }, "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA=="],
+
+    "vite/rolldown/@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w=="],
+
+    "vite/rolldown/@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng=="],
+
+    "vite/rolldown/@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg=="],
+
+    "vite/rolldown/@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ=="],
+
+    "vite/rolldown/@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw=="],
+
+    "vite/rolldown/@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.4", "", { "os": "linux", "cpu": "x64" }, "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ=="],
+
+    "vite/rolldown/@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.4", "", { "os": "none", "cpu": "arm64" }, "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.4", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg=="],
+
+    "vite/rolldown/@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA=="],
+
+    "vite/rolldown/@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.4", "", { "os": "win32", "cpu": "x64" }, "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ=="],
+
     "@grpc/proto-loader/protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "ast-kit/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.6", "", {}, "sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g=="],
+
+    "rolldown-plugin-dts/@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.6", "", {}, "sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "vite/rolldown/@rolldown/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "clean-publish": "^7.1.0",
     "publint": "^0.3.21",
     "turbo": "^2.10.0",
-    "ultracite": "7.8.3"
+    "ultracite": "7.8.3",
+    "vitest": "^4.1.9"
   },
   "packageManager": "bun@1.3.14",
   "private": true,
@@ -15,7 +16,9 @@
     "dev": "turbo dev",
     "check": "ultracite check",
     "fix": "ultracite fix",
-    "test": "turbo test",
+    "test": "turbo run test:node test:bun",
+    "test:node": "turbo run test:node",
+    "test:bun": "turbo run test:bun",
     "typecheck": "turbo typecheck"
   },
   "workspaces": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spectrum-ts/core",
   "version": "8.2.1",
-  "description": "The spectrum-ts runtime — Spectrum, content builders, fusor, and the provider authoring API.",
+  "description": "The spectrum-ts runtime \u2014 Spectrum, content builders, fusor, and the provider authoring API.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/photon-hq/spectrum-ts.git",
@@ -47,9 +47,10 @@
     "build": "bun scripts/prepare-package.ts && tsdown && node ../../scripts/smoke-import.mjs dist/index.js",
     "dev": "tsdown --watch",
     "generate:emoji": "bun scripts/generate-emoji.ts",
-    "test": "bun test",
-    "test:watch": "bun test --watch",
-    "test:coverage": "bun test --coverage",
+    "test:bun": "bun --bun vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:node": "vitest run",
+    "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -66,9 +67,13 @@
     "@types/bun": "latest",
     "@types/mime-types": "^3.0.1",
     "@types/vcf": "^2.0.7",
+    "@types/ws": "^8",
+    "@vitest/coverage-v8": "^4.1.9",
     "hotscript": "^1.0.13",
     "tsdown": "^0.22.2",
-    "unicode-emoji-json": "^0.9.0"
+    "unicode-emoji-json": "^0.9.0",
+    "vitest": "^4.1.9",
+    "ws": "^8.21.0"
   },
   "peerDependencies": {
     "ffmpeg-static": "^5",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,6 +64,7 @@
     "zod": "^4.2.1"
   },
   "devDependencies": {
+    "@opentelemetry/api": "^1.9.1",
     "@types/bun": "latest",
     "@types/mime-types": "^3.0.1",
     "@types/vcf": "^2.0.7",

--- a/packages/core/test/content/app.test.ts
+++ b/packages/core/test/content/app.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, mock } from "bun:test";
+import { describe, expect, it, vi } from "vitest";
 import type { LinkMetadata } from "@/utils/link-metadata";
 
 // `app`'s layout is parsed from the URL's link metadata, so stub the network
@@ -14,14 +14,14 @@ const DEFAULT_METADATA: LinkMetadata = {
 // JPEG magic bytes (FF D8) — `app` keeps the image only if it is real JPEG.
 const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 1, 2, 3]);
 
-const fetchLinkMetadata = mock(
+const fetchLinkMetadata = vi.fn(
   (_url: string): Promise<LinkMetadata> => Promise.resolve(DEFAULT_METADATA)
 );
-const fetchImage = mock((_url: string) =>
+const fetchImage = vi.fn((_url: string) =>
   Promise.resolve({ data: JPEG_BYTES, mimeType: "image/jpeg" })
 );
 
-mock.module("@/utils/link-metadata", () => ({ fetchLinkMetadata, fetchImage }));
+vi.doMock("@/utils/link-metadata", () => ({ fetchLinkMetadata, fetchImage }));
 
 const { app } = await import("@/content/app");
 
@@ -46,7 +46,7 @@ describe("app content — consumable url", () => {
   });
 
   it("resolves a thunk url and memoizes it (called once)", async () => {
-    const thunk = mock(() => "https://example.com/x");
+    const thunk = vi.fn(() => "https://example.com/x");
     const content = await buildApp(thunk);
     expect(await content.url()).toBe("https://example.com/x");
     expect(await content.url()).toBe("https://example.com/x");

--- a/packages/core/test/content/markdown.test.ts
+++ b/packages/core/test/content/markdown.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import { edit } from "@/content/edit";
 import { group } from "@/content/group";
 import { markdown } from "@/content/markdown";

--- a/packages/core/test/content/read.test.ts
+++ b/packages/core/test/content/read.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import { edit } from "@/content/edit";
 import { type Read, read } from "@/content/read";
 import { reply } from "@/content/reply";

--- a/packages/core/test/content/text.test.ts
+++ b/packages/core/test/content/text.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import type { StreamText, StreamTextSource } from "@/content/stream-text";
 import { text } from "@/content/text";
 import type { ContentBuilder } from "@/content/types";

--- a/packages/core/test/content/unsend.test.ts
+++ b/packages/core/test/content/unsend.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import { edit } from "@/content/edit";
 import { reply } from "@/content/reply";
 import { type Unsend, unsend } from "@/content/unsend";

--- a/packages/core/test/core/fusor/webhook.test.ts
+++ b/packages/core/test/core/fusor/webhook.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it, spyOn } from "bun:test";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
   CTX_PROBE_PLATFORM,
@@ -15,6 +14,7 @@ import {
   settleSoon,
   TICK_MS,
 } from "@spectrum-ts/test-support/timing";
+import { describe, expect, it, vi } from "vitest";
 import { FusorCore } from "@/fusor/core";
 import { Spectrum } from "@/spectrum";
 import type { Message } from "@/types/message";
@@ -343,9 +343,9 @@ describe("spectrum.webhook", () => {
   });
 
   it("never opens the Fusor stream for webhook, but does for spectrum.messages", async () => {
-    const startSpy = spyOn(FusorCore.prototype, "start").mockResolvedValue(
-      undefined
-    );
+    const startSpy = vi
+      .spyOn(FusorCore.prototype, "start")
+      .mockResolvedValue(undefined);
     try {
       const spectrum = await Spectrum({
         ...baseConfig,
@@ -379,9 +379,9 @@ describe("spectrum.webhook", () => {
   });
 
   it("does not feed spectrum.messages (webhook is request-scoped)", async () => {
-    const startSpy = spyOn(FusorCore.prototype, "start").mockResolvedValue(
-      undefined
-    );
+    const startSpy = vi
+      .spyOn(FusorCore.prototype, "start")
+      .mockResolvedValue(undefined);
     try {
       const spectrum = await Spectrum({
         ...baseConfig,

--- a/packages/core/test/core/fusor/websocket.test.ts
+++ b/packages/core/test/core/fusor/websocket.test.ts
@@ -1,9 +1,12 @@
 // FusorCore streaming: drives the real `fusor.v1.json` protocol
-// against an in-process Bun.serve websocket server.
+// against an in-process `ws` websocket server (runs under Node and Bun).
 
-import { afterEach, describe, expect, it, spyOn } from "bun:test";
+import { once } from "node:events";
+import type { AddressInfo } from "node:net";
+import { setTimeout as sleep } from "node:timers/promises";
 import { NO_MESSAGE_WAIT_MS } from "@spectrum-ts/test-support/timing";
-import { serve, sleep } from "bun";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
 import { FusorCore, type RegisteredFusorHandler } from "@/fusor/core";
 import type { FusorMessagesReturn } from "@/fusor/types";
 import { cloud } from "@/utils/cloud";
@@ -31,52 +34,50 @@ interface WsServerScript {
   onInit: (init: Frame, connection: number) => Frame[];
 }
 
-function makeFusorWsServer(script: WsServerScript) {
+async function makeFusorWsServer(script: WsServerScript) {
   const inits: Frame[] = [];
   const replies: Frame[] = [];
   let connections = 0;
-  const server = serve<{ connection: number }, never>({
+  const wss = new WebSocketServer({
     port: 0,
-    fetch(req, srv) {
-      connections += 1;
-      const upgraded = srv.upgrade(req, {
-        headers: { "Sec-WebSocket-Protocol": "fusor.v1.json" },
-        data: { connection: connections },
-      });
-      if (upgraded) {
-        return undefined as unknown as Response;
-      }
-      return new Response("not a websocket", { status: 400 });
-    },
-    websocket: {
-      message(ws, raw) {
-        const frame = JSON.parse(String(raw)) as Frame;
-        if (frame.type === "init") {
-          inits.push(frame);
-          for (const out of script.onInit(frame, ws.data.connection)) {
-            ws.send(JSON.stringify(out));
-          }
-          const close = script.closeAfterInit?.(ws.data.connection);
-          if (close) {
-            ws.close(close.code, close.reason);
-          }
-          return;
-        }
-        if (frame.type === "reply") {
-          replies.push(frame);
-        }
-      },
-    },
+    handleProtocols: () => "fusor.v1.json",
   });
+  wss.on("connection", (ws) => {
+    connections += 1;
+    const connection = connections;
+    ws.on("message", (raw) => {
+      const frame = JSON.parse(String(raw)) as Frame;
+      if (frame.type === "init") {
+        inits.push(frame);
+        for (const out of script.onInit(frame, connection)) {
+          ws.send(JSON.stringify(out));
+        }
+        const close = script.closeAfterInit?.(connection);
+        if (close) {
+          ws.close(close.code, close.reason);
+        }
+        return;
+      }
+      if (frame.type === "reply") {
+        replies.push(frame);
+      }
+    });
+  });
+  await once(wss, "listening");
+  const { port } = wss.address() as AddressInfo;
   return {
-    url: `ws://localhost:${server.port}/v1/subscribe`,
+    url: `ws://localhost:${port}/v1/subscribe`,
     inits,
     replies,
     connectionCount: () => connections,
+    // Fire-and-forget, matching the old Bun.serve stop(true): under Bun's ws
+    // shim the close callback never fires once clients were terminated
+    // server-side, so awaiting it would deadlock the afterEach cleanup.
     stop: () => {
-      server.stop(true).catch(() => {
-        // stop(true) can hang/reject with in-process clients; ignored.
-      });
+      for (const client of wss.clients) {
+        client.terminate();
+      }
+      wss.close();
     },
   };
 }
@@ -139,13 +140,13 @@ afterEach(async () => {
 
 describe("fusor websocket streaming", () => {
   it("streams events and replies only when asked", async () => {
-    const tokenSpy = spyOn(cloud, "issueFusorToken").mockResolvedValue({
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
       token: "t1",
       expiresIn: 900,
     });
     cleanups.push(() => tokenSpy.mockRestore());
 
-    const server = makeFusorWsServer({
+    const server = await makeFusorWsServer({
       onInit: () => [
         { type: "ready", projectId: "proj", heartbeatIntervalMs: 30_000 },
         eventFrame("evt-1", '{"text":"hello"}', true, 1),
@@ -189,15 +190,15 @@ describe("fusor websocket streaming", () => {
 
   it("invalidates the token on a 4401 close and reconnects with a fresh one", async () => {
     let minted = 0;
-    const tokenSpy = spyOn(cloud, "issueFusorToken").mockImplementation(
-      async () => {
+    const tokenSpy = vi
+      .spyOn(cloud, "issueFusorToken")
+      .mockImplementation(async () => {
         minted += 1;
         return { token: `t${minted}`, expiresIn: 900 };
-      }
-    );
+      });
     cleanups.push(() => tokenSpy.mockRestore());
 
-    const server = makeFusorWsServer({
+    const server = await makeFusorWsServer({
       onInit: (_init, connection) =>
         connection === 1
           ? [
@@ -235,13 +236,13 @@ describe("fusor websocket streaming", () => {
   });
 
   it("close() tears down an active websocket session promptly", async () => {
-    const tokenSpy = spyOn(cloud, "issueFusorToken").mockResolvedValue({
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
       token: "t1",
       expiresIn: 900,
     });
     cleanups.push(() => tokenSpy.mockRestore());
 
-    const server = makeFusorWsServer({
+    const server = await makeFusorWsServer({
       onInit: () => [
         { type: "ready", projectId: "proj", heartbeatIntervalMs: 30_000 },
       ],

--- a/packages/core/test/core/send-markdown-fallback.test.ts
+++ b/packages/core/test/core/send-markdown-fallback.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "bun:test";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
   baseConfig,
   makeQueue,
   record,
 } from "@spectrum-ts/test-support/platform";
+import { describe, expect, it } from "vitest";
 import z from "zod";
 import { group } from "@/content/group";
 import { markdown } from "@/content/markdown";

--- a/packages/core/test/core/send-reaction.test.ts
+++ b/packages/core/test/core/send-reaction.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "bun:test";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
   baseConfig,
   makeQueue,
   record,
 } from "@spectrum-ts/test-support/platform";
+import { describe, expect, it } from "vitest";
 import z from "zod";
 import { asReaction, reaction } from "@/content/reaction";
 import { asReply } from "@/content/reply";

--- a/packages/core/test/core/send-read.test.ts
+++ b/packages/core/test/core/send-read.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "bun:test";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
   baseConfig,
   makeQueue,
   record,
 } from "@spectrum-ts/test-support/platform";
+import { describe, expect, it } from "vitest";
 import z from "zod";
 import { read } from "@/content/read";
 import type { Content } from "@/content/types";

--- a/packages/core/test/core/send-stream-text-fallback.test.ts
+++ b/packages/core/test/core/send-stream-text-fallback.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "bun:test";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
   baseConfig,
   makeQueue,
   record,
 } from "@spectrum-ts/test-support/platform";
+import { describe, expect, it } from "vitest";
 import z from "zod";
 import { markdown } from "@/content/markdown";
 import { text } from "@/content/text";

--- a/packages/core/test/core/send-unsend.test.ts
+++ b/packages/core/test/core/send-unsend.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "bun:test";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
   baseConfig,
   makeQueue,
   record,
 } from "@spectrum-ts/test-support/platform";
+import { describe, expect, it } from "vitest";
 import z from "zod";
 import type { Content } from "@/content/types";
 import { unsend } from "@/content/unsend";

--- a/packages/core/test/core/space.test.ts
+++ b/packages/core/test/core/space.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "bun:test";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
   baseConfig,
   makeManagedProvider,
   makeSchemaProvider,
 } from "@spectrum-ts/test-support/platform";
+import { describe, expect, it } from "vitest";
 import { Spectrum } from "@/spectrum";
 
 stubCloud();

--- a/packages/core/test/core/spectrum.shutdown.test.ts
+++ b/packages/core/test/core/spectrum.shutdown.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "bun:test";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
   baseConfig,
@@ -6,6 +5,7 @@ import {
   makeNativeProvider,
 } from "@spectrum-ts/test-support/platform";
 import { withinMs } from "@spectrum-ts/test-support/timing";
+import { describe, expect, it } from "vitest";
 import { Spectrum } from "@/spectrum";
 
 stubCloud();

--- a/packages/core/test/utils/instrumented-fetch.test.ts
+++ b/packages/core/test/utils/instrumented-fetch.test.ts
@@ -1,9 +1,9 @@
-import { afterEach, describe, expect, it, mock, spyOn } from "bun:test";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { tracedFetch } from "@/utils/instrumented-fetch";
 
 describe("tracedFetch", () => {
   afterEach(() => {
-    mock.restore();
+    vi.restoreAllMocks();
   });
 
   it("delegates to a globalThis.fetch spy installed AFTER the wrapper is built", async () => {
@@ -11,10 +11,12 @@ describe("tracedFetch", () => {
     // test installs its fetch mock. Capturing globalThis.fetch here instead of
     // delegating would silently bypass the spy.
     const tf = tracedFetch("test-peer");
-    const spy = spyOn(globalThis, "fetch").mockImplementation(
-      (async () =>
-        new Response("ok", { status: 200 })) as unknown as typeof fetch
-    );
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(
+        (async () =>
+          new Response("ok", { status: 200 })) as unknown as typeof fetch
+      );
 
     const res = await tf("https://example.test/thing");
 
@@ -25,7 +27,7 @@ describe("tracedFetch", () => {
   it("forwards method, headers, and signal to the delegated fetch", async () => {
     const tf = tracedFetch("test-peer");
     let seenInit: RequestInit | undefined;
-    spyOn(globalThis, "fetch").mockImplementation((async (
+    vi.spyOn(globalThis, "fetch").mockImplementation((async (
       _input: unknown,
       init?: RequestInit
     ) => {

--- a/packages/core/test/utils/markdown.test.ts
+++ b/packages/core/test/utils/markdown.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import { markdownToPlainText } from "@/utils/markdown";
 
 describe("markdownToPlainText", () => {

--- a/packages/core/test/utils/otel-scoped.test.ts
+++ b/packages/core/test/utils/otel-scoped.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "bun:test";
 import { trace } from "@opentelemetry/api";
 import { setupOtel } from "@photon-ai/otel";
+import { describe, expect, it } from "vitest";
 
 // Regression guard for the client-facing-SDK conflict fix: scoped mode
 // (register: false) must NOT register spectrum's providers as the process-global

--- a/packages/core/test/utils/provider-packages.test.ts
+++ b/packages/core/test/utils/provider-packages.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import {
   normalizePlatformKey,
   officialProviderInstallHint,

--- a/packages/core/test/utils/resumable-stream.test.ts
+++ b/packages/core/test/utils/resumable-stream.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "bun:test";
 import { flush, withinMs } from "@spectrum-ts/test-support/timing";
+import { describe, expect, it } from "vitest";
 import {
   type CloseableAsyncIterable,
   PERSISTENT_FAILURE_ERROR_THRESHOLD,

--- a/packages/core/test/utils/telemetry.test.ts
+++ b/packages/core/test/utils/telemetry.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import { errorAttrs } from "@/utils/telemetry";
 
 describe("errorAttrs", () => {

--- a/packages/core/test/webhook/deserialize.test.ts
+++ b/packages/core/test/webhook/deserialize.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import type { Attachment } from "@/content/attachment";
 import type { Reaction } from "@/content/reaction";
 import type { Reply } from "@/content/reply";

--- a/packages/core/test/webhook/spectrum.test.ts
+++ b/packages/core/test/webhook/spectrum.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "bun:test";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import { encodeEvent, makeSlack } from "@spectrum-ts/test-support/fusor";
 import {
@@ -11,6 +10,7 @@ import {
   signSpectrum,
   textEnvelope,
 } from "@spectrum-ts/test-support/webhook";
+import { describe, expect, it } from "vitest";
 import { Spectrum } from "@/spectrum";
 import type { Message } from "@/types/message";
 

--- a/packages/core/test/webhook/verify.test.ts
+++ b/packages/core/test/webhook/verify.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "bun:test";
 import { createHmac } from "node:crypto";
+import { describe, expect, it } from "vitest";
 import { verifySpectrumSignature } from "@/webhook/verify";
 
 const SECRET = "whsec_unit_test_secret";

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,3 @@
+import { spectrumTestConfig } from "@spectrum-ts/test-support/vitest";
+
+export default spectrumTestConfig(import.meta.dirname);

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -35,7 +35,8 @@
   "scripts": {
     "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js",
     "dev": "tsdown --watch",
-    "test": "bun test",
+    "test:bun": "bun --bun vitest run",
+    "test:node": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
@@ -48,7 +49,8 @@
     "@spectrum-ts/test-support": "workspace:*",
     "@types/bun": "latest",
     "elysia": "^1",
-    "tsdown": "^0.22.2"
+    "tsdown": "^0.22.2",
+    "vitest": "^4.1.9"
   },
   "license": "MIT"
 }

--- a/packages/elysia/test/elysia.test.ts
+++ b/packages/elysia/test/elysia.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "bun:test";
 import { type Message, Spectrum } from "@spectrum-ts/core";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
@@ -13,6 +12,7 @@ import {
   textEnvelope,
 } from "@spectrum-ts/test-support/webhook";
 import { Elysia } from "elysia";
+import { describe, expect, it } from "vitest";
 import { spectrum } from "@/index";
 
 stubCloud();

--- a/packages/elysia/vitest.config.ts
+++ b/packages/elysia/vitest.config.ts
@@ -1,0 +1,3 @@
+import { spectrumTestConfig } from "@spectrum-ts/test-support/vitest";
+
+export default spectrumTestConfig(import.meta.dirname);

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -35,7 +35,8 @@
   "scripts": {
     "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js",
     "dev": "tsdown --watch",
-    "test": "bun test",
+    "test:bun": "bun --bun vitest run",
+    "test:node": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
@@ -49,7 +50,8 @@
     "@types/bun": "latest",
     "@types/express": "^5",
     "express": "^5",
-    "tsdown": "^0.22.2"
+    "tsdown": "^0.22.2",
+    "vitest": "^4.1.9"
   },
   "license": "MIT"
 }

--- a/packages/express/test/express.test.ts
+++ b/packages/express/test/express.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "bun:test";
 import type { AddressInfo } from "node:net";
 import { type Message, Spectrum } from "@spectrum-ts/core";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
@@ -14,6 +13,7 @@ import {
   textEnvelope,
 } from "@spectrum-ts/test-support/webhook";
 import express from "express";
+import { describe, expect, it } from "vitest";
 import { spectrum } from "@/index";
 
 stubCloud();

--- a/packages/express/vitest.config.ts
+++ b/packages/express/vitest.config.ts
@@ -1,0 +1,3 @@
+import { spectrumTestConfig } from "@spectrum-ts/test-support/vitest";
+
+export default spectrumTestConfig(import.meta.dirname);

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -35,7 +35,8 @@
   "scripts": {
     "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js",
     "dev": "tsdown --watch",
-    "test": "bun test",
+    "test:bun": "bun --bun vitest run",
+    "test:node": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
@@ -48,7 +49,8 @@
     "@spectrum-ts/test-support": "workspace:*",
     "@types/bun": "latest",
     "fastify": "^5",
-    "tsdown": "^0.22.2"
+    "tsdown": "^0.22.2",
+    "vitest": "^4.1.9"
   },
   "license": "MIT"
 }

--- a/packages/fastify/test/fastify.test.ts
+++ b/packages/fastify/test/fastify.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "bun:test";
 import { type Message, Spectrum } from "@spectrum-ts/core";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
@@ -13,6 +12,7 @@ import {
   textEnvelope,
 } from "@spectrum-ts/test-support/webhook";
 import Fastify from "fastify";
+import { describe, expect, it } from "vitest";
 import { spectrum } from "@/index";
 
 stubCloud();

--- a/packages/fastify/vitest.config.ts
+++ b/packages/fastify/vitest.config.ts
@@ -1,0 +1,3 @@
+import { spectrumTestConfig } from "@spectrum-ts/test-support/vitest";
+
+export default spectrumTestConfig(import.meta.dirname);

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -35,7 +35,8 @@
   "scripts": {
     "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js",
     "dev": "tsdown --watch",
-    "test": "bun test",
+    "test:bun": "bun --bun vitest run",
+    "test:node": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
@@ -48,7 +49,8 @@
     "@spectrum-ts/test-support": "workspace:*",
     "@types/bun": "latest",
     "hono": "^4",
-    "tsdown": "^0.22.2"
+    "tsdown": "^0.22.2",
+    "vitest": "^4.1.9"
   },
   "license": "MIT"
 }

--- a/packages/hono/test/hono.test.ts
+++ b/packages/hono/test/hono.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "bun:test";
 import { type Message, Spectrum } from "@spectrum-ts/core";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
@@ -13,6 +12,7 @@ import {
   textEnvelope,
 } from "@spectrum-ts/test-support/webhook";
 import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
 import { spectrum } from "@/index";
 
 stubCloud();

--- a/packages/hono/vitest.config.ts
+++ b/packages/hono/vitest.config.ts
@@ -1,0 +1,3 @@
+import { spectrumTestConfig } from "@spectrum-ts/test-support/vitest";
+
+export default spectrumTestConfig(import.meta.dirname);

--- a/packages/imessage/package.json
+++ b/packages/imessage/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spectrum-ts/imessage",
   "version": "8.2.1",
-  "description": "iMessage provider for spectrum-ts — local and remote (advanced) modes.",
+  "description": "iMessage provider for spectrum-ts \u2014 local and remote (advanced) modes.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/photon-hq/spectrum-ts.git",
@@ -40,7 +40,8 @@
   "scripts": {
     "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js",
     "dev": "tsdown --watch",
-    "test": "bun test",
+    "test:bun": "bun --bun vitest run",
+    "test:node": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -59,7 +60,8 @@
     "@spectrum-ts/core": "workspace:*",
     "@spectrum-ts/test-support": "workspace:*",
     "@types/bun": "latest",
-    "tsdown": "^0.22.2"
+    "tsdown": "^0.22.2",
+    "vitest": "^4.1.9"
   },
   "license": "MIT"
 }

--- a/packages/imessage/test/contact-card.test.ts
+++ b/packages/imessage/test/contact-card.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, mock } from "bun:test";
 import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
 import type { Space } from "@spectrum-ts/core";
+import { describe, expect, it, vi } from "vitest";
 import { isContactCard } from "@/content/contact-card";
 import { imessage, nativeContactCard } from "@/index";
 import { shareContactCard as remoteShareContactCard } from "@/remote/contact-card";
@@ -48,7 +48,7 @@ describe("nativeContactCard content", () => {
 
 describe("iMessage remote shareContactCard", () => {
   it("forwards the chat guid to chats.shareContactInfo", async () => {
-    const shareContactInfo = mock((_: string) => Promise.resolve());
+    const shareContactInfo = vi.fn((_: string) => Promise.resolve());
     const remote = {
       chats: { shareContactInfo },
     } as unknown as AdvancedIMessage;
@@ -62,7 +62,7 @@ describe("iMessage remote shareContactCard", () => {
 
 describe("iMessage send: contactCard dispatch", () => {
   it("routes the signal to chats.shareContactInfo and is fire-and-forget", async () => {
-    const shareContactInfo = mock((_: string) => Promise.resolve());
+    const shareContactInfo = vi.fn((_: string) => Promise.resolve());
 
     const result = await def.send({
       ...ctx,
@@ -91,7 +91,7 @@ describe("iMessage send: contactCard dispatch", () => {
 
 describe("space.shareContactCard sugar", () => {
   it("dispatches the contact-card content through space.send", async () => {
-    const send = mock((_: unknown) => Promise.resolve(undefined));
+    const send = vi.fn((_: unknown) => Promise.resolve(undefined));
     const action = def.space.actions?.shareContactCard;
     expect(action).toBeDefined();
 

--- a/packages/imessage/test/local/inbound.test.ts
+++ b/packages/imessage/test/local/inbound.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "bun:test";
 import type { Message as LocalIMessage } from "@photon-ai/imessage-kit";
+import { describe, expect, it } from "vitest";
 import { toMessages } from "@/local/inbound";
 
 const CREATED_AT = new Date(1_700_000_000_000);

--- a/packages/imessage/test/remote/app.test.ts
+++ b/packages/imessage/test/remote/app.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it, mock } from "bun:test";
 import type {
   AdvancedIMessage,
   Message as SDKMessage,
 } from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
 import type { Content } from "@spectrum-ts/core";
+import { describe, expect, it, vi } from "vitest";
 import { imessage } from "@/index";
 import { SPECTRUM_MINI_APP, toSpectrumMiniApp } from "@/remote/app";
 import { type RemoteClient, SHARED_PHONE } from "@/types";
@@ -52,7 +52,7 @@ describe("toSpectrumMiniApp", () => {
 
 describe("iMessage send: app dispatch", () => {
   it("renders a Spectrum mini-app card on remote", async () => {
-    const sendCustomizedMiniApp = mock((_chat: string, _content: unknown) =>
+    const sendCustomizedMiniApp = vi.fn((_chat: string, _content: unknown) =>
       Promise.resolve({
         guid: "card-guid",
         dateCreated: SENT_DATE,
@@ -79,7 +79,7 @@ describe("iMessage send: app dispatch", () => {
   });
 
   it("degrades to a bare-url text message in local mode", async () => {
-    const send = mock((_: unknown) => Promise.resolve());
+    const send = vi.fn((_: unknown) => Promise.resolve());
     const localClient = Object.assign(Object.create(IMessageSDK.prototype), {
       send,
     }) as IMessageSDK;

--- a/packages/imessage/test/remote/contact-share.test.ts
+++ b/packages/imessage/test/remote/contact-share.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, mock } from "bun:test";
 import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
 import { flush } from "@spectrum-ts/test-support/timing";
+import { describe, expect, it, vi } from "vitest";
 import {
   ContactShareTracker,
   getContactShareTracker,
@@ -15,7 +15,7 @@ const makeClient = (
 
 describe("ContactShareTracker", () => {
   it("shares once per chat across repeated inbound messages", async () => {
-    const share = mock((_: string) => Promise.resolve());
+    const share = vi.fn((_: string) => Promise.resolve());
     const client = makeClient(share);
     const tracker = new ContactShareTracker(client);
 
@@ -33,7 +33,7 @@ describe("ContactShareTracker", () => {
     const sharePromise = new Promise<void>((r) => {
       resolveShare = r;
     });
-    const share = mock((_: string) => sharePromise);
+    const share = vi.fn((_: string) => sharePromise);
     const client = makeClient(share);
     const tracker = new ContactShareTracker(client);
 
@@ -51,7 +51,7 @@ describe("ContactShareTracker", () => {
   });
 
   it("shares for distinct chats independently", async () => {
-    const share = mock((_: string) => Promise.resolve());
+    const share = vi.fn((_: string) => Promise.resolve());
     const client = makeClient(share);
     const tracker = new ContactShareTracker(client);
 
@@ -69,7 +69,7 @@ describe("ContactShareTracker", () => {
 
   it("retries on the next inbound when a share fails", async () => {
     let attempt = 0;
-    const share = mock((_: string) => {
+    const share = vi.fn((_: string) => {
       attempt += 1;
       return attempt === 1
         ? Promise.reject(new Error("transient"))
@@ -95,7 +95,7 @@ describe("ContactShareTracker", () => {
   });
 
   it("never throws synchronously even when shareContactInfo rejects", async () => {
-    const share = mock((_: string) => Promise.reject(new Error("boom")));
+    const share = vi.fn((_: string) => Promise.reject(new Error("boom")));
     const client = makeClient(share);
     const tracker = new ContactShareTracker(client);
 
@@ -122,8 +122,8 @@ describe("getContactShareTracker", () => {
   });
 
   it("shares per line — distinct clients dedupe the same chat independently", async () => {
-    const shareA = mock((_: string) => Promise.resolve());
-    const shareB = mock((_: string) => Promise.resolve());
+    const shareA = vi.fn((_: string) => Promise.resolve());
+    const shareB = vi.fn((_: string) => Promise.resolve());
     const trackerA = getContactShareTracker(makeClient(shareA));
     const trackerB = getContactShareTracker(makeClient(shareB));
 

--- a/packages/imessage/test/remote/inbound.test.ts
+++ b/packages/imessage/test/remote/inbound.test.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it } from "bun:test";
 import {
   type AdvancedIMessage,
   type MessageEvent,
   NotFoundError,
 } from "@photon-ai/advanced-imessage";
+import { describe, expect, it } from "vitest";
 import { MessageCache } from "@/cache";
 import { toInboundMessages } from "@/remote/inbound";
 

--- a/packages/imessage/test/remote/markdown.test.ts
+++ b/packages/imessage/test/remote/markdown.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import { markdownToIMessageText } from "@/remote/markdown";
 
 describe("markdownToIMessageText", () => {

--- a/packages/imessage/test/remote/reactions.test.ts
+++ b/packages/imessage/test/remote/reactions.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it, mock } from "bun:test";
 import type {
   AdvancedIMessage,
   MessageEvent,
@@ -6,6 +5,7 @@ import type {
   SettableMessageReaction,
 } from "@photon-ai/advanced-imessage";
 import { text } from "@spectrum-ts/core";
+import { describe, expect, it, vi } from "vitest";
 import { getMessageCache, MessageCache } from "@/cache";
 import { imessage } from "@/index";
 import { reactToMessage, toReactionMessages } from "@/remote/reactions";
@@ -18,7 +18,7 @@ const makeRemote = () => {
     guid: "tapback-1",
     dateCreated: SENT_DATE,
   } as unknown as SDKMessage;
-  const setReaction = mock(
+  const setReaction = vi.fn(
     (
       _chat: string,
       _message: string,
@@ -142,7 +142,7 @@ describe("iMessage remote reactToMessage", () => {
 
 describe("iMessage remote toReactionMessages", () => {
   it("marks a fetched self-authored reaction target as outbound", async () => {
-    const get = mock((_message: string) => Promise.resolve(sdkMessage()));
+    const get = vi.fn((_message: string) => Promise.resolve(sdkMessage()));
     const remote = {
       messages: { get },
     } as unknown as AdvancedIMessage;
@@ -164,7 +164,7 @@ describe("iMessage remote toReactionMessages", () => {
   });
 
   it("carries the actor's address, country, and service onto the reaction sender", async () => {
-    const get = mock((_message: string) => Promise.resolve(sdkMessage()));
+    const get = vi.fn((_message: string) => Promise.resolve(sdkMessage()));
     const remote = {
       messages: { get },
     } as unknown as AdvancedIMessage;
@@ -192,13 +192,13 @@ describe("iMessage remote toReactionMessages", () => {
 
   it("resolves tapbacks on a just-sent streamText message from the outbound cache", async () => {
     const sent = sdkMessage({ guid: "outbound-stream-guid" });
-    const sendText = mock((_chat: string, _text: string) =>
+    const sendText = vi.fn((_chat: string, _text: string) =>
       Promise.resolve(sent)
     );
-    const edit = mock((_chat: string, _guid: string, _text: string) =>
+    const edit = vi.fn((_chat: string, _guid: string, _text: string) =>
       Promise.resolve(sent)
     );
-    const get = mock((_message: string) =>
+    const get = vi.fn((_message: string) =>
       Promise.reject(new Error("message API has not caught up"))
     );
     const remote = {
@@ -242,7 +242,7 @@ describe("iMessage remote toReactionMessages", () => {
   });
 
   it("resolves tapbacks to the ordered part inside an interleaved message", async () => {
-    const get = mock((_message: string) =>
+    const get = vi.fn((_message: string) =>
       Promise.resolve(
         sdkMessage({
           content: {

--- a/packages/imessage/test/remote/send-markdown.test.ts
+++ b/packages/imessage/test/remote/send-markdown.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it, mock } from "bun:test";
 import type {
   AdvancedIMessage,
   Message as SDKMessage,
@@ -15,6 +14,7 @@ import {
   asMarkdown,
   asText,
 } from "@spectrum-ts/core/authoring";
+import { describe, expect, it, vi } from "vitest";
 import { effect } from "@/content/effect";
 import { editMessage, replyToMessage, send } from "@/remote/send";
 
@@ -26,14 +26,14 @@ const makeRemote = () => {
     guid: "msg-guid",
     dateCreated: SENT_DATE,
   } as unknown as SDKMessage;
-  const sendText = mock((_chat: string, _text: string, _options?: unknown) =>
+  const sendText = vi.fn((_chat: string, _text: string, _options?: unknown) =>
     Promise.resolve(reply)
   );
-  const sendMultipart = mock((_chat: string, _parts: unknown) =>
+  const sendMultipart = vi.fn((_chat: string, _parts: unknown) =>
     Promise.resolve(reply)
   );
-  const edit = mock(() => Promise.resolve(reply));
-  const upload = mock(() =>
+  const edit = vi.fn(() => Promise.resolve(reply));
+  const upload = vi.fn(() =>
     Promise.resolve({ attachment: { guid: "att-guid" } })
   );
   const remote = {

--- a/packages/imessage/test/remote/stream-text.test.ts
+++ b/packages/imessage/test/remote/stream-text.test.ts
@@ -1,4 +1,3 @@
-import { afterEach, describe, expect, it, mock, setSystemTime } from "bun:test";
 import type {
   AdvancedIMessage,
   Message as SDKMessage,
@@ -10,6 +9,8 @@ import {
   text,
   UnsupportedError,
 } from "@spectrum-ts/core";
+import { setSystemTime } from "@spectrum-ts/test-support/time";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { imessage } from "@/index";
 import { sendStreamText } from "@/remote/stream-text";
 
@@ -30,10 +31,10 @@ const makeRemote = () => {
     dateCreated: SENT_DATE,
   } as unknown as SDKMessage;
   const editTimes: number[] = [];
-  const sendText = mock((_chat: string, _text: string) =>
+  const sendText = vi.fn((_chat: string, _text: string) =>
     Promise.resolve(reply)
   );
-  const edit = mock((_chat: string, _guid: string, _text: string) => {
+  const edit = vi.fn((_chat: string, _guid: string, _text: string) => {
     editTimes.push(Date.now());
     return Promise.resolve(reply);
   });

--- a/packages/imessage/test/remote/unsend.test.ts
+++ b/packages/imessage/test/remote/unsend.test.ts
@@ -1,16 +1,16 @@
-import { describe, expect, it, mock } from "bun:test";
 import type {
   AdvancedIMessage,
   Message as SDKMessage,
   SettableMessageReaction,
 } from "@photon-ai/advanced-imessage";
+import { describe, expect, it, vi } from "vitest";
 import { formatChildId } from "@/remote/ids";
 import { unsendReaction } from "@/remote/reactions";
 import { unsendMessage } from "@/remote/send";
 import type { IMessageMessage } from "@/types";
 
 const makeRemote = () => {
-  const unsend = mock(
+  const unsend = vi.fn(
     (_chat: string, _message: string, _options?: { partIndex?: number }) =>
       Promise.resolve()
   );
@@ -18,7 +18,7 @@ const makeRemote = () => {
     guid: "tapback-1",
     dateCreated: new Date(0),
   } as unknown as SDKMessage;
-  const setReaction = mock(
+  const setReaction = vi.fn(
     (
       _chat: string,
       _message: string,
@@ -65,7 +65,7 @@ describe("iMessage remote unsendMessage", () => {
   });
 
   it("propagates SDK rejections (expired window, double unsend)", async () => {
-    const unsend = mock(() =>
+    const unsend = vi.fn(() =>
       Promise.reject(new Error("unsend window expired"))
     );
     const remote = { messages: { unsend } } as unknown as AdvancedIMessage;

--- a/packages/imessage/test/space.test.ts
+++ b/packages/imessage/test/space.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "bun:test";
 import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
+import { describe, expect, it } from "vitest";
 import { imessage } from "@/index";
 import type { RemoteClient } from "@/types";
 import { SHARED_PHONE } from "@/types";

--- a/packages/imessage/vitest.config.ts
+++ b/packages/imessage/vitest.config.ts
@@ -1,0 +1,3 @@
+import { spectrumTestConfig } from "@spectrum-ts/test-support/vitest";
+
+export default spectrumTestConfig(import.meta.dirname);

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -40,7 +40,8 @@
   "scripts": {
     "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js",
     "dev": "tsdown --watch",
-    "test": "bun test",
+    "test:bun": "bun --bun vitest run",
+    "test:node": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -53,8 +54,10 @@
   },
   "devDependencies": {
     "@spectrum-ts/core": "workspace:*",
+    "@spectrum-ts/test-support": "workspace:*",
     "@types/bun": "latest",
-    "tsdown": "^0.22.2"
+    "tsdown": "^0.22.2",
+    "vitest": "^4.1.9"
   },
   "license": "MIT"
 }

--- a/packages/slack/test/messages.test.ts
+++ b/packages/slack/test/messages.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "bun:test";
 import type { Message } from "@spectrum-ts/core";
 import { asRead } from "@spectrum-ts/core/authoring";
+import { describe, expect, it } from "vitest";
 import { send } from "@/messages";
 
 const target = {

--- a/packages/slack/test/space.test.ts
+++ b/packages/slack/test/space.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import { slack } from "@/index";
 
 // Reach the inline def through the provider-config seam — the hooks only

--- a/packages/slack/vitest.config.ts
+++ b/packages/slack/vitest.config.ts
@@ -1,0 +1,3 @@
+import { spectrumTestConfig } from "@spectrum-ts/test-support/vitest";
+
+export default spectrumTestConfig(import.meta.dirname);

--- a/packages/spectrum-ts/package.json
+++ b/packages/spectrum-ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spectrum-ts",
   "version": "8.2.1",
-  "description": "Bring agents to any interface — unified messaging SDK for TypeScript. Batteries-included: the runtime plus every official provider.",
+  "description": "Bring agents to any interface \u2014 unified messaging SDK for TypeScript. Batteries-included: the runtime plus every official provider.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/photon-hq/spectrum-ts.git",
@@ -67,7 +67,8 @@
     "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js && bun scripts/generate-manifest.ts",
     "dev": "tsdown --watch",
     "generate:manifest": "bun scripts/generate-manifest.ts",
-    "test": "bun test",
+    "test:bun": "bun --bun vitest run",
+    "test:node": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -79,8 +80,10 @@
     "@spectrum-ts/whatsapp-business": "8.2.1"
   },
   "devDependencies": {
+    "@spectrum-ts/test-support": "workspace:*",
     "@types/bun": "latest",
-    "tsdown": "^0.22.2"
+    "tsdown": "^0.22.2",
+    "vitest": "^4.1.9"
   },
   "license": "MIT"
 }

--- a/packages/spectrum-ts/test/providers-shims.test.ts
+++ b/packages/spectrum-ts/test/providers-shims.test.ts
@@ -6,12 +6,12 @@
 // biome-ignore-all lint/performance/noNamespaceImport: comparing full module
 // namespaces is exactly what this parity test is for.
 
-import { describe, expect, it } from "bun:test";
 import * as imessagePkg from "@spectrum-ts/imessage";
 import * as slackPkg from "@spectrum-ts/slack";
 import * as telegramPkg from "@spectrum-ts/telegram";
 import * as terminalPkg from "@spectrum-ts/terminal";
 import * as whatsappPkg from "@spectrum-ts/whatsapp-business";
+import { describe, expect, it } from "vitest";
 import * as imessageShim from "@/providers/imessage/index";
 import * as barrel from "@/providers/index";
 import * as slackShim from "@/providers/slack/index";

--- a/packages/spectrum-ts/vitest.config.ts
+++ b/packages/spectrum-ts/vitest.config.ts
@@ -1,0 +1,3 @@
+import { spectrumTestConfig } from "@spectrum-ts/test-support/vitest";
+
+export default spectrumTestConfig(import.meta.dirname);

--- a/packages/telegram/package.json
+++ b/packages/telegram/package.json
@@ -40,7 +40,8 @@
   "scripts": {
     "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js",
     "dev": "tsdown --watch",
-    "test": "bun test",
+    "test:bun": "bun --bun vitest run",
+    "test:node": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -54,8 +55,10 @@
   },
   "devDependencies": {
     "@spectrum-ts/core": "workspace:*",
+    "@spectrum-ts/test-support": "workspace:*",
     "@types/bun": "latest",
-    "tsdown": "^0.22.2"
+    "tsdown": "^0.22.2",
+    "vitest": "^4.1.9"
   },
   "license": "MIT"
 }

--- a/packages/telegram/test/inbound/messages.test.ts
+++ b/packages/telegram/test/inbound/messages.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, spyOn } from "bun:test";
+import { describe, expect, it, vi } from "vitest";
 import { configSchema } from "@/config";
 import { handleMessages } from "@/inbound/messages";
 import type { Update } from "@/types";
@@ -176,9 +176,9 @@ describe("handleMessages — media", () => {
       }
       return Promise.resolve(new Response(DOWNLOAD));
     };
-    const spy = spyOn(globalThis, "fetch").mockImplementation(
-      impl as unknown as typeof fetch
-    );
+    const spy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(impl as unknown as typeof fetch);
     try {
       const record = handle({
         document: {

--- a/packages/telegram/test/outbound/markdown.test.ts
+++ b/packages/telegram/test/outbound/markdown.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import { markdownToTelegramHtml } from "@/outbound/markdown";
 
 describe("markdownToTelegramHtml", () => {

--- a/packages/telegram/test/outbound/message.test.ts
+++ b/packages/telegram/test/outbound/message.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "bun:test";
 import {
   app,
   attachment,
@@ -12,6 +11,7 @@ import {
   text,
   voice,
 } from "@spectrum-ts/core";
+import { describe, expect, it } from "vitest";
 import { buildSend } from "@/outbound/message";
 
 const target = {

--- a/packages/telegram/test/outbound/send.test.ts
+++ b/packages/telegram/test/outbound/send.test.ts
@@ -1,14 +1,4 @@
 import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  spyOn,
-} from "bun:test";
-
-import {
   attachment,
   type Content,
   type Message,
@@ -20,6 +10,7 @@ import {
   voice,
 } from "@spectrum-ts/core";
 import { asRead } from "@spectrum-ts/core/authoring";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { configSchema } from "@/config";
 import { send } from "@/outbound/send";
 
@@ -80,13 +71,13 @@ beforeEach(() => {
       return Response.json(responseFor(method));
     });
   };
-  spyOn(globalThis, "fetch").mockImplementation(
+  vi.spyOn(globalThis, "fetch").mockImplementation(
     impl as unknown as typeof fetch
   );
 });
 
 afterEach(() => {
-  mock.restore();
+  vi.restoreAllMocks();
 });
 
 describe("send — messages", () => {

--- a/packages/telegram/test/outbound/stream-text.test.ts
+++ b/packages/telegram/test/outbound/stream-text.test.ts
@@ -1,14 +1,6 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  setSystemTime,
-  spyOn,
-} from "bun:test";
 import { markdown, text, UnsupportedError } from "@spectrum-ts/core";
+import { setSystemTime } from "@spectrum-ts/test-support/time";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { configSchema } from "@/config";
 import { send } from "@/outbound/send";
 
@@ -54,13 +46,13 @@ beforeEach(() => {
       return Response.json(responseFor(method));
     });
   };
-  spyOn(globalThis, "fetch").mockImplementation(
+  vi.spyOn(globalThis, "fetch").mockImplementation(
     impl as unknown as typeof fetch
   );
 });
 
 afterEach(() => {
-  mock.restore();
+  vi.restoreAllMocks();
   setSystemTime(); // restore the real clock after time-controlled tests
 });
 
@@ -70,8 +62,7 @@ async function* fromArray(items: string[]): AsyncIterable<string> {
   }
 }
 
-// bun's setSystemTime treats epoch 0 as "restore the real clock", so the
-// frozen timeline must start at a non-zero instant.
+// A non-zero instant so a frozen Date.now() is unmistakably mocked.
 const BASE_MS = 1_000_000;
 
 // Advances the mocked system clock by `stepMs` before each delta, so the

--- a/packages/telegram/test/redact-url.test.ts
+++ b/packages/telegram/test/redact-url.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import { redactBotToken } from "@/client";
 
 describe("redactBotToken", () => {

--- a/packages/telegram/test/space.test.ts
+++ b/packages/telegram/test/space.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import { createSpace } from "@/space";
 
 const ZERO_USERS_ERROR = /requires a recipient user/;

--- a/packages/telegram/test/verify.test.ts
+++ b/packages/telegram/test/verify.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import { configSchema } from "@/config";
 import type { TelegramPayload } from "@/types";
 import { verify } from "@/verify";

--- a/packages/telegram/test/webhook.test.ts
+++ b/packages/telegram/test/webhook.test.ts
@@ -1,12 +1,4 @@
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  mock,
-  spyOn,
-} from "bun:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { configSchema } from "@/config";
 import { ensureWebhook, webhookUrl } from "@/webhook";
 
@@ -71,7 +63,7 @@ beforeEach(() => {
       return Response.json({ ok: true, result: true });
     })();
   };
-  spyOn(globalThis, "fetch").mockImplementation(
+  vi.spyOn(globalThis, "fetch").mockImplementation(
     impl as unknown as typeof fetch
   );
 });
@@ -82,7 +74,7 @@ afterEach(() => {
   } else {
     process.env.SPECTRUM_SUPER_WEBHOOK = originalSuperWebhook;
   }
-  mock.restore();
+  vi.restoreAllMocks();
 });
 
 describe("webhookUrl", () => {

--- a/packages/telegram/vitest.config.ts
+++ b/packages/telegram/vitest.config.ts
@@ -1,0 +1,3 @@
+import { spectrumTestConfig } from "@spectrum-ts/test-support/vitest";
+
+export default spectrumTestConfig(import.meta.dirname);

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spectrum-ts/terminal",
   "version": "8.2.1",
-  "description": "Terminal (tuichat) provider for spectrum-ts — chat with your agent from the command line.",
+  "description": "Terminal (tuichat) provider for spectrum-ts \u2014 chat with your agent from the command line.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/photon-hq/spectrum-ts.git",
@@ -40,7 +40,8 @@
   "scripts": {
     "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js",
     "dev": "tsdown --watch",
-    "test": "bun test --pass-with-no-tests",
+    "test:bun": "bun --bun vitest run",
+    "test:node": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -52,8 +53,10 @@
   },
   "devDependencies": {
     "@spectrum-ts/core": "workspace:*",
+    "@spectrum-ts/test-support": "workspace:*",
     "@types/bun": "latest",
-    "tsdown": "^0.22.2"
+    "tsdown": "^0.22.2",
+    "vitest": "^4.1.9"
   },
   "license": "MIT"
 }

--- a/packages/terminal/vitest.config.ts
+++ b/packages/terminal/vitest.config.ts
@@ -1,0 +1,5 @@
+import { spectrumTestConfig } from "@spectrum-ts/test-support/vitest";
+
+export default spectrumTestConfig(import.meta.dirname, {
+  test: { passWithNoTests: true },
+});

--- a/packages/test-support/package.json
+++ b/packages/test-support/package.json
@@ -19,7 +19,8 @@
   },
   "devDependencies": {
     "@spectrum-ts/core": "workspace:*",
-    "@types/bun": "latest"
+    "@types/bun": "latest",
+    "vitest": "^4.1.9"
   },
   "license": "MIT"
 }

--- a/packages/test-support/src/cloud.ts
+++ b/packages/test-support/src/cloud.ts
@@ -1,5 +1,5 @@
-import { spyOn } from "bun:test";
 import { cloud } from "@spectrum-ts/core";
+import { vi } from "vitest";
 
 // Spectrum() fetches project metadata up-front when projectId/projectSecret are
 // supplied. Stub the cloud call so construction doesn't hit the network (and
@@ -8,7 +8,7 @@ import { cloud } from "@spectrum-ts/core";
 // Call at module top level in any test that constructs Spectrum with credentials,
 // mirroring the module-load-time spy the tests relied on when colocated.
 export const stubCloud = () =>
-  spyOn(cloud, "getProject").mockResolvedValue({
+  vi.spyOn(cloud, "getProject").mockResolvedValue({
     id: "proj",
     name: "Test Project",
     profile: {},

--- a/packages/test-support/src/time.ts
+++ b/packages/test-support/src/time.ts
@@ -1,0 +1,14 @@
+import { vi } from "vitest";
+
+// Bun-setSystemTime-compatible shim: fakes Date ONLY. The suite's timing
+// helpers (withinMs/settleSoon/flush) rely on real setTimeout/setImmediate,
+// so the timer functions themselves must never be faked. Calling with no
+// argument restores the real clock, mirroring bun:test's setSystemTime().
+export const setSystemTime = (date?: Date): void => {
+  if (date) {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(date);
+  } else {
+    vi.useRealTimers();
+  }
+};

--- a/packages/test-support/src/vitest.ts
+++ b/packages/test-support/src/vitest.ts
@@ -1,0 +1,51 @@
+import path from "node:path";
+import { defineConfig, mergeConfig, type ViteUserConfig } from "vitest/config";
+
+const packagesDir = path.resolve(import.meta.dirname, "../..");
+
+const packageSrcAlias = /^@\//;
+
+// Bun resolves workspace packages to raw TS via the "bun" exports condition;
+// Vite's resolver would pick the "default" condition and test stale dist/
+// bundles instead. Alias every workspace specifier straight to source —
+// aliased paths live outside node_modules, so Vitest transforms them.
+const workspaceAliases = [
+  {
+    find: /^@spectrum-ts\/core\/authoring$/,
+    replacement: path.join(packagesDir, "core/src/authoring.ts"),
+  },
+  {
+    find: /^@spectrum-ts\/test-support\/(.*)$/,
+    replacement: path.join(packagesDir, "test-support/src/$1.ts"),
+  },
+  {
+    find: /^@spectrum-ts\/([a-z-]+)$/,
+    replacement: path.join(packagesDir, "$1/src/index.ts"),
+  },
+  {
+    find: /^spectrum-ts$/,
+    replacement: path.join(packagesDir, "spectrum-ts/src/index.ts"),
+  },
+];
+
+export const spectrumTestConfig = (
+  packageDir: string,
+  overrides: ViteUserConfig = {}
+): ViteUserConfig =>
+  mergeConfig(
+    defineConfig({
+      resolve: {
+        alias: [
+          ...workspaceAliases,
+          {
+            find: packageSrcAlias,
+            replacement: `${path.join(packageDir, "src")}/`,
+          },
+        ],
+      },
+      test: {
+        include: ["test/**/*.test.ts"],
+      },
+    }),
+    overrides
+  );

--- a/packages/whatsapp-business/package.json
+++ b/packages/whatsapp-business/package.json
@@ -40,7 +40,8 @@
   "scripts": {
     "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js",
     "dev": "tsdown --watch",
-    "test": "bun test",
+    "test:bun": "bun --bun vitest run",
+    "test:node": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
@@ -54,9 +55,11 @@
   },
   "devDependencies": {
     "@spectrum-ts/core": "workspace:*",
+    "@spectrum-ts/test-support": "workspace:*",
     "@types/bun": "latest",
     "@types/mime-types": "^3.0.1",
-    "tsdown": "^0.22.2"
+    "tsdown": "^0.22.2",
+    "vitest": "^4.1.9"
   },
   "license": "MIT"
 }

--- a/packages/whatsapp-business/test/messages.test.ts
+++ b/packages/whatsapp-business/test/messages.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, mock } from "bun:test";
 import type { Message } from "@spectrum-ts/core";
 import { asRead } from "@spectrum-ts/core/authoring";
+import { describe, expect, it, vi } from "vitest";
 import { send } from "@/messages";
 import type { WhatsAppClients } from "@/types";
 
@@ -12,7 +12,7 @@ const target = {
 
 describe("whatsapp send — read", () => {
   it("marks the conversation read up to the target via markRead", async () => {
-    const markRead = mock(() => Promise.resolve());
+    const markRead = vi.fn(() => Promise.resolve());
     const clients = [{ messages: { markRead } }] as unknown as WhatsAppClients;
 
     const result = await send(clients, "15550001111", asRead({ target }));

--- a/packages/whatsapp-business/test/redact-url.test.ts
+++ b/packages/whatsapp-business/test/redact-url.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it } from "vitest";
 import { redactMediaUrl } from "@/messages";
 
 describe("redactMediaUrl", () => {

--- a/packages/whatsapp-business/vitest.config.ts
+++ b/packages/whatsapp-business/vitest.config.ts
@@ -1,0 +1,3 @@
+import { spectrumTestConfig } from "@spectrum-ts/test-support/vitest";
+
+export default spectrumTestConfig(import.meta.dirname);

--- a/turbo.json
+++ b/turbo.json
@@ -21,7 +21,10 @@
       "persistent": true
     },
     "check": {},
-    "test": {
+    "test:node": {
+      "dependsOn": ["^typecheck"]
+    },
+    "test:bun": {
       "dependsOn": ["^typecheck"]
     },
     "typecheck": {


### PR DESCRIPTION
Replace bun:test with Vitest across all 52 test files so the same suite runs twice — `vitest run` (Node 24) and `bun --bun vitest run` (Bun) — surfacing Bun/Node incompatibilities in CI (both steps blocking).

- Shared config (test-support/src/vitest.ts) aliases every workspace specifier to raw src/, since Vite's resolver would otherwise pick the stale dist/ "default" export condition instead of Bun's "bun" one.
- Per-package vitest.config.ts + test:node/test:bun turbo tasks.
- Fusor websocket test: Bun.serve → `ws` server; its stop() is fire-and-forget because Bun's ws shim never fires the close callback after server-side terminate() (found by this very migration).
- setSystemTime shim (test-support/src/time.ts) fakes Date only, so the suite's real-timer helpers keep working; `mock.module` → `vi.doMock`.
- Coverage stays Node-only via @vitest/coverage-v8 (core).

Both runtimes: 425/425 tests green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785631735&installation_id=127326493&pr_number=171&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F171&signature=38f8b1ffcebf03b8cf1090735d56ac975cdd1c3a6fbe1c6eadf1ef648fc4fc87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime-aware test commands (`test:node`, `test:bun`) and updated workspace task support to run tests under both Node and Bun.
  * Updated CI to validate the build and run tests in a Node/Bun matrix for broader compatibility.
* **Bug Fixes**
  * Migrated test mocking/execution to Vitest to reduce runtime-specific failures.
  * Improved WebSocket-related tests to run reliably under Node.
* **Documentation**
  * Updated contribution and agent instructions with the new dual-runtime test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->