### PR TITLE
fix(imessage): don't subscribe to group stream in shared mode (ENG-1945)

### DIFF
--- a/docs/providers.mdx.vel
+++ b/docs/providers.mdx.vel
@@ -9,7 +9,7 @@ Providers plug into Spectrum's type system and runtime. Each provider exports a 
 
 <CardGroup cols={2}>
   <Card title="iMessage" icon="comment" href="/spectrum-ts/providers/imessage">
-    Connect through local, cloud, or dedicated modes. Use tapbacks, typing indicators, threaded replies, DMs, and groups.
+    Connect through cloud or local mode. Use tapbacks, typing indicators, threaded replies, DMs, and groups.
   </Card>
   <Card title="Terminal" icon="terminal" href="/spectrum-ts/providers/terminal">
     Run a local chat interface for development, testing, and CLI-style agents.

--- a/docs/providers/imessage.mdx.vel
+++ b/docs/providers/imessage.mdx.vel
@@ -1,13 +1,13 @@
 ---
 title: "iMessage"
-description: "Receive and send iMessage across local, cloud, and dedicated modes."
+description: "Receive and send iMessage through cloud or local mode."
 ---
 
 ```ts
 import { imessage } from "spectrum-ts/providers/imessage";
 ```
 
-The iMessage provider supports three connection modes: local, cloud, and dedicated. It exposes iMessage-specific features such as tapbacks, DM and group spaces, chat backgrounds, mini-app cards, and per-phone routing through [platform narrowing](/spectrum-ts/platform-narrowing).
+The iMessage provider supports two connection modes: cloud and local. It exposes iMessage-specific features such as tapbacks, DM and group spaces, chat backgrounds, mini-app cards, and per-phone routing through [platform narrowing](/spectrum-ts/platform-narrowing). Group creation and group-change events require a dedicated cloud line.
 
 ## Quick start
 
@@ -30,21 +30,23 @@ Use local mode when you are developing on your own Mac and only need local Messa
 imessage.config({ local: true });
 ```
 
-Use dedicated mode when you operate your own iMessage relay:
+Cloud mode discovers all lines owned by your project by default. If your project owns multiple dedicated lines and you want the SDK to subscribe to only some of them, pass those cloud clients explicitly:
 
 ```ts
 imessage.config({
   clients: [
-    { address: "instance-1.example.com:443", token: "your-token", phone: "+15551111111" },
+    { address: "line-1.imsg.photon.codes:443", token: "your-token", phone: "+15551111111" },
   ],
 });
 ```
+
+This is advanced cloud configuration, not a separate connection mode. Explicit client tokens are not renewed by the SDK, so you are responsible for keeping them current. Most applications should use `imessage.config()` and let Spectrum discover and renew their cloud clients automatically.
 
 ## Explore iMessage
 
 <CardGroup cols={2}>
   <Card title="Connection and routing" icon="route" href="/spectrum-ts/providers/imessage/connection-and-routing">
-    Compare local, cloud, and dedicated modes. Learn line allocation, quotas, space types, and per-phone routing.
+    Compare cloud and local modes. Learn line allocation, quotas, space types, and per-phone routing.
   </Card>
   <Card title="Messaging features" icon="sparkles" href="/spectrum-ts/providers/imessage/messaging-features">
     Use effects, chat renames, avatars, group membership, backgrounds, mini-app cards, contact cards, attachments, and tapbacks.

--- a/docs/providers/imessage/connection-and-routing.mdx.vel
+++ b/docs/providers/imessage/connection-and-routing.mdx.vel
@@ -16,7 +16,7 @@ Use this page to choose an iMessage connection mode and understand how Spectrum 
     imessage.config();
     ```
 
-    Tokens are renewed automatically at 80% of their TTL. Requires `projectId` and `projectSecret` on the `Spectrum()` call:
+    With automatic discovery, tokens are renewed at 80% of their TTL. This requires `projectId` and `projectSecret` on the `Spectrum()` call:
 
     ```ts
     const app = await Spectrum({
@@ -25,6 +25,18 @@ Use this page to choose an iMessage connection mode and understand how Spectrum 
       providers: [imessage.config()],
     });
     ```
