### PR TITLE
feat: auto read env vars by default (ENG-1712)

### DIFF
--- a/docs/getting-started.mdx.vel
+++ b/docs/getting-started.mdx.vel
@@ -58,6 +58,11 @@ Every message arrives as a `[Space, Message]` tuple. The space gives you the abi
 
 Find your `PROJECT_ID` and `SECRET_KEY` in your project **Settings** on the [dashboard](https://app.photon.codes/).
 
+You can pass these to `Spectrum(...)` directly, or omit them and let Spectrum
+read `SPECTRUM_PROJECT_ID` and `SPECTRUM_PROJECT_SECRET` from the environment.
+The same explicit-wins-over-env fallback applies to `webhookSecret` (`SPECTRUM_WEBHOOK_SECRET`)
+and to each provider's credentials — see the provider setup pages for the per-field env var names.
+
 ### Run your first app
 
 ```ts

--- a/docs/getting-started.mdx.vel
+++ b/docs/getting-started.mdx.vel
@@ -59,9 +59,10 @@ Every message arrives as a `[Space, Message]` tuple. The space gives you the abi
 Find your `PROJECT_ID` and `SECRET_KEY` in your project **Settings** on the [dashboard](https://app.photon.codes/).
 
 You can pass these to `Spectrum(...)` directly, or omit them and let Spectrum
-read `SPECTRUM_PROJECT_ID` and `SPECTRUM_PROJECT_SECRET` from the environment.
-The same explicit-wins-over-env fallback applies to `webhookSecret` (`SPECTRUM_WEBHOOK_SECRET`)
-and to every provider's config.
+read `SPECTRUM_PROJECT_ID` and `SPECTRUM_PROJECT_SECRET` from the environment
+(the unprefixed `PROJECT_ID` / `PROJECT_SECRET` names from the dashboard's `.env`
+snippet are also honored). The same explicit-wins-over-env fallback applies to
+`webhookSecret` (`SPECTRUM_WEBHOOK_SECRET`) and to every provider's config.
 
 Provider config fallbacks are automatic and convention-based: any text config
 field can be supplied through the environment as `SPECTRUM_<PLATFORM>_<FIELD>`,

--- a/docs/getting-started.mdx.vel
+++ b/docs/getting-started.mdx.vel
@@ -59,10 +59,9 @@ Every message arrives as a `[Space, Message]` tuple. The space gives you the abi
 Find your `PROJECT_ID` and `SECRET_KEY` in your project **Settings** on the [dashboard](https://app.photon.codes/).
 
 You can pass these to `Spectrum(...)` directly, or omit them and let Spectrum
-read `SPECTRUM_PROJECT_ID` and `SPECTRUM_PROJECT_SECRET` from the environment
-(the unprefixed `PROJECT_ID` / `PROJECT_SECRET` names from the dashboard's `.env`
-snippet are also honored). The same explicit-wins-over-env fallback applies to
-`webhookSecret` (`SPECTRUM_WEBHOOK_SECRET`) and to every provider's config.
+read `SPECTRUM_PROJECT_ID` and `SPECTRUM_PROJECT_SECRET` from the environment.
+The same explicit-wins-over-env fallback applies to `webhookSecret` (`SPECTRUM_WEBHOOK_SECRET`)
+and to every provider's config.
 
 Provider config fallbacks are automatic and convention-based: any text config
 field can be supplied through the environment as `SPECTRUM_<PLATFORM>_<FIELD>`,

--- a/docs/getting-started.mdx.vel
+++ b/docs/getting-started.mdx.vel
@@ -61,7 +61,16 @@ Find your `PROJECT_ID` and `SECRET_KEY` in your project **Settings** on the [das
 You can pass these to `Spectrum(...)` directly, or omit them and let Spectrum
 read `SPECTRUM_PROJECT_ID` and `SPECTRUM_PROJECT_SECRET` from the environment.
 The same explicit-wins-over-env fallback applies to `webhookSecret` (`SPECTRUM_WEBHOOK_SECRET`)
-and to each provider's credentials — see the provider setup pages for the per-field env var names.
+and to every provider's config.
+
+Provider config fallbacks are automatic and convention-based: any text config
+field can be supplied through the environment as `SPECTRUM_<PLATFORM>_<FIELD>`,
+where `<PLATFORM>` is the provider's id upper-cased (spaces and punctuation become
+`_`) and `<FIELD>` is the config key in `UPPER_SNAKE_CASE`. For example
+Telegram's `botToken` reads from `SPECTRUM_TELEGRAM_BOT_TOKEN`, and WhatsApp
+Business's `phoneNumberId` reads from `SPECTRUM_WHATSAPP_BUSINESS_PHONE_NUMBER_ID`.
+Explicit config always wins over the environment — see the provider setup pages
+for each field's env var name.
 
 ### Run your first app
 

--- a/docs/providers/slack/setup.mdx.vel
+++ b/docs/providers/slack/setup.mdx.vel
@@ -44,11 +44,16 @@ Use `slack.config(...)` to register one or more Slack workspaces.
   </Tab>
 </Tabs>
 
-| Option | Description |
-|---|---|
-| `tokens` | A map of team ID to bot token (`xoxb-...`). At least one entry is required. |
-| `teams` | Optional metadata per team: app ID, bot user ID, granted scopes, and display name. |
-| `endpoint` | Optional custom Slack API base URL. |
+| Option | Description | Env fallback |
+|---|---|---|
+| `tokens` | A map of team ID to bot token (`xoxb-...`). At least one entry is required. | — (record, code-only) |
+| `teams` | Optional metadata per team: app ID, bot user ID, granted scopes, and display name. | — (record, code-only) |
+| `endpoint` | Optional custom Slack API base URL. | `SPECTRUM_SLACK_ENDPOINT` |
+
+`endpoint` falls back to `SPECTRUM_SLACK_ENDPOINT` when omitted (an explicit
+value wins). `tokens` and `teams` are maps, so they stay in code — for a fully
+environment-driven setup, use cloud mode (an empty `slack.config({})`) with
+`projectId`/`projectSecret`.
 
 ## Example
 

--- a/docs/providers/telegram/setup.mdx.vel
+++ b/docs/providers/telegram/setup.mdx.vel
@@ -14,10 +14,12 @@ telegram.config({
 });
 ```
 
-| Option | Description |
-|---|---|
-| `botToken` | Bot token from [@BotFather](https://t.me/BotFather). |
-| `webhookSecret` | Optional secret token for verifying webhook payloads. |
+| Option | Description | Env fallback |
+|---|---|---|
+| `botToken` | Bot token from [@BotFather](https://t.me/BotFather). | `SPECTRUM_TELEGRAM_BOT_TOKEN` |
+| `webhookSecret` | Optional secret token for verifying webhook payloads. | `SPECTRUM_TELEGRAM_WEBHOOK_SECRET` |
+| `baseUrl` | Optional Bot API base URL. Defaults to `https://api.telegram.org`. | `SPECTRUM_TELEGRAM_BASE_URL` |
+
 
 ## Example
 

--- a/docs/providers/whatsapp-business/setup.mdx.vel
+++ b/docs/providers/whatsapp-business/setup.mdx.vel
@@ -16,11 +16,18 @@ whatsappBusiness.config({
 });
 ```
 
-| Option | Description |
-|---|---|
-| `accessToken` | Permanent or system-user token from Meta for Developers. |
-| `phoneNumberId` | The phone number ID for the business account sending messages. |
-| `appSecret` | App secret used to verify webhook payload signatures. |
+| Option | Description | Env fallback |
+|---|---|---|
+| `accessToken` | Permanent or system-user token from Meta for Developers. | `SPECTRUM_WHATSAPP_BUSINESS_ACCESS_TOKEN` |
+| `phoneNumberId` | The phone number ID for the business account sending messages. | `SPECTRUM_WHATSAPP_BUSINESS_PHONE_NUMBER_ID` |
+| `appSecret` | App secret used to verify webhook payload signatures. | `SPECTRUM_WHATSAPP_BUSINESS_APP_SECRET` |
+
+Each option falls back to its environment variable when omitted (an explicit
+value always wins). If you set both `SPECTRUM_WHATSAPP_BUSINESS_ACCESS_TOKEN`
+and `SPECTRUM_WHATSAPP_BUSINESS_PHONE_NUMBER_ID`, calling
+`whatsappBusiness.config()` with no arguments boots the provider in direct mode
+from the environment. A partial set (only one of the two) instead falls back to
+cloud mode, which uses your `projectId`/`projectSecret`.
 
 Find these values in your WhatsApp Business app settings on [Meta for Developers](https://developers.facebook.com/).
 

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -62,6 +62,10 @@ export type {
 } from "./platform/types";
 // Generic translation helpers (from `utils/`).
 export { ensureM4a } from "./utils/audio";
+// Config env-var fallback — wrap a config-field schema so an omitted field
+// falls back to `process.env[envKey]` (explicit value always wins). `envFor`
+// builds the `SPECTRUM_<CHANNEL>_<KEY>` name from its parts.
+export { envFor, fromEnv } from "./utils/env";
 // Outbound-HTTP tracing — wrap a provider's own fetch so its requests get a
 // CLIENT span tagged `peer.service`, without ever touching globalThis.fetch.
 // Pair `redactUrl` with `sanitizeUrl` to strip secrets from the recorded URL.

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -65,7 +65,7 @@ export { ensureM4a } from "./utils/audio";
 // Config env-var fallback — wrap a config-field schema so an omitted field
 // falls back to `process.env[envKey]` (explicit value always wins). `envFor`
 // builds the `SPECTRUM_<CHANNEL>_<KEY>` name from its parts.
-export { envFor, fromEnv } from "./utils/env";
+export { envAwareConfig, envFor, fromEnv } from "./utils/env";
 // Outbound-HTTP tracing — wrap a provider's own fetch so its requests get a
 // CLIENT span tagged `peer.service`, without ever touching globalThis.fetch.
 // Pair `redactUrl` with `sanitizeUrl` to strip secrets from the recorded URL.

--- a/packages/core/src/platform/define.ts
+++ b/packages/core/src/platform/define.ts
@@ -4,6 +4,7 @@ import type { FusorClient, FusorMessages } from "../fusor/types";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
 import type { ProjectData } from "../utils/cloud";
+import { envAwareConfig } from "../utils/env";
 import { UnsupportedError } from "../utils/errors";
 import { classifyIdentifier as classifySingle } from "../utils/identifier";
 import type { Store } from "../utils/store";
@@ -506,7 +507,8 @@ export function definePlatform(name: string, rawDef: unknown): unknown {
   };
   type Def = AnyPlatformDef;
 
-  const fullDef = { ...def, name };
+  // Every string-leaf config field falls back to `SPECTRUM_<PLATFORM>_<KEY>`
+  const fullDef = { ...def, name, config: envAwareConfig(name, def.config) };
 
   const platformCache = new WeakMap<SpectrumLike, PlatformInstance<Def>>();
 

--- a/packages/core/src/platform/types.ts
+++ b/packages/core/src/platform/types.ts
@@ -924,11 +924,23 @@ export interface SpectrumLike<
 // Platform — the callable returned by definePlatform()
 // ---------------------------------------------------------------------------
 
+// Every string-leaf config field falls back to `SPECTRUM_<PLATFORM>_<KEY>` at
+// runtime (see `envAwareConfig`), so any declared field may be omitted and
+// supplied by the environment instead. `ConfigInput` reflects that by making the
+// top-level input keys optional. The conditional distributes over unions so a
+// `direct | cloud` config input isn't collapsed to its shared keys.
+type ConfigInput<Def extends AnyPlatformDef> =
+  z.input<Def["config"]> extends infer Input
+    ? Input extends unknown
+      ? { [K in keyof Input]?: Input[K] }
+      : never
+    : never;
+
 export interface Platform<Def extends AnyPlatformDef> {
   config(
-    ...args: Record<string, never> extends z.input<Def["config"]>
-      ? [config?: z.input<Def["config"]>]
-      : [config: z.input<Def["config"]>]
+    ...args: Record<string, never> extends ConfigInput<Def>
+      ? [config?: ConfigInput<Def>]
+      : [config: ConfigInput<Def>]
   ): PlatformProviderConfig<Def>;
   is(input: Message): input is PlatformMessage<Def>;
   is(input: Space): input is PlatformSpace<Def>;

--- a/packages/core/src/spectrum.ts
+++ b/packages/core/src/spectrum.ts
@@ -35,6 +35,7 @@ import type { Message } from "./types/message";
 import type { Space } from "./types/space";
 import type { AgentSender } from "./types/user";
 import { cloud, type ProjectData } from "./utils/cloud";
+import { envFor } from "./utils/env";
 import {
   normalizePlatformKey,
   officialProviderInstallHint,
@@ -234,6 +235,20 @@ function applyLogLevel(level: LogLevel | undefined): void {
   }
 }
 
+// Resolve project credentials, falling back to env vars when an option is
+// omitted (an explicit option always wins). Kept out of Spectrum() to hold the
+// factory under the cognitive-complexity cap.
+function resolveProjectCredentials(options: {
+  projectId?: string;
+  projectSecret?: string;
+}): { projectId: string | undefined; projectSecret: string | undefined } {
+  return {
+    projectId: options.projectId ?? process.env[envFor("PROJECT", "ID")],
+    projectSecret:
+      options.projectSecret ?? process.env[envFor("PROJECT", "SECRET")],
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Spectrum() factory
 // ---------------------------------------------------------------------------
@@ -279,11 +294,11 @@ export async function Spectrum<
         webhookSecret?: string;
       }
 ): Promise<SpectrumInstance<Providers>> {
-  spectrumConfigSchema.parse(options);
+
+  const { projectId, projectSecret } = resolveProjectCredentials(options);
+  spectrumConfigSchema.parse({ ...options, projectId, projectSecret });
 
   const {
-    projectId,
-    projectSecret,
     providers,
     options: runtimeOptions,
     telemetry,
@@ -297,7 +312,7 @@ export async function Spectrum<
   // The per-webhook signing secret for native Spectrum webhooks. Explicit option
   // wins; otherwise fall back to the env var so deployments can inject it.
   const resolvedWebhookSecret =
-    webhookSecret ?? process.env.SPECTRUM_WEBHOOK_SECRET;
+    webhookSecret ?? process.env[envFor("WEBHOOK", "SECRET")];
 
   const otelHandle = telemetry
     ? bootstrapTelemetry({ projectId, projectSecret })

--- a/packages/core/src/spectrum.ts
+++ b/packages/core/src/spectrum.ts
@@ -235,6 +235,11 @@ function applyLogLevel(level: LogLevel | undefined): void {
   }
 }
 
+function envValue(key: string): string | undefined {
+  const value = process.env[key];
+  return value === "" ? undefined : value;
+}
+
 // Resolve project credentials, falling back to env vars when an option is
 // omitted (an explicit option always wins). Precedence is
 // explicit option > `SPECTRUM_PROJECT_ID` > `PROJECT_ID`: the canonical
@@ -248,12 +253,12 @@ function resolveProjectCredentials(options: {
   return {
     projectId:
       options.projectId ??
-      process.env[envFor("PROJECT", "ID")] ??
-      process.env.PROJECT_ID,
+      envValue(envFor("PROJECT", "ID")) ??
+      envValue("PROJECT_ID"),
     projectSecret:
       options.projectSecret ??
-      process.env[envFor("PROJECT", "SECRET")] ??
-      process.env.PROJECT_SECRET,
+      envValue(envFor("PROJECT", "SECRET")) ??
+      envValue("PROJECT_SECRET"),
   };
 }
 

--- a/packages/core/src/spectrum.ts
+++ b/packages/core/src/spectrum.ts
@@ -236,16 +236,24 @@ function applyLogLevel(level: LogLevel | undefined): void {
 }
 
 // Resolve project credentials, falling back to env vars when an option is
-// omitted (an explicit option always wins). Kept out of Spectrum() to hold the
-// factory under the cognitive-complexity cap.
+// omitted (an explicit option always wins). Precedence is
+// explicit option > `SPECTRUM_PROJECT_ID` > `PROJECT_ID`: the canonical
+// `SPECTRUM_`-prefixed name is preferred, but the unprefixed `PROJECT_ID` /
+// `PROJECT_SECRET` are still honored for backwards compatibility with the
+// dashboard's `.env` snippet and existing projects that already set them.
 function resolveProjectCredentials(options: {
   projectId?: string;
   projectSecret?: string;
 }): { projectId: string | undefined; projectSecret: string | undefined } {
   return {
-    projectId: options.projectId ?? process.env[envFor("PROJECT", "ID")],
+    projectId:
+      options.projectId ??
+      process.env[envFor("PROJECT", "ID")] ??
+      process.env.PROJECT_ID,
     projectSecret:
-      options.projectSecret ?? process.env[envFor("PROJECT", "SECRET")],
+      options.projectSecret ??
+      process.env[envFor("PROJECT", "SECRET")] ??
+      process.env.PROJECT_SECRET,
   };
 }
 
@@ -294,7 +302,6 @@ export async function Spectrum<
         webhookSecret?: string;
       }
 ): Promise<SpectrumInstance<Providers>> {
-
   const { projectId, projectSecret } = resolveProjectCredentials(options);
   spectrumConfigSchema.parse({ ...options, projectId, projectSecret });
 

--- a/packages/core/src/spectrum.ts
+++ b/packages/core/src/spectrum.ts
@@ -241,24 +241,16 @@ function envValue(key: string): string | undefined {
 }
 
 // Resolve project credentials, falling back to env vars when an option is
-// omitted (an explicit option always wins). Precedence is
-// explicit option > `SPECTRUM_PROJECT_ID` > `PROJECT_ID`: the canonical
-// `SPECTRUM_`-prefixed name is preferred, but the unprefixed `PROJECT_ID` /
-// `PROJECT_SECRET` are still honored for backwards compatibility with the
-// dashboard's `.env` snippet and existing projects that already set them.
+// omitted (an explicit option always wins). Kept out of Spectrum() to hold the
+// factory under the cognitive-complexity cap.
 function resolveProjectCredentials(options: {
   projectId?: string;
   projectSecret?: string;
 }): { projectId: string | undefined; projectSecret: string | undefined } {
   return {
-    projectId:
-      options.projectId ??
-      envValue(envFor("PROJECT", "ID")) ??
-      envValue("PROJECT_ID"),
+    projectId: options.projectId ?? envValue(envFor("PROJECT", "ID")),
     projectSecret:
-      options.projectSecret ??
-      envValue(envFor("PROJECT", "SECRET")) ??
-      envValue("PROJECT_SECRET"),
+      options.projectSecret ?? envValue(envFor("PROJECT", "SECRET")),
   };
 }
 

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -43,3 +43,149 @@ export const fromEnv = <T extends z.ZodType>(envKey: string, schema: T) =>
     const envValue = process.env[envKey];
     return envValue === "" ? undefined : envValue;
   }, schema);
+
+/**
+ * Normalize a platform id into the env-var prefix segment: upper-case, with any
+ * run of non-alphanumeric characters collapsed to a single `_`. This is a
+ * whole-name transform, NOT camelCase splitting, so it reproduces the prefixes
+ * the adapters used by hand — `"telegram"` → `TELEGRAM`,
+ * `"WhatsApp Business"` → `WHATSAPP_BUSINESS`, `"Slack"` → `SLACK`.
+ */
+export const normalizePlatformName = (name: string): string =>
+  name
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+// Split camelCase (and digit boundaries) so a config key becomes its
+// UPPER_SNAKE env suffix i.e `botToken` → `BOT_TOKEN`, `phoneNumberId` →
+// `PHONE_NUMBER_ID`, `baseUrl` → `BASE_URL`.
+const CAMEL_BOUNDARY = /([a-z0-9])([A-Z])/g;
+
+/** Convert a camelCase config field name into its UPPER_SNAKE env-var suffix. */
+export const toEnvKey = (field: string): string =>
+  field.replace(CAMEL_BOUNDARY, "$1_$2").toUpperCase();
+
+// Zod wrapper node types whose inner schema is reachable via `def.innerType`.
+// Unwrapping these lets us see the base type of a decorated field.
+const INNER_TYPE_WRAPPERS = new Set([
+  "optional",
+  "nullable",
+  "default",
+  "readonly",
+  "catch",
+  "nonoptional",
+  "prefault",
+]);
+
+interface ZodInternal {
+  def: {
+    type: string;
+    innerType?: ZodInternal;
+    in?: ZodInternal;
+    out?: ZodInternal;
+    shape?: Record<string, z.ZodType>;
+    options?: z.ZodType[];
+    catchall?: ZodInternal;
+  };
+}
+
+const asInternal = (schema: z.ZodType): ZodInternal =>
+  schema as unknown as ZodInternal;
+
+// Follow wrapper/pipe nodes down to the base schema so we can classify the leaf.
+const unwrapSchema = (schema: z.ZodType): ZodInternal => {
+  let current = asInternal(schema);
+
+  for (let depth = 0; depth < 20; depth++) {
+    const { type } = current.def;
+    if (INNER_TYPE_WRAPPERS.has(type) && current.def.innerType) {
+      current = current.def.innerType;
+      continue;
+    }
+
+    if (type === "pipe" && (current.def.out || current.def.in)) {
+      current = (current.def.out ?? current.def.in) as ZodInternal;
+      continue;
+    }
+    break;
+  }
+  return current;
+};
+
+// Only string-leaf fields are env-backed: a single env var is always a string,
+// so `z.string()`/`z.url()`/`z.email()` (all base type `"string"`) map cleanly.
+const isStringLeaf = (schema: z.ZodType): boolean =>
+  unwrapSchema(schema).def.type === "string";
+
+// A strict object carries a `never` catchall. lets a reconstructed
+// object preserve `.strict()`.
+const isStrictObject = (def: ZodInternal["def"]): boolean =>
+  def.catchall?.def.type === "never";
+
+/**
+ * Rewrite a platform's config schema so every string-leaf field falls back to
+ * `SPECTRUM_<PLATFORM>_<KEY>` when omitted which is the equivalent of
+ * hand-wrapping each field with {@link fromEnv}. Called once by
+ * `definePlatform`, so adapters declare plain Zod and get env fallback for free.
+ *
+ * - **object**: each string-leaf field is wrapped with `fromEnv`; non-string
+ *   fields (records, arrays, nested objects, booleans, numbers) are left as-is.
+ *   The object is only reconstructed when a field actually changed, and
+ *   `.strict()` is preserved so an empty strict "cloud" branch is untouched.
+ * - **union**: each option is rewritten independently, so an env value only
+ *   satisfies the branch that declares that field (a direct/cloud union stays
+ *   correctly discriminated).
+ * - anything else is returned unchanged.
+ *
+ * The output type is identical to the input schema's. Only omitted fields gain
+ * an env fallback which means that `z.infer` and downstream contexts are unaffected.
+ */
+export const envAwareConfig = <T extends z.ZodType>(
+  name: string,
+  schema: T
+): T => {
+  const prefix = `SPECTRUM_${normalizePlatformName(name)}`;
+  return rewrite(prefix, schema) as T;
+};
+
+const rewrite = (prefix: string, schema: z.ZodType): z.ZodType => {
+  const { def } = asInternal(schema);
+
+  if (def.type === "object" && def.shape) {
+    return rewriteObject(prefix, def, schema);
+  }
+
+  if (def.type === "union" && def.options) {
+    const options = def.options.map((option) => rewrite(prefix, option));
+    return z.union(options as [z.ZodType, z.ZodType, ...z.ZodType[]]);
+  }
+
+  return schema;
+};
+
+const rewriteObject = (
+  prefix: string,
+  def: ZodInternal["def"],
+  original: z.ZodType
+): z.ZodType => {
+  const shape = def.shape as Record<string, z.ZodType>;
+  const nextShape: Record<string, z.ZodType> = {};
+  let changed = false;
+
+  for (const [key, field] of Object.entries(shape)) {
+    if (isStringLeaf(field)) {
+      nextShape[key] = fromEnv(`${prefix}_${toEnvKey(key)}`, field);
+      changed = true;
+    } else {
+      nextShape[key] = field;
+    }
+  }
+
+  if (!changed) {
+    return original;
+  }
+
+  const rebuilt = z.object(nextShape);
+  return isStrictObject(def) ? rebuilt.strict() : rebuilt;
+};

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -1,0 +1,45 @@
+import z from "zod";
+
+/**
+ * Build a Spectrum config env-var name from a channel and a key, centralizing
+ * the `SPECTRUM_<CHANNEL>_<KEY>` convention so the prefix can't drift or be
+ * mistyped per field. Both segments are joined verbatim (callers pass them
+ * already upper-snake-cased), e.g. `envFor("TELEGRAM", "BOT_TOKEN")` →
+ * `"SPECTRUM_TELEGRAM_BOT_TOKEN"`.
+ */
+export const envFor = (channel: string, key: string): string =>
+  `SPECTRUM_${channel}_${key}`;
+
+/**
+ * Wrap a config-field schema so it falls back to an environment variable when
+ * the field is omitted. Precedence is **explicit value > env var > the inner
+ * schema's own default/required check**:
+ *
+ * - An explicit value (anything other than `undefined`) is passed straight
+ *   through — a caller-supplied config always wins over the environment.
+ * - When the field is `undefined`, `process.env[envKey]` is substituted. An
+ *   env var set to the empty string is treated as unset (a common deploy
+ *   footgun) so it doesn't satisfy a `.min(1)` by accident.
+ * - The inner `schema` then validates the resolved value, keeping its exact
+ *   semantics — regex, `.min(1)`, `.url()`, `.optional()`, `.default(...)`.
+ *   When both the field and the env var are absent, a required inner schema
+ *   raises its normal "required" error.
+ *
+ * The output type is the inner schema's output type, so call sites are
+ * unchanged. Because substitution only happens on `undefined`, wrapping a
+ * field inside a `z.object` leaves it a plain key on the parsed result — union
+ * discriminators like `"accessToken" in config` keep working.
+ *
+ * @example
+ * ```ts
+ * botToken: fromEnv("SPECTRUM_TELEGRAM_BOT_TOKEN", z.string().regex(BOT_TOKEN_PATTERN)),
+ * ```
+ */
+export const fromEnv = <T extends z.ZodType>(envKey: string, schema: T) =>
+  z.preprocess((value) => {
+    if (value !== undefined) {
+      return value;
+    }
+    const envValue = process.env[envKey];
+    return envValue === "" ? undefined : envValue;
+  }, schema);

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -51,11 +51,10 @@ export const fromEnv = <T extends z.ZodType>(envKey: string, schema: T) =>
  * the adapters used by hand — `"telegram"` → `TELEGRAM`,
  * `"WhatsApp Business"` → `WHATSAPP_BUSINESS`, `"Slack"` → `SLACK`.
  */
+const NON_ALPHANUMERIC_RUN = /[^A-Z0-9]+/;
+
 export const normalizePlatformName = (name: string): string =>
-  name
-    .toUpperCase()
-    .replace(/[^A-Z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "");
+  name.toUpperCase().split(NON_ALPHANUMERIC_RUN).filter(Boolean).join("_");
 
 // Split camelCase (and digit boundaries) so a config key becomes its
 // UPPER_SNAKE env suffix i.e `botToken` → `BOT_TOKEN`, `phoneNumberId` →

--- a/packages/core/test/core/spectrum.env-credentials.test.ts
+++ b/packages/core/test/core/spectrum.env-credentials.test.ts
@@ -5,16 +5,7 @@ import { Spectrum } from "@/spectrum";
 
 const PROJECT_ID = "SPECTRUM_PROJECT_ID";
 const PROJECT_SECRET = "SPECTRUM_PROJECT_SECRET";
-// Legacy unprefixed names emitted by the dashboard's `.env` snippet — still
-// honored for backwards compatibility.
-const LEGACY_PROJECT_ID = "PROJECT_ID";
-const LEGACY_PROJECT_SECRET = "PROJECT_SECRET";
-const ENV_KEYS = [
-  PROJECT_ID,
-  PROJECT_SECRET,
-  LEGACY_PROJECT_ID,
-  LEGACY_PROJECT_SECRET,
-];
+const ENV_KEYS = [PROJECT_ID, PROJECT_SECRET];
 
 const getProject = stubCloud();
 
@@ -48,26 +39,6 @@ describe("Spectrum() project credential env fallback", () => {
 
     const app = await Spectrum({ providers: [provider()] });
     expect(getProject).toHaveBeenCalledWith("env-id", "env-secret");
-    await app.stop();
-  });
-
-  it("resolves credentials from the legacy unprefixed env vars", async () => {
-    process.env[LEGACY_PROJECT_ID] = "legacy-id";
-    process.env[LEGACY_PROJECT_SECRET] = "legacy-secret";
-
-    const app = await Spectrum({ providers: [provider()] });
-    expect(getProject).toHaveBeenCalledWith("legacy-id", "legacy-secret");
-    await app.stop();
-  });
-
-  it("prefers the SPECTRUM_-prefixed env vars over the legacy names", async () => {
-    process.env[PROJECT_ID] = "prefixed-id";
-    process.env[PROJECT_SECRET] = "prefixed-secret";
-    process.env[LEGACY_PROJECT_ID] = "legacy-id";
-    process.env[LEGACY_PROJECT_SECRET] = "legacy-secret";
-
-    const app = await Spectrum({ providers: [provider()] });
-    expect(getProject).toHaveBeenCalledWith("prefixed-id", "prefixed-secret");
     await app.stop();
   });
 
@@ -120,17 +91,6 @@ describe("Spectrum() project credential env fallback", () => {
 
     const app = await Spectrum({ providers: [provider()] });
     expect(getProject).not.toHaveBeenCalled();
-    await app.stop();
-  });
-
-  it("falls through an empty prefixed env var to the legacy name", async () => {
-    process.env[PROJECT_ID] = "";
-    process.env[PROJECT_SECRET] = "";
-    process.env[LEGACY_PROJECT_ID] = "legacy-id";
-    process.env[LEGACY_PROJECT_SECRET] = "legacy-secret";
-
-    const app = await Spectrum({ providers: [provider()] });
-    expect(getProject).toHaveBeenCalledWith("legacy-id", "legacy-secret");
     await app.stop();
   });
 });

--- a/packages/core/test/core/spectrum.env-credentials.test.ts
+++ b/packages/core/test/core/spectrum.env-credentials.test.ts
@@ -111,4 +111,26 @@ describe("Spectrum() project credential env fallback", () => {
 
     await expect(Spectrum({ providers: [provider()] })).rejects.toThrow();
   });
+
+  it("treats empty-string env vars as unset (no credentials)", async () => {
+    // A CI template that injects the var name without a value leaves it "".
+    // That must fall through to the "no credentials" branch, not throw.
+    process.env[PROJECT_ID] = "";
+    process.env[PROJECT_SECRET] = "";
+
+    const app = await Spectrum({ providers: [provider()] });
+    expect(getProject).not.toHaveBeenCalled();
+    await app.stop();
+  });
+
+  it("falls through an empty prefixed env var to the legacy name", async () => {
+    process.env[PROJECT_ID] = "";
+    process.env[PROJECT_SECRET] = "";
+    process.env[LEGACY_PROJECT_ID] = "legacy-id";
+    process.env[LEGACY_PROJECT_SECRET] = "legacy-secret";
+
+    const app = await Spectrum({ providers: [provider()] });
+    expect(getProject).toHaveBeenCalledWith("legacy-id", "legacy-secret");
+    await app.stop();
+  });
 });

--- a/packages/core/test/core/spectrum.env-credentials.test.ts
+++ b/packages/core/test/core/spectrum.env-credentials.test.ts
@@ -5,6 +5,16 @@ import { Spectrum } from "@/spectrum";
 
 const PROJECT_ID = "SPECTRUM_PROJECT_ID";
 const PROJECT_SECRET = "SPECTRUM_PROJECT_SECRET";
+// Legacy unprefixed names emitted by the dashboard's `.env` snippet — still
+// honored for backwards compatibility.
+const LEGACY_PROJECT_ID = "PROJECT_ID";
+const LEGACY_PROJECT_SECRET = "PROJECT_SECRET";
+const ENV_KEYS = [
+  PROJECT_ID,
+  PROJECT_SECRET,
+  LEGACY_PROJECT_ID,
+  LEGACY_PROJECT_SECRET,
+];
 
 const getProject = stubCloud();
 
@@ -15,14 +25,14 @@ describe("Spectrum() project credential env fallback", () => {
 
   beforeEach(() => {
     getProject.mockClear();
-    for (const key of [PROJECT_ID, PROJECT_SECRET]) {
+    for (const key of ENV_KEYS) {
       saved.set(key, process.env[key]);
       delete process.env[key];
     }
   });
 
   afterEach(() => {
-    for (const key of [PROJECT_ID, PROJECT_SECRET]) {
+    for (const key of ENV_KEYS) {
       const value = saved.get(key);
       if (value === undefined) {
         delete process.env[key];
@@ -38,6 +48,26 @@ describe("Spectrum() project credential env fallback", () => {
 
     const app = await Spectrum({ providers: [provider()] });
     expect(getProject).toHaveBeenCalledWith("env-id", "env-secret");
+    await app.stop();
+  });
+
+  it("resolves credentials from the legacy unprefixed env vars", async () => {
+    process.env[LEGACY_PROJECT_ID] = "legacy-id";
+    process.env[LEGACY_PROJECT_SECRET] = "legacy-secret";
+
+    const app = await Spectrum({ providers: [provider()] });
+    expect(getProject).toHaveBeenCalledWith("legacy-id", "legacy-secret");
+    await app.stop();
+  });
+
+  it("prefers the SPECTRUM_-prefixed env vars over the legacy names", async () => {
+    process.env[PROJECT_ID] = "prefixed-id";
+    process.env[PROJECT_SECRET] = "prefixed-secret";
+    process.env[LEGACY_PROJECT_ID] = "legacy-id";
+    process.env[LEGACY_PROJECT_SECRET] = "legacy-secret";
+
+    const app = await Spectrum({ providers: [provider()] });
+    expect(getProject).toHaveBeenCalledWith("prefixed-id", "prefixed-secret");
     await app.stop();
   });
 

--- a/packages/core/test/core/spectrum.env-credentials.test.ts
+++ b/packages/core/test/core/spectrum.env-credentials.test.ts
@@ -1,0 +1,84 @@
+import { stubCloud } from "@spectrum-ts/test-support/cloud";
+import { makeManagedProvider } from "@spectrum-ts/test-support/platform";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Spectrum } from "@/spectrum";
+
+const PROJECT_ID = "SPECTRUM_PROJECT_ID";
+const PROJECT_SECRET = "SPECTRUM_PROJECT_SECRET";
+
+const getProject = stubCloud();
+
+const provider = () => makeManagedProvider("managed").config({});
+
+describe("Spectrum() project credential env fallback", () => {
+  const saved = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    getProject.mockClear();
+    for (const key of [PROJECT_ID, PROJECT_SECRET]) {
+      saved.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of [PROJECT_ID, PROJECT_SECRET]) {
+      const value = saved.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it("resolves project credentials from env when omitted", async () => {
+    process.env[PROJECT_ID] = "env-id";
+    process.env[PROJECT_SECRET] = "env-secret";
+
+    const app = await Spectrum({ providers: [provider()] });
+    expect(getProject).toHaveBeenCalledWith("env-id", "env-secret");
+    await app.stop();
+  });
+
+  it("lets explicit credentials win over env", async () => {
+    process.env[PROJECT_ID] = "env-id";
+    process.env[PROJECT_SECRET] = "env-secret";
+
+    const app = await Spectrum({
+      projectId: "explicit-id",
+      projectSecret: "explicit-secret",
+      providers: [provider()],
+    });
+    expect(getProject).toHaveBeenCalledWith("explicit-id", "explicit-secret");
+    await app.stop();
+  });
+
+  it("completes a pair from a mix of explicit id and env secret", async () => {
+    process.env[PROJECT_SECRET] = "env-secret";
+
+    // The typed overloads require credentials both-or-neither, so a half-typed
+    // pair is only reachable at runtime — cast past the overload to exercise the
+    // resolved-value invariant directly.
+    const options = {
+      projectId: "explicit-id",
+      providers: [provider()],
+    } as unknown as Parameters<typeof Spectrum>[0];
+
+    const app = await Spectrum(options);
+    expect(getProject).toHaveBeenCalledWith("explicit-id", "env-secret");
+    await app.stop();
+  });
+
+  it("does not fetch a project when neither config nor env supplies credentials", async () => {
+    const app = await Spectrum({ providers: [provider()] });
+    expect(getProject).not.toHaveBeenCalled();
+    await app.stop();
+  });
+
+  it("rejects a half-supplied credential pair (id via env, no secret)", async () => {
+    process.env[PROJECT_ID] = "env-id";
+
+    await expect(Spectrum({ providers: [provider()] })).rejects.toThrow();
+  });
+});

--- a/packages/core/test/utils/env.test.ts
+++ b/packages/core/test/utils/env.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import z from "zod";
-import { envFor, fromEnv } from "@/utils/env";
+import {
+  envAwareConfig,
+  envFor,
+  fromEnv,
+  normalizePlatformName,
+  toEnvKey,
+} from "@/utils/env";
 
 const ENV_KEY = "SPECTRUM_TEST_FROM_ENV";
 
@@ -91,5 +97,159 @@ describe("fromEnv", () => {
     const parsed = schema.parse({});
     expect("accessToken" in parsed).toBe(true);
     expect(parsed.accessToken).toBe("token");
+  });
+});
+
+describe("normalizePlatformName", () => {
+  it("upper-cases a simple id", () => {
+    expect(normalizePlatformName("telegram")).toBe("TELEGRAM");
+  });
+
+  it("collapses spaces and punctuation to single underscores", () => {
+    expect(normalizePlatformName("WhatsApp Business")).toBe(
+      "WHATSAPP_BUSINESS"
+    );
+  });
+
+  it("does not split internal camelCase", () => {
+    expect(normalizePlatformName("iMessage")).toBe("IMESSAGE");
+  });
+
+  it("trims leading and trailing separators", () => {
+    expect(normalizePlatformName(" Slack! ")).toBe("SLACK");
+  });
+});
+
+describe("toEnvKey", () => {
+  it("upper-snakes a camelCase field", () => {
+    expect(toEnvKey("botToken")).toBe("BOT_TOKEN");
+  });
+
+  it("splits multiple camelCase boundaries", () => {
+    expect(toEnvKey("phoneNumberId")).toBe("PHONE_NUMBER_ID");
+  });
+
+  it("splits a digit-to-upper boundary", () => {
+    expect(toEnvKey("baseUrl")).toBe("BASE_URL");
+  });
+});
+
+describe("envAwareConfig", () => {
+  const ENV_KEYS = [
+    "SPECTRUM_TELEGRAM_BOT_TOKEN",
+    "SPECTRUM_TELEGRAM_BASE_URL",
+    "SPECTRUM_WHATSAPP_BUSINESS_ACCESS_TOKEN",
+    "SPECTRUM_WHATSAPP_BUSINESS_PHONE_NUMBER_ID",
+    "SPECTRUM_DEMO_TOKENS",
+    "SPECTRUM_DEMO_ITEMS",
+    "SPECTRUM_DEMO_ENABLED",
+  ];
+  const saved = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = saved.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it("backs a string field from SPECTRUM_<PLATFORM>_<KEY>", () => {
+    const schema = envAwareConfig(
+      "telegram",
+      z.object({ botToken: z.string() })
+    );
+    process.env.SPECTRUM_TELEGRAM_BOT_TOKEN = "123:abc";
+    expect(schema.parse({}).botToken).toBe("123:abc");
+  });
+
+  it("lets an explicit value win over the env var", () => {
+    const schema = envAwareConfig(
+      "telegram",
+      z.object({ botToken: z.string() })
+    );
+    process.env.SPECTRUM_TELEGRAM_BOT_TOKEN = "999:env";
+    expect(schema.parse({ botToken: "explicit" }).botToken).toBe("explicit");
+  });
+
+  it("preserves an inner default over env precedence", () => {
+    const schema = envAwareConfig(
+      "telegram",
+      z.object({ baseUrl: z.url().default("https://api.telegram.org") })
+    );
+    expect(schema.parse({}).baseUrl).toBe("https://api.telegram.org");
+    process.env.SPECTRUM_TELEGRAM_BASE_URL = "https://env.example";
+    expect(schema.parse({}).baseUrl).toBe("https://env.example");
+  });
+
+  it("treats an empty-string env var as unset", () => {
+    const schema = envAwareConfig(
+      "telegram",
+      z.object({ botToken: z.string() })
+    );
+    process.env.SPECTRUM_TELEGRAM_BOT_TOKEN = "";
+    expect(() => schema.parse({})).toThrow();
+  });
+
+  it("leaves non-string fields (records, arrays, booleans) untouched", () => {
+    const schema = envAwareConfig(
+      "demo",
+      z.object({
+        tokens: z.record(z.string(), z.string()),
+        items: z.array(z.string()),
+        enabled: z.boolean(),
+      })
+    );
+    // An env var named after a non-string field is ignored — the field is still
+    // required from config.
+    process.env.SPECTRUM_DEMO_TOKENS = "ignored";
+    process.env.SPECTRUM_DEMO_ITEMS = "ignored";
+    process.env.SPECTRUM_DEMO_ENABLED = "true";
+    const parsed = schema.parse({
+      tokens: { t: "x" },
+      items: ["a"],
+      enabled: false,
+    });
+    expect(parsed).toEqual({
+      tokens: { t: "x" },
+      items: ["a"],
+      enabled: false,
+    });
+  });
+
+  it("resolves each union branch independently and preserves a strict branch", () => {
+    const schema = envAwareConfig(
+      "WhatsApp Business",
+      z.union([
+        z.object({
+          accessToken: z.string().min(1),
+          phoneNumberId: z.string().min(1),
+        }),
+        z.object({}).strict(),
+      ])
+    );
+
+    // A complete env set satisfies the direct branch.
+    process.env.SPECTRUM_WHATSAPP_BUSINESS_ACCESS_TOKEN = "tok";
+    process.env.SPECTRUM_WHATSAPP_BUSINESS_PHONE_NUMBER_ID = "pid";
+    expect(schema.parse({})).toMatchObject({
+      accessToken: "tok",
+      phoneNumberId: "pid",
+    });
+
+    // With no env, the strict empty branch still accepts an empty object.
+    delete process.env.SPECTRUM_WHATSAPP_BUSINESS_ACCESS_TOKEN;
+    delete process.env.SPECTRUM_WHATSAPP_BUSINESS_PHONE_NUMBER_ID;
+    expect(schema.parse({})).toEqual({});
   });
 });

--- a/packages/core/test/utils/env.test.ts
+++ b/packages/core/test/utils/env.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import z from "zod";
+import { envFor, fromEnv } from "@/utils/env";
+
+const ENV_KEY = "SPECTRUM_TEST_FROM_ENV";
+
+describe("envFor", () => {
+  it("joins the channel and key under the SPECTRUM_ prefix", () => {
+    expect(envFor("TELEGRAM", "BOT_TOKEN")).toBe("SPECTRUM_TELEGRAM_BOT_TOKEN");
+  });
+
+  it("keeps multi-segment channels intact", () => {
+    expect(envFor("WHATSAPP_BUSINESS", "ACCESS_TOKEN")).toBe(
+      "SPECTRUM_WHATSAPP_BUSINESS_ACCESS_TOKEN"
+    );
+  });
+});
+
+describe("fromEnv", () => {
+  let original: string | undefined;
+
+  beforeEach(() => {
+    original = process.env[ENV_KEY];
+    delete process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = original;
+    }
+  });
+
+  it("uses the explicit value even when the env var is set", () => {
+    process.env[ENV_KEY] = "from-env";
+    const schema = fromEnv(ENV_KEY, z.string().min(1));
+    expect(schema.parse("explicit")).toBe("explicit");
+  });
+
+  it("falls back to the env var when the field is undefined", () => {
+    process.env[ENV_KEY] = "from-env";
+    const schema = fromEnv(ENV_KEY, z.string().min(1));
+    expect(schema.parse(undefined)).toBe("from-env");
+  });
+
+  it("treats an empty-string env var as unset", () => {
+    process.env[ENV_KEY] = "";
+    const schema = fromEnv(ENV_KEY, z.string().min(1));
+    expect(() => schema.parse(undefined)).toThrow();
+  });
+
+  it("raises the inner schema's required error when both are absent", () => {
+    const schema = fromEnv(ENV_KEY, z.string().min(1));
+    expect(() => schema.parse(undefined)).toThrow();
+  });
+
+  it("preserves the inner schema's validation on the env value", () => {
+    process.env[ENV_KEY] = "not-a-url";
+    const schema = fromEnv(ENV_KEY, z.url());
+    expect(() => schema.parse(undefined)).toThrow();
+  });
+
+  it("passes an env value that satisfies the inner schema", () => {
+    process.env[ENV_KEY] = "https://example.com";
+    const schema = fromEnv(ENV_KEY, z.url());
+    expect(schema.parse(undefined)).toBe("https://example.com");
+  });
+
+  it("applies the inner schema's default when field and env are absent", () => {
+    const schema = fromEnv(ENV_KEY, z.string().default("fallback"));
+    expect(schema.parse(undefined)).toBe("fallback");
+  });
+
+  it("lets the env var win over the inner schema's default", () => {
+    process.env[ENV_KEY] = "from-env";
+    const schema = fromEnv(ENV_KEY, z.string().default("fallback"));
+    expect(schema.parse(undefined)).toBe("from-env");
+  });
+
+  it("allows an optional field to resolve to undefined", () => {
+    const schema = fromEnv(ENV_KEY, z.string().optional());
+    expect(schema.parse(undefined)).toBeUndefined();
+  });
+
+  it("keeps a wrapped field as a plain key on a parsed object", () => {
+    process.env[ENV_KEY] = "token";
+    const schema = z.object({
+      accessToken: fromEnv(ENV_KEY, z.string().min(1)),
+    });
+    const parsed = schema.parse({});
+    expect("accessToken" in parsed).toBe(true);
+    expect(parsed.accessToken).toBe("token");
+  });
+});

--- a/packages/slack/src/types.ts
+++ b/packages/slack/src/types.ts
@@ -1,6 +1,14 @@
 import type { SlackClient } from "@photon-ai/slack";
 import type { SchemaMessage } from "@spectrum-ts/core";
+import { envFor, fromEnv } from "@spectrum-ts/core/authoring";
 import z from "zod";
+
+/**
+ * Scoped env-var fallback for a Slack config field. Each field falls back to
+ * `SPECTRUM_SLACK_<KEY>` when omitted (an explicit config value always wins).
+ */
+const env = <T extends z.ZodType>(key: string, schema: T) =>
+  fromEnv(envFor("SLACK", key), schema);
 
 const teamMetadataSchema = z.object({
   appId: z.string(),
@@ -10,7 +18,10 @@ const teamMetadataSchema = z.object({
 });
 
 const directConfig = z.object({
-  endpoint: z.string().optional(),
+  // Falls back to `SPECTRUM_SLACK_ENDPOINT` when omitted (explicit config wins).
+  // `tokens` is a record, so it stays code-only — direct mode still requires it,
+  // which means an env endpoint alone never flips the union into direct mode.
+  endpoint: env("ENDPOINT", z.string().optional()),
   teams: z.record(z.string(), teamMetadataSchema).optional(),
   tokens: z
     .record(z.string(), z.string().min(1))

--- a/packages/slack/src/types.ts
+++ b/packages/slack/src/types.ts
@@ -1,14 +1,6 @@
 import type { SlackClient } from "@photon-ai/slack";
 import type { SchemaMessage } from "@spectrum-ts/core";
-import { envFor, fromEnv } from "@spectrum-ts/core/authoring";
 import z from "zod";
-
-/**
- * Scoped env-var fallback for a Slack config field. Each field falls back to
- * `SPECTRUM_SLACK_<KEY>` when omitted (an explicit config value always wins).
- */
-const env = <T extends z.ZodType>(key: string, schema: T) =>
-  fromEnv(envFor("SLACK", key), schema);
 
 const teamMetadataSchema = z.object({
   appId: z.string(),
@@ -18,10 +10,11 @@ const teamMetadataSchema = z.object({
 });
 
 const directConfig = z.object({
-  // Falls back to `SPECTRUM_SLACK_ENDPOINT` when omitted (explicit config wins).
-  // `tokens` is a record, so it stays code-only — direct mode still requires it,
-  // which means an env endpoint alone never flips the union into direct mode.
-  endpoint: env("ENDPOINT", z.string().optional()),
+  // Falls back to `SPECTRUM_SLACK_ENDPOINT` when omitted (explicit config wins),
+  // applied automatically by `definePlatform` from the platform id. `tokens` is a
+  // record, so it stays code-only — direct mode still requires it, which means an
+  // env endpoint alone never flips the union into direct mode.
+  endpoint: z.string().optional(),
   teams: z.record(z.string(), teamMetadataSchema).optional(),
   tokens: z
     .record(z.string(), z.string().min(1))

--- a/packages/slack/test/config.test.ts
+++ b/packages/slack/test/config.test.ts
@@ -1,5 +1,10 @@
+import { envAwareConfig } from "@spectrum-ts/core/authoring";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { configSchema, isCloudConfig } from "@/types";
+import { isCloudConfig, configSchema as rawConfigSchema } from "@/types";
+
+// `definePlatform("Slack", ...)` applies the env fallback from the platform id;
+// mirror that here so the test exercises the same `SPECTRUM_SLACK_*` resolution.
+const configSchema = envAwareConfig("Slack", rawConfigSchema);
 
 const ENDPOINT = "SPECTRUM_SLACK_ENDPOINT";
 

--- a/packages/slack/test/config.test.ts
+++ b/packages/slack/test/config.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { configSchema, isCloudConfig } from "@/types";
+
+const ENDPOINT = "SPECTRUM_SLACK_ENDPOINT";
+
+describe("slack config env fallback", () => {
+  let saved: string | undefined;
+
+  beforeEach(() => {
+    saved = process.env[ENDPOINT];
+    delete process.env[ENDPOINT];
+  });
+
+  afterEach(() => {
+    if (saved === undefined) {
+      delete process.env[ENDPOINT];
+    } else {
+      process.env[ENDPOINT] = saved;
+    }
+  });
+
+  it("reads the direct-mode endpoint from the env var", () => {
+    process.env[ENDPOINT] = "https://slack.env.example";
+    const config = configSchema.parse({ tokens: { T012ABCDE: "jwt" } });
+    expect(isCloudConfig(config)).toBe(false);
+    expect(config).toMatchObject({ endpoint: "https://slack.env.example" });
+  });
+
+  it("lets an explicit endpoint win over the env var", () => {
+    process.env[ENDPOINT] = "https://slack.env.example";
+    const config = configSchema.parse({
+      endpoint: "https://slack.explicit.example",
+      tokens: { T012ABCDE: "jwt" },
+    });
+    expect(config).toMatchObject({
+      endpoint: "https://slack.explicit.example",
+    });
+  });
+
+  it("does not flip empty config into direct mode via the endpoint env var", () => {
+    process.env[ENDPOINT] = "https://slack.env.example";
+    const config = configSchema.parse({});
+    expect(isCloudConfig(config)).toBe(true);
+  });
+});

--- a/packages/telegram/src/config.ts
+++ b/packages/telegram/src/config.ts
@@ -1,12 +1,4 @@
-import { envFor, fromEnv } from "@spectrum-ts/core/authoring";
 import z from "zod";
-
-/**
- * Scoped env-var fallback for a Telegram config field. Each field falls back to
- * `SPECTRUM_TELEGRAM_<KEY>` when omitted (an explicit config value always wins).
- */
-const env = <T extends z.ZodType>(key: string, schema: T) =>
-  fromEnv(envFor("TELEGRAM", key), schema);
 
 /**
  * The platform identifier — used for ALL THREE of:
@@ -45,12 +37,9 @@ export const configSchema = z.object({
    * Bot token from @BotFather (outbound API calls + media downloads). Falls back
    * to `SPECTRUM_TELEGRAM_BOT_TOKEN` when omitted (explicit config wins).
    */
-  botToken: env(
-    "BOT_TOKEN",
-    z
-      .string()
-      .regex(BOT_TOKEN_PATTERN, "botToken must be in the form '<id>:<token>'")
-  ),
+  botToken: z
+    .string()
+    .regex(BOT_TOKEN_PATTERN, "botToken must be in the form '<id>:<token>'"),
   /**
    * The `secret_token` passed to `setWebhook`. When present, inbound webhooks
    * are verified against the `X-Telegram-Bot-Api-Secret-Token` header; when
@@ -58,15 +47,12 @@ export const configSchema = z.object({
    * this shared token is the only inbound authentication. Falls back to
    * `SPECTRUM_TELEGRAM_WEBHOOK_SECRET` when omitted.
    */
-  webhookSecret: env(
-    "WEBHOOK_SECRET",
-    z.string().regex(SECRET_TOKEN_PATTERN).optional()
-  ),
+  webhookSecret: z.string().regex(SECRET_TOKEN_PATTERN).optional(),
   /**
    * Override the Bot API base URL. Precedence is explicit config >
    * `SPECTRUM_TELEGRAM_BASE_URL` > the `https://api.telegram.org` default.
    */
-  baseUrl: env("BASE_URL", z.url().default(DEFAULT_BASE_URL)),
+  baseUrl: z.url().default(DEFAULT_BASE_URL),
 });
 
 export type TelegramConfig = z.infer<typeof configSchema>;

--- a/packages/telegram/src/config.ts
+++ b/packages/telegram/src/config.ts
@@ -1,4 +1,12 @@
+import { envFor, fromEnv } from "@spectrum-ts/core/authoring";
 import z from "zod";
+
+/**
+ * Scoped env-var fallback for a Telegram config field. Each field falls back to
+ * `SPECTRUM_TELEGRAM_<KEY>` when omitted (an explicit config value always wins).
+ */
+const env = <T extends z.ZodType>(key: string, schema: T) =>
+  fromEnv(envFor("TELEGRAM", key), schema);
 
 /**
  * The platform identifier — used for ALL THREE of:
@@ -33,19 +41,32 @@ const SECRET_TOKEN_PATTERN = /^[A-Za-z0-9_-]{1,256}$/;
 const BOT_TOKEN_PATTERN = /^\d+:[A-Za-z0-9_-]+$/;
 
 export const configSchema = z.object({
-  /** Bot token from @BotFather (outbound API calls + media downloads). */
-  botToken: z
-    .string()
-    .regex(BOT_TOKEN_PATTERN, "botToken must be in the form '<id>:<token>'"),
+  /**
+   * Bot token from @BotFather (outbound API calls + media downloads). Falls back
+   * to `SPECTRUM_TELEGRAM_BOT_TOKEN` when omitted (explicit config wins).
+   */
+  botToken: env(
+    "BOT_TOKEN",
+    z
+      .string()
+      .regex(BOT_TOKEN_PATTERN, "botToken must be in the form '<id>:<token>'")
+  ),
   /**
    * The `secret_token` passed to `setWebhook`. When present, inbound webhooks
    * are verified against the `X-Telegram-Bot-Api-Secret-Token` header; when
    * omitted, the check is skipped. Telegram does not HMAC-sign the body, so
-   * this shared token is the only inbound authentication.
+   * this shared token is the only inbound authentication. Falls back to
+   * `SPECTRUM_TELEGRAM_WEBHOOK_SECRET` when omitted.
    */
-  webhookSecret: z.string().regex(SECRET_TOKEN_PATTERN).optional(),
-  /** Override the Bot API base URL. Defaults to `https://api.telegram.org`. */
-  baseUrl: z.url().default(DEFAULT_BASE_URL),
+  webhookSecret: env(
+    "WEBHOOK_SECRET",
+    z.string().regex(SECRET_TOKEN_PATTERN).optional()
+  ),
+  /**
+   * Override the Bot API base URL. Precedence is explicit config >
+   * `SPECTRUM_TELEGRAM_BASE_URL` > the `https://api.telegram.org` default.
+   */
+  baseUrl: env("BASE_URL", z.url().default(DEFAULT_BASE_URL)),
 });
 
 export type TelegramConfig = z.infer<typeof configSchema>;

