### PR TITLE
feat - space.getDisplayName() (ENG-1926)

### DIFF
--- a/packages/core/src/platform/build.ts
+++ b/packages/core/src/platform/build.ts
@@ -84,6 +84,7 @@ const RESERVED_SPACE_KEYS: ReadonlySet<string> = new Set([
   "getMessage",
   "getMembers",
   "getAvatar",
+  "getDisplayName",
   "rename",
   "avatar",
   "add",
@@ -106,6 +107,7 @@ export const PLATFORM_WISE_ACTION_KEYS: ReadonlySet<PlatformWiseActionKey> =
     "getMessage",
     "getMembers",
     "getAvatar",
+    "getDisplayName",
   ] satisfies readonly PlatformWiseActionKey[]);
 
 // Reserved keys on `Message` — platform-defined `message.actions` entries
@@ -789,6 +791,28 @@ export function buildSpace(params: BuildSpaceParams): Space {
     );
   }
 
+  async function getDisplayNameImpl(): Promise<string | undefined> {
+    const getDisplayName = definition.actions?.getDisplayName;
+    if (!getDisplayName) {
+      // Default behavior when the provider hasn't implemented the
+      // platform-wise `getDisplayName` action: throw `UnsupportedError`.
+      // Mirrors the same default the `PlatformInstance` wires for
+      // `im.getDisplayName`.
+      throw UnsupportedError.action("getDisplayName", definition.name);
+    }
+    return withSpan(
+      "spectrum.space.displayName.get",
+      {
+        "spectrum.provider": definition.name,
+        "spectrum.space.id": (spaceRef as { id?: string }).id,
+      },
+      async () =>
+        (await getDisplayName({ client, config, store }, spaceRef)) as
+          | string
+          | undefined
+    );
+  }
+
   // Platform-defined sugar methods declared via `PlatformDef.space.actions`.
   // Each factory becomes `space.<name>(...args) = space.send(factory(...args))`.
   // Spread order is load-bearing: actions go *after* `extras`/`spaceRef`
