### PR TITLE
feat: support imessage mini app cards

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -121,7 +121,7 @@
       "name": "@spectrum-ts/imessage",
       "version": "8.1.1",
       "dependencies": {
-        "@photon-ai/advanced-imessage": "^0.12.0",
+        "@photon-ai/advanced-imessage": "^0.13.0",
         "@photon-ai/imessage-kit": "^3.0.0",
         "@photon-ai/otel": "^3.1.0",
         "lru-cache": "^11.0.0",
@@ -412,7 +412,7 @@
 
     "@parseaple/typedstream": ["@parseaple/typedstream@2.0.2", "", { "dependencies": { "@parseaple/bplist": "1.0.1" } }, "sha512-bzKNZjiBtZN2T2U7Nqq/hhv+EezkPnaWoB5WvPuBwNpQvOr3EI0XrDTkFnAzsA9DKdu57es/gcb1d2ctd1u8xw=="],
 
-    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.12.0", "", { "dependencies": { "@bufbuild/protobuf": "^2.11.0", "@grpc/grpc-js": "^1.12.6", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2" } }, "sha512-cqSq/ew48P3S+4xXpQmS/mDgpa+ijlKYKkQ4MExsQEjHfrJ0DpPJGuY5VHgzfTqV9wYVGyA3TNkDfse/ZRDxoA=="],
+    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.13.0", "", { "dependencies": { "@bufbuild/protobuf": "^2.11.0", "@grpc/grpc-js": "^1.12.6", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2" } }, "sha512-KoGrvYknlfmLKv4qcP0pLVaIMBi2bmiTyqtvsuK6S3AdsJR+/GGqS3HZ4xCyU6QjmTLrzbZSnZkE1ngx7lEUFA=="],
 
     "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-GGDETlRbrPXP5eaRvswaead7MCBGQkm8f7d3aVbx8+rXhB4GEyPiw7Q1/yz5ix53rmxqKRevWywOfG7n+kZDBw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,11 +9,11 @@
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.4",
-        "@biomejs/biome": "^2.5.1",
-        "@types/node": "^26.0.1",
+        "@biomejs/biome": "^2.5.2",
+        "@types/node": "^26.1.0",
         "clean-publish": "^7.1.0",
         "publint": "^0.3.21",
-        "turbo": "^2.10.0",
+        "turbo": "^2.10.4",
         "ultracite": "7.8.3",
       },
     },
@@ -160,12 +160,12 @@
       "name": "spectrum-ts",
       "version": "8.1.1",
       "dependencies": {
-        "@spectrum-ts/core": "8.0.0",
-        "@spectrum-ts/imessage": "8.0.0",
-        "@spectrum-ts/slack": "8.0.0",
-        "@spectrum-ts/telegram": "8.0.0",
-        "@spectrum-ts/terminal": "8.0.0",
-        "@spectrum-ts/whatsapp-business": "8.0.0",
+        "@spectrum-ts/core": "8.1.1",
+        "@spectrum-ts/imessage": "8.1.1",
+        "@spectrum-ts/slack": "8.1.1",
+        "@spectrum-ts/telegram": "8.1.1",
+        "@spectrum-ts/terminal": "8.1.1",
+        "@spectrum-ts/whatsapp-business": "8.1.1",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -258,23 +258,23 @@
 
     "@babel/types": ["@babel/types@8.0.0-rc.6", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.6", "@babel/helper-validator-identifier": "^8.0.0-rc.6" } }, "sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.5.1", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.1", "@biomejs/cli-darwin-x64": "2.5.1", "@biomejs/cli-linux-arm64": "2.5.1", "@biomejs/cli-linux-arm64-musl": "2.5.1", "@biomejs/cli-linux-x64": "2.5.1", "@biomejs/cli-linux-x64-musl": "2.5.1", "@biomejs/cli-win32-arm64": "2.5.1", "@biomejs/cli-win32-x64": "2.5.1" }, "bin": { "biome": "bin/biome" } }, "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.2", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.2", "@biomejs/cli-darwin-x64": "2.5.2", "@biomejs/cli-linux-arm64": "2.5.2", "@biomejs/cli-linux-arm64-musl": "2.5.2", "@biomejs/cli-linux-x64": "2.5.2", "@biomejs/cli-linux-x64-musl": "2.5.2", "@biomejs/cli-win32-arm64": "2.5.2", "@biomejs/cli-win32-x64": "2.5.2" }, "bin": { "biome": "bin/biome" } }, "sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A=="],
 
     "@borewit/text-codec": ["@borewit/text-codec@0.2.2", "", {}, "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ=="],
 
@@ -518,17 +518,17 @@
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
 
