### PR TITLE
feat(imessage): support custom miniapp updates

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -131,7 +131,7 @@
       "name": "@spectrum-ts/imessage",
       "version": "9.0.0",
       "dependencies": {
-        "@photon-ai/advanced-imessage": "^0.12.0",
+        "@photon-ai/advanced-imessage": "^1.0.0",
         "@photon-ai/imessage-kit": "^3.0.0",
         "@photon-ai/otel": "^3.1.0",
         "lru-cache": "^11.0.0",
@@ -436,7 +436,7 @@
 
     "@parseaple/typedstream": ["@parseaple/typedstream@2.0.2", "", { "dependencies": { "@parseaple/bplist": "1.0.1" } }, "sha512-bzKNZjiBtZN2T2U7Nqq/hhv+EezkPnaWoB5WvPuBwNpQvOr3EI0XrDTkFnAzsA9DKdu57es/gcb1d2ctd1u8xw=="],
 
-    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@0.12.0", "", { "dependencies": { "@bufbuild/protobuf": "^2.11.0", "@grpc/grpc-js": "^1.12.6", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2" } }, "sha512-cqSq/ew48P3S+4xXpQmS/mDgpa+ijlKYKkQ4MExsQEjHfrJ0DpPJGuY5VHgzfTqV9wYVGyA3TNkDfse/ZRDxoA=="],
+    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@1.0.0", "", { "dependencies": { "@bufbuild/protobuf": "^2.11.0", "@grpc/grpc-js": "^1.12.6", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2" } }, "sha512-X5xaXy0SqPa9AuLxD0d/XI04e7WMO2rpXlT94TTMbtVkW0mTlb88fnp3SCwZKl/zEpCC3wQkuEfpNAM2Xgnyww=="],
 
     "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-GGDETlRbrPXP5eaRvswaead7MCBGQkm8f7d3aVbx8+rXhB4GEyPiw7Q1/yz5ix53rmxqKRevWywOfG7n+kZDBw=="],
 

--- a/packages/core/src/content/app.ts
+++ b/packages/core/src/content/app.ts
@@ -70,6 +70,9 @@ export const appSchema = z.object({
   type: z.literal("app"),
   url: urlAccessor,
   layout: layoutAccessor,
+  // Rendering hint for platforms with an installed app extension. Platforms
+  // without a live app surface ignore it and keep their existing URL fallback.
+  live: z.boolean().optional(),
 });
 
 export type App = z.infer<typeof appSchema>;
@@ -83,6 +86,12 @@ export type AppUrl =
   | string
   | Promise<string>
   | (() => string | Promise<string>);