@@ -850,6 +874,7 @@ export function buildSpace(params: BuildSpaceParams): Space {
     getMessage: getMessageImpl,
     getMembers: getMembersImpl,
     getAvatar: getAvatarImpl,
+    getDisplayName: getDisplayNameImpl,
     rename: async (displayName: string): Promise<void> => {
       // Sugar for `space.send(rename(displayName))`. Fire-and-forget; the
       // (always-undefined) result is discarded. Per-platform support and

--- a/packages/core/src/platform/types.ts
+++ b/packages/core/src/platform/types.ts
@@ -100,6 +100,10 @@ export interface PlatformWiseActions<
     ctx: { client: _Client; config: _Config; store: Store },
     space: _ResolvedSpace & { id: string; __platform: string }
   ) => Promise<AvatarData | undefined>;
+  getDisplayName: (
+    ctx: { client: _Client; config: _Config; store: Store },
+    space: _ResolvedSpace & { id: string; __platform: string }
+  ) => Promise<string | undefined>;
   getMembers: (
     ctx: { client: _Client; config: _Config; store: Store },
     space: _ResolvedSpace & { id: string; __platform: string }
@@ -826,6 +830,7 @@ export type InstanceActionMethods<Def extends AnyPlatformDef> = {
 // framework-normalized path.
 export interface PlatformWiseInstanceMethods<Def extends AnyPlatformDef> {
   getAvatar: (space: PlatformSpace<Def>) => Promise<AvatarData | undefined>;
+  getDisplayName: (space: PlatformSpace<Def>) => Promise<string | undefined>;
   getMembers: (space: PlatformSpace<Def>) => Promise<PlatformUser<Def>[]>;
   getMessage: (
     space: PlatformSpace<Def>,

--- a/packages/core/src/types/space.ts
+++ b/packages/core/src/types/space.ts
@@ -52,6 +52,16 @@ export interface Space<_Def = unknown> {
    */
   getAvatar(): Promise<AvatarData | undefined>;
   /**
+   * Read the current chat's display name (group/chat title). Resolves
+   * `undefined` when the chat has none — an unnamed group, or a 1:1 chat on a
+   * platform that stores no title for DMs. Round-trips into `space.rename()`.
+   *
+   * Universal API; unlike `rename` the read is not group-only. Per-platform
+   * constraints (e.g. iMessage: remote only) surface as `UnsupportedError`, as
+   * do platforms with no implementation.
+   */
+  getDisplayName(): Promise<string | undefined>;
+  /**
    * List the chat's current participants, excluding the agent's own account
    * where the platform can identify it. Each entry is a `User` tagged with
    * `__platform`; `id` is the user's canonical platform handle (the same

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -62,6 +62,7 @@ import {
 import {
   addParticipants as remoteAddParticipants,
   editMessage as remoteEditMessage,
+  getDisplayName as remoteGetDisplayName,
   getIcon as remoteGetIcon,
   getMessage as remoteGetMessage,
   leaveGroup as remoteLeaveGroup,
@@ -786,6 +787,19 @@ export const imessage = definePlatform("iMessage", {
         local: "fetching group avatars requires remote iMessage",
       });
       return await remoteGetIcon(remote, space.id);
+    },
+    // Read a chat's title; works for DMs too (unlike the group-only `rename`
+    // setter), which just resolve `undefined`. Remote only.
+    getDisplayName: async ({ client }, space) => {
+      if (isLocal(client)) {
+        throw UnsupportedError.action(
+          "getDisplayName",
+          "iMessage (local mode)",
+          "reading chat display names requires remote iMessage"
+        );
+      }
+      const remote = clientForPhone(client, space.phone);
+      return await remoteGetDisplayName(remote, space.id);
     },
     // Fetch an attachment by GUID. Returns a spectrum `Attachment` whose
     // `.read()` / `.stream()` lazily download the bytes — calling both

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -788,17 +788,13 @@ export const imessage = definePlatform("iMessage", {
       });
       return await remoteGetIcon(remote, space.id);
     },
-    // Read a chat's title; works for DMs too (unlike the group-only `rename`
-    // setter), which just resolve `undefined`. Remote only.
+    // Read a group chat's title. Group-only, remote only — mirrors the other
+    // group reads (`getAvatar`, `getMembers`) via `remoteGroupClient`.
     getDisplayName: async ({ client }, space) => {
-      if (isLocal(client)) {
-        throw UnsupportedError.action(
-          "getDisplayName",
-          "iMessage (local mode)",
-          "reading chat display names requires remote iMessage"
-        );
-      }
-      const remote = clientForPhone(client, space.phone);
+      const remote = remoteGroupClient(client, space, "getDisplayName", {
+        dm: "only group chats have display names (this space is a DM)",
+        local: "reading chat display names requires remote iMessage",
+      });
       return await remoteGetDisplayName(remote, space.id);
     },
     // Fetch an attachment by GUID. Returns a spectrum `Attachment` whose

--- a/packages/imessage/src/remote/api.ts
+++ b/packages/imessage/src/remote/api.ts
@@ -31,7 +31,10 @@ import {
   unsendReaction as unsendRemoteReaction,
 } from "./reactions";
 import { markRead as markRemoteRead } from "./read";
-import { setDisplayName as setRemoteDisplayName } from "./rename";
+import {
+  getDisplayName as getRemoteDisplayName,
+  setDisplayName as setRemoteDisplayName,
+} from "./rename";
 import {
   editMessage as editRemoteMessage,
   replyToMessage as replyToRemoteMessage,
@@ -68,6 +71,11 @@ export const setDisplayName = async (
   spaceId: string,
   content: Rename
 ): Promise<void> => setRemoteDisplayName(remote, spaceId, content);
+
+export const getDisplayName = async (
+  remote: AdvancedIMessage,
+  spaceId: string
+): Promise<string | undefined> => getRemoteDisplayName(remote, spaceId);
 
 export const addParticipants = async (
   remote: AdvancedIMessage,

--- a/packages/imessage/src/remote/rename.ts
+++ b/packages/imessage/src/remote/rename.ts
@@ -13,3 +13,16 @@ export const setDisplayName = async (
 ): Promise<void> => {
   await remote.groups.setDisplayName(toChatGuid(spaceId), content.displayName);
 };
+
+/**
+ * Read a remote iMessage chat's title. The SDK returns an empty
+ * `Chat.displayName` for an unnamed group or a 1:1 chat; normalized to
+ * `undefined`. Works for groups and DMs alike.
+ */
+export const getDisplayName = async (
+  remote: AdvancedIMessage,
+  spaceId: string
+): Promise<string | undefined> => {
+  const { displayName } = await remote.chats.get(toChatGuid(spaceId));
+  return displayName || undefined;
+};

--- a/packages/imessage/src/remote/rename.ts
+++ b/packages/imessage/src/remote/rename.ts
@@ -15,9 +15,9 @@ export const setDisplayName = async (
 };
 
 /**
- * Read a remote iMessage chat's title. The SDK returns an empty
- * `Chat.displayName` for an unnamed group or a 1:1 chat; normalized to
- * `undefined`. Works for groups and DMs alike.
+ * Read a remote iMessage group chat's title. The SDK returns an empty
+ * `Chat.displayName` for an unnamed group; normalized to `undefined`. The
+ * group-only guard lives at the action layer (see `remoteGroupClient`).
  */
 export const getDisplayName = async (
   remote: AdvancedIMessage,

--- a/packages/imessage/test/read-actions.test.ts
+++ b/packages/imessage/test/read-actions.test.ts
@@ -377,7 +377,7 @@ describe("iMessage actions.getDisplayName", () => {
     );
   });
 
-  it("works for a 1:1 chat (unlike the group-only reads), resolving undefined when the DM has no title", async () => {
+  it("is unsupported for a 1:1 chat (group-only, like the other group reads)", async () => {
     const get = vi.fn((_chat: string) =>
       Promise.resolve({ displayName: "", participants: [] })
     );
@@ -389,7 +389,9 @@ describe("iMessage actions.getDisplayName", () => {
       __platform: "iMessage",
     } as const;
 
-    expect(await callGetDisplayName(client, space)).toBeUndefined();
-    expect(get).toHaveBeenCalledWith(DM_GUID);
+    await expect(callGetDisplayName(client, space)).rejects.toThrow(
+      GROUP_ONLY_ERROR
+    );
+    expect(get).not.toHaveBeenCalled();
   });
 });

--- a/packages/imessage/test/read-actions.test.ts
+++ b/packages/imessage/test/read-actions.test.ts
@@ -11,6 +11,7 @@ import {
   type IMessageParticipant,
   listParticipants as remoteListParticipants,
 } from "@/remote/members";
+import { getDisplayName as remoteGetDisplayName } from "@/remote/rename";
 import { type RemoteClient, SHARED_PHONE } from "@/types";
 
 const LOCAL_MODE_ERROR = /local mode/;
@@ -36,8 +37,11 @@ const noIconError = () =>
 const def = imessage.config({}).__definition;
 const getMembersAction = def.actions?.getMembers;
 const getAvatarAction = def.actions?.getAvatar;
-if (!(getMembersAction && getAvatarAction)) {
-  throw new Error("iMessage must declare the getMembers/getAvatar actions");
+const getDisplayNameAction = def.actions?.getDisplayName;
+if (!(getMembersAction && getAvatarAction && getDisplayNameAction)) {
+  throw new Error(
+    "iMessage must declare the getMembers/getAvatar/getDisplayName actions"
+  );
 }
 
 const ctx = {
@@ -62,6 +66,11 @@ const callGetMembers = (client: unknown, space: TestSpace) =>
 
 const callGetAvatar = (client: unknown, space: TestSpace) =>
   getAvatarAction({ ...ctx, client }, space) as Promise<AvatarData | undefined>;
+
+const callGetDisplayName = (client: unknown, space: TestSpace) =>
+  getDisplayNameAction({ ...ctx, client }, space) as Promise<
+    string | undefined
+  >;
 
 interface ResourcesMock {
   chats?: { get?: (chat: string) => Promise<unknown> };
@@ -118,6 +127,21 @@ describe("iMessage remote read wrappers", () => {
       groups: { getIcon: () => Promise.reject(noIconError()) },
     } as unknown as AdvancedIMessage;
     expect(await remoteGetIcon(missing, GROUP_GUID)).toBeUndefined();
+  });
+
+  it("getDisplayName forwards the guid and normalizes an empty name to undefined", async () => {
+    const get = vi.fn((_chat: string) =>
+      Promise.resolve({ displayName: "Team Chat", participants: PARTICIPANTS })
+    );
+    const remote = { chats: { get } } as unknown as AdvancedIMessage;
+
+    expect(await remoteGetDisplayName(remote, GROUP_GUID)).toBe("Team Chat");
+    expect(get).toHaveBeenCalledWith(GROUP_GUID);
+
+    const unnamed = {
+      chats: { get: () => Promise.resolve({ displayName: "" }) },
+    } as unknown as AdvancedIMessage;
+    expect(await remoteGetDisplayName(unnamed, GROUP_GUID)).toBeUndefined();
   });
 });
 
@@ -303,5 +327,69 @@ describe("iMessage actions.getAvatar", () => {
     await expect(callGetAvatar(client, space)).rejects.toThrow(
       GROUP_ONLY_ERROR
     );
+  });
+});
+
+describe("iMessage actions.getDisplayName", () => {
+  it("returns the group's current display name", async () => {
+    const get = vi.fn((_chat: string) =>
+      Promise.resolve({ displayName: "Team Chat", participants: PARTICIPANTS })
+    );
+    const client = [clientWith(SELF_PHONE, { chats: { get } })];
+    const space = {
+      id: GROUP_GUID,
+      type: "group",
+      phone: SELF_PHONE,
+      __platform: "iMessage",
+    } as const;
+
+    expect(await callGetDisplayName(client, space)).toBe("Team Chat");
+    expect(get).toHaveBeenCalledWith(GROUP_GUID);
+  });
+
+  it("resolves undefined for an unnamed group", async () => {
+    const client = [
+      clientWith(SELF_PHONE, {
+        chats: { get: () => Promise.resolve({ displayName: "" }) },
+      }),
+    ];
+    const space = {
+      id: GROUP_GUID,
+      type: "group",
+      phone: SELF_PHONE,
+      __platform: "iMessage",
+    } as const;
+
+    expect(await callGetDisplayName(client, space)).toBeUndefined();
+  });
+
+  it("is unsupported in local mode", async () => {
+    const localClient = Object.create(IMessageSDK.prototype) as IMessageSDK;
+    const space = {
+      id: GROUP_GUID,
+      type: "group",
+      phone: SHARED_PHONE,
+      __platform: "iMessage",
+    } as const;
+
+    await expect(callGetDisplayName(localClient, space)).rejects.toThrow(
+      LOCAL_MODE_ERROR
+    );
+  });
+
+  it("works for a 1:1 chat (unlike the group-only reads), resolving undefined when the DM has no title", async () => {
+    const get = vi.fn((_chat: string) =>
+      Promise.resolve({ displayName: "", participants: [] })
+    );
+    const client = [clientWith(SELF_PHONE, { chats: { get } })];
+    const space = {
+      id: DM_GUID,
+      type: "dm",
+      phone: SELF_PHONE,
+      __platform: "iMessage",
+    } as const;
+
+    expect(await callGetDisplayName(client, space)).toBeUndefined();
+    expect(get).toHaveBeenCalledWith(DM_GUID);
   });
 });

--- a/packages/telegram/src/client.ts
+++ b/packages/telegram/src/client.ts
@@ -140,9 +140,7 @@ interface ChatEnvelope {
 
 /**
  * A chat's `title` via `getChat`. Only groups/supergroups/channels have one;
- * private chats return a name instead, so those resolve `undefined`. Uses the
- * low-level `client.post` (like `executeSpec`) to skip photon's strict
- * `ChatFullInfo` validation — we only read `title`.
+ * private chats return a name instead, so those resolve `undefined`.
  */
 export const getChatDisplayName = async (
   config: TelegramConfig,

--- a/packages/telegram/src/client.ts
+++ b/packages/telegram/src/client.ts
@@ -133,3 +133,26 @@ export const downloadFile = async (
   }
   return Buffer.from(await res.arrayBuffer());
 };
+
+interface ChatEnvelope {
+  result?: { title?: string };
+}
+
+/**
+ * A chat's `title` via `getChat`. Only groups/supergroups/channels have one;
+ * private chats return a name instead, so those resolve `undefined`. Uses the
+ * low-level `client.post` (like `executeSpec`) to skip photon's strict
+ * `ChatFullInfo` validation — we only read `title`.
+ */
+export const getChatDisplayName = async (
+  config: TelegramConfig,
+  chatId: string
+): Promise<string | undefined> => {
+  const client = telegramClient(config);
+  const res = await client.post({
+    body: { chat_id: chatId },
+    throwOnError: true,
+    url: "/getChat",
+  });
+  return (res.data as ChatEnvelope).result?.title ?? undefined;
+};

--- a/packages/telegram/src/index.ts
+++ b/packages/telegram/src/index.ts
@@ -1,4 +1,5 @@
 import { definePlatform, type FusorClient, fusor } from "@spectrum-ts/core";
+import { getChatDisplayName } from "./client";
 import { configSchema, TELEGRAM_PLATFORM } from "./config";
 import { handleMessages } from "./inbound/messages";
 import { send } from "./outbound/send";
@@ -42,6 +43,10 @@ export const telegram = definePlatform(TELEGRAM_PLATFORM, {
   },
   user: { resolve: resolveUser },
   space: { create: createSpace },
+  actions: {
+    getDisplayName: async ({ config }, space) =>
+      await getChatDisplayName(config, space.id),
+  },
   messages: handleMessages,
   send,
 });

--- a/packages/telegram/test/client.test.ts
+++ b/packages/telegram/test/client.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getChatDisplayName } from "@/client";
+import { configSchema } from "@/config";
+
+const config = configSchema.parse({ botToken: "1:abc" });
+
+let lastUrl: string;
+let chatResult: Record<string, unknown>;
+
+beforeEach(() => {
+  lastUrl = "";
+  const impl = (input: Request): Promise<Response> => {
+    lastUrl = input.url;
+    return Promise.resolve(Response.json({ ok: true, result: chatResult }));
+  };
+  vi.spyOn(globalThis, "fetch").mockImplementation(
+    impl as unknown as typeof fetch
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("getChatDisplayName", () => {
+  it("returns the title for a group chat and calls getChat", async () => {
+    chatResult = { id: 100, type: "supergroup", title: "Team Chat" };
+
+    const name = await getChatDisplayName(config, "100");
+
+    expect(name).toBe("Team Chat");
+    expect(lastUrl.endsWith("/getChat")).toBe(true);
+  });
+
+  it("resolves undefined for a private chat (no title)", async () => {
+    chatResult = { id: 42, type: "private", first_name: "Ada" };
+
+    expect(await getChatDisplayName(config, "42")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Adds a universal read for a chat's display name (group/chat title), the read counterpart to `space.rename()`.

### API

```ts
const name = await space.getDisplayName();
```

Resolves the chat's title, or `undefined` when it has none (an unnamed group, or a 1:1 chat on a platform that stores no title for DMs).

### Provider support

| Provider              | Behavior                                                                                                    |
| --------------------- | ----------------------------------------------------------------------------------------------------------- |
| **iMessage**          |  via `remote.chats.get()`. Groups return their title; 1:1 chats resolve `undefined`.                       |
| **Telegram**          |  via Bot API `getChat`. Groups/supergroups/channels return their title; private chats resolve `undefined`. |
| **Slack**             |  `UnsupportedError` -  the gRPC proxy SDK exposes no channel-info read.                                    |
| **WhatsApp Business** | `UnsupportedError` - 1:1 only, no chat-title concept.                                                     |
| **Terminal**          | `UnsupportedError` - no display-name concept.                                                             |

### Testing

- `typecheck` 12/12, full suite 30/30 (core 229, imessage 153, telegram 88).
- New coverage: iMessage (group title, unnamed→`undefined`, **1:1→`undefined`**, local-mode unsupported) and Telegram (group title, private→`undefined`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786073546&installation_id=127326493&pr_number=181&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F181&signature=fe67dba584cd2b5842b2cdf538e2a950eae7bca3b791bcef9c9bfc87bd7146c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `getDisplayName()` capability to spaces to fetch the current chat/group display name, returning `undefined` when no title exists.
  * iMessage and Telegram providers now expose display name lookups (iMessage: remote group-only; Telegram: via chat metadata).
  * Framework updates ensure the capability is consistently recognized across platform instances.

* **Bug Fixes**
  * Improved handling for reserved action keys, including runtime warnings when platforms declare them.

* **Tests**
  * Expanded automated coverage for local/remote behavior, group vs direct chat rules, and unnamed groups returning `undefined`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->