--- a/packages/telegram/test/config.test.ts
+++ b/packages/telegram/test/config.test.ts
@@ -1,5 +1,14 @@
+import { envAwareConfig } from "@spectrum-ts/core/authoring";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { configSchema, DEFAULT_BASE_URL } from "@/config";
+import {
+  DEFAULT_BASE_URL,
+  configSchema as rawConfigSchema,
+  TELEGRAM_PLATFORM,
+} from "@/config";
+
+// `definePlatform` applies the env fallback from the platform id; mirror that
+// here so the test exercises the same `SPECTRUM_TELEGRAM_*` resolution.
+const configSchema = envAwareConfig(TELEGRAM_PLATFORM, rawConfigSchema);
 
 const BOT_TOKEN = "SPECTRUM_TELEGRAM_BOT_TOKEN";
 const WEBHOOK_SECRET = "SPECTRUM_TELEGRAM_WEBHOOK_SECRET";

--- a/packages/telegram/test/config.test.ts
+++ b/packages/telegram/test/config.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { configSchema, DEFAULT_BASE_URL } from "@/config";
+
+const BOT_TOKEN = "SPECTRUM_TELEGRAM_BOT_TOKEN";
+const WEBHOOK_SECRET = "SPECTRUM_TELEGRAM_WEBHOOK_SECRET";
+const BASE_URL = "SPECTRUM_TELEGRAM_BASE_URL";
+const ENV_KEYS = [BOT_TOKEN, WEBHOOK_SECRET, BASE_URL];
+
+const VALID_TOKEN = "123456:abcdef";
+
+describe("telegram config env fallback", () => {
+  const saved = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = saved.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it("reads botToken from the env var", () => {
+    process.env[BOT_TOKEN] = VALID_TOKEN;
+    expect(configSchema.parse({}).botToken).toBe(VALID_TOKEN);
+  });
+
+  it("lets an explicit botToken win over the env var", () => {
+    process.env[BOT_TOKEN] = "999999:fromenv";
+    expect(configSchema.parse({ botToken: VALID_TOKEN }).botToken).toBe(
+      VALID_TOKEN
+    );
+  });
+
+  it("still validates the botToken shape when read from env", () => {
+    process.env[BOT_TOKEN] = "not-a-valid-token";
+    expect(() => configSchema.parse({})).toThrow();
+  });
+
+  it("throws when botToken is absent from both config and env", () => {
+    expect(() => configSchema.parse({})).toThrow();
+  });
+
+  it("reads webhookSecret from the env var", () => {
+    process.env[BOT_TOKEN] = VALID_TOKEN;
+    process.env[WEBHOOK_SECRET] = "secret_token-1";
+    expect(configSchema.parse({}).webhookSecret).toBe("secret_token-1");
+  });
+
+  it("applies explicit > env > default precedence for baseUrl", () => {
+    process.env[BOT_TOKEN] = VALID_TOKEN;
+
+    process.env[BASE_URL] = "https://env.telegram.example";
+    expect(configSchema.parse({}).baseUrl).toBe("https://env.telegram.example");
+
+    expect(
+      configSchema.parse({ baseUrl: "https://explicit.telegram.example" })
+        .baseUrl
+    ).toBe("https://explicit.telegram.example");
+
+    delete process.env[BASE_URL];
+    expect(configSchema.parse({}).baseUrl).toBe(DEFAULT_BASE_URL);
+  });
+});

