### PR TITLE
fix(whatsapp-business): resubscribe cloud streams after token refresh

### DIFF
--- a/packages/whatsapp-business/src/auth.ts
+++ b/packages/whatsapp-business/src/auth.ts
@@ -16,6 +16,8 @@ const EXPIRY_BUFFER_MS = 30_000;
 const RETRY_DELAY_MS = 30_000;
 const RESUBSCRIBE_BACKOFF_MS = 500;
 
+const ignoreCleanupError = () => undefined;
+
 interface CloudAuth {
   dispose: () => Promise<void>;
 }
@@ -47,6 +49,7 @@ export async function createCloudClients(
   let disposed = false;
   let renewalTimer: ReturnType<typeof setTimeout> | undefined;
   let refreshFailures = 0;
+  let refreshInFlight: Promise<void> | undefined;
 
   const lines = new Map<string, LineState>();
 
@@ -109,6 +112,21 @@ export async function createCloudClients(
     }
   };
 
+  const refreshNow = async (): Promise<void> => {
+    await refreshTokens();
+    onRefreshSuccess();
+    scheduleRenewal();
+  };
+
+  const coalescedRefresh = (): Promise<void> => {
+    if (!refreshInFlight) {
+      refreshInFlight = refreshNow().finally(() => {
+        refreshInFlight = undefined;
+      });
+    }
+    return refreshInFlight;
+  };
+
   const scheduleRenewal = () => {
     if (disposed) {
       return;
@@ -117,18 +135,18 @@ export async function createCloudClients(
     const ttlMs = tokenData.expiresIn * 1000;
     const renewInMs = Math.max(ttlMs * RENEWAL_RATIO, 5000);
 
-    renewalTimer = setTimeout(async () => {
-      try {
-        await refreshTokens();
-        onRefreshSuccess();
-        scheduleRenewal();
-      } catch (err) {
+    const runScheduledRefresh = () => {
+      coalescedRefresh().catch((err) => {
         onRefreshFailure(err);
-        clearRenewalTimer();
-        renewalTimer = setTimeout(() => scheduleRenewal(), RETRY_DELAY_MS);
+        if (disposed) {
+          return;
+        }
+        renewalTimer = setTimeout(runScheduledRefresh, RETRY_DELAY_MS);
         renewalTimer?.unref?.();
-      }
-    }, renewInMs);
+      });
+    };
+
+    renewalTimer = setTimeout(runScheduledRefresh, renewInMs);
     renewalTimer?.unref?.();
   };
 
@@ -136,9 +154,7 @@ export async function createCloudClients(
     if (Date.now() < tokenExpiresAt - EXPIRY_BUFFER_MS) {
       return;
     }
-    await refreshTokens();
-    onRefreshSuccess();
-    scheduleRenewal();
+    await coalescedRefresh();
   };
 
   scheduleRenewal();
@@ -236,19 +252,67 @@ const buildClientProxy = (
 interface ResubscribeContext {
   emit: (event: WhatsAppEvent) => Promise<void>;
   getCurrent: () => WhatsAppClient;
+  isClosed: () => boolean;
   options?: SubscribeOptions;
   setActive: (stream: TypedEventStream<WhatsAppEvent> | undefined) => void;
+  swapVersion: () => number;
+  waitForSwap: (version: number) => Promise<void>;
 }
 
-const pumpOnce = async (ctx: ResubscribeContext): Promise<boolean> => {
+type PumpResult = "closed" | "ended" | "error" | "swap";
+
+type NextResult =
+  | { type: "next"; result: IteratorResult<WhatsAppEvent> }
+  | { type: "error"; error: unknown };
+
+const settleNext = (
+  next: Promise<IteratorResult<WhatsAppEvent>>
+): Promise<NextResult> =>
+  next.then(
+    (result) => ({ type: "next", result }),
+    (error) => ({ type: "error", error })
+  );
+
+const closeStream = (stream: TypedEventStream<WhatsAppEvent>): void => {
+  stream.close().catch(ignoreCleanupError);
+};
+
+const returnIterator = (iterator: AsyncIterator<WhatsAppEvent>): void => {
+  iterator.return?.(undefined).catch(ignoreCleanupError);
+};
+
+const pumpOnce = async (ctx: ResubscribeContext): Promise<PumpResult> => {
   const sub = ctx.getCurrent().events.subscribe(ctx.options);
+  const iterator = sub[Symbol.asyncIterator]();
+  const swapVersion = ctx.swapVersion();
   ctx.setActive(sub);
   try {
-    for await (const event of sub) {
-      await ctx.emit(event);
+    while (!ctx.isClosed()) {
+      const result = await Promise.race([
+        settleNext(iterator.next()),
+        ctx.waitForSwap(swapVersion).then(() => ({ type: "swap" as const })),
+      ]);
+
+      if (result.type === "swap") {
+        closeStream(sub);
+        returnIterator(iterator);
+        return ctx.isClosed() ? "closed" : "swap";
+      }
+
+      if (result.type === "error") {
+        throw result.error;
+      }
+
+      if (result.result.done) {
+        return ctx.isClosed() ? "closed" : "ended";
+      }
+
+      await ctx.emit(result.result.value);
     }
-    return true;
+    return "closed";
   } catch (error) {
+    closeStream(sub);
+    returnIterator(iterator);
     streamLog.warn(
       "whatsapp event stream interrupted; resubscribing",
       {
@@ -257,7 +321,7 @@ const pumpOnce = async (ctx: ResubscribeContext): Promise<boolean> => {
       },
       error
     );
-    return false;
+    return ctx.isClosed() ? "closed" : "error";
   } finally {
     ctx.setActive(undefined);
   }
@@ -272,20 +336,43 @@ const resubscribableStream = (
 ): TypedEventStream<WhatsAppEvent> => {
   let closed = false;
   let active: TypedEventStream<WhatsAppEvent> | undefined;
+  let swapVersion = 0;
+  let wakeSwap: (() => void) | undefined;
+
+  const wake = () => {
+    wakeSwap?.();
+    wakeSwap = undefined;
+  };
+
+  const requestResubscribe = () => {
+    swapVersion += 1;
+    wake();
+    active?.close().catch(ignoreCleanupError);
+  };
 
   const source = stream<WhatsAppEvent>((emit, end) => {
     const ctx: ResubscribeContext = {
       emit,
       getCurrent: () => state.current,
+      isClosed: () => closed,
       options,
       setActive: (s) => {
         active = s;
       },
+      swapVersion: () => swapVersion,
+      waitForSwap: (version) => {
+        if (closed || swapVersion !== version) {
+          return Promise.resolve();
+        }
+        return new Promise((resolve) => {
+          wakeSwap = resolve;
+        });
+      },
     };
     const pump = (async () => {
       while (!closed) {
-        await pumpOnce(ctx);
-        if (!closed) {
+        const result = await pumpOnce(ctx);
+        if (!closed && result !== "swap") {
           await new Promise((r) => setTimeout(r, RESUBSCRIBE_BACKOFF_MS));
         }
       }
@@ -294,7 +381,8 @@ const resubscribableStream = (
 
     return async () => {
       closed = true;
-      active?.close().catch(() => undefined);
+      wake();
+      active?.close().catch(ignoreCleanupError);
       active = undefined;
       state.subscriptions.delete(subscription);
       await pump;
@@ -304,18 +392,21 @@ const resubscribableStream = (
   const subscription: LineSubscription = {
     close: () => {
       closed = true;
-      active?.close().catch(() => undefined);
+      wake();
+      active?.close().catch(ignoreCleanupError);
     },
     swap: () => {
-      // Force the inner for-await to end; worker loop re-subscribes to state.current.
-      active?.close().catch(() => undefined);
+      // Force the worker loop to start a fresh RPC against state.current even
+      // if the SDK iterator is stuck waiting for its old stream to finish.
+      requestResubscribe();
     },
   };
   state.subscriptions.add(subscription);
 
   return new TypedEventStream<WhatsAppEvent>(source, async () => {
     closed = true;
-    active?.close().catch(() => undefined);
+    wake();
+    active?.close().catch(ignoreCleanupError);
     state.subscriptions.delete(subscription);
     await source.close();
   });

--- a/packages/whatsapp-business/test/auth.test.ts
+++ b/packages/whatsapp-business/test/auth.test.ts
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FakeTokenResponse {
+  auth: Record<string, string>;
+  expiresIn: number;
+}
+
+const issueWhatsappBusinessTokens = vi.fn(
+  async (): Promise<FakeTokenResponse> => ({
+    auth: { "phone-1": "token-1" },
+    expiresIn: 0,
+  })
+);
+
+interface FakeRawClient {
+  close: ReturnType<typeof vi.fn>;
+  events: {
+    fetchMissed: ReturnType<typeof vi.fn>;
+    subscribe: ReturnType<typeof vi.fn>;
+  };
+  media: Record<string, never>;
+  messages: {
+    markRead: ReturnType<typeof vi.fn>;
+  };
+  options: { accessToken: string };
+}
+
+const rawClients: FakeRawClient[] = [];
+let tokenIssueCount = 0;
+
+class FakeTypedEventStream<T> implements AsyncIterable<T> {
+  private cancelResolve: (() => void) | undefined;
+  private closed = false;
+  private consumed = false;
+  private readonly cleanup: (() => Promise<void>) | undefined;
+  private readonly source: AsyncIterable<T>;
+
+  constructor(source: AsyncIterable<T>, cleanup?: () => Promise<void>) {
+    this.source = source;
+    this.cleanup = cleanup;
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    if (this.closed) {
+      throw new Error("Cannot consume a closed TypedEventStream.");
+    }
+    if (this.consumed) {
+      throw new Error("TypedEventStream already has a consumer.");
+    }
+    this.consumed = true;
+    return this.iterate();
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) {
+      return;
+    }
+    this.closed = true;
+    this.cancelResolve?.();
+    await this.cleanup?.();
+  }
+
+  private async *iterate(): AsyncGenerator<T> {
+    const iterator = this.source[Symbol.asyncIterator]();
+    try {
+      while (!this.closed) {
+        const result = await Promise.race([
+          iterator.next(),
+          this.cancelPromise(),
+        ]);
+        if (result === undefined || this.closed || result.done) {
+          break;
+        }
+        yield result.value;
+      }
+    } finally {
+      await iterator.return?.(undefined);
+    }
+  }
+
+  private cancelPromise(): Promise<undefined> {
+    if (this.closed) {
+      return Promise.resolve(undefined);
+    }
+    return new Promise((resolve) => {
+      this.cancelResolve = () => resolve(undefined);
+    });
+  }
+}
+
+const neverSettlingSource = (): AsyncIterable<unknown> => ({
+  [Symbol.asyncIterator](): AsyncIterator<unknown> {
+    return {
+      next: () => new Promise<IteratorResult<unknown>>(() => undefined),
+      return: () => new Promise<IteratorResult<unknown>>(() => undefined),
+    };
+  },
+});
+
+const createClient = vi.fn((options: { accessToken: string }) => {
+  const raw: FakeRawClient = {
+    close: vi.fn(() => Promise.resolve()),
+    events: {
+      fetchMissed: vi.fn(() => Promise.resolve({ events: [] })),
+      subscribe: vi.fn(() => new FakeTypedEventStream(neverSettlingSource())),
+    },
+    media: {},
+    messages: {
+      markRead: vi.fn(() => Promise.resolve()),
+    },
+    options,
+  };
+  rawClients.push(raw);
+  return raw;
+});
+
+vi.doMock("@spectrum-ts/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@spectrum-ts/core")>();
+  return {
+    ...actual,
+    cloud: { ...actual.cloud, issueWhatsappBusinessTokens },
+  };
+});
+
+vi.doMock("@photon-ai/whatsapp-business", () => ({
+  createClient,
+  TypedEventStream: FakeTypedEventStream,
+}));
+
+const { createCloudClients, disposeCloudAuth } = await import("@/auth");
+
+const waitFor = async (
+  predicate: () => boolean,
+  message: string
+): Promise<void> => {
+  const deadline = Date.now() + 250;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  throw new Error(message);
+};
+
+describe("whatsapp cloud auth stream renewal", () => {
+  beforeEach(() => {
+    rawClients.length = 0;
+    tokenIssueCount = 0;
+    issueWhatsappBusinessTokens.mockReset();
+    issueWhatsappBusinessTokens.mockImplementation(async () => ({
+      auth: { "phone-1": `token-${++tokenIssueCount}` },
+      expiresIn: 0,
+    }));
+    createClient.mockClear();
+  });
+
+  it("opens a fresh subscription after token refresh even when the old SDK iterator does not return", async () => {
+    const clients = await createCloudClients("project-1", "secret-1");
+    const eventStream = clients[0]?.events.subscribe();
+    if (!eventStream) {
+      throw new Error("expected a WhatsApp event stream");
+    }
+
+    const iterator = eventStream[Symbol.asyncIterator]();
+    const pendingNext = iterator.next();
+
+    await waitFor(
+      () => rawClients[0]?.events.subscribe.mock.calls.length === 1,
+      "initial subscription did not start"
+    );
+
+    await clients[0]?.messages.markRead("wamid.1");
+
+    await waitFor(
+      () => rawClients[1]?.events.subscribe.mock.calls.length === 1,
+      "subscription did not reopen after token refresh"
+    );
+
+    expect(createClient).toHaveBeenCalledTimes(2);
+    expect(rawClients[0]?.options.accessToken).toBe("token-1");
+    expect(rawClients[1]?.options.accessToken).toBe("token-2");
+    expect(rawClients[0]?.close).toHaveBeenCalledTimes(1);
+
+    await eventStream.close();
+    await disposeCloudAuth(clients);
+    expect((await pendingNext).done).toBe(true);
+  });
+});

--- a/packages/whatsapp-business/test/auth.test.ts
+++ b/packages/whatsapp-business/test/auth.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 interface FakeTokenResponse {
   auth: Record<string, string>;
@@ -27,6 +27,11 @@ interface FakeRawClient {
 
 const rawClients: FakeRawClient[] = [];
 let tokenIssueCount = 0;
+
+const WAIT_FOR_TIMEOUT_MS = 250;
+const WAIT_FOR_POLL_INTERVAL_MS = 1;
+const SCHEDULED_RENEWAL_DELAY_MS = 5000;
+const REFRESH_RETRY_DELAY_MS = 30_000;
 
 class FakeTypedEventStream<T> implements AsyncIterable<T> {
   private cancelResolve: (() => void) | undefined;
@@ -133,12 +138,14 @@ const waitFor = async (
   predicate: () => boolean,
   message: string
 ): Promise<void> => {
-  const deadline = Date.now() + 250;
+  const deadline = Date.now() + WAIT_FOR_TIMEOUT_MS;
   while (Date.now() < deadline) {
     if (predicate()) {
       return;
     }
-    await new Promise((resolve) => setTimeout(resolve, 1));
+    await new Promise((resolve) =>
+      setTimeout(resolve, WAIT_FOR_POLL_INTERVAL_MS)
+    );
   }
   throw new Error(message);
 };
@@ -153,6 +160,10 @@ describe("whatsapp cloud auth stream renewal", () => {
       expiresIn: 0,
     }));
     createClient.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it("opens a fresh subscription after token refresh even when the old SDK iterator does not return", async () => {
@@ -185,5 +196,76 @@ describe("whatsapp cloud auth stream renewal", () => {
     await eventStream.close();
     await disposeCloudAuth(clients);
     expect((await pendingNext).done).toBe(true);
+  });
+
+  it("coalesces concurrent near-expiry refresh requests", async () => {
+    let resolveRefresh:
+      | ((value: FakeTokenResponse | PromiseLike<FakeTokenResponse>) => void)
+      | undefined;
+
+    issueWhatsappBusinessTokens.mockImplementationOnce(async () => ({
+      auth: { "phone-1": "token-1" },
+      expiresIn: 0,
+    }));
+    issueWhatsappBusinessTokens.mockImplementationOnce(
+      () =>
+        new Promise<FakeTokenResponse>((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+
+    const clients = await createCloudClients("project-1", "secret-1");
+    const firstMarkRead = clients[0]?.messages.markRead("wamid.1");
+    const secondMarkRead = clients[0]?.messages.markRead("wamid.2");
+
+    await waitFor(
+      () => issueWhatsappBusinessTokens.mock.calls.length === 2,
+      "refresh did not start"
+    );
+
+    expect(issueWhatsappBusinessTokens).toHaveBeenCalledTimes(2);
+    resolveRefresh?.({ auth: { "phone-1": "token-2" }, expiresIn: 0 });
+
+    await Promise.all([firstMarkRead, secondMarkRead]);
+
+    expect(issueWhatsappBusinessTokens).toHaveBeenCalledTimes(2);
+    expect(createClient).toHaveBeenCalledTimes(2);
+    expect(rawClients[1]?.options.accessToken).toBe("token-2");
+    expect(rawClients[1]?.messages.markRead).toHaveBeenCalledTimes(2);
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("retries a failed scheduled refresh after the retry delay", async () => {
+    vi.useFakeTimers();
+
+    issueWhatsappBusinessTokens.mockImplementationOnce(async () => ({
+      auth: { "phone-1": "token-1" },
+      expiresIn: 0,
+    }));
+    issueWhatsappBusinessTokens.mockImplementationOnce(() =>
+      Promise.reject(new Error("refresh failed"))
+    );
+    issueWhatsappBusinessTokens.mockImplementationOnce(async () => ({
+      auth: { "phone-1": "token-2" },
+      expiresIn: 0,
+    }));
+
+    const clients = await createCloudClients("project-1", "secret-1");
+
+    await vi.advanceTimersByTimeAsync(SCHEDULED_RENEWAL_DELAY_MS);
+    expect(issueWhatsappBusinessTokens).toHaveBeenCalledTimes(2);
+    expect(createClient).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(REFRESH_RETRY_DELAY_MS - 1);
+    expect(issueWhatsappBusinessTokens).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(issueWhatsappBusinessTokens).toHaveBeenCalledTimes(3);
+    expect(createClient).toHaveBeenCalledTimes(2);
+    expect(rawClients[0]?.close).toHaveBeenCalledTimes(1);
+    expect(rawClients[1]?.options.accessToken).toBe("token-2");
+
+    await disposeCloudAuth(clients);
   });
 });


### PR DESCRIPTION
## Summary
- make WhatsApp Cloud stream swaps interrupt the wrapper pump directly, so token refresh opens a fresh subscribeEvents RPC even if the old SDK iterator does not return
- coalesce token refreshes and retry failed scheduled refreshes after the retry delay instead of waiting another full renewal window
- add a regression test for token refresh while the old subscription iterator is stuck

## Linear
- ENG-1916

## Verification
- bun run --cwd packages/whatsapp-business test:node
- bun run --cwd packages/whatsapp-business test:bun
- bun run --cwd packages/whatsapp-business typecheck
- bunx ultracite check packages/whatsapp-business/src/auth.ts packages/whatsapp-business/test/auth.test.ts
- bun run --filter @spectrum-ts/core build
- bun run --cwd packages/whatsapp-business build
- GitHub CI run 28775509794 passed: check, test (bun), test (node)