+
+    Spectrum discovers all cloud lines owned by the project and renews their tokens automatically. For advanced routing, you can instead provide a subset of the project's cloud clients:
+
+    ```ts
+    imessage.config({
+      clients: [
+        { address: "line-1.imsg.photon.codes:443", token: "your-token", phone: "+15551111111" },
+      ],
+    });
+    ```
+
+    Explicit clients let you control which cloud-owned lines this SDK instance subscribes to. They are still cloud mode. Their tokens are not renewed by the SDK, so you are responsible for keeping them current; most applications should use automatic discovery.
   </Tab>
   <Tab title="Local">
     Reads the macOS Messages SQLite database directly. No network. Good for development on your own Mac.
@@ -37,20 +49,6 @@ Use this page to choose an iMessage connection mode and understand how Spectrum 
       Local mode only supports sending text and attachments. Reactions, typing indicators, threaded replies, group creation, chat backgrounds, chat renaming, group avatars (setting and reading), and group membership (management and listing) are not available.
     </Note>
   </Tab>
-  <Tab title="Dedicated">
-    Connect directly to one or more iMessage gRPC endpoints with your own tokens. Use this when you're running your own iMessage relay and want to skip cloud auth. Each entry must include the `phone` number the instance serves, so Spectrum can route messages through the right number:
-
-    ```ts
-    imessage.config({
-      clients: [
-        { address: "instance-1.example.com:443", token: "your-token", phone: "+15551111111" },
-        { address: "instance-2.example.com:443", token: "your-token", phone: "+15552222222" },
-      ],
-    });
-    ```
-
-    Multiple clients route messages based on the phone number associated with each space.
-  </Tab>
 </Tabs>
 
 ## Line model
@@ -62,10 +60,10 @@ Cloud mode routes your messages through phone numbers, also called lines, provis
 | **Free / Pro** | **Shared pool.** Each end user is routed through a number from a shared pool. | A normal iMessage from a number that may differ across recipients. | No group creation or inbound group-change events. |
 | **Business** | **Dedicated.** All end users text the same number, which belongs to your project. | A normal iMessage, always from the same number. | Group creation and inbound group-change events are supported. |
 
-DM delivery is identical in both modes. The developer-facing differences are sender-number allocation and group support.
+DM delivery is identical across both cloud line models. The developer-facing differences are sender-number allocation and group support.
 
 <Warning>
-  Shared-pool mode does not create group chats and does not subscribe to iMessage's group-event stream. Changes such as adding or removing a member, leaving, renaming the chat, or changing its avatar will not appear on `app.messages`. Use a Business dedicated line or your own dedicated relay when your integration depends on group workflows.
+  Shared-pool mode does not create group chats and does not subscribe to iMessage's group-event stream. Changes such as adding or removing a member, leaving, renaming the chat, or changing its avatar will not appear on `app.messages`. Use a Business dedicated line when your integration depends on group workflows.
 </Warning>
 
 ### Auto-scale
@@ -73,7 +71,7 @@ DM delivery is identical in both modes. The developer-facing differences are sen
 When traffic to a dedicated line approaches its per-line capacity, Spectrum can automatically provision an additional line so deliverability isn't affected. Auto-scale is an opt-in feature on the Business plan. Enable it in your project settings if you'd rather not get paged when a line saturates.
 
 <Note>
-  These are managed Spectrum Cloud features. If you're on the open-source path (`imessage.config({ local: true })` or your own dedicated relay), you provide your own iCloud account and managed-line concepts don't apply.
+  These are Spectrum Cloud features. In local mode (`imessage.config({ local: true })`), you provide your own iCloud account and managed-line concepts do not apply.
 </Note>
 
 ## Quotas
@@ -150,7 +148,7 @@ To look up an existing conversation by its chat GUID, use `space.get(id)`:
 const existing = await im.space.get("any;-;+15551111111");
 ```
 
-DM creation works in cloud and dedicated modes. Local mode can construct a deterministic DM reference, but it cannot create a group because the local Messages database does not expose chat creation.
+DM creation works in cloud mode. Local mode can construct a deterministic DM reference, but it cannot create a group because the local Messages database does not expose chat creation.
 
 Group creation requires a dedicated line. In shared-pool mode, passing multiple users to `space.create()` throws an `UnsupportedError`. You can use `space.get(chatGuid)` to reference an existing group, but shared mode still does not receive membership or metadata changes from the group-event stream.
 

--- a/docs/providers/imessage/connection-and-routing.mdx.vel
+++ b/docs/providers/imessage/connection-and-routing.mdx.vel
@@ -10,7 +10,7 @@ Use this page to choose an iMessage connection mode and understand how Spectrum 
 
 <Tabs>
   <Tab title="Cloud (default)">
-    Authenticates with Spectrum Cloud and connects to managed iMessage infrastructure via gRPC. Full feature set: send, receive, typing, reactions, replies, and group creation.
+    Authenticates with Spectrum Cloud and connects to managed iMessage infrastructure via gRPC. Supports sending, receiving, typing indicators, reactions, and replies. Group creation and inbound group-change events require a dedicated line.
 
     ```ts
     imessage.config();
