### PR TITLE
feat(core,imessage): group management — membership, roster/avatar reads, and inbound group events

### DIFF
--- a/docs/content.mdx.vel
+++ b/docs/content.mdx.vel
@@ -61,6 +61,9 @@ Use this section when you need to choose the right outbound content shape or und
   <Card title="Avatar" icon="image" href="/spectrum-ts/content/avatar">
     Set or clear group chat avatars.
   </Card>
+  <Card title="Membership" icon="users" href="/spectrum-ts/content/membership">
+    Add or remove group members and leave chats.
+  </Card>
   <Card title="Composing content" icon="layers" href="/spectrum-ts/content/composing-content">
     Send multiple content items or reply with multiple parts.
   </Card>

--- a/docs/content/avatar.mdx.vel
+++ b/docs/content/avatar.mdx.vel
@@ -20,6 +20,8 @@ await space.send(avatar("clear"));
 
 `space.avatar(...)` is sugar for `space.send(avatar(...))`. Per-platform constraints, such as iMessage requiring remote mode and a group chat, surface as `UnsupportedError` from the provider's send action.
 
+Avatar is bidirectional: on platforms that report it (iMessage remote mode today), someone else changing the icon arrives as an inbound message with `content.type === "avatar"` — `action.kind === "set"` carries the fetched icon behind `action.read()` with its `mimeType`, and `"clear"` mirrors icon removal. Over the Spectrum webhook, a `set` arrives metadata-only (its `read()` throws); fetch the current icon via `space.getAvatar()` instead. `message.sender` is the user who changed it, or `undefined` when the platform recorded no actor.
+
 <Note>
   The string `"clear"` is a reserved sentinel. If you have a file literally named `clear` with no extension, pass `"./clear"` or load it as a `Buffer`.
 </Note>

--- a/docs/content/membership.mdx.vel
+++ b/docs/content/membership.mdx.vel
@@ -25,3 +25,31 @@ await space.leave();
 `addMember()` and `removeMember()` accept a single `User` or id string, or an array of either. Ids use the same platform handle format `space.create` accepts (for iMessage: an E.164 phone number or email); they are passed to the provider verbatim, with no resolution step. The builders throw at construction time if the member list is empty.
 
 Per-platform constraints surface as `UnsupportedError` from the provider's send action. iMessage requires remote mode and a group chat — a DM cannot be converted into a group, so on a DM the error points you at creating a group via `space.create` instead.
+
+## Inbound membership events
+
+On platforms that report membership changes (iMessage remote mode today), the same content types arrive as inbound messages on `app.messages` — what you send is what you observe when someone else does it:
+
+```ts
+for await (const [space, message] of app.messages) {
+  switch (message.content.type) {
+    case "addMember":
+      console.log(`${message.sender?.id ?? "someone"} added ${message.content.members.join(", ")}`);
+      break;
+    case "removeMember":
+      console.log(`${message.sender?.id ?? "someone"} removed ${message.content.members.join(", ")}`);
+      break;
+    case "leaveSpace":
+      // leaveSpace carries no members — the sender IS the leaver
+      console.log(`${message.sender?.id} left`);
+      break;
+  }
+}
+```
+
+The envelope carries the event semantics:
+
+- `message.sender` is the acting user — who added or removed the members. It is `undefined` when the platform recorded no actor. A self-join surfaces with the joiner as both sender and member.
+- A voluntary leave and a removal are distinct types: `leaveSpace` (sender = the leaver) vs `removeMember` (sender = the remover, `members` = who was removed).
+- `members` are platform handles in the same format `space.create` accepts — compare them against `space.getMembers()` or feed them back into `space.add(...)`.
+- The agent's own actions are suppressed: `space.add(...)` does not echo back as an inbound event.

--- a/docs/content/membership.mdx.vel
+++ b/docs/content/membership.mdx.vel
@@ -22,7 +22,7 @@ await space.remove("+15551234567");
 await space.leave();
 ```
 
-`addMember()` and `removeMember()` accept a single `User` or id string, or an array of either. Ids use the same platform handle format `space.create` accepts (for iMessage: an E.164 phone number or email); they are passed to the provider verbatim, with no resolution step. The builders throw at construction time if the member list is empty.
+`addMember()` and `removeMember()` accept a single `User` or id string, or an array of either. Ids use the same platform handle format `space.create` accepts (for iMessage: an E.164 phone number or email); they are passed to the provider verbatim, with no resolution step. Both return a `ContentBuilder` that validates when it builds — an empty member list rejects at `space.send(...)` time, not at construction.
 
 Per-platform constraints surface as `UnsupportedError` from the provider's send action. iMessage requires remote mode and a group chat — a DM cannot be converted into a group, so on a DM the error points you at creating a group via `space.create` instead.
 
@@ -41,7 +41,7 @@ for await (const [space, message] of app.messages) {
       break;
     case "leaveSpace":
       // leaveSpace carries no members — the sender IS the leaver
-      console.log(`${message.sender?.id} left`);
+      console.log(`${message.sender?.id ?? "someone"} left`);
       break;
   }
 }

--- a/docs/content/membership.mdx.vel
+++ b/docs/content/membership.mdx.vel
@@ -1,0 +1,27 @@
+---
+title: "Membership"
+description: "Add or remove group members and leave chats through the content pipeline."
+---
+
+Use `addMember()` and `removeMember()` to manage a group chat's members, and `leaveSpace()` to make the agent's own account leave the chat. All three are fire-and-forget: `space.send(...)` resolves to `undefined`.
+
+```ts
+import { addMember, leaveSpace, removeMember } from "spectrum-ts";
+
+await space.send(addMember("+15551234567"));
+await space.send(removeMember(["+15551234567", "carol@example.com"]));
+await space.send(leaveSpace());
+```
+
+`space.add(users)`, `space.remove(users)`, and `space.leave()` are sugar for the canonical forms above.
+
+```ts
+await space.add(alice);                       // a resolved User
+await space.add(["+15551234567", bob]);       // ids and Users mix; batches land in one provider call
+await space.remove("+15551234567");
+await space.leave();
+```
+
+`addMember()` and `removeMember()` accept a single `User` or id string, or an array of either. Ids use the same platform handle format `space.create` accepts (for iMessage: an E.164 phone number or email); they are passed to the provider verbatim, with no resolution step. The builders throw at construction time if the member list is empty.
+
+Per-platform constraints surface as `UnsupportedError` from the provider's send action. iMessage requires remote mode and a group chat — a DM cannot be converted into a group, so on a DM the error points you at creating a group via `space.create` instead.

--- a/docs/content/rename.mdx.vel
+++ b/docs/content/rename.mdx.vel
@@ -14,3 +14,5 @@ await space.send(rename("New Chat Name"));
 `space.rename(displayName)` is sugar for `space.send(rename(displayName))`. The builder throws at construction time if `displayName` is empty.
 
 Per-platform constraints, such as iMessage requiring remote mode and a group chat, surface as `UnsupportedError` from the provider's send action.
+
+Rename is bidirectional: on platforms that report it (iMessage remote mode today), someone else renaming the chat arrives as an inbound message with `content.type === "rename"` and the new `displayName`. `message.sender` is the user who renamed the chat, or `undefined` when the platform recorded no actor.

--- a/docs/custom-platforms.mdx.vel
+++ b/docs/custom-platforms.mdx.vel
@@ -96,7 +96,7 @@ export const myPlatform = definePlatform("my-platform", {
 | `space.get` | No | Hydrates a space from a known platform space ID. When omitted, the framework builds `{ id }` and validates it against `space.schema`. Providers whose schema requires more fields must implement this. |
 | `space.schema` | No | Optional Zod schema for the resolved space. |
 | `space.params` | No | Zod schema for additional space parameters — surfaces as the second arg to `platform(app).space.create()` and `platform(app).space.get()`. |
-| `space.actions` | No | A map of content-builder factories that become sugar methods on the resolved space. Each `space.<name>(...args)` delegates to `space.send(factory(...args))`. Names that collide with built-in `Space` methods (`send`, `edit`, `unsend`, `startTyping`, `stopTyping`, `responding`, `getMessage`, `rename`, `avatar`) are skipped at runtime with a warning. |
+| `space.actions` | No | A map of content-builder factories that become sugar methods on the resolved space. Each `space.<name>(...args)` delegates to `space.send(factory(...args))`. Names that collide with built-in `Space` methods (`send`, `edit`, `unsend`, `read`, `startTyping`, `stopTyping`, `responding`, `getMessage`, `rename`, `avatar`, `add`, `remove`, `leave`) are skipped at runtime with a warning. |
 | `lifecycle.createClient` | Yes | Creates the platform client. Receives `config`, `projectId`, `projectSecret` (both may be `undefined`), and `store`. |
 | `lifecycle.destroyClient` | No | Tears down the client on shutdown. Omit if no cleanup is needed. |
 | `messages` | Yes | Async generator that yields incoming messages. |

--- a/docs/custom-platforms.mdx.vel
+++ b/docs/custom-platforms.mdx.vel
@@ -96,12 +96,14 @@ export const myPlatform = definePlatform("my-platform", {
 | `space.get` | No | Hydrates a space from a known platform space ID. When omitted, the framework builds `{ id }` and validates it against `space.schema`. Providers whose schema requires more fields must implement this. |
 | `space.schema` | No | Optional Zod schema for the resolved space. |
 | `space.params` | No | Zod schema for additional space parameters — surfaces as the second arg to `platform(app).space.create()` and `platform(app).space.get()`. |
-| `space.actions` | No | A map of content-builder factories that become sugar methods on the resolved space. Each `space.<name>(...args)` delegates to `space.send(factory(...args))`. Names that collide with built-in `Space` methods (`send`, `edit`, `unsend`, `read`, `startTyping`, `stopTyping`, `responding`, `getMessage`, `rename`, `avatar`, `add`, `remove`, `leave`) are skipped at runtime with a warning. |
+| `space.actions` | No | A map of content-builder factories that become sugar methods on the resolved space. Each `space.<name>(...args)` delegates to `space.send(factory(...args))`. Names that collide with built-in `Space` methods (`send`, `edit`, `unsend`, `read`, `startTyping`, `stopTyping`, `responding`, `getMessage`, `getMembers`, `getAvatar`, `rename`, `avatar`, `add`, `remove`, `leave`) are skipped at runtime with a warning. |
 | `lifecycle.createClient` | Yes | Creates the platform client. Receives `config`, `projectId`, `projectSecret` (both may be `undefined`), and `store`. |
 | `lifecycle.destroyClient` | No | Tears down the client on shutdown. Omit if no cleanup is needed. |
 | `messages` | Yes | Async generator that yields incoming messages. |
 | `send` | Yes | Dispatches a content item to a space. All content types — text, markdown, attachments, reactions, replies, edits, unsends, typing indicators — flow through this single action. Return a `ProviderMessageRecord` for content that produces a message (including reactions — the record is the unsend handle), or `undefined` for fire-and-forget signals (typing, edits, unsends). |
 | `actions.getMessage` | No | Fetches a message by ID from a space. Receives `(ctx, space, messageId)` where `ctx` is `{ client, config, store }`. Powers `space.getMessage(id)`. When omitted, `space.getMessage()` throws `UnsupportedError`. |
+| `actions.getMembers` | No | Lists a space's current participants. Receives `(ctx, space)` and returns raw `{ id, ...extras }` records; `space.getMembers()` tags each with `__platform`. When omitted, `space.getMembers()` throws `UnsupportedError`. |
+| `actions.getAvatar` | No | Downloads the space's avatar. Receives `(ctx, space)` and returns `{ data: Buffer, mimeType }` — or `undefined` when no avatar is set. Powers `space.getAvatar()`. When omitted, `space.getAvatar()` throws `UnsupportedError`. |
 | `actions.[custom]` | No | Platform-specific methods projected onto the platform instance. Each receives `(ctx, ...args)` where `ctx` is `{ client, config, store }`; the public signature drops `ctx`. Names that collide with reserved instance keys (`user`, `space`, `messages`, plus any event names) are skipped at runtime with a warning. |
 | `events.[custom]` | No | Additional async generators for platform-specific events — exposed on `app.[eventName]`. |
 | `message.schema` | No | Zod schema for extra properties on incoming messages. |
@@ -174,7 +176,7 @@ Methods declared in `actions` are projected onto the platform instance returned 
 
 Two tiers share the `actions` slot:
 
-- **Platform-wise actions** (`getMessage`) — framework-recognized names. Always present on every platform instance. When omitted, the framework wires a default that throws `UnsupportedError`.
+- **Platform-wise actions** (`getMessage`, `getMembers`, `getAvatar`) — framework-recognized names. Always present on every platform instance. When omitted, the framework wires a default that throws `UnsupportedError`.
 - **Platform-specific actions** — free-form keys for platform ergonomics (e.g. iMessage's `getAttachment`). Only present when declared.
 
 ```ts

