### PR TITLE
feat(imessage): outbound over the HTTP middleware

### DIFF
--- a/packages/imessage/package.json
+++ b/packages/imessage/package.json
@@ -45,7 +45,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@photon-ai/advanced-imessage": "^1.0.0",
+    "@photon-ai/advanced-imessage": "^2.0.0",
     "@photon-ai/otel": "^3.1.0",
     "lru-cache": "^11.0.0",
     "marked": "^18.0.5",

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -27,6 +27,17 @@ interface CloudAuth {
 
 const cloudAuthState = new WeakMap<RemoteClient[], CloudAuth>();
 
+/**
+ * The HTTP middleware (imessage-server-v2-http) every outbound unary call
+ * dials, in both shared and dedicated modes. Dedicated routing happens
+ * server-side via the SDK's `server` option (x-photon-server), not by
+ * dialing per-instance hosts — those speak only gRPC and serve only the
+ * inbound event streams.
+ */
+export const middlewareAddress = (): string =>
+  process.env.SPECTRUM_IMESSAGE_HTTP_ADDRESS ??
+  "imessage.spectrum.photon.codes:443";
+
 const requirePhone = (data: DedicatedTokenData, instanceId: string): string => {
   const phone = data.numbers?.[instanceId];
   if (!phone) {
@@ -163,13 +174,7 @@ export async function createCloudClients(
   };
   const cloudAuth: CloudAuth = { dispose, forceRefresh };
 
-  // Outbound unary calls dial the HTTP middleware (imessage-server-v2-http)
-  // in both modes; dedicated routing happens server-side via the SDK's
-  // `server` option, not by dialing per-instance hosts. The gRPC address
-  // below serves only the inbound event streams.
-  const httpAddress =
-    process.env.SPECTRUM_IMESSAGE_HTTP_ADDRESS ??
-    "imessage.spectrum.photon.codes:443";
+  const httpAddress = middlewareAddress();
 
   if (tokenData.type === "shared") {
     const address =

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -1,4 +1,7 @@
-import { createClient } from "@photon-ai/advanced-imessage";
+import {
+  createGrpcClient,
+  createHttpClient,
+} from "@photon-ai/advanced-imessage";
 import {
   cloud,
   type DedicatedTokenData,
@@ -160,26 +163,40 @@ export async function createCloudClients(
   };
   const cloudAuth: CloudAuth = { dispose, forceRefresh };
 
+  // Outbound unary calls dial the HTTP middleware (imessage-server-v2-http)
+  // in both modes; dedicated routing happens server-side via the SDK's
+  // `server` option, not by dialing per-instance hosts. The gRPC address
+  // below serves only the inbound event streams.
+  const httpAddress =
+    process.env.SPECTRUM_IMESSAGE_HTTP_ADDRESS ??
+    "imessage.spectrum.photon.codes:443";
+
   if (tokenData.type === "shared") {
     const address =
       process.env.SPECTRUM_IMESSAGE_ADDRESS ??
       "imessage.spectrum.photon.codes:443";
+    const sharedToken = async () => {
+      await refreshIfNeeded();
+      return (tokenData as SharedTokenData).token;
+    };
     const entries: RemoteClient[] = [
       {
         phone: SHARED_PHONE,
-        client: createClient({
-          address,
+        client: createHttpClient({
+          address: httpAddress,
           // Auto-retry transient unary failures so a brief server blip during
           // an outbound action (send/react/reply) doesn't surface as an
           // uncaught error. `autoIdempotency` attaches an x-idempotency-key to
-          // mutating RPCs so the retry can't double-apply.
+          // mutating calls so the retry can't double-apply.
           autoIdempotency: true,
           retry: true,
           tls: true,
-          token: async () => {
-            await refreshIfNeeded();
-            return (tokenData as SharedTokenData).token;
-          },
+          token: sharedToken,
+        }),
+        streams: createGrpcClient({
+          address,
+          tls: true,
+          token: sharedToken,
         }),
       },
     ];
@@ -191,18 +208,26 @@ export async function createCloudClients(
 
   const dedicated = tokenData;
   for (const [instanceId, token] of Object.entries(dedicated.auth)) {
+    const dedicatedToken = async () => {
+      await refreshIfNeeded();
+      const data = tokenData as DedicatedTokenData;
+      return data.auth[instanceId] ?? token;
+    };
     const entry: RemoteClient = {
       phone: requirePhone(dedicated, instanceId),
-      client: createClient({
-        address: `${instanceId}.imsg.photon.codes:443`,
+      client: createHttpClient({
+        address: httpAddress,
         autoIdempotency: true,
         retry: true,
+        // Routes every call to this dedicated instance (x-photon-server).
+        server: instanceId,
         tls: true,
-        token: async () => {
-          await refreshIfNeeded();
-          const data = tokenData as DedicatedTokenData;
-          return data.auth[instanceId] ?? token;
-        },
+        token: dedicatedToken,
+      }),
+      streams: createGrpcClient({
+        address: `${instanceId}.imsg.photon.codes:443`,
+        tls: true,
+        token: dedicatedToken,
       }),
     };
     records.push({ entry, instanceId });

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -487,7 +487,7 @@ export const imessage = definePlatform("iMessage", {
         return entries.map((e) => ({
           phone: e.phone,
           client: createHttpClient({
-            address: middlewareAddress(),
+            address: e.httpAddress ?? middlewareAddress(),
             // Auto-retry transient unary failures (idempotency-keyed so retries
             // can't double-apply) so a server blip during an outbound action
             // doesn't crash the app.

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -37,7 +37,11 @@ export {
 } from "./content/customized-mini-app";
 export { effect, type IMessageMessageEffect } from "./content/effect";
 
-import { createCloudClients, disposeCloudAuth } from "./auth";
+import {
+  createCloudClients,
+  disposeCloudAuth,
+  middlewareAddress,
+} from "./auth";
 import { getMessageCache } from "./cache";
 import {
   type Background,
@@ -477,18 +481,19 @@ export const imessage = definePlatform("iMessage", {
         const entries = Array.isArray(config.clients)
           ? config.clients
           : [config.clients];
-        // Explicit clients carry a single operator-controlled address: it
-        // must serve the HTTP middleware for outbound and, during the
-        // transition, the gRPC event streams for inbound.
+        // `address` keeps its historical meaning — the per-line gRPC plane
+        // (event streams). Outbound rides the HTTP middleware like the cloud
+        // path; dedicated static tokens set `server` for instance routing.
         return entries.map((e) => ({
           phone: e.phone,
           client: createHttpClient({
-            address: e.address,
+            address: middlewareAddress(),
             // Auto-retry transient unary failures (idempotency-keyed so retries
             // can't double-apply) so a server blip during an outbound action
             // doesn't crash the app.
             autoIdempotency: true,
             retry: true,
+            server: e.server,
             tls: true,
             token: e.token,
           }),

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -1,6 +1,7 @@
 import {
   type AdvancedIMessage,
-  createClient,
+  createGrpcClient,
+  createHttpClient,
   type MiniAppCardSession,
 } from "@photon-ai/advanced-imessage";
 import { withSpan } from "@photon-ai/otel";
@@ -476,15 +477,23 @@ export const imessage = definePlatform("iMessage", {
         const entries = Array.isArray(config.clients)
           ? config.clients
           : [config.clients];
+        // Explicit clients carry a single operator-controlled address: it
+        // must serve the HTTP middleware for outbound and, during the
+        // transition, the gRPC event streams for inbound.
         return entries.map((e) => ({
           phone: e.phone,
-          client: createClient({
+          client: createHttpClient({
             address: e.address,
             // Auto-retry transient unary failures (idempotency-keyed so retries
             // can't double-apply) so a server blip during an outbound action
             // doesn't crash the app.
             autoIdempotency: true,
             retry: true,
+            tls: true,
+            token: e.token,
+          }),
+          streams: createGrpcClient({
+            address: e.address,
             tls: true,
             token: e.token,
           }),
@@ -502,7 +511,9 @@ export const imessage = definePlatform("iMessage", {
 
     destroyClient: async ({ client }) => {
       await disposeCloudAuth(client);
-      await Promise.all(client.map((entry) => entry.client.close()));
+      await Promise.all(
+        client.flatMap((entry) => [entry.client.close(), entry.streams.close()])
+      );
     },
   },
 

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -2,6 +2,7 @@ import {
   type AdvancedIMessage,
   type CatchUpEvent,
   type GroupEvent,
+  type GrpcAdvancedIMessage,
   type MessageEvent,
   type PollEvent,
   ValidationError,
@@ -224,7 +225,7 @@ const isGroupEvent = (event: CatchUpEvent): event is GroupEvent =>
   event.type === "group.changed";
 
 async function* catchUpEvents<T extends MessageEvent | PollEvent | GroupEvent>(
-  client: AdvancedIMessage,
+  streams: GrpcAdvancedIMessage,
   cursor: string,
   isWanted: (event: CatchUpEvent) => event is T
 ): AsyncGenerator<T | CatchUpCompleteEvent> {
@@ -233,7 +234,7 @@ async function* catchUpEvents<T extends MessageEvent | PollEvent | GroupEvent>(
     return;
   }
 
-  for await (const event of client.events.catchUp(since)) {
+  for await (const event of streams.events.catchUp(since)) {
     if (event.type === "catchup.complete") {
       yield event;
       return;
@@ -281,12 +282,13 @@ const withClose = <T extends MessageEvent | PollEvent | GroupEvent>(
 
 const messageStream = (
   client: AdvancedIMessage,
+  streams: GrpcAdvancedIMessage,
   phone: string,
   onInbound?: OnInboundMessage,
   recover?: () => Promise<void>
 ): ManagedStream<IMessageMessage> =>
   resumableOrderedStream<MessageEvent, MessageCatchUpEvent, IMessageMessage>({
-    fetchMissed: (cursor) => catchUpEvents(client, cursor, isMessageEvent),
+    fetchMissed: (cursor) => catchUpEvents(streams, cursor, isMessageEvent),
     isCursorRejectedError: isCursorRejectedIMessageError,
     label: streamLabel("messages", phone),
     recover,
@@ -313,17 +315,18 @@ const messageStream = (
               )
           ),
     subscribeLive: (cursor) =>
-      withClose(client.messages.subscribeEvents(), cursor),
+      withClose(streams.messages.subscribeEvents(), cursor),
   });
 
 const pollStream = (
   client: AdvancedIMessage,
+  streams: GrpcAdvancedIMessage,
   pollCache: PollCache,
   phone: string,
   recover?: () => Promise<void>
 ): ManagedStream<IMessageMessage> =>
   resumableOrderedStream<PollEvent, PollCatchUpEvent, IMessageMessage>({
-    fetchMissed: (cursor) => catchUpEvents(client, cursor, isPollEvent),
+    fetchMissed: (cursor) => catchUpEvents(streams, cursor, isPollEvent),
     isCursorRejectedError: isCursorRejectedIMessageError,
     label: streamLabel("polls", phone),
     recover,
@@ -347,16 +350,17 @@ const pollStream = (
               )
           ),
     subscribeLive: (cursor) =>
-      withClose(client.polls.subscribeEvents(), cursor),
+      withClose(streams.polls.subscribeEvents(), cursor),
   });
 
 const groupStream = (
   client: AdvancedIMessage,
+  streams: GrpcAdvancedIMessage,
   phone: string,
   recover?: () => Promise<void>
 ): ManagedStream<IMessageMessage> =>
   resumableOrderedStream<GroupEvent, GroupCatchUpEvent, IMessageMessage>({
-    fetchMissed: (cursor) => catchUpEvents(client, cursor, isGroupEvent),
+    fetchMissed: (cursor) => catchUpEvents(streams, cursor, isGroupEvent),
     isCursorRejectedError: isCursorRejectedIMessageError,
     label: streamLabel("groups", phone),
     recover,
@@ -373,27 +377,27 @@ const groupStream = (
             () => toGroupItem(client, event, phone, String(event.sequence))
           ),
     subscribeLive: (cursor) =>
-      withClose(client.groups.subscribeEvents(), cursor),
+      withClose(streams.groups.subscribeEvents(), cursor),
   });
 
 const clientStream = (
-  client: AdvancedIMessage,
+  entry: RemoteClient,
   pollCache: PollCache,
-  phone: string,
   includeGroupEvents: boolean,
   onInbound?: OnInboundMessage,
   recover?: () => Promise<void>
 ): ManagedStream<IMessageMessage> => {
-  const streams: ManagedStream<IMessageMessage>[] = [
-    messageStream(client, phone, onInbound, recover),
-    pollStream(client, pollCache, phone, recover),
+  const { client, streams, phone } = entry;
+  const merged: ManagedStream<IMessageMessage>[] = [
+    messageStream(client, streams, phone, onInbound, recover),
+    pollStream(client, streams, pollCache, phone, recover),
   ];
 
   if (includeGroupEvents) {
-    streams.push(groupStream(client, phone, recover));
+    merged.push(groupStream(client, streams, phone, recover));
   }
 
-  return mergeStreams(streams);
+  return mergeStreams(merged);
 };
 
 export const messages = (
@@ -418,9 +422,8 @@ export const messages = (
         ? getContactShareTracker(entry.client)
         : undefined;
       return clientStream(
-        entry.client,
+        entry,
         pollCache,
-        entry.phone,
         includeGroupEvents,
         tracker ? (chatGuid) => tracker.maybeShare(chatGuid) : undefined,
         recover

--- a/packages/imessage/src/types.ts
+++ b/packages/imessage/src/types.ts
@@ -30,6 +30,12 @@ const clientEntry = z.object({
   token: z.string(),
   phone: z.string(),
   /**
+   * HTTP middleware address for outbound calls. Defaults to
+   * `SPECTRUM_IMESSAGE_HTTP_ADDRESS` / the production middleware — set it to
+   * keep a self-hosted config fully self-contained.
+   */
+  httpAddress: z.string().optional(),
+  /**
    * Dedicated instance id, sent as `x-photon-server` so the HTTP middleware
    * routes outbound calls to that instance. Omit for shared-mode tokens.
    */

--- a/packages/imessage/src/types.ts
+++ b/packages/imessage/src/types.ts
@@ -1,10 +1,19 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type {
+  AdvancedIMessage,
+  GrpcAdvancedIMessage,
+} from "@photon-ai/advanced-imessage";
 import type { SchemaMessage } from "@spectrum-ts/core";
 import z from "zod";
 
 export interface RemoteClient {
+  /** Outbound unary calls ride the HTTP middleware (imessage-server-v2-http). */
   client: AdvancedIMessage;
   phone: string;
+  /**
+   * Inbound event streams (`subscribeEvents` / `events.catchUp`) stay on the
+   * direct gRPC plane until Fusor delivery replaces them.
+   */
+  streams: GrpcAdvancedIMessage;
 }
 
 export type IMessageClient = RemoteClient[];

--- a/packages/imessage/src/types.ts
+++ b/packages/imessage/src/types.ts
@@ -29,6 +29,11 @@ const clientEntry = z.object({
   address: z.string(),
   token: z.string(),
   phone: z.string(),
+  /**
+   * Dedicated instance id, sent as `x-photon-server` so the HTTP middleware
+   * routes outbound calls to that instance. Omit for shared-mode tokens.
+   */
+  server: z.string().optional(),
 });
 
 export const configSchema = z.strictObject({

--- a/packages/imessage/test/config.test.ts
+++ b/packages/imessage/test/config.test.ts
@@ -9,4 +9,21 @@ describe("iMessage cloud config", () => {
   it("rejects the removed local flag", () => {
     expect(() => configSchema.parse({ local: true })).toThrow();
   });
+
+  it("accepts an explicit client without a server id", () => {
+    const entry = { address: "a.example:443", token: "t", phone: "+15550100" };
+    expect(configSchema.parse({ clients: entry })).toEqual({ clients: entry });
+  });
+
+  it("accepts an explicit client with a dedicated server id", () => {
+    const entry = {
+      address: "a.example:443",
+      phone: "+15550100",
+      server: "instance-a",
+      token: "t",
+    };
+    expect(configSchema.parse({ clients: [entry] })).toEqual({
+      clients: [entry],
+    });
+  });
 });

--- a/packages/imessage/test/config.test.ts
+++ b/packages/imessage/test/config.test.ts
@@ -26,4 +26,16 @@ describe("iMessage cloud config", () => {
       clients: [entry],
     });
   });
+
+  it("accepts a self-contained explicit client with its own middleware", () => {
+    const entry = {
+      address: "a.example:443",
+      httpAddress: "http://localhost:8080",
+      phone: "+15550100",
+      token: "t",
+    };
+    expect(configSchema.parse({ clients: [entry] })).toEqual({
+      clients: [entry],
+    });
+  });
 });

--- a/packages/imessage/test/contact-card.test.ts
+++ b/packages/imessage/test/contact-card.test.ts
@@ -1,10 +1,16 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type {
+  AdvancedIMessage,
+  GrpcAdvancedIMessage,
+} from "@photon-ai/advanced-imessage";
 import type { Space } from "@spectrum-ts/core";
 import { describe, expect, it, vi } from "vitest";
 import { isContactCard } from "@/content/contact-card";
 import { imessage, nativeContactCard } from "@/index";
 import { shareContactCard as remoteShareContactCard } from "@/remote/contact-card";
 import { type RemoteClient, SHARED_PHONE } from "@/types";
+
+// Streams are the gRPC inbound plane; these outbound tests never touch it.
+const noStreams = {} as unknown as GrpcAdvancedIMessage;
 
 const SIGNAL = {
   type: "contactCard",
@@ -25,6 +31,7 @@ const sharedClient = (
   {
     phone: SHARED_PHONE,
     client: { chats: { shareContactInfo } } as unknown as AdvancedIMessage,
+    streams: noStreams,
   },
 ];
 

--- a/packages/imessage/test/membership.test.ts
+++ b/packages/imessage/test/membership.test.ts
@@ -1,4 +1,7 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type {
+  AdvancedIMessage,
+  GrpcAdvancedIMessage,
+} from "@photon-ai/advanced-imessage";
 import { addMember, leaveSpace, removeMember } from "@spectrum-ts/core";
 import { describe, expect, it, vi } from "vitest";
 import { imessage } from "@/index";
@@ -8,6 +11,9 @@ import {
   removeParticipants as remoteRemoveParticipants,
 } from "@/remote/members";
 import { type RemoteClient, SHARED_PHONE } from "@/types";
+
+// Streams are the gRPC inbound plane; these outbound tests never touch it.
+const noStreams = {} as unknown as GrpcAdvancedIMessage;
 
 const GROUP_ONLY_ERROR = /only group chats/;
 const CREATE_GROUP_HINT = /space\.create/;
@@ -31,6 +37,7 @@ interface GroupsMock {
 const clientWithGroups = (phone: string, groups: GroupsMock): RemoteClient => ({
   phone,
   client: { groups } as unknown as AdvancedIMessage,
+  streams: noStreams,
 });
 
 describe("iMessage remote members wrappers", () => {

--- a/packages/imessage/test/read-actions.test.ts
+++ b/packages/imessage/test/read-actions.test.ts
@@ -1,5 +1,6 @@
 import {
   type AdvancedIMessage,
+  type GrpcAdvancedIMessage,
   NotFoundError,
 } from "@photon-ai/advanced-imessage";
 import type { AvatarData } from "@spectrum-ts/core";
@@ -12,6 +13,9 @@ import {
 } from "@/remote/members";
 import { getDisplayName as remoteGetDisplayName } from "@/remote/rename";
 import { type RemoteClient, SHARED_PHONE } from "@/types";
+
+// Streams are the gRPC inbound plane; these outbound tests never touch it.
+const noStreams = {} as unknown as GrpcAdvancedIMessage;
 
 const GROUP_ONLY_ERROR = /only group chats/;
 
@@ -78,6 +82,7 @@ interface ResourcesMock {
 const clientWith = (phone: string, resources: ResourcesMock): RemoteClient => ({
   phone,
   client: resources as unknown as AdvancedIMessage,
+  streams: noStreams,
 });
 
 describe("iMessage remote read wrappers", () => {

--- a/packages/imessage/test/remote/app.test.ts
+++ b/packages/imessage/test/remote/app.test.ts
@@ -1,5 +1,6 @@
 import type {
   AdvancedIMessage,
+  GrpcAdvancedIMessage,
   MiniAppCardSession,
   MiniAppMessageResult,
 } from "@photon-ai/advanced-imessage";
@@ -9,6 +10,9 @@ import { asCustomizedMiniApp } from "@/content/customized-mini-app";
 import { imessage } from "@/index";
 import { SPECTRUM_MINI_APP, toSpectrumMiniApp } from "@/remote/app";
 import { type RemoteClient, SHARED_PHONE } from "@/types";
+
+// Streams are the gRPC inbound plane; these outbound tests never touch it.
+const noStreams = {} as unknown as GrpcAdvancedIMessage;
 
 const SENT_DATE = new Date(1_700_000_000_000);
 const MINI_APP_SESSION: MiniAppCardSession = {
@@ -51,6 +55,7 @@ const remoteClient = (messages: Record<string, unknown>): RemoteClient[] => [
     client: {
       messages,
     } as unknown as AdvancedIMessage,
+    streams: noStreams,
   },
 ];
 

--- a/packages/imessage/test/remote/stream.test.ts
+++ b/packages/imessage/test/remote/stream.test.ts
@@ -1,4 +1,7 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type {
+  AdvancedIMessage,
+  GrpcAdvancedIMessage,
+} from "@photon-ai/advanced-imessage";
 import { flush, settleSoon } from "@spectrum-ts/test-support/timing";
 import { describe, expect, it, vi } from "vitest";
 import { messages } from "@/remote/stream";
@@ -43,11 +46,12 @@ const remoteClient = (phone: string) => {
   const subscribeToGroups = vi.fn(idleEventStream);
   const entry: RemoteClient = {
     phone,
-    client: {
+    client: {} as unknown as AdvancedIMessage,
+    streams: {
       groups: { subscribeEvents: subscribeToGroups },
       messages: { subscribeEvents: subscribeToMessages },
       polls: { subscribeEvents: subscribeToPolls },
-    } as unknown as AdvancedIMessage,
+    } as unknown as GrpcAdvancedIMessage,
   };
 
   return {
@@ -133,12 +137,13 @@ describe("remote iMessage streams", () => {
 
     const entry: RemoteClient = {
       phone: SHARED_PHONE,
-      client: {
+      client: {} as unknown as AdvancedIMessage,
+      streams: {
         messages: {
           subscribeEvents: () => eventStream([poison, valid]),
         },
         polls: { subscribeEvents: idleEventStream },
-      } as unknown as AdvancedIMessage,
+      } as unknown as GrpcAdvancedIMessage,
     };
 
     const stream = messages([entry]);
@@ -207,11 +212,12 @@ describe("remote iMessage streams", () => {
 
     const entry: RemoteClient = {
       phone: SHARED_PHONE,
-      client: {
+      client: {} as unknown as AdvancedIMessage,
+      streams: {
         // Reconnect resubscribes; the same event replays and now maps.
         messages: { subscribeEvents: () => idleAfter([flakyEvent]) },
         polls: { subscribeEvents: idleEventStream },
-      } as unknown as AdvancedIMessage,
+      } as unknown as GrpcAdvancedIMessage,
     };
 
     const stream = messages([entry]);

--- a/packages/imessage/test/space.test.ts
+++ b/packages/imessage/test/space.test.ts
@@ -1,8 +1,14 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type {
+  AdvancedIMessage,
+  GrpcAdvancedIMessage,
+} from "@photon-ai/advanced-imessage";
 import { describe, expect, it } from "vitest";
 import { imessage } from "@/index";
 import type { RemoteClient } from "@/types";
 import { SHARED_PHONE } from "@/types";
+
+// Streams are the gRPC inbound plane; these outbound tests never touch it.
+const noStreams = {} as unknown as GrpcAdvancedIMessage;
 
 const SHARED_GROUP_ERROR = /shared mode cannot create group chats/;
 const MULTI_CLIENT_ERROR = /params\.phone.*\+15550100, \+15550111/;
@@ -38,7 +44,11 @@ const clients = (
     onCreate?: (addresses: string[]) => { guid: string; isGroup: boolean },
   ][]
 ): RemoteClient[] =>
-  entries.map(([phone, onCreate]) => ({ phone, client: fakeRemote(onCreate) }));
+  entries.map(([phone, onCreate]) => ({
+    phone,
+    client: fakeRemote(onCreate),
+    streams: noStreams,
+  }));
 
 describe("imessage space.create", () => {
   it("shared mode: builds the deterministic DM guid without an API call", async () => {


### PR DESCRIPTION
Moves iMessage outbound off the per-instance gRPC hosts and onto the HTTP middleware (`imessage-server-v2-http`) via advanced-imessage 2.0's fetch transport.

Inbound is not this PR's concern — it stays exactly as on main and moves to Fusor in #195.

## What changed

- Every outbound unary call rides `createHttpClient`. Both modes dial one middleware host: `SPECTRUM_IMESSAGE_HTTP_ADDRESS`, default `imessage.spectrum.photon.codes:443`.
- Dedicated lines no longer dial `{instanceId}.imsg.photon.codes` directly — they pass `server: instanceId`, sent as `x-photon-server`, and the middleware routes server-side.
- Outbound retry semantics preserved: `autoIdempotency` + `retry`, idempotency-keyed so retries can't double-apply.
- Explicit (static-token) clients: `address` keeps its historical meaning. Outbound rides the middleware — per-entry optional `httpAddress` (falls back to `SPECTRUM_IMESSAGE_HTTP_ADDRESS`/default) keeps self-hosted configs self-contained, and optional `server` carries the dedicated instance id for routing.

## Dependency / draft blocker

Bumps `@photon-ai/advanced-imessage` to `^2.0.0` — unpublished; requires [advanced-imessage-ts #47](https://github.com/photon-hq/advanced-imessage-ts/pull/47) (`feat/http-client-combined`, pinned locally at `a053778`). `bun.lock` is intentionally untouched until 2.0.0 is released; local dev resolves the SDK via symlink.

## Validation

- `bun run typecheck` (all 13 packages)
- `bun x ultracite check`
- `packages/imessage`: 142 tests via `vitest` (node + bun runners)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Splits transport for all outbound iMessage actions and changes dedicated routing to middleware headers; depends on unpublished SDK 2.0, so regressions in send/retry or streaming are possible until release.
> 
> **Overview**
> **Outbound iMessage calls now go through the HTTP middleware** (`imessage-server-v2-http`) via `@photon-ai/advanced-imessage` **2.0** (`createHttpClient`), instead of unary gRPC on per-instance hosts. Shared and dedicated cloud clients dial one middleware host (`SPECTRUM_IMESSAGE_HTTP_ADDRESS`, default `imessage.spectrum.photon.codes:443`); dedicated lines pass `server: instanceId` for middleware routing instead of calling `{instanceId}.imsg.photon.codes` for sends. **Inbound is unchanged in behavior** but wired through a new `streams` gRPC client on each `RemoteClient`; catch-up and live subscriptions use `streams`, while send/edit/react and other outbound paths still use `client`.
> 
> Explicit static-token config keeps `address` for the gRPC event plane and adds optional `httpAddress` and `server`. Teardown closes both HTTP and gRPC clients. Tests and config schema cover the new fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be062a916839799e362f284902bc130ffe8f785b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for routing outbound iMessage requests via configurable HTTP middleware endpoints.
  * Enabled separate HTTP (outbound/unary) and gRPC (inbound/event streaming) handling.
  * Added optional dedicated server routing and configuration overrides for advanced client setups.
  * Improved event catch-up and live subscription wiring.

* **Bug Fixes**
  * Updated iMessage client initialization/teardown to better preserve reliable event streaming and request retry behavior.

* **Tests**
  * Adjusted iMessage test mocks to account for the new split HTTP/gRPC remote client shape.

* **Chores**
  * Upgraded the advanced iMessage dependency to the latest major version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->