@@ -57,12 +57,16 @@ Use this page to choose an iMessage connection mode and understand how Spectrum 
 
 Cloud mode routes your messages through phone numbers, also called lines, provisioned by Spectrum. Which lines you get depends on your plan, and the difference is mostly invisible to end users.
 
-| Plan | Line allocation | What end users see |
-|---|---|---|
-| **Free / Pro** | **Shared pool.** Each of your end users is routed through a different number from a shared pool. | A normal iMessage from a number that may differ across recipients. |
-| **Business** | **Dedicated.** All of your end users text the same number, which belongs to your project. | A normal iMessage, always from the same number. |
+| Plan | Line allocation | What end users see | Group support |
+|---|---|---|---|
+| **Free / Pro** | **Shared pool.** Each end user is routed through a number from a shared pool. | A normal iMessage from a number that may differ across recipients. | No group creation or inbound group-change events. |
+| **Business** | **Dedicated.** All end users text the same number, which belongs to your project. | A normal iMessage, always from the same number. | Group creation and inbound group-change events are supported. |
 
-End-user delivery is identical in both modes. The distinction is which number sends.
+DM delivery is identical in both modes. The developer-facing differences are sender-number allocation and group support.
+
+<Warning>
+  Shared-pool mode does not create group chats and does not subscribe to iMessage's group-event stream. Changes such as adding or removing a member, leaving, renaming the chat, or changing its avatar will not appear on `app.messages`. Use a Business dedicated line or your own dedicated relay when your integration depends on group workflows.
+</Warning>
 
 ### Auto-scale
 
@@ -135,7 +139,7 @@ const bob = await im.user("+15552222222");
 const dm = await im.space.create(alice);
 await dm.send("Hi Alice");
 
-// Group
+// Group (dedicated lines only)
 const group = await im.space.create([alice, bob]);
 await group.send("Welcome to the group.");
 ```
@@ -146,7 +150,9 @@ To look up an existing conversation by its chat GUID, use `space.get(id)`:
 const existing = await im.space.get("any;-;+15551111111");
 ```
 
-Space creation requires cloud or dedicated mode. In local mode `space.create()` throws because the local Messages database doesn't expose chat creation. Shared mode cannot create group chats. Use a dedicated number, or `space.get(chatGuid)` for an existing group.
+DM creation works in cloud and dedicated modes. Local mode can construct a deterministic DM reference, but it cannot create a group because the local Messages database does not expose chat creation.
+
+Group creation requires a dedicated line. In shared-pool mode, passing multiple users to `space.create()` throws an `UnsupportedError`. You can use `space.get(chatGuid)` to reference an existing group, but shared mode still does not receive membership or metadata changes from the group-event stream.
 
 ### Per-phone routing
 

--- a/docs/providers/imessage/messaging-features.mdx.vel
+++ b/docs/providers/imessage/messaging-features.mdx.vel
@@ -127,7 +127,11 @@ Membership management requires cloud or dedicated mode and only works on group c
 
 ## Inbound group events
 
-In cloud or dedicated mode, group changes made by other members arrive as inbound messages on `app.messages` carrying the same content types you send — local mode drops them:
+Inbound group events require a dedicated line: either a Business line managed by Spectrum Cloud or a client configured with your own dedicated relay. Group changes made by other members then arrive as inbound messages on `app.messages`, carrying the same content types you send:
+
+<Warning>
+  Shared-pool and local modes do not subscribe to the group-event stream. Your app will not receive membership or group-metadata changes through `app.messages` in either mode. If you use `space.get(chatGuid)` to reference an existing group in shared mode, that reference does not enable group events.
+</Warning>
 
 | Someone… | `content.type` | `message.sender` |
 |---|---|---|