+
+/** Optional rendering behavior for an app card. */
+export interface AppOptions {
+  /** Render the installed app extension's live UI when the platform supports it. */
+  live?: boolean;
+}
 
 const memoize = <T>(factory: () => Promise<T>): (() => Promise<T>) => {
   let cached: Promise<T> | undefined;
@@ -157,7 +166,7 @@ const buildLayout = (
  * across `url()` / `layout()`; fetch / parse failures resolve to a host-only
  * caption (no throw, no retry).
  */
-export const asApp = (url: AppUrl): App => {
+export const asApp = (url: AppUrl, options: AppOptions = {}): App => {
   const getUrl = resolveUrl(url);
   const getMetadata = memoize(async () => fetchLinkMetadata(await getUrl()));
   const getLayout = memoize(async (): Promise<AppLayout> => {
@@ -175,11 +184,22 @@ export const asApp = (url: AppUrl): App => {
     return buildLayout(metadata, resolvedUrl, image);
   });
 
-  return appSchema.parse({ type: "app", url: getUrl, layout: getLayout });
+  return appSchema.parse({
+    type: "app",
+    url: getUrl,
+    layout: getLayout,
+    ...options,
+  });
 };
 
-export function app(url: AppUrl): ContentBuilder {
+/**
+ * Construct an app card from a URL.
+ *
+ * Pass `{ live: true }` to ask supported platforms to render the installed
+ * app extension's live UI. Other platforms retain their normal URL fallback.
+ */
+export function app(url: AppUrl, options: AppOptions = {}): ContentBuilder {
   return {
-    build: async () => asApp(url),
+    build: async () => asApp(url, options),
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export {
   type App,
   type AppLayout,
+  type AppOptions,
   type AppUrl,
   app,
   appLayoutSchema,

--- a/packages/core/test/content/app.test.ts
+++ b/packages/core/test/content/app.test.ts
@@ -25,8 +25,11 @@ vi.doMock("@/utils/link-metadata", () => ({ fetchLinkMetadata, fetchImage }));
 
 const { app } = await import("@/content/app");
 
-const buildApp = async (url: Parameters<typeof app>[0]) => {
-  const content = await app(url).build();
+const buildApp = async (
+  url: Parameters<typeof app>[0],
+  options?: Parameters<typeof app>[1]
+) => {
+  const content = await app(url, options).build();
   if (content.type !== "app") {
     throw new Error(`expected app content, got ${content.type}`);
   }
@@ -51,6 +54,16 @@ describe("app content — consumable url", () => {
     expect(await content.url()).toBe("https://example.com/x");
     expect(await content.url()).toBe("https://example.com/x");
     expect(thunk).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports an optional live rendering hint", async () => {
+    const liveContent = await buildApp("https://example.com/live", {
+      live: true,
+    });
+    const defaultContent = await buildApp("https://example.com/default");
+
+    expect(liveContent.live).toBe(true);
+    expect(defaultContent).not.toHaveProperty("live");
   });
 });
 

--- a/packages/imessage/package.json
+++ b/packages/imessage/package.json
@@ -45,7 +45,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@photon-ai/advanced-imessage": "^0.12.0",
+    "@photon-ai/advanced-imessage": "^1.0.0",
     "@photon-ai/imessage-kit": "^3.0.0",
     "@photon-ai/otel": "^3.1.0",
     "lru-cache": "^11.0.0",

--- a/packages/imessage/src/content/customized-mini-app.ts
+++ b/packages/imessage/src/content/customized-mini-app.ts
@@ -36,6 +36,8 @@ export const customizedMiniAppSchema = z.object({
   extensionBundleId: z.string().nonempty(),
   // Visible card layout.
   layout: layoutSchema,
+  // Render with the installed extension's live UI when available.
+  live: z.boolean().optional(),
   // 10-character uppercase alphanumeric Apple Team ID.
   teamId: z.string(),
   // Absolute URL delivered to the installed extension on tap.
@@ -70,7 +72,8 @@ export const asCustomizedMiniApp = (
  * the recipient taps the card; the server constructs the matching
  * `MSMessageExtensionBalloonPlugin` plugin id from these values. `appStoreId`
  * is optional and only points recipients without the extension at its App
- * Store entry.
+ * Store entry. `live` is optional; when omitted, the remote server keeps the
+ * static layout preview visible.
  *
  * `space.send(customizedMiniApp(...))` is the canonical form.
  *

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -2,6 +2,7 @@ import {
   type AdvancedIMessage,
   createClient,
   MessageEffect,
+  type MiniAppCardSession,
 } from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
 import { withSpan } from "@photon-ai/otel";
@@ -82,6 +83,7 @@ import {
   stopTyping as remoteStopTyping,
   unsendMessage as remoteUnsendMessage,
   unsendReaction as remoteUnsendReaction,
+  updateCustomizedMiniApp as remoteUpdateCustomizedMiniApp,
 } from "./remote/api";
 import { toSpectrumMiniApp } from "./remote/app";
 import { getRemoteAttachment } from "./remote/attachments";
@@ -131,11 +133,72 @@ const cacheRemoteOutbound = <T extends ProviderMessageRecord | undefined>(
 
 const handleEdit = async (
   client: IMessageClient,
-  space: { id: string; phone: string },
+  space: { id: string; phone: string; type: "dm" | "group" },
   content: Edit
 ): Promise<void> => {
   if (isLocal(client)) {
     throw UnsupportedError.action("edit", "iMessage (local mode)");
+  }
+  const miniAppCardSession = (
+    content.target as unknown as { miniAppCardSession?: MiniAppCardSession }
+  ).miniAppCardSession;
+  const updateMiniAppCardSession = (
+    record: ProviderMessageRecord | undefined
+  ): void => {
+    const nextSession = record?.miniAppCardSession;
+    if (nextSession) {
+      (
+        content.target as unknown as {
+          miniAppCardSession?: MiniAppCardSession;
+        }
+      ).miniAppCardSession = nextSession as MiniAppCardSession;
+    }
+  };
+  if (content.content.type === "app") {
+    if (!miniAppCardSession) {
+      throw UnsupportedError.content(
+        "edit",
+        "iMessage",
+        "mini app card edits require a miniAppCardSession from the original send"
+      );
+    }
+    const url = await content.content.url();
+    const layout = await content.content.layout();
+    const remote = clientForPhone(client, space.phone);
+    const record = cacheRemoteOutbound(
+      remote,
+      space,
+      await remoteUpdateCustomizedMiniApp(
+        remote,
+        space.id,
+        miniAppCardSession,
+        toSpectrumMiniApp(url, layout)
+      )
+    );
+    updateMiniAppCardSession(record);
+    return;
+  }
+  if (isCustomizedMiniApp(content.content)) {
+    if (!miniAppCardSession) {
+      throw UnsupportedError.content(
+        "edit",
+        "iMessage",
+        "customized mini app card edits require a miniAppCardSession from the original send"
+      );
+    }
+    const remote = clientForPhone(client, space.phone);
+    const record = cacheRemoteOutbound(
+      remote,
+      space,
+      await remoteUpdateCustomizedMiniApp(
+        remote,
+        space.id,
+        miniAppCardSession,
+        content.content
+      )
+    );
+    updateMiniAppCardSession(record);
+    return;
   }
   if (content.content.type !== "text") {
     // Mirrors `remoteEditMessage`'s own check — surface as an

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -172,7 +172,7 @@ const handleEdit = async (
         remote,
         space.id,
         miniAppCardSession,
-        toSpectrumMiniApp(url, layout)
+        toSpectrumMiniApp(url, layout, content.content.live)
       )
     );
     updateMiniAppCardSession(record);
@@ -326,7 +326,7 @@ const handleApp = async (
     await remoteSendCustomizedMiniApp(
       remote,
       space.id,
-      toSpectrumMiniApp(url, layout)
+      toSpectrumMiniApp(url, layout, content.live)
     )
   );
 };

--- a/packages/imessage/src/remote/api.ts
+++ b/packages/imessage/src/remote/api.ts
@@ -1,4 +1,7 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type {
+  AdvancedIMessage,
+  MiniAppCardSession,
+} from "@photon-ai/advanced-imessage";
 import type {
   AddMember,
   Avatar,
@@ -17,7 +20,10 @@ import type { IMessageMessage, RemoteClient } from "../types";
 import { getIcon as getRemoteIcon, setIcon as setRemoteIcon } from "./avatar";
 import { setBackground as setRemoteBackground } from "./background";
 import { shareContactCard as shareRemoteContactCard } from "./contact-card";
-import { sendCustomizedMiniApp as sendRemoteCustomizedMiniApp } from "./customized-mini-app";
+import {
+  sendCustomizedMiniApp as sendRemoteCustomizedMiniApp,
+  updateCustomizedMiniApp as updateRemoteCustomizedMiniApp,
+} from "./customized-mini-app";
 import { getMessage as getRemoteMessage } from "./inbound";
 import {
   addParticipants as addRemoteParticipants,
@@ -62,6 +68,14 @@ export const sendCustomizedMiniApp = async (
   content: CustomizedMiniApp
 ): Promise<ProviderMessageRecord> =>
   sendRemoteCustomizedMiniApp(remote, spaceId, content);
+
+export const updateCustomizedMiniApp = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  session: MiniAppCardSession,
+  content: CustomizedMiniApp
+): Promise<ProviderMessageRecord> =>
+  updateRemoteCustomizedMiniApp(remote, spaceId, session, content);
 
 export const setDisplayName = async (
   remote: AdvancedIMessage,

--- a/packages/imessage/src/remote/app.ts
+++ b/packages/imessage/src/remote/app.ts
@@ -20,11 +20,17 @@ export const SPECTRUM_MINI_APP = {
 
 /**
  * Build the iMessage mini-app card for an `app` content: Spectrum's fixed
- * identity plus the per-message `url` and the `layout` already derived from the
- * URL's link metadata.
+ * identity plus the per-message `url`, optional live-rendering hint, and the
+ * `layout` already derived from the URL's link metadata.
  */
 export const toSpectrumMiniApp = (
   url: string,
-  layout: AppLayout
+  layout: AppLayout,
+  live?: boolean
 ): CustomizedMiniApp =>
-  asCustomizedMiniApp({ ...SPECTRUM_MINI_APP, url, layout });
+  asCustomizedMiniApp({
+    ...SPECTRUM_MINI_APP,
+    url,
+    layout,
+    ...(live === undefined ? {} : { live }),
+  });

--- a/packages/imessage/src/remote/customized-mini-app.ts
+++ b/packages/imessage/src/remote/customized-mini-app.ts
@@ -1,8 +1,25 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type {
+  AdvancedIMessage,
+  MiniAppCardSession,
+  MiniAppMessageResult,
+} from "@photon-ai/advanced-imessage";
 import type { Content } from "@spectrum-ts/core";
 import type { ProviderMessageRecord } from "@spectrum-ts/core/authoring";
 import type { CustomizedMiniApp } from "../content/customized-mini-app";
 import { toChatGuid } from "./ids";
+
+const toProviderRecord = (
+  result: MiniAppMessageResult,
+  content: CustomizedMiniApp,
+  spaceId: string
+): ProviderMessageRecord => ({
+  id: result.guid,
+  content: content as unknown as Content,
+  direction: "outbound",
+  miniAppCardSession: result.miniAppCardSession,
+  space: { id: spaceId },
+  timestamp: result.dateCreated,
+});
 
 /**
  * Send a `CustomizedMiniApp` card to a remote iMessage chat.
@@ -19,12 +36,19 @@ export const sendCustomizedMiniApp = async (
   content: CustomizedMiniApp
 ): Promise<ProviderMessageRecord> => {
   const chat = toChatGuid(spaceId);
-  const message = await remote.messages.sendCustomizedMiniApp(chat, content);
-  return {
-    id: message.guid,
-    content: content as unknown as Content,
-    direction: "outbound",
-    space: { id: spaceId },
-    timestamp: message.dateCreated,
-  };
+  const result = await remote.messages.sendCustomizedMiniApp(chat, content);
+  return toProviderRecord(result, content, spaceId);
+};
+
+export const updateCustomizedMiniApp = async (
+  remote: AdvancedIMessage,
+  spaceId: string,
+  session: MiniAppCardSession,
+  content: CustomizedMiniApp
+): Promise<ProviderMessageRecord> => {
+  const result = await remote.messages.updateCustomizedMiniApp(
+    session,
+    content
+  );
+  return toProviderRecord(result, content, spaceId);
 };

--- a/packages/imessage/src/types.ts
+++ b/packages/imessage/src/types.ts
@@ -58,6 +58,13 @@ export const spaceParamsSchema = z.object({
   phone: z.string().optional(),
 });
 
+const miniAppCardSessionSchema = z.object({
+  chatGuid: z.string(),
+  messageGuid: z.string(),
+  sessionId: z.string(),
+  targetMessageGuid: z.string(),
+});
+
 /**
  * iMessage-specific per-message metadata surfaced on `IMessageMessage`.
  * - `partIndex`: ordered part index within a multi-part message. Text and
@@ -65,8 +72,11 @@ export const spaceParamsSchema = z.object({
  *   messages; 0..N-1 for a group's sub-items).
  * - `parentId`: guid of the parent message for a group sub-item. Undefined
  *   when the message itself is the parent.
+ * - `miniAppCardSession`: stable handle returned by mini-app card sends and
+ *   updates. It is required to update the card in place later.
  */
 export const messageSchema = z.object({
+  miniAppCardSession: miniAppCardSessionSchema.optional(),
   partIndex: z.number().int().nonnegative().optional(),
   parentId: z.string().optional(),
 });
@@ -76,6 +86,7 @@ export type IMessageMessage = SchemaMessage<
   typeof spaceSchema
 > & {
   direction?: "inbound" | "outbound";
+  miniAppCardSession?: z.infer<typeof miniAppCardSessionSchema>;
   partIndex?: number;
   parentId?: string;
 };

--- a/packages/imessage/test/remote/app.test.ts
+++ b/packages/imessage/test/remote/app.test.ts
@@ -23,12 +23,14 @@ const MINI_APP_SESSION: MiniAppCardSession = {
 // network (the real `app()` would parse the layout from the URL).
 const appContent = (
   url: string,
-  layout: Record<string, unknown> = { caption: "Store", subcaption: "Hi" }
+  layout: Record<string, unknown> = { caption: "Store", subcaption: "Hi" },
+  live?: boolean
 ): Content =>
   ({
     type: "app",
     url: () => Promise.resolve(url),
     layout: () => Promise.resolve(layout),
+    ...(live === undefined ? {} : { live }),
   }) as unknown as Content;
 
 const def = imessage.config({}).__definition;
@@ -93,6 +95,27 @@ describe("iMessage send: app dispatch", () => {
     expect(record?.timestamp).toEqual(SENT_DATE);
   });
 
+  it("renders a live Spectrum mini-app card when requested", async () => {
+    const sendCustomizedMiniApp = vi.fn((_chat: string, _content: unknown) =>
+      Promise.resolve(miniAppResult())
+    );
+
+    await def.send({
+      ...ctx,
+      client: remoteClient({ sendCustomizedMiniApp }),
+      space: { id: "any;-;+15550123", type: "dm", phone: SHARED_PHONE },
+      content: appContent("https://x.example/live", { caption: "Live" }, true),
+    });
+
+    const [, sent] = sendCustomizedMiniApp.mock.calls[0] ?? [];
+    expect(sent).toMatchObject({
+      ...SPECTRUM_MINI_APP,
+      url: "https://x.example/live",
+      layout: { caption: "Live" },
+      live: true,
+    });
+  });
+
   it("updates a Spectrum mini-app card via edit(app(...), message)", async () => {
     const updatedSession = { ...MINI_APP_SESSION, sessionId: "session-2" };
     const updateCustomizedMiniApp = vi.fn(
@@ -114,7 +137,7 @@ describe("iMessage send: app dispatch", () => {
       content: {
         type: "edit",
         target: target as never,
-        content: appContent("https://x.example/2", { caption: "New" }),
+        content: appContent("https://x.example/2", { caption: "New" }, true),
       } as never,
     });
 
@@ -125,8 +148,8 @@ describe("iMessage send: app dispatch", () => {
       ...SPECTRUM_MINI_APP,
       url: "https://x.example/2",
       layout: { caption: "New" },
+      live: true,
     });
-    expect(sent).not.toHaveProperty("live");
     expect(target.miniAppCardSession).toEqual(updatedSession);
   });
 

--- a/packages/imessage/test/remote/app.test.ts
+++ b/packages/imessage/test/remote/app.test.ts
@@ -1,15 +1,23 @@
 import type {
   AdvancedIMessage,
-  Message as SDKMessage,
+  MiniAppCardSession,
+  MiniAppMessageResult,
 } from "@photon-ai/advanced-imessage";
 import { IMessageSDK } from "@photon-ai/imessage-kit";
 import type { Content } from "@spectrum-ts/core";
 import { describe, expect, it, vi } from "vitest";
+import { asCustomizedMiniApp } from "@/content/customized-mini-app";
 import { imessage } from "@/index";
 import { SPECTRUM_MINI_APP, toSpectrumMiniApp } from "@/remote/app";
 import { type RemoteClient, SHARED_PHONE } from "@/types";
 
 const SENT_DATE = new Date(1_700_000_000_000);
+const MINI_APP_SESSION: MiniAppCardSession = {
+  chatGuid: "any;-;+15550123",
+  messageGuid: "card-guid",
+  sessionId: "session-1",
+  targetMessageGuid: "target-guid",
+};
 
 // A minimal `app` content with stub accessors — keeps the dispatch test off the
 // network (the real `app()` would parse the layout from the URL).
@@ -26,13 +34,21 @@ const appContent = (
 const def = imessage.config({}).__definition;
 const ctx = { config: {} as never, store: undefined as never };
 
-const remoteClient = (
-  sendCustomizedMiniApp: (chat: string, content: unknown) => Promise<SDKMessage>
-): RemoteClient[] => [
+const miniAppResult = (
+  guid = "card-guid",
+  session: MiniAppCardSession = MINI_APP_SESSION
+): MiniAppMessageResult =>
+  ({
+    guid,
+    dateCreated: SENT_DATE,
+    miniAppCardSession: session,
+  }) as MiniAppMessageResult;
+
+const remoteClient = (messages: Record<string, unknown>): RemoteClient[] => [
   {
     phone: SHARED_PHONE,
     client: {
-      messages: { sendCustomizedMiniApp },
+      messages,
     } as unknown as AdvancedIMessage,
   },
 ];
@@ -53,15 +69,12 @@ describe("toSpectrumMiniApp", () => {
 describe("iMessage send: app dispatch", () => {
   it("renders a Spectrum mini-app card on remote", async () => {
     const sendCustomizedMiniApp = vi.fn((_chat: string, _content: unknown) =>
-      Promise.resolve({
-        guid: "card-guid",
-        dateCreated: SENT_DATE,
-      } as unknown as SDKMessage)
+      Promise.resolve(miniAppResult())
     );
 
     const record = await def.send({
       ...ctx,
-      client: remoteClient(sendCustomizedMiniApp),
+      client: remoteClient({ sendCustomizedMiniApp }),
       space: { id: "any;-;+15550123", type: "dm", phone: SHARED_PHONE },
       content: appContent("https://x.example/1"),
     });
@@ -74,8 +87,116 @@ describe("iMessage send: app dispatch", () => {
       url: "https://x.example/1",
       layout: { caption: "Store", subcaption: "Hi" },
     });
+    expect(sent).not.toHaveProperty("live");
     expect(record?.id).toBe("card-guid");
+    expect(record?.miniAppCardSession).toEqual(MINI_APP_SESSION);
     expect(record?.timestamp).toEqual(SENT_DATE);
+  });
+
+  it("updates a Spectrum mini-app card via edit(app(...), message)", async () => {
+    const updatedSession = { ...MINI_APP_SESSION, sessionId: "session-2" };
+    const updateCustomizedMiniApp = vi.fn(
+      (_session: MiniAppCardSession, _content: unknown) =>
+        Promise.resolve(miniAppResult("updated-guid", updatedSession))
+    );
+    const target = {
+      id: "card-guid",
+      content: appContent("https://x.example/1"),
+      direction: "outbound",
+      miniAppCardSession: MINI_APP_SESSION,
+      space: { id: "any;-;+15550123", type: "dm", phone: SHARED_PHONE },
+    };
+
+    await def.send({
+      ...ctx,
+      client: remoteClient({ updateCustomizedMiniApp }),
+      space: { id: "any;-;+15550123", type: "dm", phone: SHARED_PHONE },
+      content: {
+        type: "edit",
+        target: target as never,
+        content: appContent("https://x.example/2", { caption: "New" }),
+      } as never,
+    });
+
+    expect(updateCustomizedMiniApp).toHaveBeenCalledTimes(1);
+    const [session, sent] = updateCustomizedMiniApp.mock.calls[0] ?? [];
+    expect(session).toEqual(MINI_APP_SESSION);
+    expect(sent).toMatchObject({
+      ...SPECTRUM_MINI_APP,
+      url: "https://x.example/2",
+      layout: { caption: "New" },
+    });
+    expect(sent).not.toHaveProperty("live");
+    expect(target.miniAppCardSession).toEqual(updatedSession);
+  });
+
+  it("updates a customized mini-app card via edit(customizedMiniApp(...), message)", async () => {
+    const updatedSession = { ...MINI_APP_SESSION, messageGuid: "updated-guid" };
+    const updateCustomizedMiniApp = vi.fn(
+      (_session: MiniAppCardSession, _content: unknown) =>
+        Promise.resolve(miniAppResult("updated-guid", updatedSession))
+    );
+    const card = asCustomizedMiniApp({
+      appName: "Other",
+      extensionBundleId: "com.example.Messages",
+      layout: { caption: "Updated" },
+      live: true,
+      teamId: "ABCDE12345",
+      url: "https://x.example/custom",
+    });
+    const target = {
+      id: "card-guid",
+      content: card,
+      direction: "outbound",
+      miniAppCardSession: MINI_APP_SESSION,
+      space: { id: "any;-;+15550123", type: "dm", phone: SHARED_PHONE },
+    };
+
+    await def.send({
+      ...ctx,
+      client: remoteClient({ updateCustomizedMiniApp }),
+      space: { id: "any;-;+15550123", type: "dm", phone: SHARED_PHONE },
+      content: {
+        type: "edit",
+        target: target as never,
+        content: card,
+      } as never,
+    });
+
+    expect(updateCustomizedMiniApp).toHaveBeenCalledTimes(1);
+    const [session, sent] = updateCustomizedMiniApp.mock.calls[0] ?? [];
+    expect(session).toEqual(MINI_APP_SESSION);
+    expect(sent).toEqual(card);
+    expect(sent).toMatchObject({ live: true });
+    expect(target.miniAppCardSession).toEqual(updatedSession);
+  });
+
+  it("sends a customized mini-app card with live preserved", async () => {
+    const sendCustomizedMiniApp = vi.fn((_chat: string, _content: unknown) =>
+      Promise.resolve(miniAppResult())
+    );
+    const card = asCustomizedMiniApp({
+      appName: "Other",
+      extensionBundleId: "com.example.Messages",
+      layout: { caption: "Live Card" },
+      live: true,
+      teamId: "ABCDE12345",
+      url: "https://x.example/custom-live",
+    });
+
+    const record = await def.send({
+      ...ctx,
+      client: remoteClient({ sendCustomizedMiniApp }),
+      space: { id: "any;-;+15550123", type: "dm", phone: SHARED_PHONE },
+      content: card as never,
+    });
+
+    expect(sendCustomizedMiniApp).toHaveBeenCalledTimes(1);
+    const [chat, sent] = sendCustomizedMiniApp.mock.calls[0] ?? [];
+    expect(chat).toBe("any;-;+15550123");
+    expect(sent).toEqual(card);
+    expect(sent).toMatchObject({ live: true });
+    expect(record?.miniAppCardSession).toEqual(MINI_APP_SESSION);
   });
 
   it("degrades to a bare-url text message in local mode", async () => {


### PR DESCRIPTION
## Summary
- upgrade the iMessage provider to @photon-ai/advanced-imessage 1.0.0
- preserve mini app card sessions on outbound records
- support editing Spectrum app cards and customized mini app cards through the custom miniapp update API
- pass through the customized mini app live flag

## Tests
- bun --filter @spectrum-ts/imessage typecheck
- bun --filter @spectrum-ts/imessage test:bun
- real spectrum-ts iMessage send/update test against local signed advanced-imessage-server on 127.0.0.1:50167

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786007818&installation_id=127326493&pr_number=179&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F179&signature=b84858dc9403f2d9508047f4e227c04a9992308a338b7e21a413364f2f787556"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for updating iMessage mini-app cards after they’ve been sent (including card-session aware edits).
  * Mini-app cards can now include an optional `live` rendering hint for both app and customized mini-app content.
* **Bug Fixes**
  * Improved mini-app card edit handling to apply updates reliably while preserving the latest session details.
  * Ensured edit payloads and returned records remain consistent for live and non-live mini-apps.
* **Chores**
  * Updated the iMessage integration dependency to a newer major version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->