--- a/packages/whatsapp-business/src/types.ts
+++ b/packages/whatsapp-business/src/types.ts
@@ -1,24 +1,17 @@
 import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
 import type { SchemaMessage } from "@spectrum-ts/core";
-import { envFor, fromEnv } from "@spectrum-ts/core/authoring";
 import z from "zod";
 
-/**
- * Scoped env-var fallback for a WhatsApp Business config field. Each field falls
- * back to `SPECTRUM_WHATSAPP_BUSINESS_<KEY>` when omitted (explicit config wins).
- */
-const env = <T extends z.ZodType>(key: string, schema: T) =>
-  fromEnv(envFor("WHATSAPP_BUSINESS", key), schema);
-
 // Direct-mode credentials fall back to `SPECTRUM_WHATSAPP_BUSINESS_*` env vars
-// (explicit config wins). A complete env set — access token + phone number id —
-// satisfies `directConfig` even when `whatsappBusiness.config()` is called
-// empty, so the union resolves to direct mode; a partial set fails `directConfig`
-// and falls through to `cloudConfig`.
+// (explicit config wins), applied automatically by `definePlatform` from the
+// platform id. A complete env set — access token + phone number id — satisfies
+// `directConfig` even when `whatsappBusiness.config()` is called empty, so the
+// union resolves to direct mode; a partial set fails `directConfig` and falls
+// through to `cloudConfig`.
 const directConfig = z.object({
-  accessToken: env("ACCESS_TOKEN", z.string().min(1)),
-  appSecret: env("APP_SECRET", z.string().optional()),
-  phoneNumberId: env("PHONE_NUMBER_ID", z.string().min(1)),
+  accessToken: z.string().min(1),
+  appSecret: z.string().optional(),
+  phoneNumberId: z.string().min(1),
 });
 
 const cloudConfig = z.object({}).strict();