@@ -151,7 +155,7 @@ Semantics to rely on:
 - `message.sender` may be `undefined` — Apple does not always record the actor. The affected member is always present (in `members`, or as the sender for `leaveSpace`).
 - The agent's own actions never echo back: `space.add(...)`, `space.rename(...)`, and friends are suppressed from the inbound stream, matching how self-sent messages behave.
 - Icon-change events carry a snapshot of the icon fetched at event time; an icon that was already replaced or removed by then is skipped (the follow-up event carries the current state).
-- Group events ride the same durable catch-up log as messages and polls, so changes that happen while the app is down are replayed on reconnect. After a cursor gap, reconcile with `space.getMembers()` / `space.getAvatar()`.
+- On dedicated lines, group events ride the same durable catch-up log as messages and polls, so changes that happen while the app is down are replayed on reconnect. After a cursor gap, reconcile with `space.getMembers()` / `space.getAvatar()`.
 
 ## Chat backgrounds
 

--- a/docs/providers/imessage/messaging-features.mdx.vel
+++ b/docs/providers/imessage/messaging-features.mdx.vel
@@ -58,7 +58,7 @@ await space.rename("Book Club");
 await space.send(rename("Book Club"));
 ```
 
-Renaming requires cloud or dedicated mode and only works on group chats. In local mode or on a DM, `rename()` throws an `UnsupportedError`.
+Renaming requires cloud mode and only works on group chats. In local mode or on a DM, `rename()` throws an `UnsupportedError`.
 
 ## Group avatars
 
@@ -86,7 +86,7 @@ if (icon) {
 }
 ```
 
-Group avatars require cloud or dedicated mode and only work on group chats. In local mode or on a DM, `avatar()` and `getAvatar()` throw an `UnsupportedError`.
+Group avatars require cloud mode and only work on group chats. In local mode or on a DM, `avatar()` and `getAvatar()` throw an `UnsupportedError`.
 
 ## Group membership
 
@@ -123,11 +123,11 @@ for (const member of detailed) {
 }
 ```
 
-Membership management requires cloud or dedicated mode and only works on group chats. In local mode or on a DM it throws an `UnsupportedError` — a DM cannot be converted into a group, so to add someone to a 1:1 conversation, create a group with `space.create` instead. `getMembers()` has the same constraints: a DM has no roster to list.
+Membership management requires cloud mode and only works on group chats. In local mode or on a DM it throws an `UnsupportedError` — a DM cannot be converted into a group, so to add someone to a 1:1 conversation, create a group with `space.create` instead. `getMembers()` has the same constraints: a DM has no roster to list.
 
 ## Inbound group events
 
-Inbound group events require a dedicated line: either a Business line managed by Spectrum Cloud or a client configured with your own dedicated relay. Group changes made by other members then arrive as inbound messages on `app.messages`, carrying the same content types you send:
+Inbound group events require a dedicated cloud line, available on the Business plan. Group changes made by other members then arrive as inbound messages on `app.messages`, carrying the same content types you send:
 
 <Warning>
   Shared-pool and local modes do not subscribe to the group-event stream. Your app will not receive membership or group-metadata changes through `app.messages` in either mode. If you use `space.get(chatGuid)` to reference an existing group in shared mode, that reference does not enable group events.
@@ -203,7 +203,7 @@ Background UI may not appear in these cases:
 </Note>
 
 <Note>
-  Chat backgrounds require cloud or dedicated mode. In local mode, `background()` throws an `UnsupportedError`.
+  Chat backgrounds require cloud mode. In local mode, `background()` throws an `UnsupportedError`.
 </Note>
 
 <Note>
@@ -261,7 +261,7 @@ const sent = await space.send(customizedMiniApp({
 </AccordionGroup>
 
 <Note>
-  Mini-app cards require cloud or dedicated mode. In local mode, `customizedMiniApp()` throws an `UnsupportedError`.
+  Mini-app cards require cloud mode. In local mode, `customizedMiniApp()` throws an `UnsupportedError`.
 </Note>
 
 ## Native contact card sharing
@@ -289,7 +289,7 @@ Share the bot account's own iMessage contact card directly in a chat. Use `nativ
 This shares the bot's own contact card as it appears in iMessage. Recipients can tap it to save the contact. Use it in onboarding flows where you want users to add your bot to their contacts.
 
 <Note>