--- a/docs/messages.mdx.vel
+++ b/docs/messages.mdx.vel
@@ -42,7 +42,7 @@ Every message conforms to <TypeTooltip name="Message" type={`{{ message.signatur
     </tr>
     <tr>
       <td><code>sender</code></td>
-      <td>The <TypeTooltip name="User" type={`{{ symbol("ts:spectrum-ts#User").signature }}`} /> who sent the message.</td>
+      <td>The <TypeTooltip name="User" type={`{{ symbol("ts:spectrum-ts#User").signature }}`} /> who sent the message — <code>undefined</code> for events with no attributable author (e.g. a group-management event whose platform recorded no actor).</td>
     </tr>
     <tr>
       <td><code>space</code></td>
@@ -160,7 +160,7 @@ For unified logic, compare the sender to a known identity:
 
 ```ts
 for await (const [space, message] of app.messages) {
-  if (message.sender.id === myAccountId) continue;
+  if (message.sender?.id === myAccountId) continue;
   // handle incoming
 }
 ```

--- a/docs/messages.mdx.vel
+++ b/docs/messages.mdx.vel
@@ -112,6 +112,9 @@ for await (const [space, message] of app.messages) {
     case "group":
       console.log(`group of ${message.content.items.length} items`);
       break;
+    case "addMember":
+      console.log(`${message.sender?.id ?? "someone"} added ${message.content.members.join(", ")}`);
+      break;
     case "custom":
       console.log(message.content.raw);
       break;
@@ -132,6 +135,11 @@ for await (const [space, message] of app.messages) {
   | `"poll"` | `title: string`, `options: { title: string }[]` |
   | `"poll_option"` | `option: { title }`, `poll: Poll`, `selected: boolean`, `title: string` — sent as a vote |
   | `"group"` | `items: Message[]` — bundled multi-message unit |
+  | `"rename"` | `displayName: string` — the chat was renamed |
+  | `"avatar"` | `action: { kind: "set", read(), mimeType } \| { kind: "clear" }` — group icon set or cleared |
+  | `"addMember"` | `members: string[]` — members added; `sender` is who added them |
+  | `"removeMember"` | `members: string[]` — members removed; `sender` is who removed them |
+  | `"leaveSpace"` | *(no fields)* — `sender` is the member who left |
   | `"reply"` | `content: Content`, `target: Message` — threaded reply wrapping inner content |
   | `"edit"` | `content: Content`, `target: Message` — rewrite of a previously-sent message |
   | `"unsend"` | `target: Message` — retraction of a previously-sent message |
@@ -141,6 +149,8 @@ for await (const [space, message] of app.messages) {
 </Accordion>
 
 Outgoing-only variants like `"effect"` (an iMessage screen effect wrapping inner content) appear on messages you sent and are echoed by the platform; see [iMessage](/spectrum-ts/providers/imessage) for the builder.
+
+Group-management events (`rename`, `avatar`, `addMember`, `removeMember`, `leaveSpace`) arrive with `message.sender` set to the acting user — or `undefined` when the platform recorded no actor — so narrow with `message.sender?.id`. The agent's own actions (e.g. `space.add(...)`) are not echoed back.
 
 ## Filtering out your own messages
 

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -38,6 +38,7 @@
         "spectrum-ts/content/typing-indicators",
         "spectrum-ts/content/rename",
         "spectrum-ts/content/avatar",
+        "spectrum-ts/content/membership",
         "spectrum-ts/content/composing-content"
       ]
     },

--- a/docs/providers/imessage.mdx.vel
+++ b/docs/providers/imessage.mdx.vel
@@ -47,6 +47,6 @@ imessage.config({
     Compare local, cloud, and dedicated modes. Learn line allocation, quotas, space types, and per-phone routing.
   </Card>
   <Card title="Messaging features" icon="sparkles" href="/spectrum-ts/providers/imessage/messaging-features">
-    Use effects, chat renames, avatars, backgrounds, mini-app cards, contact cards, attachments, and tapbacks.
+    Use effects, chat renames, avatars, group membership, backgrounds, mini-app cards, contact cards, attachments, and tapbacks.
   </Card>
 </CardGroup>

--- a/docs/providers/imessage/connection-and-routing.mdx.vel
+++ b/docs/providers/imessage/connection-and-routing.mdx.vel
@@ -34,7 +34,7 @@ Use this page to choose an iMessage connection mode and understand how Spectrum 
     ```
 
     <Note>
-      Local mode only supports sending text and attachments. Reactions, typing indicators, threaded replies, group creation, chat backgrounds, chat renaming, and group avatars are not available.
+      Local mode only supports sending text and attachments. Reactions, typing indicators, threaded replies, group creation, chat backgrounds, chat renaming, group avatars, and group membership management are not available.
     </Note>
   </Tab>
   <Tab title="Dedicated">

--- a/docs/providers/imessage/connection-and-routing.mdx.vel
+++ b/docs/providers/imessage/connection-and-routing.mdx.vel
@@ -34,7 +34,7 @@ Use this page to choose an iMessage connection mode and understand how Spectrum 
     ```
 
     <Note>
-      Local mode only supports sending text and attachments. Reactions, typing indicators, threaded replies, group creation, chat backgrounds, chat renaming, group avatars, and group membership management are not available.
+      Local mode only supports sending text and attachments. Reactions, typing indicators, threaded replies, group creation, chat backgrounds, chat renaming, group avatars (setting and reading), and group membership (management and listing) are not available.
     </Note>
   </Tab>
   <Tab title="Dedicated">

--- a/docs/providers/imessage/messaging-features.mdx.vel
+++ b/docs/providers/imessage/messaging-features.mdx.vel
@@ -125,6 +125,34 @@ for (const member of detailed) {
 
 Membership management requires cloud or dedicated mode and only works on group chats. In local mode or on a DM it throws an `UnsupportedError` — a DM cannot be converted into a group, so to add someone to a 1:1 conversation, create a group with `space.create` instead. `getMembers()` has the same constraints: a DM has no roster to list.
 
+## Inbound group events
+
+In cloud or dedicated mode, group changes made by other members arrive as inbound messages on `app.messages` carrying the same content types you send — local mode drops them:
+
+| Someone… | `content.type` | `message.sender` |
+|---|---|---|
+| adds a member | `"addMember"` (`members` = who was added) | who added them |
+| removes a member | `"removeMember"` (`members` = who was removed) | who removed them |
+| leaves the group | `"leaveSpace"` | the leaver |
+| renames the group | `"rename"` (`displayName`) | who renamed it |
+| changes the icon | `"avatar"` (`action.kind === "set"`, bytes behind `action.read()`) | who changed it |
+| clears the icon | `"avatar"` (`action.kind === "clear"`) | who cleared it |
+
+```ts
+for await (const [space, message] of app.messages) {
+  if (message.content.type === "addMember") {
+    console.log(`${message.sender?.id ?? "someone"} added ${message.content.members.join(", ")}`);
+  }
+}
+```
+
+Semantics to rely on:
+
+- `message.sender` may be `undefined` — Apple does not always record the actor. The affected member is always present (in `members`, or as the sender for `leaveSpace`).
+- The agent's own actions never echo back: `space.add(...)`, `space.rename(...)`, and friends are suppressed from the inbound stream, matching how self-sent messages behave.
+- Icon-change events carry a snapshot of the icon fetched at event time; an icon that was already replaced or removed by then is skipped (the follow-up event carries the current state).
+- Group events ride the same durable catch-up log as messages and polls, so changes that happen while the app is down are replayed on reconnect. After a cursor gap, reconcile with `space.getMembers()` / `space.getAvatar()`.
+
 ## Chat backgrounds
 
 Set or clear the chat background image. Import `background` from the iMessage provider and use the sugar method on a narrowed space:

--- a/docs/providers/imessage/messaging-features.mdx.vel
+++ b/docs/providers/imessage/messaging-features.mdx.vel
@@ -77,7 +77,16 @@ await space.avatar("clear");
 await space.send(avatar("./icon.png"));
 ```
 
-Group avatars require cloud or dedicated mode and only work on group chats. In local mode or on a DM, `avatar()` throws an `UnsupportedError`.
+Read the current icon back with `space.getAvatar()` — it resolves `{ data, mimeType }` (or `undefined` when the group has no icon), and the result round-trips into the setter:
+
+```ts
+const icon = await space.getAvatar();
+if (icon) {
+  await otherGroup.avatar(icon.data, { mimeType: icon.mimeType });
+}
+```
+
+Group avatars require cloud or dedicated mode and only work on group chats. In local mode or on a DM, `avatar()` and `getAvatar()` throw an `UnsupportedError`.
 
 ## Group membership
 
@@ -100,7 +109,21 @@ await space.send(leaveSpace());
 
 Members are E.164 phone numbers or emails — the same handles `space.create` accepts.
 
-Membership management requires cloud or dedicated mode and only works on group chats. In local mode or on a DM it throws an `UnsupportedError` — a DM cannot be converted into a group, so to add someone to a 1:1 conversation, create a group with `space.create` instead.
+List the current roster with `space.getMembers()`. Each entry's `id` is the canonical address, so the results feed straight back into `add()` / `remove()` / `space.create()`; the agent's own number is excluded:
+
+```ts
+const members = await space.getMembers();
+await space.remove(members.filter((m) => m.id.endsWith("@example.com")));
+
+// Typed extras (address/country/service) via the narrowed instance
+const im = imessage(app);
+const detailed = await im.getMembers(space);
+for (const member of detailed) {
+  console.log(member.address, member.service);
+}
+```
+
+Membership management requires cloud or dedicated mode and only works on group chats. In local mode or on a DM it throws an `UnsupportedError` — a DM cannot be converted into a group, so to add someone to a 1:1 conversation, create a group with `space.create` instead. `getMembers()` has the same constraints: a DM has no roster to list.
 
 ## Chat backgrounds
 

--- a/docs/providers/imessage/messaging-features.mdx.vel
+++ b/docs/providers/imessage/messaging-features.mdx.vel
@@ -79,6 +79,29 @@ await space.send(avatar("./icon.png"));
 
 Group avatars require cloud or dedicated mode and only work on group chats. In local mode or on a DM, `avatar()` throws an `UnsupportedError`.
 
+## Group membership
+
+Add or remove members with `space.add()` / `space.remove()`, or leave the group with `space.leave()` — or use the canonical `addMember()` / `removeMember()` / `leaveSpace()` content builders:
+
+```ts
+import { addMember, leaveSpace, removeMember } from "spectrum-ts";
+
+// Sugar
+await space.add("+15553333333");
+await space.add([alice, "carol@example.com"]); // batches land in one call
+await space.remove("+15553333333");
+await space.leave();
+
+// Canonical
+await space.send(addMember("+15553333333"));
+await space.send(removeMember("+15553333333"));
+await space.send(leaveSpace());
+```
+
+Members are E.164 phone numbers or emails — the same handles `space.create` accepts.
+
+Membership management requires cloud or dedicated mode and only works on group chats. In local mode or on a DM it throws an `UnsupportedError` — a DM cannot be converted into a group, so to add someone to a 1:1 conversation, create a group with `space.create` instead.
+
 ## Chat backgrounds
 
 Set or clear the chat background image. Import `background` from the iMessage provider and use the sugar method on a narrowed space:

--- a/docs/spaces-and-users.mdx.vel
+++ b/docs/spaces-and-users.mdx.vel
@@ -25,6 +25,9 @@ Every <TypeTooltip name="Space" type={`{{ space.signature }}`} /> exposes the sa
 | `getMessage(id)` | Fetch a message by ID from the conversation. Throws `UnsupportedError` on platforms that don't support it. |
 | `rename(displayName)` | Rename the chat. Sugar for `send(rename(displayName))`. |
 | `avatar(input, options?)` | Set or clear the chat avatar. Sugar for `send(avatar(input, options?))`. |
+| `add(users)` | Add members to the chat. Sugar for `send(addMember(users))`. |
+| `remove(users)` | Remove members from the chat. Sugar for `send(removeMember(users))`. |
+| `leave()` | Leave the chat with the agent's own account. Sugar for `send(leaveSpace())`. |
 
 ```ts
 for await (const [space, message] of app.messages) {

--- a/docs/spaces-and-users.mdx.vel
+++ b/docs/spaces-and-users.mdx.vel
@@ -23,6 +23,8 @@ Every <TypeTooltip name="Space" type={`{{ space.signature }}`} /> exposes the sa
 | `stopTyping()` | Hide the typing indicator. |
 | `responding(fn)` | Start a typing indicator, run `fn`, and stop the indicator when it completes — even if `fn` throws. |
 | `getMessage(id)` | Fetch a message by ID from the conversation. Throws `UnsupportedError` on platforms that don't support it. |
+| `getMembers()` | List the chat's current participants as `User`s, excluding the agent's own account where identifiable. Throws `UnsupportedError` on platforms that can't list members. |
+| `getAvatar()` | Download the chat avatar (group icon) as `{ data, mimeType }`. Resolves `undefined` when none is set; throws `UnsupportedError` on platforms that can't fetch avatars. |
 | `rename(displayName)` | Rename the chat. Sugar for `send(rename(displayName))`. |
 | `avatar(input, options?)` | Set or clear the chat avatar. Sugar for `send(avatar(input, options?))`. |
 | `add(users)` | Add members to the chat. Sugar for `send(addMember(users))`. |

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -37,14 +37,21 @@ export {
 } from "@photon-ai/otel";
 // Content factories, schemas, and the inbound-record type (from `content/`).
 export { asAttachment } from "./content/attachment";
+export { avatarSchema } from "./content/avatar";
 export { asContact } from "./content/contact";
 export { asCustom } from "./content/custom";
 export { messageEffectSchema } from "./content/effect";
 export { asGroup, groupSchema } from "./content/group";
 export { asMarkdown } from "./content/markdown";
+export {
+  addMemberSchema,
+  leaveSpaceSchema,
+  removeMemberSchema,
+} from "./content/membership";
 export { asPoll, asPollOption } from "./content/poll";
 export { asReaction, reactionSchema } from "./content/reaction";
 export { asRead } from "./content/read";
+export { renameSchema } from "./content/rename";
 export { asRichlink } from "./content/richlink";
 export { asText } from "./content/text";
 export { asVoice } from "./content/voice";

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -48,7 +48,10 @@ export { asRead } from "./content/read";
 export { asRichlink } from "./content/richlink";
 export { asText } from "./content/text";
 export { asVoice } from "./content/voice";
-export type { ProviderMessageRecord } from "./platform/types";
+export type {
+  ProviderMessageRecord,
+  ProviderUserRecord,
+} from "./platform/types";
 // Generic translation helpers (from `utils/`).
 export { ensureM4a } from "./utils/audio";
 // Outbound-HTTP tracing — wrap a provider's own fetch so its requests get a

--- a/packages/core/src/content/avatar.ts
+++ b/packages/core/src/content/avatar.ts
@@ -16,6 +16,12 @@ import type { ContentBuilder } from "./types";
  * universal sugar that delegates here. Per-platform constraints (e.g.
  * group-only, remote-only) surface as `UnsupportedError` from the provider's
  * `send` action so the canonical and sugar forms share one error path.
+ *
+ * Bidirectional: providers also surface platform icon changes as inbound
+ * `Message`s carrying this content — `action.kind === "set"` arrives with
+ * the fetched icon behind `read()`, `"clear"` mirrors icon removal.
+ * `message.sender` is the user who changed it (may be `undefined` when the
+ * platform recorded no actor).
  */
 export const avatarSchema = z.object({
   type: z.literal("avatar"),

--- a/packages/core/src/content/avatar.ts
+++ b/packages/core/src/content/avatar.ts
@@ -27,6 +27,16 @@ export type Avatar = z.infer<typeof avatarSchema>;
 export type AvatarInput = PhotoInput;
 
 /**
+ * The current chat avatar as returned by `space.getAvatar()`: raw image bytes
+ * plus MIME type. `data` is a Buffer so the value round-trips into the
+ * setter — `space.avatar(res.data, { mimeType: res.mimeType })`.
+ */
+export interface AvatarData {
+  data: Buffer;
+  mimeType: string;
+}
+
+/**
  * Build an `Avatar` content value.
  *
  * - `avatar("clear")` — remove the current chat avatar.

--- a/packages/core/src/content/edit.ts
+++ b/packages/core/src/content/edit.ts
@@ -27,7 +27,8 @@ const isContent = (v: unknown): boolean =>
  * (no new message id is produced; the existing message mutates in place).
  *
  * Edit cannot wrap `edit`, `reply`, `reaction`, `group`, `typing`, `rename`,
- * `avatar`, `unsend`, or `read` content.
+ * `avatar`, `addMember`, `removeMember`, `leaveSpace`, `unsend`, or `read`
+ * content.
  */
 export const editSchema = z.object({
   type: z.literal("edit"),
@@ -81,6 +82,9 @@ export function edit(
         resolved.type === "typing" ||
         resolved.type === "rename" ||
         resolved.type === "avatar" ||
+        resolved.type === "addMember" ||
+        resolved.type === "removeMember" ||
+        resolved.type === "leaveSpace" ||
         resolved.type === "unsend" ||
         resolved.type === "read"
       ) {

--- a/packages/core/src/content/membership.ts
+++ b/packages/core/src/content/membership.ts
@@ -1,0 +1,86 @@
+import z from "zod";
+import type { User } from "../types/user";
+import type { ContentBuilder } from "./types";
+
+/**
+ * Group-membership management content. Universal content — providers
+ * dispatch by `content.type` in their `send` action and decide their own
+ * support story (e.g. iMessage only supports it for remote group chats;
+ * on a DM it surfaces an `UnsupportedError` telling the caller to create
+ * a group via `space.create` instead).
+ *
+ * `space.send(addMember(users))` is the canonical form; `space.add(...)`,
+ * `space.remove(...)`, and `space.leave()` are universal sugar that
+ * delegate here. All three are fire-and-forget — no `Message` is produced.
+ *
+ * Members are id strings (or `User`s, normalized to their `id`) in the same
+ * platform handle format `space.create` accepts. No async resolution happens
+ * in the builder — ids reach the provider verbatim.
+ */
+export const addMemberSchema = z.object({
+  type: z.literal("addMember"),
+  members: z
+    .array(z.string())
+    .min(1, "addMember() requires at least one member"),
+});
+
+export type AddMember = z.infer<typeof addMemberSchema>;
+
+export const removeMemberSchema = z.object({
+  type: z.literal("removeMember"),
+  members: z
+    .array(z.string())
+    .min(1, "removeMember() requires at least one member"),
+});
+
+export type RemoveMember = z.infer<typeof removeMemberSchema>;
+
+export const leaveSpaceSchema = z.object({
+  type: z.literal("leaveSpace"),
+});
+
+export type LeaveSpace = z.infer<typeof leaveSpaceSchema>;
+
+/** Accepted member input: a `User`, a raw id string, or an array of either. */
+export type MemberInput = User | string | (User | string)[];
+
+const toMemberIds = (users: MemberInput): string[] =>
+  (Array.isArray(users) ? users : [users]).map((u) =>
+    typeof u === "string" ? u : u.id
+  );
+
+/**
+ * Build an `AddMember` content value inviting `users` into the current
+ * group chat. Accepts a single `User` or id string, or an array of either
+ * — batches land in one provider call.
+ */
+export function addMember(users: MemberInput): ContentBuilder {
+  return {
+    build: async () =>
+      addMemberSchema.parse({ type: "addMember", members: toMemberIds(users) }),
+  };
+}
+
+/**
+ * Build a `RemoveMember` content value removing `users` from the current
+ * group chat. Accepts the same input shapes as `addMember`.
+ */
+export function removeMember(users: MemberInput): ContentBuilder {
+  return {
+    build: async () =>
+      removeMemberSchema.parse({
+        type: "removeMember",
+        members: toMemberIds(users),
+      }),
+  };
+}
+
+/**
+ * Build a `LeaveSpace` content value making the agent's own account leave
+ * the current group chat.
+ */
+export function leaveSpace(): ContentBuilder {
+  return {
+    build: async () => leaveSpaceSchema.parse({ type: "leaveSpace" }),
+  };
+}

--- a/packages/core/src/content/membership.ts
+++ b/packages/core/src/content/membership.ts
@@ -13,6 +13,13 @@ import type { ContentBuilder } from "./types";
  * `space.remove(...)`, and `space.leave()` are universal sugar that
  * delegate here. All three are fire-and-forget — no `Message` is produced.
  *
+ * Bidirectional: providers also surface platform membership events as
+ * inbound `Message`s carrying this content. `message.sender` is the acting
+ * user — who added/removed the members — and may be `undefined` when the
+ * platform recorded no actor. For `leaveSpace` the sender is the leaver
+ * (the content carries no `members`). The agent's own actions are
+ * suppressed: `space.add(...)` does not echo back as an inbound event.
+ *
  * Members are id strings (or `User`s, normalized to their `id`) in the same
  * platform handle format `space.create` accepts. No async resolution happens
  * in the builder — ids reach the provider verbatim.

--- a/packages/core/src/content/rename.ts
+++ b/packages/core/src/content/rename.ts
@@ -9,6 +9,10 @@ import type { ContentBuilder } from "./types";
  * `space.send(rename("New Name"))` is the canonical form; `space.rename(...)`
  * is universal sugar that delegates here.
  *
+ * Bidirectional: providers also surface platform rename events as inbound
+ * `Message`s carrying this content; `message.sender` is the user who renamed
+ * the chat (may be `undefined` when the platform recorded no actor).
+ *
  * Throws at build time if `displayName` is empty. Per-platform constraints
  * (e.g. group-only, remote-only) surface as `UnsupportedError` from the
  * provider's `send` action so the canonical and sugar forms share one

--- a/packages/core/src/content/reply.ts
+++ b/packages/core/src/content/reply.ts
@@ -26,7 +26,8 @@ const isContent = (v: unknown): boolean =>
  * `reply` like any other content type and route to a threaded send.
  *
  * Reply cannot wrap `reply`, `edit`, `reaction`, `group`, `typing`,
- * `rename`, `avatar`, `unsend`, or `read` content.
+ * `rename`, `avatar`, `addMember`, `removeMember`, `leaveSpace`, `unsend`,
+ * or `read` content.
  */
 export const replySchema = z.object({
   type: z.literal("reply"),
@@ -68,6 +69,9 @@ export function reply(
         resolved.type === "typing" ||
         resolved.type === "rename" ||
         resolved.type === "avatar" ||
+        resolved.type === "addMember" ||
+        resolved.type === "removeMember" ||
+        resolved.type === "leaveSpace" ||
         resolved.type === "unsend" ||
         resolved.type === "read"
       ) {

--- a/packages/core/src/content/types.ts
+++ b/packages/core/src/content/types.ts
@@ -8,6 +8,11 @@ import { editSchema } from "./edit";
 import { messageEffectSchema } from "./effect";
 import { groupSchema } from "./group";
 import { markdownSchema } from "./markdown";
+import {
+  addMemberSchema,
+  leaveSpaceSchema,
+  removeMemberSchema,
+} from "./membership";
 import { pollOptionSchema, pollSchema } from "./poll";
 import { reactionSchema } from "./reaction";
 import { readSchema } from "./read";
@@ -45,6 +50,9 @@ const baseContentSchemas = [
   typingSchema,
   renameSchema,
   avatarSchema,
+  addMemberSchema,
+  removeMemberSchema,
+  leaveSpaceSchema,
 ] as const;
 
 export const baseContentSchema = z.discriminatedUnion(

--- a/packages/core/src/content/types.ts
+++ b/packages/core/src/content/types.ts
@@ -25,6 +25,13 @@ import { typingSchema } from "./typing";
 import { unsendSchema } from "./unsend";
 import { voiceSchema } from "./voice";
 
+// Content values describe state changes and are direction-agnostic — the same
+// discriminants serve `space.send(...)` and inbound Messages (e.g. `reaction`
+// is both sent by the agent and constructed by providers when a user reacts;
+// membership/rename/avatar likewise). The Message envelope carries `direction`
+// and the actor (`sender`); names stay flat and mood-neutral, not command- or
+// event-flavored.
+//
 // `baseContentSchema` is everything except `reply`, `edit`, `unsend`, and
 // `read`. It exists so the inner content of a `Reply` (and `Edit`) can be
 // typed against this non-circular union without `Content` referencing itself

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,6 +27,15 @@ export { type Edit, edit } from "./content/edit";
 export { type Group, group } from "./content/group";
 export { type Markdown, markdown } from "./content/markdown";
 export {
+  type AddMember,
+  addMember,
+  type LeaveSpace,
+  leaveSpace,
+  type MemberInput,
+  type RemoveMember,
+  removeMember,
+} from "./content/membership";
+export {
   option,
   type Poll,
   type PollChoice,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,12 @@ export {
   type AttachmentInput,
   attachment,
 } from "./content/attachment";
-export { type Avatar, type AvatarInput, avatar } from "./content/avatar";
+export {
+  type Avatar,
+  type AvatarData,
+  type AvatarInput,
+  avatar,
+} from "./content/avatar";
 export {
   type Contact,
   type ContactAddress,

--- a/packages/core/src/platform/build.ts
+++ b/packages/core/src/platform/build.ts
@@ -3,6 +3,12 @@ import { type AvatarInput, avatar as avatarContent } from "../content/avatar";
 import { edit as editContent } from "../content/edit";
 import { asMarkdown, type Markdown } from "../content/markdown";
 import {
+  addMember as addMemberContent,
+  leaveSpace as leaveSpaceContent,
+  type MemberInput,
+  removeMember as removeMemberContent,
+} from "../content/membership";
+import {
   type Reaction,
   reaction as reactionContent,
 } from "../content/reaction";
@@ -48,6 +54,9 @@ const FIRE_AND_FORGET_TYPES: ReadonlySet<string> = new Set([
   "edit",
   "rename",
   "avatar",
+  "addMember",
+  "removeMember",
+  "leaveSpace",
   "unsend",
   "read",
 ]);
@@ -70,6 +79,9 @@ const RESERVED_SPACE_KEYS: ReadonlySet<string> = new Set([
   "getMessage",
   "rename",
   "avatar",
+  "add",
+  "remove",
+  "leave",
   "startTyping",
   "stopTyping",
   "responding",
@@ -770,6 +782,24 @@ export function buildSpace(params: BuildSpaceParams): Space {
       }
       await space.send(avatarContent(input, { mimeType: options.mimeType }));
     }) as Space["avatar"],
+    add: async (users: MemberInput): Promise<void> => {
+      // Sugar for `space.send(addMember(users))`. Fire-and-forget; the
+      // (always-undefined) result is discarded. Per-platform support and
+      // constraints live in each provider's `send` action.
+      await space.send(addMemberContent(users));
+    },
+    remove: async (users: MemberInput): Promise<void> => {
+      // Sugar for `space.send(removeMember(users))`. Fire-and-forget; the
+      // (always-undefined) result is discarded. Per-platform support and
+      // constraints live in each provider's `send` action.
+      await space.send(removeMemberContent(users));
+    },
+    leave: async (): Promise<void> => {
+      // Sugar for `space.send(leaveSpace())`. Fire-and-forget; the
+      // (always-undefined) result is discarded. Per-platform support and
+      // constraints live in each provider's `send` action.
+      await space.send(leaveSpaceContent());
+    },
     startTyping: async () => {
       // Sugar for `space.send(typing("start"))`. Typing is fire-and-forget;
       // providers handle it inside their `send` action and any platforms

--- a/packages/core/src/platform/build.ts
+++ b/packages/core/src/platform/build.ts
@@ -739,16 +739,25 @@ export function buildSpace(params: BuildSpaceParams): Space {
         "spectrum.space.id": (spaceRef as { id?: string }).id,
       },
       async () => {
-        const raw = (await getMembers(
+        const raw: unknown = await getMembers(
           { client, config, store },
           spaceRef
-        )) as readonly ProviderUserRecord[];
+        );
+        // Guard the provider contract at the JS boundary — a nullish or
+        // non-array result would otherwise escape as a raw TypeError from
+        // `.map` below.
+        if (!Array.isArray(raw)) {
+          throw new Error(
+            `${definition.name} getMembers() must resolve an array of member records (got ${raw === null ? "null" : typeof raw})`
+          );
+        }
+        const records = raw as readonly ProviderUserRecord[];
         // Reads bypass `wrapProviderMessage`, so the platform tag is applied
         // here — mirrors `buildSenderWithPlatform` for message senders. The
         // `as object` spread drops the record's index signature so the
         // literal stays assignable to `User`; provider extras still ride
         // along at runtime.
-        return raw.map(
+        return records.map(
           (member): User => ({
             ...(member as object),
             id: member.id,

--- a/packages/core/src/platform/build.ts
+++ b/packages/core/src/platform/build.ts
@@ -1,5 +1,9 @@
 import { createLogger, withSpan } from "@photon-ai/otel";
-import { type AvatarInput, avatar as avatarContent } from "../content/avatar";
+import {
+  type AvatarData,
+  type AvatarInput,
+  avatar as avatarContent,
+} from "../content/avatar";
 import { edit as editContent } from "../content/edit";
 import { asMarkdown, type Markdown } from "../content/markdown";
 import {
@@ -27,7 +31,7 @@ import { typing as typingContent } from "../content/typing";
 import { unsend as unsendContent } from "../content/unsend";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
-import type { AgentSender } from "../types/user";
+import type { AgentSender, User } from "../types/user";
 import { UnsupportedError } from "../utils/errors";
 import { markdownToPlainText } from "../utils/markdown";
 import type { Store } from "../utils/store";
@@ -36,6 +40,7 @@ import type {
   AnyPlatformDef,
   PlatformWiseActionKey,
   ProviderMessageRecord,
+  ProviderUserRecord,
 } from "./types";
 
 const platformLog = createLogger("spectrum.platform");
@@ -77,6 +82,8 @@ const RESERVED_SPACE_KEYS: ReadonlySet<string> = new Set([
   "unsend",
   "read",
   "getMessage",
+  "getMembers",
+  "getAvatar",
   "rename",
   "avatar",
   "add",
@@ -91,9 +98,15 @@ const RESERVED_SPACE_KEYS: ReadonlySet<string> = new Set([
 // distinguish platform-wise overrides from platform-specific extensions, and
 // to wire the same set onto every `PlatformInstance` regardless of override
 // status. The runtime list must stay in sync with `PlatformWiseActions` in
-// `types.ts` — the typed `satisfies` here catches typos at the element level.
+// `types.ts` — the typed `satisfies` here catches typos at the element level
+// but not omissions (a key missing here silently never reaches the
+// instance); the platform-wise-reads tests pin the wiring.
 export const PLATFORM_WISE_ACTION_KEYS: ReadonlySet<PlatformWiseActionKey> =
-  new Set(["getMessage"] satisfies readonly PlatformWiseActionKey[]);
+  new Set([
+    "getMessage",
+    "getMembers",
+    "getAvatar",
+  ] satisfies readonly PlatformWiseActionKey[]);
 
 // Reserved keys on `Message` — platform-defined `message.actions` entries
 // with these names are skipped at runtime (with a warning) so the universal
@@ -695,6 +708,62 @@ export function buildSpace(params: BuildSpaceParams): Space {
     );
   }
 
+  async function getMembersImpl(): Promise<User[]> {
+    const getMembers = definition.actions?.getMembers;
+    if (!getMembers) {
+      // Default behavior when the provider hasn't implemented the
+      // platform-wise `getMembers` action: throw `UnsupportedError`. Mirrors
+      // the same default the `PlatformInstance` wires for `im.getMembers`.
+      throw UnsupportedError.action("getMembers", definition.name);
+    }
+    return withSpan(
+      "spectrum.space.members.get",
+      {
+        "spectrum.provider": definition.name,
+        "spectrum.space.id": (spaceRef as { id?: string }).id,
+      },
+      async () => {
+        const raw = (await getMembers(
+          { client, config, store },
+          spaceRef
+        )) as readonly ProviderUserRecord[];
+        // Reads bypass `wrapProviderMessage`, so the platform tag is applied
+        // here — mirrors `buildSenderWithPlatform` for message senders. The
+        // `as object` spread drops the record's index signature so the
+        // literal stays assignable to `User`; provider extras still ride
+        // along at runtime.
+        return raw.map(
+          (member): User => ({
+            ...(member as object),
+            id: member.id,
+            __platform: definition.name,
+          })
+        );
+      }
+    );
+  }
+
+  async function getAvatarImpl(): Promise<AvatarData | undefined> {
+    const getAvatar = definition.actions?.getAvatar;
+    if (!getAvatar) {
+      // Default behavior when the provider hasn't implemented the
+      // platform-wise `getAvatar` action: throw `UnsupportedError`. Mirrors
+      // the same default the `PlatformInstance` wires for `im.getAvatar`.
+      throw UnsupportedError.action("getAvatar", definition.name);
+    }
+    return withSpan(
+      "spectrum.space.avatar.get",
+      {
+        "spectrum.provider": definition.name,
+        "spectrum.space.id": (spaceRef as { id?: string }).id,
+      },
+      async () =>
+        (await getAvatar({ client, config, store }, spaceRef)) as
+          | AvatarData
+          | undefined
+    );
+  }
+
   // Platform-defined sugar methods declared via `PlatformDef.space.actions`.
   // Each factory becomes `space.<name>(...args) = space.send(factory(...args))`.
   // Spread order is load-bearing: actions go *after* `extras`/`spaceRef`
@@ -754,6 +823,8 @@ export function buildSpace(params: BuildSpaceParams): Space {
       await space.send(readContent(message));
     },
     getMessage: getMessageImpl,
+    getMembers: getMembersImpl,
+    getAvatar: getAvatarImpl,
     rename: async (displayName: string): Promise<void> => {
       // Sugar for `space.send(rename(displayName))`. Fire-and-forget; the
       // (always-undefined) result is discarded. Per-platform support and

--- a/packages/core/src/platform/types.ts
+++ b/packages/core/src/platform/types.ts
@@ -1,5 +1,6 @@
 import type { Fn, Pipe, Tuples } from "hotscript";
 import type z from "zod";
+import type { AvatarData } from "../content/avatar";
 import type { Content } from "../content/types";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
@@ -16,7 +17,8 @@ import type { ManagedStream } from "../utils/stream";
  * side effect.
  *
  * Names that collide with reserved `Space` keys (`send`, `edit`, `unsend`,
- * `getMessage`, `startTyping`, `stopTyping`, `responding`, `id`,
+ * `read`, `getMessage`, `getMembers`, `getAvatar`, `rename`, `avatar`, `add`,
+ * `remove`, `leave`, `startTyping`, `stopTyping`, `responding`, `id`,
  * `__platform`) are skipped at runtime with a warning and excluded at the
  * type level via `Exclude<…, keyof Space>`.
  */
@@ -52,11 +54,12 @@ export type MessageActionFn = (
  *
  * Two tiers live in the same `actions?` slot:
  *
- * - **Platform-wise actions** — fixed framework-known names (currently just
- *   `getMessage`) whose signatures are defined by `PlatformWiseActions`. They
- *   power universal sugar (`space.getMessage(id)`) AND surface on the
- *   platform instance. If a provider omits one, the framework wires a
- *   default that throws `UnsupportedError`.
+ * - **Platform-wise actions** — fixed framework-known names (`getMessage`,
+ *   `getMembers`, `getAvatar`) whose signatures are defined by
+ *   `PlatformWiseActions`. They power universal sugar
+ *   (`space.getMessage(id)`, `space.getMembers()`, `space.getAvatar()`) AND
+ *   surface on the platform instance. If a provider omits one, the framework
+ *   wires a default that throws `UnsupportedError`.
  * - **Platform-specific actions** — free-form keys each platform declares
  *   for its own ergonomics (e.g. iMessage's `getAttachment`). Surface on
  *   the platform instance only.
@@ -80,9 +83,12 @@ export type InstanceActionFn = (
  * by declaring the key inside their `actions` slot, and platforms that omit
  * the key get a default that throws `UnsupportedError`.
  *
- * Add a new platform-wise capability by extending this record (and the
- * runtime list in `define.ts`); the corresponding instance method will be
- * surfaced on every `PlatformInstance` automatically.
+ * Add a new platform-wise capability by extending this record along with:
+ * `PlatformWiseInstanceMethods` (the public instance signature), the runtime
+ * list `PLATFORM_WISE_ACTION_KEYS` in `build.ts`, and — when the capability
+ * surfaces as universal `Space` sugar — the `Space` interface plus a
+ * `buildSpace` impl and `RESERVED_SPACE_KEYS` entry. The instance method is
+ * then surfaced on every `PlatformInstance` automatically.
  */
 export interface PlatformWiseActions<
   _ResolvedSpace extends { id: string },
@@ -90,6 +96,14 @@ export interface PlatformWiseActions<
   _Client,
   _Config,
 > {
+  getAvatar: (
+    ctx: { client: _Client; config: _Config; store: Store },
+    space: _ResolvedSpace & { id: string; __platform: string }
+  ) => Promise<AvatarData | undefined>;
+  getMembers: (
+    ctx: { client: _Client; config: _Config; store: Store },
+    space: _ResolvedSpace & { id: string; __platform: string }
+  ) => Promise<readonly ProviderUserRecord[]>;
   getMessage: (
     ctx: { client: _Client; config: _Config; store: Store },
     space: _ResolvedSpace & { id: string; __platform: string },
@@ -174,6 +188,16 @@ export type ProviderMessageRecord = {
   space: { id: string } & Record<string, unknown>;
   timestamp?: Date;
 } & Record<string, unknown>;
+
+/**
+ * A chat participant a provider returned from `actions.getMembers` — the raw
+ * record shape, mirroring `ProviderMessageRecord.sender`. `id` is the user's
+ * canonical platform identifier (the same handle format `space.create`
+ * accepts); platform extras (e.g. iMessage's `address`/`country`/`service`)
+ * ride along untyped. `space.getMembers()` tags each record with
+ * `__platform` before surfacing it as a `User`.
+ */
+export type ProviderUserRecord = { id: string } & Record<string, unknown>;
 
 type MergeSchema<
   TSchema extends z.ZodType | undefined,
@@ -283,13 +307,14 @@ export interface PlatformDef<
    *
    * Two tiers share this slot:
    *
-   * 1. **Platform-wise actions** (`getMessage`) — framework-recognized names
-   *    declared in `PlatformWiseActions`. Override by declaring the key here
-   *    with the matching signature. The framework injects `ctx = { client,
-   *    config, store }` as the first arg and surfaces the method on the
-   *    platform instance (`im.getMessage(space, id)`). If omitted, the
-   *    framework wires a default that throws `UnsupportedError`. Powers
-   *    universal sugar like `space.getMessage(id)`.
+   * 1. **Platform-wise actions** (`getMessage`, `getMembers`, `getAvatar`) —
+   *    framework-recognized names declared in `PlatformWiseActions`. Override
+   *    by declaring the key here with the matching signature. The framework
+   *    injects `ctx = { client, config, store }` as the first arg and
+   *    surfaces the method on the platform instance
+   *    (`im.getMessage(space, id)`). If omitted, the framework wires a
+   *    default that throws `UnsupportedError`. Powers universal sugar like
+   *    `space.getMessage(id)`.
    *
    * 2. **Platform-specific actions** — free-form keys like `getAttachment`.
    *    Each gets `ctx = { client, config, store }` as the first arg; the
@@ -444,9 +469,10 @@ export interface PlatformDef<
      * lives here for platform-specific surface area.
      *
      * Names that collide with reserved `Space` keys (`send`, `edit`,
-     * `unsend`, `getMessage`, `startTyping`, `stopTyping`, `responding`,
-     * `id`, `__platform`) are skipped at runtime with a warning and excluded
-     * at the type level.
+     * `unsend`, `read`, `getMessage`, `getMembers`, `getAvatar`, `rename`,
+     * `avatar`, `add`, `remove`, `leave`, `startTyping`, `stopTyping`,
+     * `responding`, `id`, `__platform`) are skipped at runtime with a
+     * warning and excluded at the type level.
      */
     actions?: _SpaceActions;
   };
@@ -767,7 +793,8 @@ type InstanceActionFns<Def extends AnyPlatformDef> = Def["actions"] extends
 // Reserved keys on `PlatformInstance` — same set the runtime guards. Includes
 // the base members (`user`, `space`, `messages`) plus every event name the
 // platform projects onto the instance, plus the platform-wise action keys
-// (`getMessage`) whose public signatures come from `PlatformWiseInstanceMethods`.
+// (`getMessage`, `getMembers`, `getAvatar`) whose public signatures come from
+// `PlatformWiseInstanceMethods`.
 type ReservedInstanceKeys<Def extends AnyPlatformDef> =
   | "user"
   | "space"
@@ -789,9 +816,14 @@ export type InstanceActionMethods<Def extends AnyPlatformDef> = {
 
 // Methods derived from `PlatformWiseActions` — always present on the
 // platform instance regardless of whether the provider overrides them.
-// Signatures use the platform's resolved Space/Message types so they
-// type-check against `space.getMessage`-style sugar.
+// Signatures use the platform's resolved Space/Message/User types so they
+// type-check against `space.getMessage`-style sugar. The instance path
+// returns the provider's records raw (no wrapping or `__platform` tagging —
+// same pass-through contract as `im.getMessage`); the `space.*` sugar is the
+// framework-normalized path.
 export interface PlatformWiseInstanceMethods<Def extends AnyPlatformDef> {
+  getAvatar: (space: PlatformSpace<Def>) => Promise<AvatarData | undefined>;
+  getMembers: (space: PlatformSpace<Def>) => Promise<PlatformUser<Def>[]>;
   getMessage: (
     space: PlatformSpace<Def>,
     messageId: string

--- a/packages/core/src/platform/types.ts
+++ b/packages/core/src/platform/types.ts
@@ -164,7 +164,10 @@ export type ProviderMessage<
 > = {
   id: string;
   content: Content;
-  sender: TSender;
+  // Optional so providers can surface system signals with no attributable
+  // author (e.g. a membership change whose platform recorded no actor) —
+  // mirrors `ProviderMessageRecord.sender` and `Message.sender | undefined`.
+  sender?: TSender;
   space: TSpace;
   timestamp?: Date;
 } & TExtra;

--- a/packages/core/src/types/space.ts
+++ b/packages/core/src/types/space.ts
@@ -1,3 +1,4 @@
+import type { MemberInput } from "../content/membership";
 import type { Reaction, ReactionBuilder } from "../content/reaction";
 import type { ContentInput } from "../content/types";
 import type { Message } from "./message";
@@ -5,6 +6,16 @@ import type { AgentSender } from "./user";
 
 export interface Space<_Def = unknown> {
   readonly __platform: string;
+  /**
+   * Add members to the current chat. Sugar for `send(addMember(users))`.
+   * Accepts a single `User` or id string, or an array of either — batches
+   * land in one provider call. Fire-and-forget.
+   *
+   * Universal API; per-platform constraints (e.g. iMessage: remote + group
+   * only — a DM cannot be converted, create a group via `space.create`)
+   * surface as `UnsupportedError` from the provider's send action.
+   */
+  add(users: MemberInput): Promise<void>;
   /**
    * Set or clear the current chat's avatar (group icon). Sugar for
    * `send(avatar(input, options?))`.
@@ -38,6 +49,14 @@ export interface Space<_Def = unknown> {
   getMessage(id: string): Promise<Message | undefined>;
   readonly id: string;
   /**
+   * Leave the current chat with the agent's own account. Sugar for
+   * `send(leaveSpace())`. Fire-and-forget.
+   *
+   * Universal API; per-platform constraints (e.g. iMessage: remote + group
+   * only) surface as `UnsupportedError` from the provider's send action.
+   */
+  leave(): Promise<void>;
+  /**
    * Mark the conversation as read up to `message`, surfacing a read receipt
    * to the sender where the platform supports one. Sugar for
    * `send(read(message))`. Fire-and-forget; only inbound messages can be
@@ -50,6 +69,15 @@ export interface Space<_Def = unknown> {
    * everywhere — same contract as `startTyping()`.
    */
   read(message: Message): Promise<void>;
+  /**
+   * Remove members from the current chat. Sugar for
+   * `send(removeMember(users))`. Accepts the same input shapes as `add`.
+   * Fire-and-forget.
+   *
+   * Universal API; per-platform constraints (e.g. iMessage: remote + group
+   * only) surface as `UnsupportedError` from the provider's send action.
+   */
+  remove(users: MemberInput): Promise<void>;
   /**
    * Rename the current chat. Sugar for `send(rename(displayName))`.
    *

--- a/packages/core/src/types/space.ts
+++ b/packages/core/src/types/space.ts
@@ -1,8 +1,9 @@
+import type { AvatarData } from "../content/avatar";
 import type { MemberInput } from "../content/membership";
 import type { Reaction, ReactionBuilder } from "../content/reaction";
 import type { ContentInput } from "../content/types";
 import type { Message } from "./message";
-import type { AgentSender } from "./user";
+import type { AgentSender, User } from "./user";
 
 export interface Space<_Def = unknown> {
   readonly __platform: string;
@@ -40,6 +41,30 @@ export interface Space<_Def = unknown> {
    * `send` results chain without narrowing; an undefined target throws.
    */
   edit(message: Message | undefined, newContent: ContentInput): Promise<void>;
+  /**
+   * Download the current chat avatar (group icon). Resolves `undefined` when
+   * the chat has none. The result round-trips into the setter:
+   * `space.avatar(res.data, { mimeType: res.mimeType })`.
+   *
+   * Universal API; per-platform constraints (e.g. iMessage: remote + group
+   * only — a DM throws) surface as `UnsupportedError`, as do platforms with
+   * no implementation.
+   */
+  getAvatar(): Promise<AvatarData | undefined>;
+  /**
+   * List the chat's current participants, excluding the agent's own account
+   * where the platform can identify it. Each entry is a `User` tagged with
+   * `__platform`; `id` is the user's canonical platform handle (the same
+   * format `space.create` accepts), so results feed straight back into
+   * `add()` / `remove()` / `space.create()`. Platform extras (e.g.
+   * iMessage's `address`/`country`/`service`) ride along untyped — use the
+   * platform instance's `getMembers(space)` for typed extras.
+   *
+   * Universal API; per-platform constraints (e.g. iMessage: remote + group
+   * only — a DM throws) surface as `UnsupportedError`, as do platforms with
+   * no implementation.
+   */
+  getMembers(): Promise<User[]>;
   /**
    * Look up a message in this space by its id. Returns `undefined` if the
    * platform has no way to resolve the id (e.g. cache miss with no by-id

--- a/packages/core/src/webhook/deserialize.ts
+++ b/packages/core/src/webhook/deserialize.ts
@@ -1,10 +1,17 @@
 import { asAttachment } from "../content/attachment";
+import { avatarSchema } from "../content/avatar";
 import {
   asContact,
   type ContactInput,
   type ContactPhone,
 } from "../content/contact";
 import { asCustom } from "../content/custom";
+import {
+  addMemberSchema,
+  leaveSpaceSchema,
+  removeMemberSchema,
+} from "../content/membership";
+import { renameSchema } from "../content/rename";
 import type { Content } from "../content/types";
 import type { ProviderMessageRecord } from "../platform/build";
 import { UnsupportedError } from "../utils/errors";
@@ -135,9 +142,69 @@ const mapContent = (
       return deserializeGroup(raw, platform, spaceRef, ctx);
     case "attachment":
       return deserializeAttachment(raw, platform, spaceRef, ctx);
+    case "addMember":
+      return addMemberSchema.parse({
+        type: "addMember",
+        members: memberStrings(raw.members),
+      });
+    case "removeMember":
+      return removeMemberSchema.parse({
+        type: "removeMember",
+        members: memberStrings(raw.members),
+      });
+    case "leaveSpace":
+      // The leaver rides on the envelope (`message.sender`), not the content.
+      return leaveSpaceSchema.parse({ type: "leaveSpace" });
+    case "rename":
+      // Empty displayName fails min(1) and degrades the delivery to `custom`.
+      return renameSchema.parse({
+        type: "rename",
+        displayName: asString(raw.displayName),
+      });
+    case "avatar":
+      return deserializeAvatar(raw, platform);
     default:
       return asCustom(content);
   }
+};
+
+// Non-string entries are dropped; an empty result fails the schema's min(1)
+// and the delivery degrades to `custom`.
+const memberStrings = (value: unknown): string[] =>
+  Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
+
+const deserializeAvatar = (
+  raw: Record<string, unknown>,
+  platform: string
+): Content => {
+  const action = isRecord(raw.action) ? raw.action : {};
+  if (action.kind === "clear") {
+    return avatarSchema.parse({ type: "avatar", action: { kind: "clear" } });
+  }
+  if (action.kind !== "set") {
+    throw new Error(`unknown avatar action kind: ${String(action.kind)}`);
+  }
+  // The webhook delivers avatar metadata only — there is no per-avatar id to
+  // resolve bytes by (unlike attachments), so `read()` fails on use and
+  // points at `space.getAvatar()` for the current icon.
+  const unavailable = (): Promise<never> =>
+    Promise.reject(
+      UnsupportedError.action(
+        "getAvatar",
+        platform,
+        "avatar bytes are not delivered over the Spectrum webhook — fetch the current icon via space.getAvatar()"
+      )
+    );
+  return avatarSchema.parse({
+    type: "avatar",
+    action: {
+      kind: "set",
+      mimeType: asString(action.mimeType) || DEFAULT_MIME_TYPE,
+      read: unavailable,
+    },
+  });
 };
 
 const deserializeAttachment = (

--- a/packages/core/test/content/membership.test.ts
+++ b/packages/core/test/content/membership.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "bun:test";
+import { edit } from "@/content/edit";
+import {
+  type AddMember,
+  addMember,
+  type LeaveSpace,
+  leaveSpace,
+  type RemoveMember,
+  removeMember,
+} from "@/content/membership";
+import { reply } from "@/content/reply";
+import type { Message } from "@/types/message";
+import type { User } from "@/types/user";
+
+const EMPTY_ADD = /addMember\(\) requires at least one member/;
+const EMPTY_REMOVE = /removeMember\(\) requires at least one member/;
+const REPLY_CANNOT_WRAP_ADD = /reply\(\) cannot wrap "addMember"/;
+const REPLY_CANNOT_WRAP_REMOVE = /reply\(\) cannot wrap "removeMember"/;
+const REPLY_CANNOT_WRAP_LEAVE = /reply\(\) cannot wrap "leaveSpace"/;
+const EDIT_CANNOT_WRAP_ADD = /edit\(\) cannot wrap "addMember"/;
+const EDIT_CANNOT_WRAP_REMOVE = /edit\(\) cannot wrap "removeMember"/;
+const EDIT_CANNOT_WRAP_LEAVE = /edit\(\) cannot wrap "leaveSpace"/;
+
+const makeMessage = (direction: "inbound" | "outbound"): Message =>
+  ({
+    id: "m1",
+    content: { type: "text", text: "hi" },
+    direction,
+  }) as unknown as Message;
+
+const alice: User = { __platform: "test", id: "+15550100" };
+const bob: User = { __platform: "test", id: "bob@example.com" };
+
+describe("membership builders", () => {
+  it("addMember builds from a single id string", async () => {
+    const built = (await addMember("+15550100").build()) as AddMember;
+
+    expect(built.type).toBe("addMember");
+    expect(built.members).toEqual(["+15550100"]);
+  });
+
+  it("addMember normalizes a single User to its id", async () => {
+    const built = (await addMember(alice).build()) as AddMember;
+
+    expect(built.members).toEqual([alice.id]);
+  });
+
+  it("addMember normalizes a mixed User/string array", async () => {
+    const built = (await addMember([
+      alice,
+      "carol@example.com",
+      bob,
+    ]).build()) as AddMember;
+
+    expect(built.members).toEqual([alice.id, "carol@example.com", bob.id]);
+  });
+
+  it("addMember rejects an empty array at build time", async () => {
+    await expect(addMember([]).build()).rejects.toThrow(EMPTY_ADD);
+  });
+
+  it("removeMember builds from a single id string", async () => {
+    const built = (await removeMember("+15550100").build()) as RemoveMember;
+
+    expect(built.type).toBe("removeMember");
+    expect(built.members).toEqual(["+15550100"]);
+  });
+
+  it("removeMember normalizes a mixed User/string array", async () => {
+    const built = (await removeMember([
+      bob,
+      "+15550101",
+    ]).build()) as RemoveMember;
+
+    expect(built.members).toEqual([bob.id, "+15550101"]);
+  });
+
+  it("removeMember rejects an empty array at build time", async () => {
+    await expect(removeMember([]).build()).rejects.toThrow(EMPTY_REMOVE);
+  });
+
+  it("leaveSpace builds a payload-free value", async () => {
+    const built = (await leaveSpace().build()) as LeaveSpace;
+
+    expect(built).toEqual({ type: "leaveSpace" });
+  });
+
+  it("cannot be wrapped by reply()", async () => {
+    const target = makeMessage("inbound");
+    await expect(reply(addMember("u1"), target).build()).rejects.toThrow(
+      REPLY_CANNOT_WRAP_ADD
+    );
+    await expect(reply(removeMember("u1"), target).build()).rejects.toThrow(
+      REPLY_CANNOT_WRAP_REMOVE
+    );
+    await expect(reply(leaveSpace(), target).build()).rejects.toThrow(
+      REPLY_CANNOT_WRAP_LEAVE
+    );
+  });
+
+  it("cannot be wrapped by edit()", async () => {
+    const target = makeMessage("outbound");
+    await expect(edit(addMember("u1"), target).build()).rejects.toThrow(
+      EDIT_CANNOT_WRAP_ADD
+    );
+    await expect(edit(removeMember("u1"), target).build()).rejects.toThrow(
+      EDIT_CANNOT_WRAP_REMOVE
+    );
+    await expect(edit(leaveSpace(), target).build()).rejects.toThrow(
+      EDIT_CANNOT_WRAP_LEAVE
+    );
+  });
+});

--- a/packages/core/test/core/platform-wise-reads.test.ts
+++ b/packages/core/test/core/platform-wise-reads.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "bun:test";
+import { stubCloud } from "@spectrum-ts/test-support/cloud";
+import { baseConfig, makeQueue } from "@spectrum-ts/test-support/platform";
+import z from "zod";
+import { definePlatform } from "@/platform/define";
+import type { ProviderMessage } from "@/platform/types";
+import { Spectrum } from "@/spectrum";
+import { UnsupportedError } from "@/utils/errors";
+
+stubCloud();
+
+const MEMBERS = [{ id: "u1", role: "admin" }, { id: "u2" }];
+const ICON_BYTES = "png-bytes";
+const ICON_MIME = "image/png";
+
+const MEMBERS_UNSUPPORTED =
+  /reads-members-bare does not support action "getMembers"/;
+const AVATAR_UNSUPPORTED =
+  /reads-avatar-bare does not support action "getAvatar"/;
+const INSTANCE_MEMBERS_UNSUPPORTED =
+  /reads-instance-bare does not support action "getMembers"/;
+const INSTANCE_AVATAR_UNSUPPORTED =
+  /reads-instance-bare does not support action "getAvatar"/;
+
+// Shared def slots for a minimal provider. The message queue is closed
+// immediately — every test gets its space from `space.create`, not the
+// inbound stream.
+const baseSlots = () => {
+  const queue = makeQueue<ProviderMessage<{ id: string }, { id: string }>>();
+  queue.close();
+  return {
+    config: z.object({}),
+    lifecycle: {
+      createClient: () => Promise.resolve({}),
+    },
+    user: {
+      resolve: ({ input }: { input: { userID: string } }) =>
+        Promise.resolve({ id: input.userID }),
+    },
+    space: {
+      create: ({ input }: { input: { users: { id: string }[] } }) =>
+        Promise.resolve({ id: input.users[0]?.id ?? "s1" }),
+    },
+    messages: () => queue.iter,
+    send: () => Promise.resolve(undefined),
+  };
+};
+
+// Provider that implements both platform-wise read actions. `avatar: "none"`
+// makes `getAvatar` resolve `undefined` (a group with no icon set).
+const makeReadProvider = (name: string, opts?: { avatar?: "none" }) =>
+  definePlatform(name, {
+    ...baseSlots(),
+    actions: {
+      getMembers: () => Promise.resolve(MEMBERS),
+      getAvatar: () =>
+        Promise.resolve(
+          opts?.avatar === "none"
+            ? undefined
+            : { data: Buffer.from(ICON_BYTES), mimeType: ICON_MIME }
+        ),
+    },
+  });
+
+// Provider with no `actions` slot at all — both reads fall back to the
+// framework default (`UnsupportedError`).
+const makeBareProvider = (name: string) => definePlatform(name, baseSlots());
+
+describe("space.getMembers()", () => {
+  it("returns provider records tagged with __platform, extras preserved", async () => {
+    const provider = makeReadProvider("reads-members");
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const space = await provider(app).space.create("u1");
+      const members = await space.getMembers();
+
+      expect(members.map((m) => m.id)).toEqual(["u1", "u2"]);
+      expect(members.map((m) => m.__platform)).toEqual([
+        "reads-members",
+        "reads-members",
+      ]);
+      expect((members[0] as { role?: string }).role).toBe("admin");
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("throws UnsupportedError when the provider has no implementation", async () => {
+    const provider = makeBareProvider("reads-members-bare");
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const space = await provider(app).space.create("u1");
+      await expect(space.getMembers()).rejects.toThrow(UnsupportedError);
+      await expect(space.getMembers()).rejects.toThrow(MEMBERS_UNSUPPORTED);
+    } finally {
+      await app.stop();
+    }
+  });
+});
+
+describe("space.getAvatar()", () => {
+  it("passes the provider's { data, mimeType } through untouched", async () => {
+    const provider = makeReadProvider("reads-avatar");
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const space = await provider(app).space.create("u1");
+      const icon = await space.getAvatar();
+
+      expect(icon?.mimeType).toBe(ICON_MIME);
+      expect(Buffer.isBuffer(icon?.data)).toBe(true);
+      expect(icon?.data.toString()).toBe(ICON_BYTES);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("resolves undefined when the provider reports no avatar", async () => {
+    const provider = makeReadProvider("reads-avatar-none", { avatar: "none" });
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const space = await provider(app).space.create("u1");
+      expect(await space.getAvatar()).toBeUndefined();
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("throws UnsupportedError when the provider has no implementation", async () => {
+    const provider = makeBareProvider("reads-avatar-bare");
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const space = await provider(app).space.create("u1");
+      await expect(space.getAvatar()).rejects.toThrow(AVATAR_UNSUPPORTED);
+    } finally {
+      await app.stop();
+    }
+  });
+});
+
+describe("platform instance read methods", () => {
+  it("im.getMembers/getAvatar resolve the provider records raw", async () => {
+    const provider = makeReadProvider("reads-instance");
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const instance = provider(app);
+      const space = await instance.space.create("u1");
+
+      const members = await instance.getMembers(space);
+      expect(members.map((m) => m.id)).toEqual(["u1", "u2"]);
+
+      const icon = await instance.getAvatar(space);
+      expect(icon?.mimeType).toBe(ICON_MIME);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("defaults to UnsupportedError when the provider omits the actions", async () => {
+    // Pins the PLATFORM_WISE_ACTION_KEYS wiring: a key missing from the
+    // runtime list would surface as "not a function", not UnsupportedError.
+    // The instance default throws synchronously (define.ts wires a plain
+    // `() => { throw ... }`) — same contract as `im.getMessage` — so these
+    // asserts use `toThrow`, not `rejects`.
+    const provider = makeBareProvider("reads-instance-bare");
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const instance = provider(app);
+      const space = await instance.space.create("u1");
+
+      expect(() => instance.getMembers(space)).toThrow(
+        INSTANCE_MEMBERS_UNSUPPORTED
+      );
+      expect(() => instance.getAvatar(space)).toThrow(
+        INSTANCE_AVATAR_UNSUPPORTED
+      );
+    } finally {
+      await app.stop();
+    }
+  });
+});

--- a/packages/core/test/core/receive-membership.test.ts
+++ b/packages/core/test/core/receive-membership.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "bun:test";
+import { stubCloud } from "@spectrum-ts/test-support/cloud";
+import { baseConfig, makeQueue } from "@spectrum-ts/test-support/platform";
+import z from "zod";
+import { definePlatform } from "@/platform/define";
+import type { ProviderMessage } from "@/platform/types";
+import { Spectrum } from "@/spectrum";
+
+stubCloud();
+
+const EVENT_TIMESTAMP = new Date(456);
+
+type InboundRecord = ProviderMessage<{ id: string }, { id: string }>;
+
+// Providers surface platform group events as inbound records whose content
+// is membership; `sender` may be absent when no actor was recorded.
+const makeInboundProvider = (name: string, records: InboundRecord[]) => {
+  const queue = makeQueue<InboundRecord>();
+  for (const item of records) {
+    queue.push(item);
+  }
+  queue.close();
+  return definePlatform(name, {
+    config: z.object({}),
+    lifecycle: {
+      createClient: () => Promise.resolve({}),
+    },
+    user: { resolve: ({ input }) => Promise.resolve({ id: input.userID }) },
+    space: {
+      create: ({ input }) =>
+        Promise.resolve({ id: input.users[0]?.id ?? "s1" }),
+    },
+    messages: () => queue.iter,
+    send: () => Promise.resolve(undefined),
+  });
+};
+
+const firstMessage = async (app: Awaited<ReturnType<typeof Spectrum>>) => {
+  const iterator = app.messages[Symbol.asyncIterator]();
+  const first = await iterator.next();
+  if (first.done) {
+    throw new Error("expected an inbound message");
+  }
+  return first.value;
+};
+
+describe("inbound membership events", () => {
+  it("delivers a sender-less membership event with content intact", async () => {
+    const provider = makeInboundProvider("membership-inbound", [
+      {
+        id: "evt-1",
+        content: { type: "addMember", members: ["+15550100"] },
+        space: { id: "s1" },
+        timestamp: EVENT_TIMESTAMP,
+      },
+    ]);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space, message] = await firstMessage(app);
+      expect(space.id).toBe("s1");
+      expect(message.content).toEqual({
+        type: "addMember",
+        members: ["+15550100"],
+      });
+      expect(message.direction).toBe("inbound");
+      expect(message.sender).toBeUndefined();
+      expect(message.timestamp).toEqual(EVENT_TIMESTAMP);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("tags an inbound membership sender with the platform", async () => {
+    const provider = makeInboundProvider("membership-inbound-sender", [
+      {
+        id: "evt-2",
+        content: { type: "removeMember", members: ["+15550100"] },
+        sender: { id: "+15550111" },
+        space: { id: "s1" },
+        timestamp: EVENT_TIMESTAMP,
+      },
+    ]);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [, message] = await firstMessage(app);
+      expect(message.content.type).toBe("removeMember");
+      expect(message.sender).toEqual({
+        id: "+15550111",
+        __platform: "membership-inbound-sender",
+      });
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("delivers leaveSpace with the leaver as sender", async () => {
+    const provider = makeInboundProvider("membership-inbound-leave", [
+      {
+        id: "evt-3",
+        content: { type: "leaveSpace" },
+        sender: { id: "+15550122" },
+        space: { id: "s1" },
+        timestamp: EVENT_TIMESTAMP,
+      },
+    ]);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [, message] = await firstMessage(app);
+      expect(message.content).toEqual({ type: "leaveSpace" });
+      expect(message.sender?.id).toBe("+15550122");
+    } finally {
+      await app.stop();
+    }
+  });
+});

--- a/packages/core/test/core/send-membership.test.ts
+++ b/packages/core/test/core/send-membership.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "bun:test";
+import { stubCloud } from "@spectrum-ts/test-support/cloud";
+import {
+  baseConfig,
+  makeQueue,
+  record,
+} from "@spectrum-ts/test-support/platform";
+import z from "zod";
+import { addMember } from "@/content/membership";
+import type { Content } from "@/content/types";
+import { definePlatform } from "@/platform/define";
+import type { ProviderMessage, ProviderMessageRecord } from "@/platform/types";
+import { Spectrum } from "@/spectrum";
+import { UnsupportedError } from "@/utils/errors";
+
+stubCloud();
+
+const SENT_TIMESTAMP = new Date(123);
+
+const MEMBERSHIP_TYPES = new Set(["addMember", "removeMember", "leaveSpace"]);
+
+type SendImpl = (
+  content: Content
+) => Promise<ProviderMessageRecord | undefined>;
+
+// One inbound text message, then a `send` whose behavior the test controls.
+// Mirrors makeReadProvider in send-read.test.ts.
+const makeMembershipProvider = (name: string, sendImpl: SendImpl) => {
+  const queue = makeQueue<ProviderMessage<{ id: string }, { id: string }>>();
+  queue.push(record("m1"));
+  queue.close();
+  return definePlatform(name, {
+    config: z.object({}),
+    lifecycle: {
+      createClient: () => Promise.resolve({}),
+    },
+    user: { resolve: ({ input }) => Promise.resolve({ id: input.userID }) },
+    space: {
+      create: ({ input }) =>
+        Promise.resolve({ id: input.users[0]?.id ?? "s1" }),
+    },
+    messages: () => queue.iter,
+    send: ({ content }) => sendImpl(content),
+  });
+};
+
+const firstMessage = async (app: Awaited<ReturnType<typeof Spectrum>>) => {
+  const iterator = app.messages[Symbol.asyncIterator]();
+  const first = await iterator.next();
+  if (first.done) {
+    throw new Error("expected an inbound message");
+  }
+  return first.value;
+};
+
+// Records every dispatched content; membership ops are fire-and-forget
+// (void), everything else produces a record so the caller gets a Message.
+const recordingSend = () => {
+  const seen: Content[] = [];
+  const sendImpl: SendImpl = (content) => {
+    seen.push(content);
+    if (MEMBERSHIP_TYPES.has(content.type)) {
+      return Promise.resolve(undefined);
+    }
+    return Promise.resolve({
+      id: `${content.type}-1`,
+      content,
+      space: { id: "s1" },
+      timestamp: SENT_TIMESTAMP,
+    });
+  };
+  return { seen, sendImpl };
+};
+
+describe("membership sends are fire-and-forget", () => {
+  it("space.add() dispatches addMember content with normalized members", async () => {
+    const { seen, sendImpl } = recordingSend();
+    const provider = makeMembershipProvider("membership-add", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      await space.add("u2");
+
+      const dispatched = seen.at(-1);
+      expect(dispatched?.type).toBe("addMember");
+      expect((dispatched as { members?: string[] }).members).toEqual(["u2"]);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("space.add() batches an array into one dispatch", async () => {
+    const { seen, sendImpl } = recordingSend();
+    const provider = makeMembershipProvider("membership-add-batch", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      const before = seen.length;
+      await space.add(["u2", "u3"]);
+
+      expect(seen.length).toBe(before + 1);
+      const dispatched = seen.at(-1);
+      expect((dispatched as { members?: string[] }).members).toEqual([
+        "u2",
+        "u3",
+      ]);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("space.remove() dispatches removeMember content", async () => {
+    const { seen, sendImpl } = recordingSend();
+    const provider = makeMembershipProvider("membership-remove", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      await space.remove("u2");
+
+      const dispatched = seen.at(-1);
+      expect(dispatched?.type).toBe("removeMember");
+      expect((dispatched as { members?: string[] }).members).toEqual(["u2"]);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("space.leave() dispatches leaveSpace content", async () => {
+    const { seen, sendImpl } = recordingSend();
+    const provider = makeMembershipProvider("membership-leave", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      await space.leave();
+
+      expect(seen.at(-1)?.type).toBe("leaveSpace");
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("space.send(addMember(...)) resolves undefined", async () => {
+    const { sendImpl } = recordingSend();
+    const provider = makeMembershipProvider("membership-canonical", sendImpl);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      expect(await space.send(addMember("u2"))).toBeUndefined();
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("resolves silently when the platform does not support membership", async () => {
+    const provider = makeMembershipProvider(
+      "membership-unsupported",
+      (content) => {
+        if (MEMBERSHIP_TYPES.has(content.type)) {
+          return Promise.reject(
+            UnsupportedError.content(content.type, "membership-unsupported")
+          );
+        }
+        return Promise.resolve({
+          id: "t1",
+          content,
+          space: { id: "s1" },
+          timestamp: SENT_TIMESTAMP,
+        });
+      }
+    );
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space] = await firstMessage(app);
+      // Warn-and-skip: the unsupported error is logged, not thrown.
+      expect(await space.add("u2")).toBeUndefined();
+      expect(await space.remove("u2")).toBeUndefined();
+      expect(await space.leave()).toBeUndefined();
+    } finally {
+      await app.stop();
+    }
+  });
+});

--- a/packages/core/test/webhook/deserialize.test.ts
+++ b/packages/core/test/webhook/deserialize.test.ts
@@ -212,4 +212,101 @@ describe("deserializeSpectrumMessage", () => {
       raw: { type: "future-thing", foo: "bar" },
     });
   });
+
+  it("maps membership content and filters non-string members", () => {
+    const added = deserialize({
+      type: "addMember",
+      members: ["+15550100", 42, "+15550101"],
+    });
+    expect(added.record.content).toEqual({
+      type: "addMember",
+      members: ["+15550100", "+15550101"],
+    });
+
+    const removed = deserialize({
+      type: "removeMember",
+      members: ["+15550100"],
+    });
+    expect(removed.record.content).toEqual({
+      type: "removeMember",
+      members: ["+15550100"],
+    });
+  });
+
+  it("degrades membership content with no valid members to custom", () => {
+    const { record } = deserialize({ type: "addMember", members: [42] });
+    expect(record.content).toEqual({
+      type: "custom",
+      raw: { type: "addMember", members: [42] },
+    });
+  });
+
+  it("maps leaveSpace content", () => {
+    const { record } = deserialize({ type: "leaveSpace" });
+    expect(record.content).toEqual({ type: "leaveSpace" });
+  });
+
+  it("maps rename content and degrades an empty displayName to custom", () => {
+    const renamed = deserialize({ type: "rename", displayName: "Ski Trip" });
+    expect(renamed.record.content).toEqual({
+      type: "rename",
+      displayName: "Ski Trip",
+    });
+
+    const cleared = deserialize({ type: "rename", displayName: "" });
+    expect(cleared.record.content).toEqual({
+      type: "custom",
+      raw: { type: "rename", displayName: "" },
+    });
+  });
+
+  it("maps an avatar clear action", () => {
+    const { record } = deserialize({
+      type: "avatar",
+      action: { kind: "clear" },
+    });
+    expect(record.content).toEqual({
+      type: "avatar",
+      action: { kind: "clear" },
+    });
+  });
+
+  it("delivers an avatar set as metadata with a throwing read()", async () => {
+    const { record } = deserialize({
+      type: "avatar",
+      action: { kind: "set", mimeType: "image/png" },
+    });
+    const content = record.content as {
+      type: string;
+      action: { kind: string; mimeType: string; read: () => Promise<Buffer> };
+    };
+    expect(content.type).toBe("avatar");
+    expect(content.action.kind).toBe("set");
+    expect(content.action.mimeType).toBe("image/png");
+    await expect(content.action.read()).rejects.toThrow(
+      UNSUPPORTED_ATTACHMENT_ERROR
+    );
+  });
+
+  it("defaults a missing avatar set mimeType", () => {
+    const { record } = deserialize({
+      type: "avatar",
+      action: { kind: "set" },
+    });
+    const content = record.content as {
+      action: { mimeType: string };
+    };
+    expect(content.action.mimeType).toBe("application/octet-stream");
+  });
+
+  it("degrades an unknown avatar action kind to custom", () => {
+    const { record } = deserialize({
+      type: "avatar",
+      action: { kind: "rotate" },
+    });
+    expect(record.content).toEqual({
+      type: "custom",
+      raw: { type: "avatar", action: { kind: "rotate" } },
+    });
+  });
 });

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -6,12 +6,14 @@ import {
 import { IMessageSDK } from "@photon-ai/imessage-kit";
 import { withSpan } from "@photon-ai/otel";
 import {
+  type AddMember,
   type App,
   type Attachment,
   type Avatar,
   type Content,
   definePlatform,
   type Edit,
+  type RemoveMember,
   type Rename,
   type Space,
   type StreamText,
@@ -58,11 +60,14 @@ import {
   send as localSend,
 } from "./local/api";
 import {
+  addParticipants as remoteAddParticipants,
   editMessage as remoteEditMessage,
   getMessage as remoteGetMessage,
+  leaveGroup as remoteLeaveGroup,
   markRead as remoteMarkRead,
   messages as remoteMessages,
   reactToMessage as remoteReactToMessage,
+  removeParticipants as remoteRemoveParticipants,
   replyToMessage as remoteReplyToMessage,
   send as remoteSend,
   sendCustomizedMiniApp as remoteSendCustomizedMiniApp,
@@ -353,6 +358,65 @@ const handleAvatar = async (
   }
   const remote = clientForPhone(client, space.phone);
   await remoteSetIcon(remote, space.id, content);
+};
+
+/**
+ * Shared guard for the membership handlers: remote-only, group-only, then
+ * per-phone client resolution. Mirrors the `handleRename` / `handleAvatar`
+ * guard sequence.
+ */
+const remoteGroupClient = (
+  client: IMessageClient,
+  space: { id: string; phone: string; type: "dm" | "group" },
+  action: string,
+  detail: { dm: string; local: string }
+): AdvancedIMessage => {
+  if (isLocal(client)) {
+    throw UnsupportedError.action(
+      action,
+      "iMessage (local mode)",
+      detail.local
+    );
+  }
+  if (space.type !== "group") {
+    throw UnsupportedError.action(action, "iMessage", detail.dm);
+  }
+  return clientForPhone(client, space.phone);
+};
+
+const handleAddMember = async (
+  client: IMessageClient,
+  space: { id: string; phone: string; type: "dm" | "group" },
+  content: AddMember
+): Promise<void> => {
+  const remote = remoteGroupClient(client, space, "addMember", {
+    dm: "only group chats can add members (this space is a DM — iMessage cannot convert a DM into a group; create a group via space.create instead)",
+    local: "adding members requires remote iMessage",
+  });
+  await remoteAddParticipants(remote, space.id, content);
+};
+
+const handleRemoveMember = async (
+  client: IMessageClient,
+  space: { id: string; phone: string; type: "dm" | "group" },
+  content: RemoveMember
+): Promise<void> => {
+  const remote = remoteGroupClient(client, space, "removeMember", {
+    dm: "only group chats can remove members (this space is a DM — iMessage cannot convert a DM into a group; create a group via space.create instead)",
+    local: "removing members requires remote iMessage",
+  });
+  await remoteRemoveParticipants(remote, space.id, content);
+};
+
+const handleLeaveSpace = async (
+  client: IMessageClient,
+  space: { id: string; phone: string; type: "dm" | "group" }
+): Promise<void> => {
+  const remote = remoteGroupClient(client, space, "leaveSpace", {
+    dm: "only group chats can be left (this space is a DM)",
+    local: "leaving chats requires remote iMessage",
+  });
+  await remoteLeaveGroup(remote, space.id);
 };
 
 /**
@@ -648,6 +712,18 @@ export const imessage = definePlatform("iMessage", {
     }
     if (content.type === "avatar") {
       await handleAvatar(client, space, content);
+      return;
+    }
+    if (content.type === "addMember") {
+      await handleAddMember(client, space, content);
+      return;
+    }
+    if (content.type === "removeMember") {
+      await handleRemoveMember(client, space, content);
+      return;
+    }
+    if (content.type === "leaveSpace") {
+      await handleLeaveSpace(client, space);
       return;
     }
     if (content.type === "read") {

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -62,8 +62,10 @@ import {
 import {
   addParticipants as remoteAddParticipants,
   editMessage as remoteEditMessage,
+  getIcon as remoteGetIcon,
   getMessage as remoteGetMessage,
   leaveGroup as remoteLeaveGroup,
+  listParticipants as remoteListParticipants,
   markRead as remoteMarkRead,
   messages as remoteMessages,
   reactToMessage as remoteReactToMessage,
@@ -764,6 +766,26 @@ export const imessage = definePlatform("iMessage", {
       }
       const remote = clientForPhone(client, space.phone);
       return remoteGetMessage(remote, space.id, messageId, space.phone);
+    },
+    // List a remote group chat's current participants. Remote + group only;
+    // the agent's own number is excluded. `id` is the canonical address
+    // (E.164 phone or email); `address`/`country`/`service` ride along per
+    // `userSchema`.
+    getMembers: async ({ client }, space) => {
+      const remote = remoteGroupClient(client, space, "getMembers", {
+        dm: "only group chats support listing members (this space is a DM)",
+        local: "listing members requires remote iMessage",
+      });
+      return await remoteListParticipants(remote, space.id, space.phone);
+    },
+    // Download the group chat's current icon; `undefined` when none is set.
+    // Remote + group only — mirrors the avatar setter's guards.
+    getAvatar: async ({ client }, space) => {
+      const remote = remoteGroupClient(client, space, "getAvatar", {
+        dm: "only group chats have avatars (this space is a DM)",
+        local: "fetching group avatars requires remote iMessage",
+      });
+      return await remoteGetIcon(remote, space.id);
     },
     // Fetch an attachment by GUID. Returns a spectrum `Attachment` whose
     // `.read()` / `.stream()` lazily download the bytes — calling both

--- a/packages/imessage/src/remote/api.ts
+++ b/packages/imessage/src/remote/api.ts
@@ -1,9 +1,11 @@
 import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
 import type {
+  AddMember,
   Avatar,
   Content,
   ManagedStream,
   ProjectData,
+  RemoveMember,
   Rename,
   StreamText,
 } from "@spectrum-ts/core";
@@ -16,6 +18,11 @@ import { setBackground as setRemoteBackground } from "./background";
 import { shareContactCard as shareRemoteContactCard } from "./contact-card";
 import { sendCustomizedMiniApp as sendRemoteCustomizedMiniApp } from "./customized-mini-app";
 import { getMessage as getRemoteMessage } from "./inbound";
+import {
+  addParticipants as addRemoteParticipants,
+  leaveGroup as leaveRemoteGroup,
+  removeParticipants as removeRemoteParticipants,
+} from "./members";
 import {
   reactToMessage as reactToRemoteMessage,
   unsendReaction as unsendRemoteReaction,
@@ -58,6 +65,23 @@ export const setDisplayName = async (
   spaceId: string,
   content: Rename
 ): Promise<void> => setRemoteDisplayName(remote, spaceId, content);
+
+export const addParticipants = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  content: AddMember
+): Promise<void> => addRemoteParticipants(remote, spaceId, content);
+
+export const removeParticipants = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  content: RemoveMember
+): Promise<void> => removeRemoteParticipants(remote, spaceId, content);
+
+export const leaveGroup = async (
+  remote: AdvancedIMessage,
+  spaceId: string
+): Promise<void> => leaveRemoteGroup(remote, spaceId);
 
 export const setIcon = async (
   remote: AdvancedIMessage,

--- a/packages/imessage/src/remote/api.ts
+++ b/packages/imessage/src/remote/api.ts
@@ -2,6 +2,7 @@ import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
 import type {
   AddMember,
   Avatar,
+  AvatarData,
   Content,
   ManagedStream,
   ProjectData,
@@ -13,14 +14,16 @@ import type { ProviderMessageRecord } from "@spectrum-ts/core/authoring";
 import type { Background } from "../content/background";
 import type { CustomizedMiniApp } from "../content/customized-mini-app";
 import type { IMessageMessage, RemoteClient } from "../types";
-import { setIcon as setRemoteIcon } from "./avatar";
+import { getIcon as getRemoteIcon, setIcon as setRemoteIcon } from "./avatar";
 import { setBackground as setRemoteBackground } from "./background";
 import { shareContactCard as shareRemoteContactCard } from "./contact-card";
 import { sendCustomizedMiniApp as sendRemoteCustomizedMiniApp } from "./customized-mini-app";
 import { getMessage as getRemoteMessage } from "./inbound";
 import {
   addParticipants as addRemoteParticipants,
+  type IMessageParticipant,
   leaveGroup as leaveRemoteGroup,
+  listParticipants as listRemoteParticipants,
   removeParticipants as removeRemoteParticipants,
 } from "./members";
 import {
@@ -82,6 +85,18 @@ export const leaveGroup = async (
   remote: AdvancedIMessage,
   spaceId: string
 ): Promise<void> => leaveRemoteGroup(remote, spaceId);
+
+export const listParticipants = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  selfPhone: string
+): Promise<IMessageParticipant[]> =>
+  listRemoteParticipants(remote, spaceId, selfPhone);
+
+export const getIcon = async (
+  remote: AdvancedIMessage,
+  spaceId: string
+): Promise<AvatarData | undefined> => getRemoteIcon(remote, spaceId);
 
 export const setIcon = async (
   remote: AdvancedIMessage,

--- a/packages/imessage/src/remote/avatar.ts
+++ b/packages/imessage/src/remote/avatar.ts
@@ -1,5 +1,8 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
-import type { Avatar } from "@spectrum-ts/core";
+import {
+  type AdvancedIMessage,
+  NotFoundError,
+} from "@photon-ai/advanced-imessage";
+import type { Avatar, AvatarData } from "@spectrum-ts/core";
 import { toChatGuid } from "./ids";
 
 /**
@@ -25,4 +28,27 @@ export const setIcon = async (
     chat,
     new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
   );
+};
+
+/**
+ * Download the current icon of a remote iMessage group chat. Resolves
+ * `undefined` when the group has no icon (the SDK's `NotFoundError` with
+ * code `groupIconNotFound`); any other error — including a `chatNotFound`
+ * `NotFoundError` — propagates. Bytes are copied into a Buffer so the result
+ * round-trips into `setIcon` / `space.avatar(...)`. The caller (`getAvatar`
+ * in the iMessage provider) owns the group-only / remote-only guards.
+ */
+export const getIcon = async (
+  remote: AdvancedIMessage,
+  spaceId: string
+): Promise<AvatarData | undefined> => {
+  try {
+    const icon = await remote.groups.getIcon(toChatGuid(spaceId));
+    return { data: Buffer.from(icon.data), mimeType: icon.mimeType };
+  } catch (err) {
+    if (err instanceof NotFoundError && err.code === "groupIconNotFound") {
+      return;
+    }
+    throw err;
+  }
 };

--- a/packages/imessage/src/remote/group-events.ts
+++ b/packages/imessage/src/remote/group-events.ts
@@ -1,0 +1,160 @@
+import type {
+  AdvancedIMessage,
+  GroupEvent,
+  SingleServiceAddressInfo,
+} from "@photon-ai/advanced-imessage";
+import type { Content } from "@spectrum-ts/core";
+import {
+  addMemberSchema,
+  avatarSchema,
+  createLogger,
+  errorAttrs,
+  leaveSpaceSchema,
+  removeMemberSchema,
+  renameSchema,
+} from "@spectrum-ts/core/authoring";
+import type { IMessageMessage } from "../types";
+import { getIcon } from "./avatar";
+import { chatTypeFromGuid } from "./ids";
+import { toSenderRef } from "./inbound";
+
+const log = createLogger("spectrum.imessage.group");
+
+/**
+ * Synthetic id for a `group.changed` event — shared between the stream item
+ * (the dedup key across live/catch-up) and the surfaced message. `sequence`
+ * is monotonic per line, so the id is unique across all change kinds.
+ */
+export const groupEventMessageId = (event: GroupEvent): string =>
+  `${event.chatGuid}:group:${event.sequence}`;
+
+/**
+ * The acting party of a group change. For `participantLeft` that is the
+ * leaver (`change.participant`) — nobody leaves on someone else's behalf
+ * (third-party removal is `participantRemoved`), and `leaveSpace` content
+ * carries no members, so the leaver's identity can only travel on
+ * `message.sender`. Every other change acts through `event.actor`, which the
+ * platform doesn't always record.
+ */
+export const groupEventActor = (
+  event: GroupEvent
+): SingleServiceAddressInfo | undefined =>
+  event.change.type === "participantLeft"
+    ? event.change.participant
+    : event.actor;
+
+// `toSenderRef(undefined)` fabricates `{id: ""}` — branch explicitly so an
+// unrecorded actor surfaces as `sender: undefined` on the message.
+const toOptionalSenderRef = (
+  addr: SingleServiceAddressInfo | undefined
+): ReturnType<typeof toSenderRef> | undefined =>
+  addr?.address ? toSenderRef(addr) : undefined;
+
+// The event carries no image bytes, so snapshot the icon eagerly — one RPC
+// per (rare) icon change, and the bytes match the event rather than whatever
+// the icon is by the time a consumer calls `read()`. A missing icon (already
+// replaced or removed by fetch time) or a fetch failure drops the event; a
+// follow-up `iconRemoved`/`iconChanged` carries the current state.
+const fetchIconContent = async (
+  client: AdvancedIMessage,
+  event: GroupEvent
+): Promise<Content | undefined> => {
+  try {
+    const icon = await getIcon(client, event.chatGuid);
+    if (!icon) {
+      return;
+    }
+    return avatarSchema.parse({
+      type: "avatar",
+      action: {
+        kind: "set",
+        mimeType: icon.mimeType,
+        read: () => Promise.resolve(icon.data),
+      },
+    });
+  } catch (e) {
+    log.error(
+      "failed to fetch changed group icon",
+      {
+        "spectrum.imessage.group.chat": event.chatGuid,
+        ...errorAttrs(e),
+      },
+      e
+    );
+    return;
+  }
+};
+
+const toGroupChangeContent = async (
+  client: AdvancedIMessage,
+  event: GroupEvent
+): Promise<Content | undefined> => {
+  const change = event.change;
+  switch (change.type) {
+    case "participantAdded":
+      return change.participant.address
+        ? addMemberSchema.parse({
+            type: "addMember",
+            members: [change.participant.address],
+          })
+        : undefined;
+    case "participantRemoved":
+      return change.participant.address
+        ? removeMemberSchema.parse({
+            type: "removeMember",
+            members: [change.participant.address],
+          })
+        : undefined;
+    case "participantLeft":
+      return leaveSpaceSchema.parse({ type: "leaveSpace" });
+    case "displayNameChanged":
+      // Apple can clear a group name; `rename` requires non-empty, so a
+      // name-removal event is dropped.
+      return change.displayName
+        ? renameSchema.parse({
+            type: "rename",
+            displayName: change.displayName,
+          })
+        : undefined;
+    case "iconChanged":
+      return await fetchIconContent(client, event);
+    case "iconRemoved":
+      return avatarSchema.parse({ type: "avatar", action: { kind: "clear" } });
+    default:
+      // Forward-compat: change kinds from a newer SDK are skipped.
+      return;
+  }
+};
+
+/**
+ * Convert a `group.changed` event into inbound spectrum messages. Unlike
+ * reactions — where an event without an actor is dropped because the actor
+ * is itself the substance — membership/rename/avatar changes surface even
+ * when the platform recorded no actor: the state change is the payload, so
+ * the message ships with `sender: undefined`.
+ */
+export const toGroupEventMessages = async (
+  client: AdvancedIMessage,
+  event: GroupEvent,
+  phone: string
+): Promise<IMessageMessage[]> => {
+  const content = await toGroupChangeContent(client, event);
+  if (!content) {
+    return [];
+  }
+  return [
+    {
+      // No `direction`: the stream path defaults provider records to inbound
+      // (the agent's own echoes are suppressed before conversion).
+      id: groupEventMessageId(event),
+      content,
+      sender: toOptionalSenderRef(groupEventActor(event)),
+      space: {
+        id: event.chatGuid,
+        type: chatTypeFromGuid(event.chatGuid),
+        phone,
+      },
+      timestamp: event.occurredAt,
+    },
+  ];
+};

--- a/packages/imessage/src/remote/members.ts
+++ b/packages/imessage/src/remote/members.ts
@@ -1,4 +1,7 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type {
+  AdvancedIMessage,
+  ChatServiceType,
+} from "@photon-ai/advanced-imessage";
 import type { AddMember, RemoveMember } from "@spectrum-ts/core";
 import { toChatGuid } from "./ids";
 
@@ -38,4 +41,41 @@ export const leaveGroup = async (
   spaceId: string
 ): Promise<void> => {
   await remote.groups.leave(toChatGuid(spaceId));
+};
+
+/**
+ * A group participant mapped to spectrum's user shape. `id` is the canonical
+ * address (E.164 phone or email — the same handle format `space.create`
+ * accepts); `address`/`country`/`service` mirror the SDK record and match
+ * the extras declared by the provider's `userSchema`.
+ */
+// biome-ignore lint/style/useConsistentTypeDefinitions: must stay a type alias — interfaces lack the implicit index signature needed to satisfy core's `ProviderUserRecord`
+export type IMessageParticipant = {
+  id: string;
+  address: string;
+  country?: string;
+  service: ChatServiceType;
+};
+
+/**
+ * List a remote group chat's current participants, excluding the agent's own
+ * handle (`selfPhone` — the dedicated number that owns the chat; the shared
+ * sentinel never matches a canonical address, so shared mode returns the
+ * full roster). The caller (`getMembers` in the iMessage provider) owns the
+ * group-only / remote-only guards.
+ */
+export const listParticipants = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  selfPhone: string
+): Promise<IMessageParticipant[]> => {
+  const { participants } = await remote.chats.get(toChatGuid(spaceId));
+  return participants
+    .filter((p) => p.address !== selfPhone)
+    .map((p) => ({
+      id: p.address,
+      address: p.address,
+      country: p.country,
+      service: p.service,
+    }));
 };

--- a/packages/imessage/src/remote/members.ts
+++ b/packages/imessage/src/remote/members.ts
@@ -1,0 +1,41 @@
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { AddMember, RemoveMember } from "@spectrum-ts/core";
+import { toChatGuid } from "./ids";
+
+/**
+ * Apply an `AddMember` content value to a remote iMessage group chat.
+ * Fire-and-forget — the `Chat` returned by `addParticipants` is discarded.
+ * The caller (`handleAddMember` in the iMessage provider) is responsible
+ * for the group-only / remote-only guards.
+ */
+export const addParticipants = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  content: AddMember
+): Promise<void> => {
+  await remote.groups.addParticipants(toChatGuid(spaceId), content.members);
+};
+
+/**
+ * Apply a `RemoveMember` content value to a remote iMessage group chat.
+ * Fire-and-forget — the `Chat` returned by `removeParticipants` is
+ * discarded.
+ */
+export const removeParticipants = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  content: RemoveMember
+): Promise<void> => {
+  await remote.groups.removeParticipants(toChatGuid(spaceId), content.members);
+};
+
+/**
+ * Make the agent's own account leave a remote iMessage group chat.
+ * Fire-and-forget.
+ */
+export const leaveGroup = async (
+  remote: AdvancedIMessage,
+  spaceId: string
+): Promise<void> => {
+  await remote.groups.leave(toChatGuid(spaceId));
+};

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -1,6 +1,7 @@
 import {
   type AdvancedIMessage,
   type CatchUpEvent,
+  type GroupEvent,
   type MessageEvent,
   type PollEvent,
   ValidationError,
@@ -24,6 +25,11 @@ import {
   SHARED_PHONE,
 } from "../types";
 import { getContactShareTracker } from "./contact-share";
+import {
+  groupEventActor,
+  groupEventMessageId,
+  toGroupEventMessages,
+} from "./group-events";
 import { toInboundMessages } from "./inbound";
 import { cachePollEvent, toPollDeltaMessages } from "./polls";
 import { toReactionMessages } from "./reactions";
@@ -34,11 +40,14 @@ import { toReactionMessages } from "./reactions";
 const isCursorRejectedIMessageError = (error: unknown): boolean =>
   error instanceof ValidationError;
 
-const streamLabel = (kind: "messages" | "polls", phone: string): string =>
+const streamLabel = (
+  kind: "messages" | "polls" | "groups",
+  phone: string
+): string =>
   `imessage.${kind}:${phone === SHARED_PHONE ? phone : sanitizePhone(phone)}`;
 
 const isEventFromCurrentAccount = (
-  event: Pick<MessageEvent | PollEvent, "actor" | "isFromMe">,
+  event: Pick<MessageEvent | PollEvent | GroupEvent, "actor" | "isFromMe">,
   phone: string
 ): boolean =>
   event.isFromMe ||
@@ -126,6 +135,28 @@ const toPollItem = async (
   };
 };
 
+const toGroupItem = async (
+  client: AdvancedIMessage,
+  event: GroupEvent,
+  phone: string,
+  cursor: string
+): Promise<ResumableStreamItem<IMessageMessage>> => {
+  const id = groupEventMessageId(event);
+  // Self-check against the acting party — for a leave that is the leaver
+  // (`event.actor` is often absent there), so the agent's own departure via
+  // `space.leave()` doesn't echo back as an inbound event.
+  const actor = groupEventActor(event);
+  if (isEventFromCurrentAccount({ actor, isFromMe: event.isFromMe }, phone)) {
+    return { cursor, id, values: [] };
+  }
+
+  return {
+    cursor,
+    id,
+    values: await toGroupEventMessages(client, event, phone),
+  };
+};
+
 const toCatchUpCompleteItem = (
   event: Extract<CatchUpEvent, { type: "catchup.complete" }>
 ): ResumableStreamItem<IMessageMessage> => ({
@@ -137,6 +168,7 @@ const toCatchUpCompleteItem = (
 type CatchUpCompleteEvent = Extract<CatchUpEvent, { type: "catchup.complete" }>;
 type MessageCatchUpEvent = MessageEvent | CatchUpCompleteEvent;
 type PollCatchUpEvent = PollEvent | CatchUpCompleteEvent;
+type GroupCatchUpEvent = GroupEvent | CatchUpCompleteEvent;
 
 const isMessageEvent = (event: CatchUpEvent): event is MessageEvent =>
   event.type.startsWith("message.");
@@ -144,7 +176,10 @@ const isMessageEvent = (event: CatchUpEvent): event is MessageEvent =>
 const isPollEvent = (event: CatchUpEvent): event is PollEvent =>
   event.type === "poll.changed";
 
-async function* catchUpEvents<T extends MessageEvent | PollEvent>(
+const isGroupEvent = (event: CatchUpEvent): event is GroupEvent =>
+  event.type === "group.changed";
+
+async function* catchUpEvents<T extends MessageEvent | PollEvent | GroupEvent>(
   client: AdvancedIMessage,
   cursor: string,
   isWanted: (event: CatchUpEvent) => event is T
@@ -174,9 +209,9 @@ const toResumeAfter = (cursor: string | undefined): number | undefined => {
 };
 
 async function* afterCursor(
-  stream: CloseableAsyncIterable<MessageEvent | PollEvent>,
+  stream: CloseableAsyncIterable<MessageEvent | PollEvent | GroupEvent>,
   cursor?: string
-): AsyncGenerator<MessageEvent | PollEvent> {
+): AsyncGenerator<MessageEvent | PollEvent | GroupEvent> {
   const resumeAfter = toResumeAfter(cursor);
   try {
     for await (const event of stream) {
@@ -190,7 +225,7 @@ async function* afterCursor(
   }
 }
 
-const withClose = <T extends MessageEvent | PollEvent>(
+const withClose = <T extends MessageEvent | PollEvent | GroupEvent>(
   source: CloseableAsyncIterable<T>,
   cursor?: string
 ): CloseableAsyncIterable<T> =>
@@ -248,6 +283,26 @@ const pollStream = (
       withClose(client.polls.subscribeEvents(), cursor),
   });
 
+const groupStream = (
+  client: AdvancedIMessage,
+  phone: string,
+  recover?: () => Promise<void>
+): ManagedStream<IMessageMessage> =>
+  resumableOrderedStream<GroupEvent, GroupCatchUpEvent, IMessageMessage>({
+    fetchMissed: (cursor) => catchUpEvents(client, cursor, isGroupEvent),
+    isCursorRejectedError: isCursorRejectedIMessageError,
+    label: streamLabel("groups", phone),
+    recover,
+    processLive: (event) =>
+      toGroupItem(client, event, phone, String(event.sequence)),
+    processMissed: (event) =>
+      event.type === "catchup.complete"
+        ? Promise.resolve(toCatchUpCompleteItem(event))
+        : toGroupItem(client, event, phone, String(event.sequence)),
+    subscribeLive: (cursor) =>
+      withClose(client.groups.subscribeEvents(), cursor),
+  });
+
 const clientStream = (
   client: AdvancedIMessage,
   pollCache: PollCache,
@@ -258,6 +313,7 @@ const clientStream = (
   mergeStreams([
     messageStream(client, phone, onInbound, recover),
     pollStream(client, pollCache, phone, recover),
+    groupStream(client, phone, recover),
   ]);
 
 export const messages = (

--- a/packages/imessage/test/membership.test.ts
+++ b/packages/imessage/test/membership.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import { IMessageSDK } from "@photon-ai/imessage-kit";
+import { addMember, leaveSpace, removeMember } from "@spectrum-ts/core";
+import { imessage } from "@/index";
+import {
+  addParticipants as remoteAddParticipants,
+  leaveGroup as remoteLeaveGroup,
+  removeParticipants as remoteRemoveParticipants,
+} from "@/remote/members";
+import { type RemoteClient, SHARED_PHONE } from "@/types";
+
+const LOCAL_MODE_ERROR = /local mode/;
+const GROUP_ONLY_ERROR = /only group chats/;
+const CREATE_GROUP_HINT = /space\.create/;
+
+const GROUP_GUID = "iMessage;+;chat42";
+const DM_GUID = "any;-;+15550123";
+
+const def = imessage.config({}).__definition;
+
+const ctx = {
+  config: {} as never,
+  store: undefined as never,
+};
+
+interface GroupsMock {
+  addParticipants?: (chat: string, addresses: string[]) => Promise<unknown>;
+  leave?: (chat: string) => Promise<void>;
+  removeParticipants?: (chat: string, addresses: string[]) => Promise<unknown>;
+}
+
+const clientWithGroups = (phone: string, groups: GroupsMock): RemoteClient => ({
+  phone,
+  client: { groups } as unknown as AdvancedIMessage,
+});
+
+describe("iMessage remote members wrappers", () => {
+  it("addParticipants forwards guid and members to groups.addParticipants", async () => {
+    const addParticipants = mock((_chat: string, _addresses: string[]) =>
+      Promise.resolve({ guid: GROUP_GUID })
+    );
+    const remote = {
+      groups: { addParticipants },
+    } as unknown as AdvancedIMessage;
+
+    await remoteAddParticipants(remote, GROUP_GUID, {
+      type: "addMember",
+      members: ["+15550111", "carol@example.com"],
+    });
+
+    expect(addParticipants).toHaveBeenCalledTimes(1);
+    expect(addParticipants).toHaveBeenCalledWith(GROUP_GUID, [
+      "+15550111",
+      "carol@example.com",
+    ]);
+  });
+
+  it("removeParticipants forwards guid and members to groups.removeParticipants", async () => {
+    const removeParticipants = mock((_chat: string, _addresses: string[]) =>
+      Promise.resolve({ guid: GROUP_GUID })
+    );
+    const remote = {
+      groups: { removeParticipants },
+    } as unknown as AdvancedIMessage;
+
+    await remoteRemoveParticipants(remote, GROUP_GUID, {
+      type: "removeMember",
+      members: ["+15550111"],
+    });
+
+    expect(removeParticipants).toHaveBeenCalledWith(GROUP_GUID, ["+15550111"]);
+  });
+
+  it("leaveGroup forwards the guid to groups.leave", async () => {
+    const leave = mock((_chat: string) => Promise.resolve());
+    const remote = { groups: { leave } } as unknown as AdvancedIMessage;
+
+    await remoteLeaveGroup(remote, GROUP_GUID);
+
+    expect(leave).toHaveBeenCalledWith(GROUP_GUID);
+  });
+});
+
+describe("iMessage send: membership dispatch", () => {
+  it("routes addMember to groups.addParticipants and is fire-and-forget", async () => {
+    const addParticipants = mock((_chat: string, _addresses: string[]) =>
+      Promise.resolve({ guid: GROUP_GUID })
+    );
+
+    const result = await def.send({
+      ...ctx,
+      client: [clientWithGroups(SHARED_PHONE, { addParticipants })],
+      space: { id: GROUP_GUID, type: "group", phone: SHARED_PHONE },
+      content: await addMember(["+15550111"]).build(),
+    });
+
+    expect(result).toBeUndefined();
+    expect(addParticipants).toHaveBeenCalledWith(GROUP_GUID, ["+15550111"]);
+  });
+
+  it("routes removeMember to groups.removeParticipants and is fire-and-forget", async () => {
+    const removeParticipants = mock((_chat: string, _addresses: string[]) =>
+      Promise.resolve({ guid: GROUP_GUID })
+    );
+
+    const result = await def.send({
+      ...ctx,
+      client: [clientWithGroups(SHARED_PHONE, { removeParticipants })],
+      space: { id: GROUP_GUID, type: "group", phone: SHARED_PHONE },
+      content: await removeMember("+15550111").build(),
+    });
+
+    expect(result).toBeUndefined();
+    expect(removeParticipants).toHaveBeenCalledWith(GROUP_GUID, ["+15550111"]);
+  });
+
+  it("routes leaveSpace to groups.leave and is fire-and-forget", async () => {
+    const leave = mock((_chat: string) => Promise.resolve());
+
+    const result = await def.send({
+      ...ctx,
+      client: [clientWithGroups(SHARED_PHONE, { leave })],
+      space: { id: GROUP_GUID, type: "group", phone: SHARED_PHONE },
+      content: await leaveSpace().build(),
+    });
+
+    expect(result).toBeUndefined();
+    expect(leave).toHaveBeenCalledWith(GROUP_GUID);
+  });
+
+  it("is unsupported in local mode for all three ops", async () => {
+    const localClient = Object.create(IMessageSDK.prototype) as IMessageSDK;
+    const space = { id: DM_GUID, type: "dm", phone: SHARED_PHONE } as const;
+
+    for (const content of [
+      await addMember("+15550111").build(),
+      await removeMember("+15550111").build(),
+      await leaveSpace().build(),
+    ]) {
+      await expect(
+        def.send({ ...ctx, client: localClient, space, content })
+      ).rejects.toThrow(LOCAL_MODE_ERROR);
+    }
+  });
+
+  it("rejects DMs for all three ops", async () => {
+    const client = [clientWithGroups(SHARED_PHONE, {})];
+    const space = { id: DM_GUID, type: "dm", phone: SHARED_PHONE } as const;
+
+    for (const content of [
+      await addMember("+15550111").build(),
+      await removeMember("+15550111").build(),
+      await leaveSpace().build(),
+    ]) {
+      await expect(
+        def.send({ ...ctx, client, space, content })
+      ).rejects.toThrow(GROUP_ONLY_ERROR);
+    }
+  });
+
+  it("points add/remove DM rejections at space.create", async () => {
+    const client = [clientWithGroups(SHARED_PHONE, {})];
+    const space = { id: DM_GUID, type: "dm", phone: SHARED_PHONE } as const;
+
+    for (const content of [
+      await addMember("+15550111").build(),
+      await removeMember("+15550111").build(),
+    ]) {
+      await expect(
+        def.send({ ...ctx, client, space, content })
+      ).rejects.toThrow(CREATE_GROUP_HINT);
+    }
+  });
+
+  it("routes by space.phone across multiple clients", async () => {
+    const wrongAdd = mock((_chat: string, _addresses: string[]) =>
+      Promise.resolve({ guid: GROUP_GUID })
+    );
+    const rightAdd = mock((_chat: string, _addresses: string[]) =>
+      Promise.resolve({ guid: GROUP_GUID })
+    );
+
+    await def.send({
+      ...ctx,
+      client: [
+        clientWithGroups("+15550100", { addParticipants: wrongAdd }),
+        clientWithGroups("+15550200", { addParticipants: rightAdd }),
+      ],
+      space: { id: GROUP_GUID, type: "group", phone: "+15550200" },
+      content: await addMember("+15550111").build(),
+    });
+
+    expect(wrongAdd).not.toHaveBeenCalled();
+    expect(rightAdd).toHaveBeenCalledWith(GROUP_GUID, ["+15550111"]);
+  });
+});

--- a/packages/imessage/test/read-actions.test.ts
+++ b/packages/imessage/test/read-actions.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it, mock } from "bun:test";
+import {
+  type AdvancedIMessage,
+  NotFoundError,
+} from "@photon-ai/advanced-imessage";
+import { IMessageSDK } from "@photon-ai/imessage-kit";
+import type { AvatarData } from "@spectrum-ts/core";
+import { imessage } from "@/index";
+import { getIcon as remoteGetIcon } from "@/remote/avatar";
+import {
+  type IMessageParticipant,
+  listParticipants as remoteListParticipants,
+} from "@/remote/members";
+import { type RemoteClient, SHARED_PHONE } from "@/types";
+
+const LOCAL_MODE_ERROR = /local mode/;
+const GROUP_ONLY_ERROR = /only group chats/;
+
+const GROUP_GUID = "iMessage;+;chat42";
+const DM_GUID = "any;-;+15550123";
+const SELF_PHONE = "+15550100";
+
+const PARTICIPANTS = [
+  { address: SELF_PHONE, service: "iMessage" },
+  { address: "+15550111", country: "US", service: "SMS" },
+  { address: "carol@example.com", service: "iMessage" },
+];
+
+const noIconError = () =>
+  new NotFoundError("group icon not found", {
+    code: "groupIconNotFound",
+    grpcCode: 5,
+    retryable: false,
+  });
+
+const def = imessage.config({}).__definition;
+const getMembersAction = def.actions?.getMembers;
+const getAvatarAction = def.actions?.getAvatar;
+if (!(getMembersAction && getAvatarAction)) {
+  throw new Error("iMessage must declare the getMembers/getAvatar actions");
+}
+
+const ctx = {
+  config: {} as never,
+  store: undefined as never,
+};
+
+interface TestSpace {
+  __platform: string;
+  id: string;
+  phone: string;
+  type: "dm" | "group";
+}
+
+// `__definition` erases action signatures to `InstanceActionFn`
+// (`Promise<unknown>`), so these helpers re-assert the concrete return types
+// the provider declares.
+const callGetMembers = (client: unknown, space: TestSpace) =>
+  getMembersAction({ ...ctx, client }, space) as Promise<
+    readonly IMessageParticipant[]
+  >;
+
+const callGetAvatar = (client: unknown, space: TestSpace) =>
+  getAvatarAction({ ...ctx, client }, space) as Promise<AvatarData | undefined>;
+
+interface ResourcesMock {
+  chats?: { get?: (chat: string) => Promise<unknown> };
+  groups?: { getIcon?: (chat: string) => Promise<unknown> };
+}
+
+const clientWith = (phone: string, resources: ResourcesMock): RemoteClient => ({
+  phone,
+  client: resources as unknown as AdvancedIMessage,
+});
+
+describe("iMessage remote read wrappers", () => {
+  it("listParticipants forwards the guid and filters the agent's own handle", async () => {
+    const get = mock((_chat: string) =>
+      Promise.resolve({ participants: PARTICIPANTS })
+    );
+    const remote = { chats: { get } } as unknown as AdvancedIMessage;
+
+    const members = await remoteListParticipants(
+      remote,
+      GROUP_GUID,
+      SELF_PHONE
+    );
+
+    expect(get).toHaveBeenCalledWith(GROUP_GUID);
+    expect(members).toEqual([
+      { id: "+15550111", address: "+15550111", country: "US", service: "SMS" },
+      {
+        id: "carol@example.com",
+        address: "carol@example.com",
+        country: undefined,
+        service: "iMessage",
+      },
+    ]);
+  });
+
+  it("getIcon copies bytes into a Buffer and maps groupIconNotFound to undefined", async () => {
+    const getIcon = mock((_chat: string) =>
+      Promise.resolve({
+        data: new Uint8Array([1, 2, 3]),
+        mimeType: "image/png",
+      })
+    );
+    const remote = { groups: { getIcon } } as unknown as AdvancedIMessage;
+
+    const icon = await remoteGetIcon(remote, GROUP_GUID);
+
+    expect(getIcon).toHaveBeenCalledWith(GROUP_GUID);
+    expect(icon?.mimeType).toBe("image/png");
+    expect(Buffer.isBuffer(icon?.data)).toBe(true);
+    expect(Array.from(icon?.data ?? [])).toEqual([1, 2, 3]);
+
+    const missing = {
+      groups: { getIcon: () => Promise.reject(noIconError()) },
+    } as unknown as AdvancedIMessage;
+    expect(await remoteGetIcon(missing, GROUP_GUID)).toBeUndefined();
+  });
+});
+
+describe("iMessage actions.getMembers", () => {
+  it("lists group participants, excluding the agent's own number", async () => {
+    const get = mock((_chat: string) =>
+      Promise.resolve({ participants: PARTICIPANTS })
+    );
+    const client = [clientWith(SELF_PHONE, { chats: { get } })];
+    const space = {
+      id: GROUP_GUID,
+      type: "group",
+      phone: SELF_PHONE,
+      __platform: "iMessage",
+    } as const;
+
+    const members = await callGetMembers(client, space);
+
+    expect(get).toHaveBeenCalledWith(GROUP_GUID);
+    expect(members.map((m) => m.id)).toEqual([
+      "+15550111",
+      "carol@example.com",
+    ]);
+  });
+
+  it("returns the full roster in shared mode (sentinel never matches)", async () => {
+    const get = mock((_chat: string) =>
+      Promise.resolve({ participants: PARTICIPANTS })
+    );
+    const client = [clientWith(SHARED_PHONE, { chats: { get } })];
+    const space = {
+      id: GROUP_GUID,
+      type: "group",
+      phone: SHARED_PHONE,
+      __platform: "iMessage",
+    } as const;
+
+    const members = await callGetMembers(client, space);
+
+    expect(members).toHaveLength(3);
+  });
+
+  it("is unsupported in local mode", async () => {
+    const localClient = Object.create(IMessageSDK.prototype) as IMessageSDK;
+    const space = {
+      id: GROUP_GUID,
+      type: "group",
+      phone: SHARED_PHONE,
+      __platform: "iMessage",
+    } as const;
+
+    await expect(callGetMembers(localClient, space)).rejects.toThrow(
+      LOCAL_MODE_ERROR
+    );
+  });
+
+  it("rejects DMs", async () => {
+    const client = [clientWith(SELF_PHONE, {})];
+    const space = {
+      id: DM_GUID,
+      type: "dm",
+      phone: SELF_PHONE,
+      __platform: "iMessage",
+    } as const;
+
+    await expect(callGetMembers(client, space)).rejects.toThrow(
+      GROUP_ONLY_ERROR
+    );
+  });
+
+  it("routes by space.phone across multiple clients", async () => {
+    const wrongGet = mock((_chat: string) =>
+      Promise.resolve({ participants: [] })
+    );
+    const rightGet = mock((_chat: string) =>
+      Promise.resolve({ participants: PARTICIPANTS })
+    );
+    const space = {
+      id: GROUP_GUID,
+      type: "group",
+      phone: "+15550200",
+      __platform: "iMessage",
+    } as const;
+
+    await callGetMembers(
+      [
+        clientWith(SELF_PHONE, { chats: { get: wrongGet } }),
+        clientWith("+15550200", { chats: { get: rightGet } }),
+      ],
+      space
+    );
+
+    expect(wrongGet).not.toHaveBeenCalled();
+    expect(rightGet).toHaveBeenCalledWith(GROUP_GUID);
+  });
+});
+
+describe("iMessage actions.getAvatar", () => {
+  it("downloads the group icon as Buffer + mimeType", async () => {
+    const getIcon = mock((_chat: string) =>
+      Promise.resolve({ data: new Uint8Array([9, 8]), mimeType: "image/heic" })
+    );
+    const client = [clientWith(SELF_PHONE, { groups: { getIcon } })];
+    const space = {
+      id: GROUP_GUID,
+      type: "group",
+      phone: SELF_PHONE,
+      __platform: "iMessage",
+    } as const;
+
+    const icon = await callGetAvatar(client, space);
+
+    expect(getIcon).toHaveBeenCalledWith(GROUP_GUID);
+    expect(icon?.mimeType).toBe("image/heic");
+    expect(Buffer.isBuffer(icon?.data)).toBe(true);
+    expect(Array.from(icon?.data ?? [])).toEqual([9, 8]);
+  });
+
+  it("resolves undefined when the group has no icon", async () => {
+    const client = [
+      clientWith(SELF_PHONE, {
+        groups: { getIcon: () => Promise.reject(noIconError()) },
+      }),
+    ];
+    const space = {
+      id: GROUP_GUID,
+      type: "group",
+      phone: SELF_PHONE,
+      __platform: "iMessage",
+    } as const;
+
+    expect(await callGetAvatar(client, space)).toBeUndefined();
+  });
+
+  it("propagates other NotFoundErrors (e.g. chatNotFound)", async () => {
+    const client = [
+      clientWith(SELF_PHONE, {
+        groups: {
+          getIcon: () =>
+            Promise.reject(
+              new NotFoundError("chat not found", {
+                code: "chatNotFound",
+                grpcCode: 5,
+                retryable: false,
+              })
+            ),
+        },
+      }),
+    ];
+    const space = {
+      id: GROUP_GUID,
+      type: "group",
+      phone: SELF_PHONE,
+      __platform: "iMessage",
+    } as const;
+
+    await expect(callGetAvatar(client, space)).rejects.toThrow(NotFoundError);
+  });
+
+  it("is unsupported in local mode", async () => {
+    const localClient = Object.create(IMessageSDK.prototype) as IMessageSDK;
+    const space = {
+      id: GROUP_GUID,
+      type: "group",
+      phone: SHARED_PHONE,
+      __platform: "iMessage",
+    } as const;
+
+    await expect(callGetAvatar(localClient, space)).rejects.toThrow(
+      LOCAL_MODE_ERROR
+    );
+  });
+
+  it("rejects DMs", async () => {
+    const client = [clientWith(SELF_PHONE, {})];
+    const space = {
+      id: DM_GUID,
+      type: "dm",
+      phone: SELF_PHONE,
+      __platform: "iMessage",
+    } as const;
+
+    await expect(callGetAvatar(client, space)).rejects.toThrow(
+      GROUP_ONLY_ERROR
+    );
+  });
+});

--- a/packages/imessage/test/remote/group-events.test.ts
+++ b/packages/imessage/test/remote/group-events.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, mock } from "bun:test";
+import type {
+  AdvancedIMessage,
+  GroupChange,
+  GroupEvent,
+  GroupIcon,
+} from "@photon-ai/advanced-imessage";
+import { NotFoundError } from "@photon-ai/advanced-imessage";
+import { toGroupEventMessages } from "@/remote/group-events";
+
+const OCCURRED_AT = new Date(1_700_000_000_000);
+const GROUP_GUID = "iMessage;+;chat123";
+const PHONE = "+15551234567";
+
+// Non-icon change kinds never touch the client.
+const NO_CLIENT = {} as AdvancedIMessage;
+
+const groupEvent = (
+  change: unknown,
+  overrides: Partial<GroupEvent> = {}
+): GroupEvent =>
+  ({
+    actor: { address: "actor@example.com" },
+    chatGuid: GROUP_GUID,
+    change: change as GroupChange,
+    isFromMe: false,
+    occurredAt: OCCURRED_AT,
+    sequence: 7,
+    type: "group.changed",
+    ...overrides,
+  }) as unknown as GroupEvent;
+
+const clientWithIcon = (getIcon: (chat: string) => Promise<GroupIcon>) => {
+  const getIconMock = mock(getIcon);
+  const client = {
+    groups: { getIcon: getIconMock },
+  } as unknown as AdvancedIMessage;
+  return { client, getIconMock };
+};
+
+describe("iMessage remote toGroupEventMessages", () => {
+  it("maps participantAdded to addMember with the actor as sender", async () => {
+    const messages = await toGroupEventMessages(
+      NO_CLIENT,
+      groupEvent(
+        {
+          type: "participantAdded",
+          participant: { address: "+15550100" },
+        },
+        {
+          actor: {
+            address: "+15557654321",
+            country: "ca",
+            service: "iMessage",
+          },
+        } as Partial<GroupEvent>
+      ),
+      PHONE
+    );
+
+    expect(messages).toHaveLength(1);
+    const message = messages[0];
+    expect(message?.id).toBe(`${GROUP_GUID}:group:7`);
+    expect(message?.content).toEqual({
+      type: "addMember",
+      members: ["+15550100"],
+    });
+    expect(message?.sender).toEqual({
+      id: "+15557654321",
+      address: "+15557654321",
+      country: "ca",
+      service: "iMessage",
+    });
+    expect(message?.space).toEqual({
+      id: GROUP_GUID,
+      type: "group",
+      phone: PHONE,
+    });
+    expect(message?.timestamp).toEqual(OCCURRED_AT);
+  });
+
+  it("maps participantRemoved to removeMember", async () => {
+    const messages = await toGroupEventMessages(
+      NO_CLIENT,
+      groupEvent({
+        type: "participantRemoved",
+        participant: { address: "+15550100" },
+      }),
+      PHONE
+    );
+
+    expect(messages[0]?.content).toEqual({
+      type: "removeMember",
+      members: ["+15550100"],
+    });
+    expect(messages[0]?.sender?.id).toBe("actor@example.com");
+  });
+
+  it("emits an actor-less membership change with sender undefined", async () => {
+    // Unlike reactions (dropped when actor-less — the actor is the
+    // substance), the membership change itself is the payload.
+    const messages = await toGroupEventMessages(
+      NO_CLIENT,
+      groupEvent(
+        { type: "participantAdded", participant: { address: "+15550100" } },
+        { actor: undefined }
+      ),
+      PHONE
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.content.type).toBe("addMember");
+    expect(messages[0]?.sender).toBeUndefined();
+  });
+
+  it("maps participantLeft to leaveSpace with the leaver as sender, ignoring the actor", async () => {
+    const messages = await toGroupEventMessages(
+      NO_CLIENT,
+      groupEvent(
+        { type: "participantLeft", participant: { address: "+15550100" } },
+        {
+          actor: { address: "someone-else@example.com" },
+        } as Partial<GroupEvent>
+      ),
+      PHONE
+    );
+
+    expect(messages[0]?.content).toEqual({ type: "leaveSpace" });
+    expect(messages[0]?.sender?.id).toBe("+15550100");
+  });
+
+  it("maps an actor-less participantLeft to the leaver", async () => {
+    const messages = await toGroupEventMessages(
+      NO_CLIENT,
+      groupEvent(
+        { type: "participantLeft", participant: { address: "+15550100" } },
+        { actor: undefined }
+      ),
+      PHONE
+    );
+
+    expect(messages[0]?.sender?.id).toBe("+15550100");
+  });
+
+  it("drops add/remove events whose participant has no address", async () => {
+    const messages = await toGroupEventMessages(
+      NO_CLIENT,
+      groupEvent({ type: "participantAdded", participant: {} }),
+      PHONE
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("maps displayNameChanged to rename and drops an empty name", async () => {
+    const renamed = await toGroupEventMessages(
+      NO_CLIENT,
+      groupEvent({ type: "displayNameChanged", displayName: "Ski Trip" }),
+      PHONE
+    );
+    expect(renamed[0]?.content).toEqual({
+      type: "rename",
+      displayName: "Ski Trip",
+    });
+
+    const cleared = await toGroupEventMessages(
+      NO_CLIENT,
+      groupEvent({ type: "displayNameChanged", displayName: "" }),
+      PHONE
+    );
+    expect(cleared).toEqual([]);
+  });
+
+  it("maps iconChanged to an avatar set carrying the fetched icon", async () => {
+    const { client, getIconMock } = clientWithIcon(() =>
+      Promise.resolve({
+        data: new TextEncoder().encode("icon-bytes"),
+        mimeType: "image/png",
+      })
+    );
+
+    const messages = await toGroupEventMessages(
+      client,
+      groupEvent({ type: "iconChanged" }),
+      PHONE
+    );
+
+    expect(getIconMock).toHaveBeenCalledWith(GROUP_GUID);
+    const content = messages[0]?.content;
+    expect(content?.type).toBe("avatar");
+    if (content?.type !== "avatar" || content.action.kind !== "set") {
+      throw new Error("expected an avatar set action");
+    }
+    expect(content.action.mimeType).toBe("image/png");
+    expect((await content.action.read()).toString()).toBe("icon-bytes");
+  });
+
+  it("drops iconChanged when the icon is already gone or the fetch fails", async () => {
+    const missing = clientWithIcon(() =>
+      Promise.reject(
+        new NotFoundError("no icon", {
+          code: "groupIconNotFound",
+          grpcCode: 5,
+          retryable: false,
+        })
+      )
+    );
+    expect(
+      await toGroupEventMessages(
+        missing.client,
+        groupEvent({ type: "iconChanged" }),
+        PHONE
+      )
+    ).toEqual([]);
+
+    const failing = clientWithIcon(() =>
+      Promise.reject(new Error("transport exploded"))
+    );
+    expect(
+      await toGroupEventMessages(
+        failing.client,
+        groupEvent({ type: "iconChanged" }),
+        PHONE
+      )
+    ).toEqual([]);
+  });
+
+  it("maps iconRemoved to an avatar clear without fetching", async () => {
+    const { client, getIconMock } = clientWithIcon(() =>
+      Promise.reject(new Error("must not be called"))
+    );
+
+    const messages = await toGroupEventMessages(
+      client,
+      groupEvent({ type: "iconRemoved" }),
+      PHONE
+    );
+
+    expect(getIconMock).not.toHaveBeenCalled();
+    expect(messages[0]?.content).toEqual({
+      type: "avatar",
+      action: { kind: "clear" },
+    });
+  });
+});

--- a/packages/telegram/src/outbound/send.ts
+++ b/packages/telegram/src/outbound/send.ts
@@ -185,6 +185,9 @@ export const send = async ({
     case "effect":
     case "rename":
     case "avatar":
+    case "addMember":
+    case "removeMember":
+    case "leaveSpace":
       throw UnsupportedError.content(content.type, TELEGRAM_PLATFORM);
     default:
       return await sendContent(client, space, content);


### PR DESCRIPTION
## Summary

Adds end-to-end group management to the framework and the iMessage provider, across three capability areas:

**1. Outbound membership management (universal content).** New `addMember()` / `removeMember()` / `leaveSpace()` content builders and their `space.add()` / `space.remove()` / `space.leave()` sugar. All fire-and-forget. `add`/`remove` accept a `User`, an id string, or an array of either; a batch lands in one provider call. Members are the same platform-handle format `space.create` accepts (E.164 or email) and reach the provider verbatim — no resolution step. iMessage is remote + group only; on a DM it throws `UnsupportedError` pointing the caller at `space.create` (a DM can't be converted into a group).

**2. Space reads.** Two new platform-wise actions alongside `getMessage`: `space.getMembers()` (the roster as `User[]`, agent's own account excluded, tagged with `__platform`) and `space.getAvatar()` (the group icon as `{ data: Buffer, mimeType }`, or `undefined` when none is set). Providers that don't implement them get a default that throws `UnsupportedError`. The platform instance also surfaces `im.getMembers(space)` / `im.getAvatar(space)`, returning the provider's raw records with typed extras (iMessage: `address` / `country` / `service`).

**3. Inbound group events (iMessage).** `group.changed` events surface on `app.messages` as inbound `Message`s carrying the *same* content types you send — what you send is what you observe when someone else does it. A new `groupStream` is merged into the stream and rides the durable catch-up log, so changes that happen while the app is down replay on reconnect. Semantics:
- `message.sender` is the acting user, or `undefined` when the platform recorded no actor. Unlike reactions (dropped when actor-less), a membership/rename/avatar change *is* the payload, so it still surfaces with `sender: undefined`.
- `participantLeft` maps to `leaveSpace` with the leaver as `sender` (distinct from a third-party `removeMember`).
- The agent's own actions never echo back (self-echo suppressed by the current-account check).
- Icon changes snapshot the icon eagerly at event time (one RPC); an icon already replaced/removed by fetch time is dropped, and the follow-up event carries the current state.

Supporting changes: `ProviderMessage.sender` is now optional (to carry actor-less system events); the Spectrum webhook `deserialize`s these content types (an avatar `set` arrives metadata-only — its `read()` throws and points at `space.getAvatar()`); Telegram explicitly rejects all three membership types with `UnsupportedError`.

## Usage

```ts
import { addMember, leaveSpace, removeMember } from "spectrum-ts";

// Manage members (sugar + canonical are equivalent)
await space.add(["+15551234567", "carol@example.com"]); // one batched call
await space.remove("+15551234567");
await space.leave();
await space.send(addMember("+15551234567"));

// Read current state — round-trips back into the setters
const members = await space.getMembers();
const icon = await space.getAvatar();
if (icon) {
  await otherGroup.avatar(icon.data, { mimeType: icon.mimeType });
}

// Observe changes others make
for await (const [space, message] of app.messages) {
  switch (message.content.type) {
    case "addMember":
      console.log(`${message.sender?.id ?? "someone"} added ${message.content.members.join(", ")}`);
      break;
    case "leaveSpace":
      console.log(`${message.sender?.id} left`);
      break;
  }
}
```

## Changes

**`packages/core`**
- `content/membership.ts` *(new)* — `addMember` / `removeMember` / `leaveSpace` schemas + builders; `MemberInput` and `User`→id normalization.
- `content/avatar.ts` — `AvatarData` type (`{ data, mimeType }`) for `getAvatar()`; bidirectional doc note.
- `content/types.ts` — membership schemas added to the base content union; comment on direction-agnostic discriminants.
- `content/edit.ts`, `content/reply.ts` — membership types cannot be wrapped by `edit()` / `reply()`.
- `types/space.ts` — `add` / `remove` / `leave` / `getMembers` / `getAvatar` on the `Space` interface.
- `platform/types.ts` — `getMembers` / `getAvatar` added to `PlatformWiseActions` + `PlatformWiseInstanceMethods`; new `ProviderUserRecord`; `ProviderMessage.sender` made optional.
- `platform/build.ts` — `getMembersImpl` / `getAvatarImpl`, the `add`/`remove`/`leave` sugar, and the new keys wired into `FIRE_AND_FORGET_TYPES`, `RESERVED_SPACE_KEYS`, `PLATFORM_WISE_ACTION_KEYS`.
- `webhook/deserialize.ts` — maps inbound `addMember` / `removeMember` / `leaveSpace` / `rename` / `avatar`; avatar `set` is metadata-only with a throwing `read()`.
- `authoring.ts`, `index.ts` — export the new schemas/types.

**`packages/imessage`**
- `src/remote/members.ts` *(new)* — `addParticipants` / `removeParticipants` / `leaveGroup` / `listParticipants` (filters the agent's own handle) + `IMessageParticipant`.
- `src/remote/group-events.ts` *(new)* — `group.changed` → inbound `Message`s; actor resolution, eager icon snapshot, forward-compat skip of unknown change kinds.
- `src/remote/avatar.ts` — `getIcon` (maps `groupIconNotFound` → `undefined`, copies bytes into a `Buffer`).
- `src/remote/stream.ts` — `groupStream` merged into the client stream with catch-up + self-echo suppression.
- `src/remote/api.ts`, `src/index.ts` — wire the send handlers (shared remote/group guard) and the `getMembers` / `getAvatar` actions.

**`packages/telegram`**
- `src/outbound/send.ts` — `addMember` / `removeMember` / `leaveSpace` throw `UnsupportedError`.

**`docs/`** — new `content/membership.mdx.vel`; updates to avatar, rename, messages, spaces-and-users, custom-platforms, the iMessage messaging-features / connection-and-routing pages, `nav.json`, and `content.mdx.vel`.

**Tests** — new `core/test/content/membership.test.ts`, `core/test/core/{platform-wise-reads,receive-membership,send-membership}.test.ts`, `imessage/test/{membership,read-actions}.test.ts`, `imessage/test/remote/group-events.test.ts`, plus `core/test/webhook/deserialize.test.ts` additions.

## Linear

ENG-1878

## Verification

Merged `main` (now v8.2.2) into the branch: resolved the `authoring.ts` export conflict (keep both `renameSchema` and main's `asReply`/`replySchema`) and migrated the 8 group-management test files from `bun:test` to Vitest to match main's ENG-1746 test-runner switch (#171). All numbers below are post-merge and re-verified under **both** runtimes CI exercises:

- [x] `bun run typecheck` — 12/12 packages pass
- [x] `@spectrum-ts/core` — 229 tests pass (27 files); Node (`vitest run`) + Bun (`bun --bun vitest run`)
- [x] `@spectrum-ts/imessage` — 148 tests pass (14 files); Node + Bun
- [x] `@spectrum-ts/telegram` — 86 tests pass (9 files); Node + Bun
- [x] `bunx ultracite check` on the changed files — clean

(The `fusor websocket streaming` tests that used to time out under `bun:test` now pass under Vitest, so the earlier flake caveat no longer applies.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added group membership operations (add/remove members, leave chat) plus APIs to list members and fetch group avatars where supported.
  * Introduced platform-wise `getMembers()`/`getAvatar()` and convenient `space.add(...)` / `space.remove(...)` / `space.leave()` dispatches.
* **Bug Fixes**
  * Improved inbound handling for membership, rename, and avatar events, including correct `sender` semantics and safer degradation when data is missing.
* **Documentation**
  * Updated guides for membership/avatar/group events and clarified local-mode and DM limitations.
* **Chores**
  * Extended Telegram to treat membership content types as unsupported (consistent errors).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->