-    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-EwvHThXzpY0KGd1/NAmuewI5D+aVa3Rl/OlxE36yfjUKb/+ySrfJrSlEFt8aD1OXwnnaHnQnPKHFndor0Zxlsg=="],
+    "@turbo/darwin-64": ["@turbo/darwin-64@2.10.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-m1MUEI4MJ69r5CwfMYxmHi0H0rrgiYCBOp0tgBZ9x/YVvOb5uu/lRIDyDwdtH054R2yWeQaIigUGu6aCX9f8cA=="],
 
-    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9d2fTyyG0lf5Wq1bwJA9qUaeecViMkLcdctWaMMmCkxZ/JqypmqOwK3W6vmejeKVgkr06gSoiX8bD+xN5Jpxcg=="],
+    "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.10.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-VQ1Yxs5zkPT+2z7t1P4mvn6JmcKLkOCAsPuK9XbOvuVj0DlTlETfIXNisX0771v/vTWHOQqiwoGi+TtAUq8efw=="],
 
-    "@turbo/linux-64": ["@turbo/linux-64@2.10.0", "", { "os": "linux", "cpu": "x64" }, "sha512-sZBtjMuufitanjzi6UssoUpJMnnPlLMcdcJj3m3ptNsSq31Xh7MnjhwA5nWvLDTfEFg8GPcbYFXMo8vSdKRfqQ=="],
+    "@turbo/linux-64": ["@turbo/linux-64@2.10.4", "", { "os": "linux", "cpu": "x64" }, "sha512-IzV1QovmwX7mfGnVinmE++2IB8tbeo38weltiuH5zNqwCTBjLs/DytyRKx+bmnhHdXIq9SheR8p0Nip/LBUPHg=="],
 
-    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vkq/Z8R+1DQ+kifWFa810IjRy2NNBVvha3cg9sWA3nFh6nnGrHSMnnJKrzH7c/No9kq4Jb55Ru44YKsCSBgrKg=="],
+    "@turbo/linux-arm64": ["@turbo/linux-arm64@2.10.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-rfujSQkP5aYiRn0PgTM7F00WkJCP/bKDVZbOx3WmrZwa/vHA0bplhCl328kpX7VI9HH2vI90ISGwuSVgJgoqTw=="],
 
-    "@turbo/windows-64": ["@turbo/windows-64@2.10.0", "", { "os": "win32", "cpu": "x64" }, "sha512-CRUEguLWxFQHptYZS7HjPhNhAFawfea07iR+xAQ5e4klgLrPCMdexBkXwSCwOxqTFknJ7RZFN3gOaADsw+Gttg=="],
+    "@turbo/windows-64": ["@turbo/windows-64@2.10.4", "", { "os": "win32", "cpu": "x64" }, "sha512-NnspP7Wd5fa3Wwnqv9bKfhegqZzuHBgbPxdZU/idTLQcazx/vgKu95JlCx2YHY0hdvKCnPcARrDwM+KEUmaO7A=="],
 
-    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-dVHGaf9F8twzgibcBqKoADT/LLqf9++jDb+hq/LPWWaOmRpp4M+/pVOm7vy4z9D++xg8eaxWLT0+wQxFwhYu9A=="],
+    "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-Iv02YgOpaEShc2OkG7mgCJ2pEw1RUKiKbs0h8W5wAf4jZ5vpmraTEjuGTgHRuOORQnC1GN3KHo5WB+hu1abRMA=="],
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg=="],
 
@@ -550,7 +550,7 @@
 
     "@types/mime-types": ["@types/mime-types@3.0.1", "", {}, "sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ=="],
 
-    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
+    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
 
     "@types/qs": ["@types/qs@6.15.1", "", {}, "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw=="],
 
