### PR TITLE
fix(whatsapp): retry failed token renewal instead of waiting a full TTL

### DIFF
--- a/packages/whatsapp-business/src/auth.ts
+++ b/packages/whatsapp-business/src/auth.ts
@@ -13,7 +13,13 @@ const streamLog = createLogger("spectrum.whatsapp.stream");
 
 const RENEWAL_RATIO = 0.8;
 const EXPIRY_BUFFER_MS = 30_000;
-const RETRY_DELAY_MS = 30_000;
+// Failed-renewal retry: exponential backoff from BASE, capped at MAX, with
+// half-jitter. Backoff keeps a sustained cloud outage from turning every
+// project into a 30s retry storm; jitter stops all projects from retrying in
+// lockstep (thundering herd). The token is already expired during an outage,
+// so the only cost of backing off is up to MAX of extra recovery latency.
+const RETRY_BASE_MS = 30_000;
+const RETRY_MAX_MS = 120_000;
 const RESUBSCRIBE_BACKOFF_MS = 500;
 
 interface CloudAuth {
@@ -47,6 +53,10 @@ export async function createCloudClients(
   let disposed = false;
   let renewalTimer: ReturnType<typeof setTimeout> | undefined;
   let refreshFailures = 0;
+  // Coalesces the timer-driven renewal and the per-RPC lazy refresh so the two
+  // can never run concurrent token swaps (racing client rebuilds / leaked
+  // clients). Cleared when the in-flight refresh settles.
+  let inFlightRefresh: Promise<void> | undefined;
 
   const lines = new Map<string, LineState>();
 
@@ -60,15 +70,30 @@ export async function createCloudClients(
     return createClient({ accessToken, appSecret: "", phoneNumberId });
   };
 
-  const refreshTokens = async (): Promise<void> => {
-    tokenData = await cloud.issueWhatsappBusinessTokens(
+  const doRefresh = async (): Promise<void> => {
+    const next = await cloud.issueWhatsappBusinessTokens(
       projectId,
       projectSecret
     );
+    // Bail if disposed while the token request was in flight — otherwise we'd
+    // build clients that dispose() already finished closing (it snapshots the
+    // line set) and they would leak, never being closed.
+    if (disposed) {
+      return;
+    }
+    tokenData = next;
     tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
 
     for (const [phoneNumberId, state] of lines) {
       if (!tokenData.auth[phoneNumberId]) {
+        // The refreshed response no longer carries this line, so we cannot
+        // rebuild its client — the existing one keeps running on a token that
+        // will expire, and its event stream goes quiet with no other signal.
+        // Surface it rather than dropping it silently.
+        log.warn(
+          "whatsapp line missing from refreshed token response; keeping existing client (its stream may stop until the line returns)",
+          { "spectrum.whatsapp.auth.phone_number_id": phoneNumberId }
+        );
         continue;
       }
       const old = state.current;
@@ -80,6 +105,17 @@ export async function createCloudClients(
     }
   };
 
+  // Single-flight wrapper: concurrent callers share one refresh instead of
+  // issuing racing token swaps.
+  const refreshTokens = (): Promise<void> => {
+    if (!inFlightRefresh) {
+      inFlightRefresh = doRefresh().finally(() => {
+        inFlightRefresh = undefined;
+      });
+    }
+    return inFlightRefresh;
+  };
+
   const onRefreshSuccess = () => {
     if (refreshFailures > 0) {
       log.info("whatsapp token refresh recovered", {
@@ -89,23 +125,56 @@ export async function createCloudClients(
     }
   };
 
-  const onRefreshFailure = (error: unknown) => {
+  // Exponential backoff with half-jitter, from the already-incremented failure
+  // count. E.g. ~15–30s, ~30–60s, ~60–120s, then capped at ~60–120s.
+  const nextRetryDelayMs = (): number => {
+    const exp = Math.min(
+      RETRY_BASE_MS * 2 ** (refreshFailures - 1),
+      RETRY_MAX_MS
+    );
+    return Math.round(exp * (0.5 + Math.random() * 0.5));
+  };
+
+  const onRefreshFailure = (error: unknown): number => {
     refreshFailures += 1;
+    const retryInMs = nextRetryDelayMs();
     log.warn(
       "whatsapp token refresh failed; retrying",
       {
         "spectrum.whatsapp.auth.attempt": refreshFailures,
-        "spectrum.whatsapp.auth.retry_in_ms": RETRY_DELAY_MS,
+        "spectrum.whatsapp.auth.retry_in_ms": retryInMs,
         ...errorAttrs(error),
       },
       error
     );
+    return retryInMs;
   };
 
   const clearRenewalTimer = () => {
     if (renewalTimer !== undefined) {
       clearTimeout(renewalTimer);
       renewalTimer = undefined;
+    }
+  };
+
+  // One renewal attempt. On success, schedule the next at the TTL ratio; on
+  // failure, RETRY the refresh itself after a jittered backoff. The old code
+  // rescheduled scheduleRenewal() on failure, which waited another full
+  // ~0.8×TTL against the STALE expiry before trying again — so a single 500
+  // from cloud left the token to expire and the stream silent for ~12 minutes.
+  const runRenewal = async (): Promise<void> => {
+    try {
+      await refreshTokens();
+      onRefreshSuccess();
+      scheduleRenewal();
+    } catch (err) {
+      const retryInMs = onRefreshFailure(err);
+      if (disposed) {
+        return;
+      }
+      clearRenewalTimer();
+      renewalTimer = setTimeout(runRenewal, retryInMs);
+      renewalTimer?.unref?.();
     }
   };
 
@@ -117,18 +186,7 @@ export async function createCloudClients(
     const ttlMs = tokenData.expiresIn * 1000;
     const renewInMs = Math.max(ttlMs * RENEWAL_RATIO, 5000);
 
-    renewalTimer = setTimeout(async () => {
-      try {
-        await refreshTokens();
-        onRefreshSuccess();
-        scheduleRenewal();
-      } catch (err) {
-        onRefreshFailure(err);
-        clearRenewalTimer();
-        renewalTimer = setTimeout(() => scheduleRenewal(), RETRY_DELAY_MS);
-        renewalTimer?.unref?.();
-      }
-    }, renewInMs);
+    renewalTimer = setTimeout(runRenewal, renewInMs);
     renewalTimer?.unref?.();
   };
 

--- a/packages/whatsapp-business/test/auth-renewal.test.ts
+++ b/packages/whatsapp-business/test/auth-renewal.test.ts
@@ -1,0 +1,126 @@
+import { cloud } from "@spectrum-ts/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createCloudClients, disposeCloudAuth } from "@/auth";
+
+type TokenData = Awaited<ReturnType<typeof cloud.issueWhatsappBusinessTokens>>;
+
+const TTL_SECONDS = 900; // 15 min — matches WHATSAPP_BUSINESS_TOKEN_TTL_SECONDS
+const RENEW_AT_MS = TTL_SECONDS * 1000 * 0.8; // 720_000 (RENEWAL_RATIO)
+const RETRY_BASE_MS = 30_000;
+const RETRY_MAX_MS = 120_000;
+
+const tokenResponse: TokenData = {
+  auth: { PN1: "token" },
+  numbers: { PN1: "+15550001111" },
+  expiresIn: TTL_SECONDS,
+};
+
+describe("whatsapp token renewal", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // Pin jitter to its upper bound (0.5 + 1*0.5 = 1.0) so the backoff delays
+    // are the exact exponential values and assertions stay deterministic.
+    vi.spyOn(Math, "random").mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("retries a failed renewal after ~RETRY_BASE_MS, not another full TTL", async () => {
+    const callTimes: number[] = [];
+    const spy = vi
+      .spyOn(cloud, "issueWhatsappBusinessTokens")
+      .mockImplementation(() => {
+        callTimes.push(Date.now());
+        // 1st call = initial issue (ok), 2nd = scheduled renewal (fails),
+        // 3rd = the retry we are asserting about (ok).
+        if (callTimes.length === 2) {
+          return Promise.reject(new Error("Internal server error"));
+        }
+        return Promise.resolve(tokenResponse);
+      });
+
+    const clients = await createCloudClients("proj", "secret");
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // Reach the scheduled renewal — it fails.
+    await vi.advanceTimersByTimeAsync(RENEW_AT_MS);
+    expect(spy).toHaveBeenCalledTimes(2);
+
+    // The bug: the failure path rescheduled a full ~0.8×TTL out, so nothing
+    // retried for ~12 min and the token expired. The fix retries at ~30s.
+    await vi.advanceTimersByTimeAsync(RETRY_BASE_MS - 1);
+    expect(spy).toHaveBeenCalledTimes(2); // not yet
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(spy).toHaveBeenCalledTimes(3); // retry fired
+
+    // The gap is the first backoff step (~30s), not 720s.
+    expect((callTimes[2] as number) - (callTimes[1] as number)).toBe(
+      RETRY_BASE_MS
+    );
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("backs off exponentially and caps on repeated failures", async () => {
+    const callTimes: number[] = [];
+    vi.spyOn(cloud, "issueWhatsappBusinessTokens").mockImplementation(() => {
+      callTimes.push(Date.now());
+      // Initial issue ok; every renewal after that fails.
+      if (callTimes.length === 1) {
+        return Promise.resolve(tokenResponse);
+      }
+      return Promise.reject(new Error("Internal server error"));
+    });
+
+    const clients = await createCloudClients("proj", "secret");
+
+    await vi.advanceTimersByTimeAsync(RENEW_AT_MS); // call 2 (fail)
+    await vi.advanceTimersByTimeAsync(RETRY_BASE_MS); // call 3 (+30s)
+    await vi.advanceTimersByTimeAsync(RETRY_BASE_MS * 2); // call 4 (+60s)
+    await vi.advanceTimersByTimeAsync(RETRY_MAX_MS); // call 5 (+120s, capped)
+    await vi.advanceTimersByTimeAsync(RETRY_MAX_MS); // call 6 (+120s, capped)
+
+    expect(callTimes).toHaveLength(6);
+    const gaps = [
+      (callTimes[2] as number) - (callTimes[1] as number),
+      (callTimes[3] as number) - (callTimes[2] as number),
+      (callTimes[4] as number) - (callTimes[3] as number),
+      (callTimes[5] as number) - (callTimes[4] as number),
+    ];
+    expect(gaps).toEqual([30_000, 60_000, 120_000, 120_000]);
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("after a successful retry, schedules the next renewal at the TTL ratio", async () => {
+    let calls = 0;
+    const spy = vi
+      .spyOn(cloud, "issueWhatsappBusinessTokens")
+      .mockImplementation(() => {
+        calls += 1;
+        if (calls === 2) {
+          return Promise.reject(new Error("Internal server error"));
+        }
+        return Promise.resolve(tokenResponse);
+      });
+
+    const clients = await createCloudClients("proj", "secret");
+
+    await vi.advanceTimersByTimeAsync(RENEW_AT_MS); // renewal fails (call 2)
+    await vi.advanceTimersByTimeAsync(RETRY_BASE_MS); // retry succeeds (call 3)
+    expect(spy).toHaveBeenCalledTimes(3);
+
+    // Next renewal must be a full ratio-of-TTL away, NOT another backoff step.
+    await vi.advanceTimersByTimeAsync(RETRY_MAX_MS);
+    expect(spy).toHaveBeenCalledTimes(3);
+
+    await vi.advanceTimersByTimeAsync(RENEW_AT_MS);
+    expect(spy).toHaveBeenCalledTimes(4);
+
+    await disposeCloudAuth(clients);
+  });
+});


### PR DESCRIPTION
On a failed refresh the renewal path rescheduled the next renewal a full ~0.8xTTL out against the stale expiry, so one transient cloud error let the token expire and the event stream go silent for ~12 minutes. Retry the refresh itself, on jittered exponential backoff (30s base, 120s cap) that resets on recovery.

- Single-flight refresh: the timer path and the per-RPC lazy path share one in-flight refresh so they cannot run racing token swaps.
- Bail from a refresh that resolves after dispose() so it cannot rebuild (and leak) clients dispose already closed.
- Log, rather than silently drop, a line missing from a refreshed token response; its stream would otherwise die quietly.
- tests: retry timing, exponential/capped backoff, post-recovery schedule.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785733508&installation_id=127326493&pr_number=172&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F172&signature=617c45e44f718eda9750bd1ebd1a8945a4ad498d42a78fe842ae8c10441846ac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->