### PR TITLE
ci(docs): dispatch docs build on docs changes

### DIFF
--- a/.github/workflows/dispatch-docs.yaml
+++ b/.github/workflows/dispatch-docs.yaml
@@ -1,0 +1,38 @@
+name: Dispatch Docs Build
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      # repository_dispatch to another repo needs a token with contents:write on
+      # the target; the default GITHUB_TOKEN cannot reach photon-hq/docs.
+      - name: Generate App token for docs
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: photon-hq
+          repositories: docs
+          # Least privilege: repository_dispatch needs contents:write + metadata:read.
+          permission-contents: write
+          permission-metadata: read
+
+      - name: Dispatch docs build
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/photon-hq/docs/dispatches \
+            --method POST \
+            -f event_type=spectrum-ts-docs
+          echo "Dispatched spectrum-ts-docs -> photon-hq/docs"


### PR DESCRIPTION
Refs ENG-1881

## Summary
- Add a source-repo workflow that runs on pushes to main when docs/** changes.
- Generate a GitHub App token scoped to photon-hq/docs and send repository_dispatch event_type=spectrum-ts-docs.
- Keep workflow_dispatch available for manual rebuilds.

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dispatch-docs.yaml")'

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/178"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785989904&installation_id=127326493&pr_number=178&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F178&signature=025e1abae6da69c948087f510bdadaa465507823c0e44130149e6cdb5ce392a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated docs build trigger for changes to documentation on the main branch.
  * Added a manual option to dispatch a docs build on demand.
  * Enabled secure cross-repository triggering for the docs site build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->