@@ -1090,7 +1090,7 @@
 
     "tunnel-agent": ["tunnel-agent@0.6.0", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w=="],
 
-    "turbo": ["turbo@2.10.0", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.0", "@turbo/darwin-arm64": "2.10.0", "@turbo/linux-64": "2.10.0", "@turbo/linux-arm64": "2.10.0", "@turbo/windows-64": "2.10.0", "@turbo/windows-arm64": "2.10.0" }, "bin": { "turbo": "bin/turbo" } }, "sha512-o016H9PPtuH2deb3mh3Vci3Avfi9UYgM/RONQisY7HnloupP0IFSbFS3gFYJgFJP8nwBrByHWFQIDa8T2zIXPw=="],
+    "turbo": ["turbo@2.10.4", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.4", "@turbo/darwin-arm64": "2.10.4", "@turbo/linux-64": "2.10.4", "@turbo/linux-arm64": "2.10.4", "@turbo/windows-64": "2.10.4", "@turbo/windows-arm64": "2.10.4" }, "bin": { "turbo": "bin/turbo" } }, "sha512-GQpduILaKjoaGljw097ScsSyKTtZSY7cZ3bJktzfTkPMyCf3ShKLuXK2IaOEN2Plziml+ArR7WJ1m+V4VbnaKQ=="],
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 

--- a/docs/content/app.mdx.vel
+++ b/docs/content/app.mdx.vel
@@ -19,4 +19,4 @@ On iMessage, app cards open inside the [Spectrum Mini App](https://apps.apple.co
 
 The launcher keeps a library of every mini app a recipient has opened, so they can reopen those apps later or share them with friends.
 
-For customized iMessage app with layout control, see [Mini-app cards](/spectrum-ts/providers/imessage/messaging-features#mini-app-cards).
+To send a card that opens your own iMessage extension instead of the Spectrum Mini App, see [Mini-app cards](/spectrum-ts/providers/imessage/messaging-features#mini-app-cards).

--- a/docs/providers/imessage/messaging-features.mdx.vel
+++ b/docs/providers/imessage/messaging-features.mdx.vel
@@ -134,7 +134,15 @@ Background UI may not appear in these cases:
 
 ## Mini-app cards
 
-Send a customized iMessage mini-app card: a remote-only rich bubble that shows app metadata, a deep link, and a visual layout. Import `customizedMiniApp` from the iMessage provider:
+Universal `app(url)` content renders as a server-managed Spectrum mini-app card in remote iMessage mode. You provide the URL; Spectrum derives the visible preview from link metadata and the Advanced iMessage server owns the Spectrum iMessage extension identity.
+
+```ts
+import { app } from "spectrum-ts";
+
+const sent = await space.send(app("https://example.com/deep-link"));
+```
+
+Use `customizedMiniApp(...)` only when you want the card to open your own iMessage extension instead of Spectrum's server-managed extension. It is a remote-only rich bubble that shows your app metadata, a deep link, and a visual layout:
 
 ```ts
 import { customizedMiniApp } from "spectrum-ts/providers/imessage";
@@ -153,7 +161,11 @@ const sent = await space.send(customizedMiniApp({
 
 `space.send(customizedMiniApp(...))` returns the sent message record. Unlike `background` and `read`, mini-app cards are real outbound messages.
 
+Mini-app card messages can be updated in place with the standard edit API, for example `await sent.edit(app("https://example.com/next"))` or `await sent.edit(customizedMiniApp(...))`.
+
 `appStoreId` is optional. Omit it to send a card whose extension isn't published on the App Store. When set, recipients without the extension are directed to its App Store entry.
+
+Both `app(...)` and `customizedMiniApp(...)` require cloud or dedicated mode for native iMessage cards. In local mode, `app(...)` degrades to a plain URL text message, while `customizedMiniApp(...)` throws an `UnsupportedError`.
 
 <AccordionGroup>
   <Accordion title="CustomizedMiniAppInput" description="Fields for building a mini-app card.">
@@ -181,10 +193,6 @@ const sent = await space.send(customizedMiniApp({
     At least one of `caption`, `subcaption`, `trailingCaption`, `trailingSubcaption`, or `image` must be set.
   </Accordion>
 </AccordionGroup>
-
-<Note>
-  Mini-app cards require cloud or dedicated mode. In local mode, `customizedMiniApp()` throws an `UnsupportedError`.
-</Note>
 
 ## Native contact card sharing
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.4",
-    "@biomejs/biome": "^2.5.1",
-    "@types/node": "^26.0.1",
+    "@biomejs/biome": "^2.5.2",
+    "@types/node": "^26.1.0",
     "clean-publish": "^7.1.0",
     "publint": "^0.3.21",
-    "turbo": "^2.10.0",
+    "turbo": "^2.10.4",
     "ultracite": "7.8.3"
   },
   "packageManager": "bun@1.3.14",

--- a/packages/imessage/package.json
+++ b/packages/imessage/package.json
@@ -44,7 +44,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@photon-ai/advanced-imessage": "^0.12.0",
+    "@photon-ai/advanced-imessage": "^0.13.0",
     "@photon-ai/imessage-kit": "^3.0.0",
     "@photon-ai/otel": "^3.1.0",
     "lru-cache": "^11.0.0",

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -2,6 +2,7 @@ import {
   type AdvancedIMessage,
   createClient,
   MessageEffect,
+  type MiniAppCardSession,
 } from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
 import { withSpan } from "@photon-ai/otel";
@@ -66,6 +67,7 @@ import {
   replyToMessage as remoteReplyToMessage,
   send as remoteSend,
   sendCustomizedMiniApp as remoteSendCustomizedMiniApp,
+  sendMiniApp as remoteSendMiniApp,
   sendStreamText as remoteSendStreamText,
   setBackground as remoteSetBackground,
   setDisplayName as remoteSetDisplayName,
@@ -75,6 +77,8 @@ import {
   stopTyping as remoteStopTyping,
   unsendMessage as remoteUnsendMessage,
   unsendReaction as remoteUnsendReaction,
+  updateCustomizedMiniApp as remoteUpdateCustomizedMiniApp,
+  updateMiniApp as remoteUpdateMiniApp,
 } from "./remote/api";
 import { toSpectrumMiniApp } from "./remote/app";
 import { getRemoteAttachment } from "./remote/attachments";
@@ -124,11 +128,72 @@ const cacheRemoteOutbound = <T extends ProviderMessageRecord | undefined>(
 
 const handleEdit = async (
   client: IMessageClient,
-  space: { id: string; phone: string },
+  space: { id: string; phone: string; type: "dm" | "group" },
   content: Edit
 ): Promise<void> => {
   if (isLocal(client)) {
     throw UnsupportedError.action("edit", "iMessage (local mode)");
+  }
+  const remote = clientForPhone(client, space.phone);
+  const miniAppCardSession = (
+    content.target as unknown as { miniAppCardSession?: MiniAppCardSession }
+  ).miniAppCardSession;
+  const updateMiniAppTargetSession = (
+    record: ProviderMessageRecord | undefined
+  ): void => {
+    const nextSession = record?.miniAppCardSession;
+    if (nextSession) {
+      (
+        content.target as unknown as {
+          miniAppCardSession?: MiniAppCardSession;
+        }
+      ).miniAppCardSession = nextSession as MiniAppCardSession;
+    }
+  };
+  if (content.content.type === "app") {
+    if (!miniAppCardSession) {
+      throw UnsupportedError.action(
+        "edit",
+        "iMessage",
+        "mini app card edits require a miniAppCardSession from the original send"
+      );
+    }
+    const url = await content.content.url();
+    const layout = await content.content.layout();
+    const record = cacheRemoteOutbound(
+      remote,
+      space,
+      await remoteUpdateMiniApp(
+        remote,
+        space.id,
+        miniAppCardSession,
+        toSpectrumMiniApp(url, layout),
+        content.content
+      )
+    );
+    updateMiniAppTargetSession(record);
+    return;
+  }
+  if (isCustomizedMiniApp(content.content)) {
+    if (!miniAppCardSession) {
+      throw UnsupportedError.action(
+        "edit",
+        "iMessage",
+        "customized mini app card edits require a miniAppCardSession from the original send"
+      );
+    }
+    const record = cacheRemoteOutbound(
+      remote,
+      space,
+      await remoteUpdateCustomizedMiniApp(
+        remote,
+        space.id,
+        miniAppCardSession,
+        content.content
+      )
+    );
+    updateMiniAppTargetSession(record);
+    return;
   }
   if (content.content.type !== "text") {
     // Mirrors `remoteEditMessage`'s own check — surface as an
@@ -139,7 +204,6 @@ const handleEdit = async (
       `only text content can be edited (got "${content.content.type}")`
     );
   }
-  const remote = clientForPhone(client, space.phone);
   await remoteEditMessage(remote, space.id, content.target.id, content.content);
 };
 
@@ -235,9 +299,9 @@ const handleCustomizedMiniApp = async (
 
 /**
  * Render the universal `app` content. On remote it becomes a native Spectrum
- * mini-app card (fixed `SPECTRUM_MINI_APP` identity + the URL + the layout
- * already parsed from the URL's link metadata). Local mode cannot send cards,
- * so it degrades to the bare URL as a text message.
+ * mini-app card with the server-managed Spectrum extension identity, the URL,
+ * and the layout already parsed from the URL's link metadata. Local mode cannot
+ * send cards, so it degrades to the bare URL as a text message.
  */
 const handleApp = async (
   client: IMessageClient,
@@ -253,10 +317,11 @@ const handleApp = async (
   return cacheRemoteOutbound(
     remote,
     space,
-    await remoteSendCustomizedMiniApp(
+    await remoteSendMiniApp(
       remote,
       space.id,
-      toSpectrumMiniApp(url, layout)
+      toSpectrumMiniApp(url, layout),
+      content
     )
   );
 };

--- a/packages/imessage/src/remote/api.ts
+++ b/packages/imessage/src/remote/api.ts
@@ -1,4 +1,7 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type {
+  AdvancedIMessage,
+  MiniAppCardSession,
+} from "@photon-ai/advanced-imessage";
 import type {
   Avatar,
   Content,
@@ -11,11 +14,19 @@ import type { ProviderMessageRecord } from "@spectrum-ts/core/authoring";
 import type { Background } from "../content/background";
 import type { CustomizedMiniApp } from "../content/customized-mini-app";
 import type { IMessageMessage, RemoteClient } from "../types";
+import type { SpectrumMiniApp } from "./app";
 import { setIcon as setRemoteIcon } from "./avatar";
 import { setBackground as setRemoteBackground } from "./background";
 import { shareContactCard as shareRemoteContactCard } from "./contact-card";
-import { sendCustomizedMiniApp as sendRemoteCustomizedMiniApp } from "./customized-mini-app";
+import {
+  sendCustomizedMiniApp as sendRemoteCustomizedMiniApp,
+  updateCustomizedMiniApp as updateRemoteCustomizedMiniApp,
+} from "./customized-mini-app";
 import { getMessage as getRemoteMessage } from "./inbound";
+import {
+  sendMiniApp as sendRemoteMiniApp,
+  updateMiniApp as updateRemoteMiniApp,
+} from "./mini-app";
 import {
   reactToMessage as reactToRemoteMessage,
   unsendReaction as unsendRemoteReaction,
@@ -52,6 +63,31 @@ export const sendCustomizedMiniApp = async (
   content: CustomizedMiniApp
 ): Promise<ProviderMessageRecord> =>
   sendRemoteCustomizedMiniApp(remote, spaceId, content);
+
+export const sendMiniApp = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  content: SpectrumMiniApp,
+  recordContent: Content
+): Promise<ProviderMessageRecord> =>
+  sendRemoteMiniApp(remote, spaceId, content, recordContent);
+
+export const updateMiniApp = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  session: MiniAppCardSession,
+  content: SpectrumMiniApp,
+  recordContent: Content
+): Promise<ProviderMessageRecord> =>
+  updateRemoteMiniApp(remote, spaceId, session, content, recordContent);
+
+export const updateCustomizedMiniApp = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  session: MiniAppCardSession,
+  content: CustomizedMiniApp
+): Promise<ProviderMessageRecord> =>
+  updateRemoteCustomizedMiniApp(remote, spaceId, session, content);
 
 export const setDisplayName = async (
   remote: AdvancedIMessage,

--- a/packages/imessage/src/remote/app.ts
+++ b/packages/imessage/src/remote/app.ts
@@ -1,30 +1,34 @@
+import type { MiniAppMessage } from "@photon-ai/advanced-imessage";
 import type { AppLayout } from "@spectrum-ts/core";
-import {
-  asCustomizedMiniApp,
-  type CustomizedMiniApp,
-} from "../content/customized-mini-app";
 
 /**
- * Fixed identity of Spectrum's own iMessage extension. The universal `app`
- * content renders through this extension, so callers never supply (or even see)
- * these constants — they pass only a URL and the card opens it inside the
- * Spectrum mini app on tap. Callers shipping their *own* extension use the
- * low-level `customizedMiniApp()` instead.
+ * Server-managed Spectrum mini-app card for universal `app` content. Callers
+ * supply only a URL; the advanced iMessage server owns the Spectrum extension
+ * identity and wraps the URL for the mini-app host. Callers shipping their own
+ * extension use the low-level `customizedMiniApp()` instead.
  */
-export const SPECTRUM_MINI_APP = {
-  appName: "Spectrum",
-  extensionBundleId: "codes.photon.Spectrum.MessagesExtension",
-  teamId: "P8XT6232SL",
-  appStoreId: 6_777_616_651,
-} as const;
+export type SpectrumMiniApp = MiniAppMessage;
+
+const previewTitle = (url: string, layout: AppLayout): string =>
+  layout.caption ?? layout.imageTitle ?? layout.summary ?? new URL(url).host;
 
 /**
- * Build the iMessage mini-app card for an `app` content: Spectrum's fixed
- * identity plus the per-message `url` and the `layout` already derived from the
- * URL's link metadata.
+ * Build the server-managed iMessage mini-app card for an `app` content: the
+ * per-message `url` plus the static preview already derived from link metadata.
  */
 export const toSpectrumMiniApp = (
   url: string,
   layout: AppLayout
-): CustomizedMiniApp =>
-  asCustomizedMiniApp({ ...SPECTRUM_MINI_APP, url, layout });
+): SpectrumMiniApp => ({
+  url,
+  preview: {
+    title: previewTitle(url, layout),
+    subtitle: layout.imageSubtitle,
+    body: layout.subcaption,
+    imageJpeg: layout.image,
+    caption: layout.caption,
+    footer: layout.trailingCaption,
+    detail: layout.trailingSubcaption,
+    summary: layout.summary ?? layout.caption ?? layout.imageTitle,
+  },
+});

--- a/packages/imessage/src/remote/customized-mini-app.ts
+++ b/packages/imessage/src/remote/customized-mini-app.ts
@@ -1,8 +1,25 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type {
+  AdvancedIMessage,
+  MiniAppCardSession,
+  MiniAppMessageResult,
+} from "@photon-ai/advanced-imessage";
 import type { Content } from "@spectrum-ts/core";
 import type { ProviderMessageRecord } from "@spectrum-ts/core/authoring";
 import type { CustomizedMiniApp } from "../content/customized-mini-app";
 import { toChatGuid } from "./ids";
+
+const toCustomizedMiniAppRecord = (
+  spaceId: string,
+  message: MiniAppMessageResult,
+  content: CustomizedMiniApp
+): ProviderMessageRecord => ({
+  id: message.guid,
+  content: content as unknown as Content,
+  direction: "outbound",
+  miniAppCardSession: message.miniAppCardSession,
+  space: { id: spaceId },
+  timestamp: message.dateCreated,
+});
 
 /**
  * Send a `CustomizedMiniApp` card to a remote iMessage chat.
@@ -20,11 +37,18 @@ export const sendCustomizedMiniApp = async (
 ): Promise<ProviderMessageRecord> => {
   const chat = toChatGuid(spaceId);
   const message = await remote.messages.sendCustomizedMiniApp(chat, content);
-  return {
-    id: message.guid,
-    content: content as unknown as Content,
-    direction: "outbound",
-    space: { id: spaceId },
-    timestamp: message.dateCreated,
-  };
+  return toCustomizedMiniAppRecord(spaceId, message, content);
+};
+
+export const updateCustomizedMiniApp = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  session: MiniAppCardSession,
+  content: CustomizedMiniApp
+): Promise<ProviderMessageRecord> => {
+  const message = await remote.messages.updateCustomizedMiniApp(
+    session,
+    content
+  );
+  return toCustomizedMiniAppRecord(spaceId, message, content);
 };

--- a/packages/imessage/src/remote/mini-app.ts
+++ b/packages/imessage/src/remote/mini-app.ts
@@ -1,0 +1,51 @@
+import type {
+  AdvancedIMessage,
+  MiniAppCardSession,
+  MiniAppMessageResult,
+} from "@photon-ai/advanced-imessage";
+import type { Content } from "@spectrum-ts/core";
+import type { ProviderMessageRecord } from "@spectrum-ts/core/authoring";
+import type { SpectrumMiniApp } from "./app";
+import { toChatGuid } from "./ids";
+
+const toMiniAppRecord = (
+  spaceId: string,
+  message: MiniAppMessageResult,
+  recordContent: Content
+): ProviderMessageRecord => ({
+  id: message.guid,
+  content: recordContent,
+  direction: "outbound",
+  miniAppCardSession: message.miniAppCardSession,
+  space: { id: spaceId },
+  timestamp: message.dateCreated,
+});
+
+/**
+ * Send a server-managed Spectrum mini-app card to a remote iMessage chat.
+ *
+ * This uses Advanced iMessage's `SendMiniAppMessage` path, so Spectrum's
+ * extension identity stays server-managed instead of being duplicated in this
+ * provider.
+ */
+export const sendMiniApp = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  content: SpectrumMiniApp,
+  recordContent: Content
+): Promise<ProviderMessageRecord> => {
+  const chat = toChatGuid(spaceId);
+  const message = await remote.messages.sendMiniApp(chat, content);
+  return toMiniAppRecord(spaceId, message, recordContent);
+};
+
+export const updateMiniApp = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  session: MiniAppCardSession,
+  content: SpectrumMiniApp,
+  recordContent: Content
+): Promise<ProviderMessageRecord> => {
+  const message = await remote.messages.updateMiniApp(session, content);
+  return toMiniAppRecord(spaceId, message, recordContent);
+};

--- a/packages/imessage/src/types.ts
+++ b/packages/imessage/src/types.ts
@@ -1,4 +1,7 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type {
+  AdvancedIMessage,
+  MiniAppCardSession,
+} from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
 import type { SchemaMessage } from "@spectrum-ts/core";
 import z from "zod";
@@ -66,7 +69,15 @@ export const spaceParamsSchema = z.object({
  * - `parentId`: guid of the parent message for a group sub-item. Undefined
  *   when the message itself is the parent.
  */
+const miniAppCardSessionSchema = z.object({
+  chatGuid: z.string(),
+  messageGuid: z.string(),
+  sessionId: z.string(),
+  targetMessageGuid: z.string(),
+});
+
 export const messageSchema = z.object({
+  miniAppCardSession: miniAppCardSessionSchema.optional(),
   partIndex: z.number().int().nonnegative().optional(),
   parentId: z.string().optional(),
 });
@@ -76,6 +87,7 @@ export type IMessageMessage = SchemaMessage<
   typeof spaceSchema
 > & {
   direction?: "inbound" | "outbound";
+  miniAppCardSession?: MiniAppCardSession;
   partIndex?: number;
   parentId?: string;
 };

--- a/packages/imessage/test/remote/app.test.ts
+++ b/packages/imessage/test/remote/app.test.ts
@@ -1,15 +1,22 @@
 import { describe, expect, it, mock } from "bun:test";
 import type {
   AdvancedIMessage,
-  Message as SDKMessage,
+  MiniAppMessageResult,
 } from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
 import type { Content } from "@spectrum-ts/core";
+import { asCustomizedMiniApp } from "@/content/customized-mini-app";
 import { imessage } from "@/index";
-import { SPECTRUM_MINI_APP, toSpectrumMiniApp } from "@/remote/app";
+import { toSpectrumMiniApp } from "@/remote/app";
 import { type RemoteClient, SHARED_PHONE } from "@/types";
 
 const SENT_DATE = new Date(1_700_000_000_000);
+const MINI_APP_SESSION = {
+  chatGuid: "any;-;+15550123",
+  messageGuid: "card-guid",
+  sessionId: "session-id",
+  targetMessageGuid: "card-guid",
+};
 
 // A minimal `app` content with stub accessors — keeps the dispatch test off the
 // network (the real `app()` would parse the layout from the URL).
@@ -26,56 +33,192 @@ const appContent = (
 const def = imessage.config({}).__definition;
 const ctx = { config: {} as never, store: undefined as never };
 
-const remoteClient = (
-  sendCustomizedMiniApp: (chat: string, content: unknown) => Promise<SDKMessage>
-): RemoteClient[] => [
+const remoteClient = (messages: Record<string, unknown>): RemoteClient[] => [
   {
     phone: SHARED_PHONE,
     client: {
-      messages: { sendCustomizedMiniApp },
+      messages,
     } as unknown as AdvancedIMessage,
   },
 ];
 
 describe("toSpectrumMiniApp", () => {
-  it("merges Spectrum's fixed identity with the url and layout", () => {
+  it("maps app layout to the server-managed mini-app preview", () => {
     const card = toSpectrumMiniApp("https://x.example/1", { caption: "C" });
-    expect(card).toMatchObject({
-      type: "customized-mini-app",
-      __platform: "iMessage",
-      ...SPECTRUM_MINI_APP,
+    expect(card).toEqual({
       url: "https://x.example/1",
-      layout: { caption: "C" },
+      preview: {
+        title: "C",
+        body: undefined,
+        caption: "C",
+        detail: undefined,
+        footer: undefined,
+        imageJpeg: undefined,
+        subtitle: undefined,
+        summary: "C",
+      },
     });
   });
 });
 
 describe("iMessage send: app dispatch", () => {
   it("renders a Spectrum mini-app card on remote", async () => {
-    const sendCustomizedMiniApp = mock((_chat: string, _content: unknown) =>
+    const sendMiniApp = mock((_chat: string, _content: unknown) =>
       Promise.resolve({
         guid: "card-guid",
         dateCreated: SENT_DATE,
-      } as unknown as SDKMessage)
+        miniAppCardSession: MINI_APP_SESSION,
+      } as unknown as MiniAppMessageResult)
     );
 
     const record = await def.send({
       ...ctx,
-      client: remoteClient(sendCustomizedMiniApp),
+      client: remoteClient({ sendMiniApp }),
       space: { id: "any;-;+15550123", type: "dm", phone: SHARED_PHONE },
       content: appContent("https://x.example/1"),
     });
 
-    expect(sendCustomizedMiniApp).toHaveBeenCalledTimes(1);
-    const [chat, sent] = sendCustomizedMiniApp.mock.calls[0] ?? [];
+    expect(sendMiniApp).toHaveBeenCalledTimes(1);
+    const [chat, sent] = sendMiniApp.mock.calls[0] ?? [];
     expect(chat).toBe("any;-;+15550123");
-    expect(sent).toMatchObject({
-      ...SPECTRUM_MINI_APP,
+    expect(sent).toEqual({
       url: "https://x.example/1",
-      layout: { caption: "Store", subcaption: "Hi" },
+      preview: {
+        title: "Store",
+        subtitle: undefined,
+        body: "Hi",
+        imageJpeg: undefined,
+        caption: "Store",
+        footer: undefined,
+        detail: undefined,
+        summary: "Store",
+      },
     });
     expect(record?.id).toBe("card-guid");
+    expect(record?.miniAppCardSession).toEqual(MINI_APP_SESSION);
     expect(record?.timestamp).toEqual(SENT_DATE);
+    expect(record?.content.type).toBe("app");
+  });
+
+  it("updates a Spectrum mini-app card via edit(app(...), message)", async () => {
+    const updatedSession = {
+      ...MINI_APP_SESSION,
+      messageGuid: "updated-card-guid",
+    };
+    const updateMiniApp = mock((_session: unknown, _content: unknown) =>
+      Promise.resolve({
+        guid: "updated-card-guid",
+        dateCreated: SENT_DATE,
+        miniAppCardSession: updatedSession,
+      } as unknown as MiniAppMessageResult)
+    );
+    const target = {
+      id: "card-guid",
+      content: appContent("https://x.example/1"),
+      direction: "outbound",
+      miniAppCardSession: MINI_APP_SESSION,
+    };
+
+    await def.send({
+      ...ctx,
+      client: remoteClient({ updateMiniApp }),
+      space: { id: "any;-;+15550123", type: "dm", phone: SHARED_PHONE },
+      content: {
+        type: "edit",
+        content: appContent("https://x.example/2", { caption: "Updated" }),
+        target,
+      } as unknown as Content,
+    });
+
+    expect(updateMiniApp).toHaveBeenCalledTimes(1);
+    const [session, sent] = updateMiniApp.mock.calls[0] ?? [];
+    expect(session).toEqual(MINI_APP_SESSION);
+    expect(sent).toEqual({
+      url: "https://x.example/2",
+      preview: {
+        title: "Updated",
+        subtitle: undefined,
+        body: undefined,
+        imageJpeg: undefined,
+        caption: "Updated",
+        footer: undefined,
+        detail: undefined,
+        summary: "Updated",
+      },
+    });
+    expect(target.miniAppCardSession).toEqual(updatedSession);
+
+    await def.send({
+      ...ctx,
+      client: remoteClient({ updateMiniApp }),
+      space: { id: "any;-;+15550123", type: "dm", phone: SHARED_PHONE },
+      content: {
+        type: "edit",
+        content: appContent("https://x.example/3", { caption: "Again" }),
+        target,
+      } as unknown as Content,
+    });
+
+    expect(updateMiniApp.mock.calls[1]?.[0]).toEqual(updatedSession);
+  });
+
+  it("updates a customized mini-app card via edit(customizedMiniApp(...), message)", async () => {
+    const updatedSession = {
+      ...MINI_APP_SESSION,
+      messageGuid: "updated-custom-guid",
+    };
+    const updated = asCustomizedMiniApp({
+      appName: "Custom App",
+      appStoreId: 123,
+      extensionBundleId: "com.example.MessagesExtension",
+      layout: { caption: "Custom Updated" },
+      teamId: "ABCDE12345",
+      url: "https://x.example/custom-updated",
+    });
+    const updateCustomizedMiniApp = mock(
+      (_session: unknown, _content: unknown) =>
+        Promise.resolve({
+          guid: "updated-custom-guid",
+          dateCreated: SENT_DATE,
+          miniAppCardSession: updatedSession,
+        } as unknown as MiniAppMessageResult)
+    );
+    const target = {
+      id: "custom-card-guid",
+      content: asCustomizedMiniApp({
+        appName: "Custom App",
+        extensionBundleId: "com.example.MessagesExtension",
+        layout: { caption: "Custom" },
+        teamId: "ABCDE12345",
+        url: "https://x.example/custom",
+      }),
+      direction: "outbound",
+      miniAppCardSession: MINI_APP_SESSION,
+    };
+
+    await def.send({
+      ...ctx,
+      client: remoteClient({ updateCustomizedMiniApp }),
+      space: { id: "any;-;+15550123", type: "dm", phone: SHARED_PHONE },
+      content: {
+        type: "edit",
+        content: updated,
+        target,
+      } as unknown as Content,
+    });
+
+    expect(updateCustomizedMiniApp).toHaveBeenCalledTimes(1);
+    const [session, sent] = updateCustomizedMiniApp.mock.calls[0] ?? [];
+    expect(session).toEqual(MINI_APP_SESSION);
+    expect(sent).toMatchObject({
+      appName: "Custom App",
+      appStoreId: 123,
+      extensionBundleId: "com.example.MessagesExtension",
+      layout: { caption: "Custom Updated" },
+      teamId: "ABCDE12345",
+      url: "https://x.example/custom-updated",
+    });
+    expect(target.miniAppCardSession).toEqual(updatedSession);
   });
 
   it("degrades to a bare-url text message in local mode", async () => {


### PR DESCRIPTION
## Summary
- route universal app content through server-managed iMessage mini app cards
- preserve mini app card sessions and support in-place updates through edit
- keep customized mini app cards on the caller-owned extension path

## Tests
- bun --filter @spectrum-ts/imessage typecheck
- bun --filter @spectrum-ts/imessage test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/175"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785946999&installation_id=127326493&pr_number=175&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F175&signature=8f7b7cf595846f770f12fe154e12dc87a4a91b953cd46e1085e5a33319687809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->