--- a/packages/whatsapp-business/src/types.ts
+++ b/packages/whatsapp-business/src/types.ts
@@ -1,11 +1,24 @@
 import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
 import type { SchemaMessage } from "@spectrum-ts/core";
+import { envFor, fromEnv } from "@spectrum-ts/core/authoring";
 import z from "zod";
 
+/**
+ * Scoped env-var fallback for a WhatsApp Business config field. Each field falls
+ * back to `SPECTRUM_WHATSAPP_BUSINESS_<KEY>` when omitted (explicit config wins).
+ */
+const env = <T extends z.ZodType>(key: string, schema: T) =>
+  fromEnv(envFor("WHATSAPP_BUSINESS", key), schema);
+
+// Direct-mode credentials fall back to `SPECTRUM_WHATSAPP_BUSINESS_*` env vars
+// (explicit config wins). A complete env set — access token + phone number id —
+// satisfies `directConfig` even when `whatsappBusiness.config()` is called
+// empty, so the union resolves to direct mode; a partial set fails `directConfig`
+// and falls through to `cloudConfig`.
 const directConfig = z.object({
-  accessToken: z.string().min(1),
-  appSecret: z.string().optional(),
-  phoneNumberId: z.string().min(1),
+  accessToken: env("ACCESS_TOKEN", z.string().min(1)),
+  appSecret: env("APP_SECRET", z.string().optional()),
+  phoneNumberId: env("PHONE_NUMBER_ID", z.string().min(1)),
 });
 
 const cloudConfig = z.object({}).strict();