-  Native contact card sharing requires cloud or dedicated mode. In local mode, `nativeContactCard()` throws an `UnsupportedError`.
+  Native contact card sharing requires cloud mode. In local mode, `nativeContactCard()` throws an `UnsupportedError`.
 </Note>
 
 ## Fetching attachments
@@ -317,7 +317,7 @@ const att = await im.getAttachment("p:0/GUID", "+15559999999");
 When only one phone is configured, or in shared-pool mode, the phone parameter is optional.
 
 <Note>
-  `getAttachment` requires cloud or dedicated mode. In local mode it throws an `UnsupportedError`.
+  `getAttachment` requires cloud mode. In local mode it throws an `UnsupportedError`.
 </Note>
 
 ## Tapback constants

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -24,6 +24,7 @@ import {
   type RemoteClient,
   SHARED_PHONE,
 } from "../types";
+import { isSharedMode } from "./client";
 import { getContactShareTracker } from "./contact-share";
 import {
   groupEventActor,
@@ -307,14 +308,21 @@ const clientStream = (
   client: AdvancedIMessage,
   pollCache: PollCache,
   phone: string,
+  includeGroupEvents: boolean,
   onInbound?: OnInboundMessage,
   recover?: () => Promise<void>
-): ManagedStream<IMessageMessage> =>
-  mergeStreams([
+): ManagedStream<IMessageMessage> => {
+  const streams: ManagedStream<IMessageMessage>[] = [
     messageStream(client, phone, onInbound, recover),
     pollStream(client, pollCache, phone, recover),
-    groupStream(client, phone, recover),
-  ]);
+  ];
+
+  if (includeGroupEvents) {
+    streams.push(groupStream(client, phone, recover));
+  }
+
+  return mergeStreams(streams);
+};
 
 export const messages = (
   clients: RemoteClient[],
@@ -331,6 +339,7 @@ export const messages = (
   // return undefined (nothing to refresh). Shared across this client array's
   // streams so the message + poll loops coalesce onto one re-mint.
   const recover = getCloudRecover(clients);
+  const includeGroupEvents = !isSharedMode(clients);
   return mergeStreams(
     clients.map((entry) => {
       const tracker = shareEnabled
@@ -340,6 +349,7 @@ export const messages = (
         entry.client,
         pollCache,
         entry.phone,
+        includeGroupEvents,
         tracker ? (chatGuid) => tracker.maybeShare(chatGuid) : undefined,
         recover
       );

--- a/packages/imessage/test/remote/stream.test.ts
+++ b/packages/imessage/test/remote/stream.test.ts
@@ -1,0 +1,89 @@
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import { flush, settleSoon } from "@spectrum-ts/test-support/timing";
+import { describe, expect, it, vi } from "vitest";
+import { messages } from "@/remote/stream";
+import { type RemoteClient, SHARED_PHONE } from "@/types";
+
+const idleEventStream = () => {
+  let closed = false;
+  let resolveNext:
+    | ((result: IteratorResult<never, undefined>) => void)
+    | undefined;
+
+  const close = (): Promise<void> => {
+    closed = true;
+    resolveNext?.({ done: true, value: undefined });
+    resolveNext = undefined;
+    return Promise.resolve();
+  };
+
+  return {
+    close,
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<never, undefined>> {
+          if (closed) {
+            return Promise.resolve({ done: true, value: undefined });
+          }
+          return new Promise((resolve) => {
+            resolveNext = resolve;
+          });
+        },
+        return(): Promise<IteratorResult<never, undefined>> {
+          return close().then(() => ({ done: true, value: undefined }));
+        },
+      };
+    },
+  };
+};
+
+const remoteClient = (phone: string) => {
+  const subscribeToMessages = vi.fn(idleEventStream);
+  const subscribeToPolls = vi.fn(idleEventStream);
+  const subscribeToGroups = vi.fn(idleEventStream);
+  const entry: RemoteClient = {
+    phone,
+    client: {
+      groups: { subscribeEvents: subscribeToGroups },
+      messages: { subscribeEvents: subscribeToMessages },
+      polls: { subscribeEvents: subscribeToPolls },
+    } as unknown as AdvancedIMessage,
+  };
+
+  return {
+    entry,
+    subscribeToGroups,
+    subscribeToMessages,
+    subscribeToPolls,
+  };
+};
+
+const startAndClose = async (clients: RemoteClient[]): Promise<void> => {
+  const stream = messages(clients);
+  const pendingMessage = stream[Symbol.asyncIterator]().next();
+  await flush();
+  await stream.close();
+  await settleSoon(pendingMessage);
+};
+
+describe("remote iMessage streams", () => {
+  it("does not subscribe to group events in shared mode", async () => {
+    const shared = remoteClient(SHARED_PHONE);
+
+    await startAndClose([shared.entry]);
+
+    expect(shared.subscribeToMessages).toHaveBeenCalledTimes(1);
+    expect(shared.subscribeToPolls).toHaveBeenCalledTimes(1);
+    expect(shared.subscribeToGroups).not.toHaveBeenCalled();
+  });
+
+  it("subscribes to group events for a dedicated line", async () => {
+    const dedicated = remoteClient("+15550100");
+
+    await startAndClose([dedicated.entry]);
+
+    expect(dedicated.subscribeToMessages).toHaveBeenCalledTimes(1);
+    expect(dedicated.subscribeToPolls).toHaveBeenCalledTimes(1);
+    expect(dedicated.subscribeToGroups).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Shared-pool cloud lines (Free/Pro) don't support group chats and never receive group events, yet the SDK was still opening a `groupStream` subscription against them. This skips that subscription in shared mode — only dedicated lines subscribe to the group-event stream.
- `clientStream()` now takes an `includeGroupEvents` flag; `messages()` computes it once per client array via `isSharedMode(clients)` and merges `groupStream` only when the line is dedicated.
- Message and poll streams are untouched — shared mode still receives DMs, tapbacks, typing, replies, and polls exactly as before.
- Docs: dropped "dedicated" as a separate connection mode (iMessage now has two — **cloud** and **local**) and clarified that group creation and inbound group-change events require a Business dedicated line. Explicit `clients: [...]` is reframed as advanced cloud configuration, not a distinct mode.

## Why

`isSharedMode` is a single client on the `SHARED_PHONE` sentinel — each end user is routed through a rotating number from a shared pool, which has no group support. Subscribing to the group-event stream there is wasted work and surfaces a stream the mode can never meaningfully serve. Gating the subscription on `!isSharedMode(clients)` restricts it to dedicated lines.

## Changes

**`packages/imessage/src/remote/stream.ts`**
- `clientStream()` gains an `includeGroupEvents` param; `groupStream` is only pushed into the merged stream when it is `true`.
- `messages()` computes `includeGroupEvents = !isSharedMode(clients)` once and threads it into each per-client stream.

**`packages/imessage/test/remote/stream.test.ts`** *(new)*
- Shared mode subscribes to messages + polls but **not** groups.
- A dedicated line subscribes to all three.

**`docs/`**
- `providers.mdx.vel`, `providers/imessage.mdx.vel` — two modes (cloud, local); dedicated is advanced cloud config with caller-managed tokens.
- `providers/imessage/connection-and-routing.mdx.vel` — removed the Dedicated tab; added a group-support column and a shared-pool warning to the line model.
- `providers/imessage/messaging-features.mdx.vel` — group creation / rename / avatar / membership / inbound events require a dedicated line; shared-pool and local modes don't subscribe to the group stream.

## Linear

ENG-1945

## Verification

- [x] `bun --filter @spectrum-ts/imessage typecheck` — clean
- [x] `bun --filter @spectrum-ts/imessage test:node` — 159 pass (15 files)
- [x] `bun --filter @spectrum-ts/imessage test:bun` — 159 pass (15 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786312972&installation_id=127326493&pr_number=185&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F185&signature=f1d5e95b24c06510dac92097ac816ebe0b015aaa840072196f84de3b53f14214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified iMessage cloud and local connection modes.
  * Documented dedicated-line requirements for group creation, membership updates, and group events.
  * Added guidance for cloud client selection and token renewal.
  * Clarified feature availability and limitations across cloud, local, and shared-pool modes.

* **Bug Fixes**
  * Shared-pool connections no longer subscribe to unsupported group event streams.

* **Tests**
  * Added coverage confirming group events are enabled for dedicated lines and excluded from shared mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->