--- a/packages/whatsapp-business/test/config.test.ts
+++ b/packages/whatsapp-business/test/config.test.ts
@@ -1,5 +1,11 @@
+import { envAwareConfig } from "@spectrum-ts/core/authoring";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { configSchema, isCloudConfig } from "@/types";
+import { isCloudConfig, configSchema as rawConfigSchema } from "@/types";
+
+// `definePlatform("WhatsApp Business", ...)` applies the env fallback from the
+// platform id; mirror that here so the test exercises the same
+// `SPECTRUM_WHATSAPP_BUSINESS_*` resolution.
+const configSchema = envAwareConfig("WhatsApp Business", rawConfigSchema);
 
 const ACCESS_TOKEN = "SPECTRUM_WHATSAPP_BUSINESS_ACCESS_TOKEN";
 const PHONE_NUMBER_ID = "SPECTRUM_WHATSAPP_BUSINESS_PHONE_NUMBER_ID";

--- a/packages/whatsapp-business/test/config.test.ts
+++ b/packages/whatsapp-business/test/config.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { configSchema, isCloudConfig } from "@/types";
+
+const ACCESS_TOKEN = "SPECTRUM_WHATSAPP_BUSINESS_ACCESS_TOKEN";
+const PHONE_NUMBER_ID = "SPECTRUM_WHATSAPP_BUSINESS_PHONE_NUMBER_ID";
+const APP_SECRET = "SPECTRUM_WHATSAPP_BUSINESS_APP_SECRET";
+const ENV_KEYS = [ACCESS_TOKEN, PHONE_NUMBER_ID, APP_SECRET];
+
+describe("whatsapp-business config env fallback", () => {
+  const saved = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved.set(key, process.env[key]);
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      const value = saved.get(key);
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  });
+
+  it("enables direct mode from a complete env credential set", () => {
+    process.env[ACCESS_TOKEN] = "env-token";
+    process.env[PHONE_NUMBER_ID] = "env-phone";
+    const config = configSchema.parse({});
+    expect(isCloudConfig(config)).toBe(false);
+    expect(config).toMatchObject({
+      accessToken: "env-token",
+      phoneNumberId: "env-phone",
+    });
+  });
+
+  it("falls back to cloud mode when the env set is partial", () => {
+    process.env[ACCESS_TOKEN] = "env-token";
+    const config = configSchema.parse({});
+    expect(isCloudConfig(config)).toBe(true);
+  });
+
+  it("lets explicit config override env credentials", () => {
+    process.env[ACCESS_TOKEN] = "env-token";
+    process.env[PHONE_NUMBER_ID] = "env-phone";
+    const config = configSchema.parse({
+      accessToken: "explicit-token",
+      phoneNumberId: "explicit-phone",
+    });
+    expect(config).toMatchObject({
+      accessToken: "explicit-token",
+      phoneNumberId: "explicit-phone",
+    });
+  });
+
+  it("stays cloud mode with no explicit config and no env vars", () => {
+    const config = configSchema.parse({});
+    expect(isCloudConfig(config)).toBe(true);
+  });
+
+  it("mixes an explicit access token with an env phone number id", () => {
+    process.env[PHONE_NUMBER_ID] = "env-phone";
+    const config = configSchema.parse({ accessToken: "explicit-token" });
+    expect(isCloudConfig(config)).toBe(false);
+    expect(config).toMatchObject({
+      accessToken: "explicit-token",
+      phoneNumberId: "env-phone",
+    });
+  });
+});


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786140097&installation_id=127326493&pr_number=184&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F184&signature=ec486be9f5cb6af33049c0595d6067e425b882697ac360d4f3b13fbec8cf701e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added environment-variable fallbacks for project credentials and webhook secrets.
  * Provider config fields can now be auto-populated from standardized environment variables.
  * Empty-string environment values are treated as unset.
  * Explicit configuration continues to take precedence over environment values.

* **Documentation**
  * Updated setup guides for core credentials and Slack/Telegram/WhatsApp Business to clarify env fallback, precedence, and mode selection.

* **Tests**
  * Added coverage for credential resolution, env precedence, and strict validation behavior across providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->