### PR TITLE
feat(whatsapp): tag spaces with their line and route outbound per-line

### DIFF
--- a/packages/whatsapp-business/src/auth.ts
+++ b/packages/whatsapp-business/src/auth.ts
@@ -7,6 +7,7 @@ import {
 } from "@photon-ai/whatsapp-business";
 import { cloud, stream } from "@spectrum-ts/core";
 import { createLogger, errorAttrs } from "@spectrum-ts/core/authoring";
+import type { LineClient, WhatsAppClients } from "./types";
 
 const log = createLogger("spectrum.whatsapp.auth");
 const streamLog = createLogger("spectrum.whatsapp.stream");
@@ -32,7 +33,27 @@ interface LineState {
   subscriptions: Set<LineSubscription>;
 }
 
-const cloudAuthState = new WeakMap<WhatsAppClient[], CloudAuth>();
+const cloudAuthState = new WeakMap<WhatsAppClients, CloudAuth>();
+
+// Cloud mode can grow lines at runtime (a token refresh may return a
+// phoneNumberId that wasn't in the original payload). Listeners let the
+// message stream subscribe to lines added after startup.
+type LineAddedListener = (entry: LineClient) => void;
+const lineListeners = new WeakMap<WhatsAppClients, Set<LineAddedListener>>();
+
+export const subscribeLineAdded = (
+  clients: WhatsAppClients,
+  listener: LineAddedListener
+): (() => void) | undefined => {
+  const listeners = lineListeners.get(clients);
+  if (!listeners) {
+    return;
+  }
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
 
 // `@photon-ai/whatsapp-business` 0.1.x does not accept a token callback, so we
 // recreate the underlying client before each RPC when the token is near expiry,
@@ -40,7 +61,7 @@ const cloudAuthState = new WeakMap<WhatsAppClient[], CloudAuth>();
 export async function createCloudClients(
   projectId: string,
   projectSecret: string
-): Promise<WhatsAppClient[]> {
+): Promise<WhatsAppClients> {
   let tokenData = await cloud.issueWhatsappBusinessTokens(
     projectId,
     projectSecret
@@ -80,6 +101,23 @@ export async function createCloudClients(
         sub.swap();
       }
       await old.close().catch(() => undefined);
+    }
+
+    // A line added to the project after startup shows up as a new
+    // phoneNumberId in the refreshed payload: give it a client, expose it for
+    // outbound routing, and let subscribed message streams pick it up.
+    for (const phoneNumberId of Object.keys(tokenData.auth)) {
+      if (lines.has(phoneNumberId) || disposed) {
+        continue;
+      }
+      const entry = addLine(phoneNumberId);
+      clients.push(entry);
+      log.info("whatsapp line added at runtime", {
+        "spectrum.whatsapp.line": phoneNumberId,
+      });
+      for (const listener of listeners) {
+        listener(entry);
+      }
     }
   };
 
@@ -159,16 +197,23 @@ export async function createCloudClients(
 
   scheduleRenewal();
 
-  const clients: WhatsAppClient[] = Object.keys(tokenData.auth).map(
-    (phoneNumberId) => {
-      const state: LineState = {
-        current: buildRawClient(phoneNumberId),
-        subscriptions: new Set(),
-      };
-      lines.set(phoneNumberId, state);
-      return buildClientProxy(state, refreshIfNeeded);
-    }
-  );
+  // The proxy (not `state.current`, which is swapped on token refresh) is the
+  // stable per-line handle carried in the LineClient entry.
+  const addLine = (phoneNumberId: string): LineClient => {
+    const state: LineState = {
+      current: buildRawClient(phoneNumberId),
+      subscriptions: new Set(),
+    };
+    lines.set(phoneNumberId, state);
+    return {
+      client: buildClientProxy(state, refreshIfNeeded),
+      line: phoneNumberId,
+    };
+  };
+
+  const clients: WhatsAppClients = Object.keys(tokenData.auth).map(addLine);
+  const listeners = new Set<LineAddedListener>();
+  lineListeners.set(clients, listeners);
 
   cloudAuthState.set(clients, {
     dispose: async () => {
@@ -190,7 +235,7 @@ export async function createCloudClients(
 }
 
 export async function disposeCloudAuth(
-  clients: WhatsAppClient[]
+  clients: WhatsAppClients
 ): Promise<void> {
   const auth = cloudAuthState.get(clients);
   if (!auth) {

--- a/packages/whatsapp-business/src/auth.ts
+++ b/packages/whatsapp-business/src/auth.ts
@@ -84,6 +84,21 @@ export async function createCloudClients(
     return createClient({ accessToken, appSecret: "", phoneNumberId });
   };
 
+  const removeLine = async (
+    phoneNumberId: string,
+    state: LineState
+  ): Promise<void> => {
+    lines.delete(phoneNumberId);
+    const index = clients.findIndex((c) => c.line === phoneNumberId);
+    if (index !== -1) {
+      clients.splice(index, 1);
+    }
+    for (const sub of state.subscriptions) {
+      sub.close();
+    }
+    await state.current.close().catch(ignoreCleanupError);
+  };
+
   const refreshTokens = async (): Promise<void> => {
     tokenData = await cloud.issueWhatsappBusinessTokens(
       projectId,
@@ -93,6 +108,7 @@ export async function createCloudClients(
 
     for (const [phoneNumberId, state] of lines) {
       if (!tokenData.auth[phoneNumberId]) {
+        await removeLine(phoneNumberId, state);
         continue;
       }
       const old = state.current;

--- a/packages/whatsapp-business/src/index.ts
+++ b/packages/whatsapp-business/src/index.ts
@@ -7,6 +7,7 @@ import {
   isCloudConfig,
   spaceSchema,
   type WhatsAppClients,
+  type WhatsAppSpace,
 } from "./types";
 
 export const whatsappBusiness = definePlatform("WhatsApp Business", {
@@ -20,11 +21,14 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
     }): Promise<WhatsAppClients> => {
       if (!isCloudConfig(config)) {
         return [
-          createClient({
-            accessToken: config.accessToken,
-            appSecret: config.appSecret ?? "",
-            phoneNumberId: config.phoneNumberId,
-          }),
+          {
+            client: createClient({
+              accessToken: config.accessToken,
+              appSecret: config.appSecret ?? "",
+              phoneNumberId: config.phoneNumberId,
+            }),
+            line: config.phoneNumberId,
+          },
         ];
       }
 
@@ -45,7 +49,7 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
       // closes use `.catch(() => undefined)` for the same reason) — settle all
       // so one non-idempotent `close()` can't reject and abort cleanup.
       await disposeCloudAuth(client);
-      await Promise.allSettled(client.map((c) => c.close()));
+      await Promise.allSettled(client.map((c) => c.client.close()));
     },
   },
 
@@ -55,7 +59,7 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
 
   space: {
     schema: spaceSchema,
-    create: async ({ input }) => {
+    create: async ({ input, client }): Promise<WhatsAppSpace> => {
       if (input.users.length === 0) {
         throw new Error("WhatsApp space creation requires at least one user");
       }
@@ -70,12 +74,13 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
       if (!user) {
         throw new Error("WhatsApp space creation requires a user");
       }
-      return { id: user.id };
+
+      return { id: user.id, line: client[0]?.line };
     },
   },
 
   messages: ({ client }) => messages(client),
 
   send: async ({ space, content, client }) =>
-    await send(client, space.id, content),
+    await send(client, space.id, content, space.line),
 });

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -8,7 +8,6 @@ import {
   type Contact,
   type Content,
   type ManagedStream,
-  mergeStreams,
   type Poll,
   type Reaction,
   type ContactAddress as SpectrumContactAddress,
@@ -31,18 +30,19 @@ import {
   tracedFetch,
 } from "@spectrum-ts/core/authoring";
 import { extension as mimeExtension } from "mime-types";
+import { subscribeLineAdded } from "./auth";
 import { pollOptionId, pollToInteractive } from "./poll";
-import type { WhatsAppClients, WhatsAppMessage } from "./types";
+import type { LineClient, WhatsAppClients, WhatsAppMessage } from "./types";
 
-// v1 routes outbound traffic to the first line. When multi-line send becomes a
-// requirement, extend spaceSchema with an optional `line` (phoneNumberId) and
-// pick the matching client here.
-const primary = (clients: WhatsAppClients): WhatsAppClient => {
-  const client = clients[0];
-  if (!client) {
+// Outbound traffic routes to the line the space is tagged with (the line an
+// inbound message arrived on). Spaces without a line — or whose line has since
+// left the project — fall back to the first line.
+const clientFor = (clients: WhatsAppClients, line?: string): LineClient => {
+  const entry = (line && clients.find((c) => c.line === line)) || clients[0];
+  if (!entry) {
     throw new Error("No WhatsApp Business client available");
   }
-  return client;
+  return entry;
 };
 
 type WaSendResult = Awaited<ReturnType<WhatsAppClient["messages"]["send"]>>;
@@ -50,11 +50,12 @@ type WaSendResult = Awaited<ReturnType<WhatsAppClient["messages"]["send"]>>;
 const toRecord = (
   result: WaSendResult,
   spaceId: string,
-  content: Content
+  content: Content,
+  line: string
 ): ProviderMessageRecord => ({
   id: result.messageId,
   content,
-  space: { id: spaceId },
+  space: { id: spaceId, line },
   timestamp: new Date(),
 });
 
@@ -245,12 +246,12 @@ const waContactToSpectrum = (card: ContactCard): Content => {
 };
 
 const toMessages = (
-  client: WhatsAppClient,
+  { client, line }: LineClient,
   msg: InboundMessage
 ): WhatsAppMessage[] => {
   const base = {
     sender: { id: msg.from },
-    space: { id: msg.from },
+    space: { id: msg.from, line },
     timestamp: msg.timestamp,
   };
   if (msg.content.type === "contacts") {
@@ -486,10 +487,8 @@ const contactToWa = (contact: Contact): ContactCardInput => {
 
 const streamLog = createLogger("spectrum.whatsapp.stream");
 
-const clientStream = (
-  client: WhatsAppClient
-): ManagedStream<WhatsAppMessage> => {
-  const eventStream = client.events
+const clientStream = (entry: LineClient): ManagedStream<WhatsAppMessage> => {
+  const eventStream = entry.client.events
     .subscribe({
       // The client heals disconnects AND silently stalled streams on its own
       // (its stallTimeoutMs converts missed heartbeats into a reconnect with
@@ -513,7 +512,7 @@ const clientStream = (
     const pump = (async () => {
       try {
         for await (const event of eventStream) {
-          for (const m of toMessages(client, event.message)) {
+          for (const m of toMessages(entry, event.message)) {
             await emit(m);
           }
         }
@@ -529,25 +528,78 @@ const clientStream = (
   });
 };
 
+// In cloud mode lines can appear after startup (subscribeLineAdded), so the
+// merge is dynamic: fixed streams via mergeStreams semantics, plus a pump per
+// late-added line. The stream only ends early when every line's stream ends
+// and no dynamic source exists (direct mode).
 export const messages = (
   clients: WhatsAppClients
-): ManagedStream<WhatsAppMessage> => mergeStreams(clients.map(clientStream));
+): ManagedStream<WhatsAppMessage> =>
+  stream<WhatsAppMessage>((emit, end) => {
+    const inner = new Set<ManagedStream<WhatsAppMessage>>();
+    const pumps: Promise<void>[] = [];
+    let open = 0;
+    let closed = false;
+    let unsubscribe: (() => void) | undefined;
+
+    const add = (entry: LineClient) => {
+      if (closed) {
+        return;
+      }
+      const source = clientStream(entry);
+      inner.add(source);
+      open += 1;
+      pumps.push(
+        (async () => {
+          try {
+            for await (const value of source) {
+              await emit(value);
+            }
+          } catch (error) {
+            end(error);
+          } finally {
+            open -= 1;
+            if (open === 0 && !unsubscribe) {
+              end();
+            }
+          }
+        })()
+      );
+    };
+
+    for (const entry of clients) {
+      add(entry);
+    }
+    unsubscribe = subscribeLineAdded(clients, add);
+    if (open === 0 && !unsubscribe) {
+      end();
+    }
+
+    return async () => {
+      closed = true;
+      unsubscribe?.();
+      await Promise.allSettled([...inner].map((source) => source.close()));
+      await Promise.allSettled(pumps);
+    };
+  });
 
 export const send = async (
   clients: WhatsAppClients,
   spaceId: string,
-  content: Content
+  content: Content,
+  line?: string
 ): Promise<ProviderMessageRecord | undefined> => {
   if (content.type === "reply") {
     return await replyToMessage(
       clients,
       spaceId,
       content.target.id,
-      content.content
+      content.content,
+      line
     );
   }
   if (content.type === "reaction") {
-    return await reactToMessage(clients, spaceId, content);
+    return await reactToMessage(clients, spaceId, content, line);
   }
   if (content.type === "typing") {
     // WhatsApp Business has no typing-indicator API. Silently ignore so
@@ -558,16 +610,17 @@ export const send = async (
   if (content.type === "read") {
     // Cumulative receipt: the Cloud API marks `target` and every earlier
     // message in the conversation as read (blue ticks for the sender).
-    await primary(clients).messages.markRead(content.target.id);
+    await clientFor(clients, line).client.messages.markRead(content.target.id);
     return;
   }
-  const client = primary(clients);
+  const { client, line: clientLine } = clientFor(clients, line);
   switch (content.type) {
     case "text":
       return toRecord(
         await client.messages.send({ to: spaceId, text: content.text }),
         spaceId,
-        content
+        content,
+        clientLine
       );
     case "attachment": {
       const { mediaId } = await client.media.upload({
@@ -586,7 +639,8 @@ export const send = async (
           [mediaType]: mediaPayload,
         } as Parameters<typeof client.messages.send>[0]),
         spaceId,
-        content
+        content,
+        clientLine
       );
     }
     case "contact":
@@ -596,7 +650,8 @@ export const send = async (
           contacts: [contactToWa(content)],
         }),
         spaceId,
-        content
+        content,
+        clientLine
       );
     case "voice": {
       const { mediaId } = await client.media.upload({
@@ -610,7 +665,8 @@ export const send = async (
           audio: { id: mediaId },
         } as Parameters<typeof client.messages.send>[0]),
         spaceId,
-        content
+        content,
+        clientLine
       );
     }
     case "poll": {
@@ -619,14 +675,15 @@ export const send = async (
         interactive: pollToInteractive(content),
       });
       cachePoll(client, result.messageId, content);
-      return toRecord(result, spaceId, content);
+      return toRecord(result, spaceId, content, clientLine);
     }
     case "app":
       // No mini-app surface on WhatsApp — send the bare URL as text.
       return toRecord(
         await client.messages.send({ to: spaceId, text: await content.url() }),
         spaceId,
-        content
+        content,
+        clientLine
       );
     default:
       throw UnsupportedError.content(content.type);
@@ -636,24 +693,27 @@ export const send = async (
 const reactToMessage = async (
   clients: WhatsAppClients,
   spaceId: string,
-  content: Reaction
+  content: Reaction,
+  line?: string
 ): Promise<ProviderMessageRecord> => {
+  const { client, line: clientLine } = clientFor(clients, line);
   // The Cloud API returns a real message id for reaction sends, so the
   // record carries a genuine handle (usable by a future unsend).
-  const result = await primary(clients).messages.send({
+  const result = await client.messages.send({
     to: spaceId,
     reaction: { messageId: content.target.id, emoji: content.emoji },
   });
-  return toRecord(result, spaceId, content);
+  return toRecord(result, spaceId, content, clientLine);
 };
 
 export const replyToMessage = async (
   clients: WhatsAppClients,
   spaceId: string,
   messageId: string,
-  content: Content
+  content: Content,
+  line?: string
 ): Promise<ProviderMessageRecord> => {
-  const client = primary(clients);
+  const { client, line: clientLine } = clientFor(clients, line);
   switch (content.type) {
     case "text":
       return toRecord(
@@ -663,7 +723,8 @@ export const replyToMessage = async (
           text: content.text,
         }),
         spaceId,
-        content
+        content,
+        clientLine
       );
     case "attachment": {
       const { mediaId } = await client.media.upload({
@@ -683,7 +744,8 @@ export const replyToMessage = async (
           [mediaType]: mediaPayload,
         } as Parameters<typeof client.messages.send>[0]),
         spaceId,
-        content
+        content,
+        clientLine
       );
     }
     case "contact":
@@ -694,7 +756,8 @@ export const replyToMessage = async (
           contacts: [contactToWa(content)],
         }),
         spaceId,
-        content
+        content,
+        clientLine
       );
     case "voice": {
       const { mediaId } = await client.media.upload({
@@ -709,7 +772,8 @@ export const replyToMessage = async (
           audio: { id: mediaId },
         } as Parameters<typeof client.messages.send>[0]),
         spaceId,
-        content
+        content,
+        clientLine
       );
     }
     case "poll": {
@@ -719,7 +783,7 @@ export const replyToMessage = async (
         interactive: pollToInteractive(content),
       });
       cachePoll(client, result.messageId, content);
-      return toRecord(result, spaceId, content);
+      return toRecord(result, spaceId, content, clientLine);
     }
     case "app":
       // No mini-app surface on WhatsApp — send the bare URL as text.
@@ -730,7 +794,8 @@ export const replyToMessage = async (
           text: await content.url(),
         }),
         spaceId,
-        content
+        content,
+        clientLine
       );
     default:
       throw UnsupportedError.content(content.type);

--- a/packages/whatsapp-business/src/types.ts
+++ b/packages/whatsapp-business/src/types.ts
@@ -19,7 +19,15 @@ const cloudConfig = z.object({}).strict();
 export const configSchema = z.union([directConfig, cloudConfig]);
 
 export type WhatsAppConfig = z.infer<typeof configSchema>;
-export type WhatsAppClients = WhatsAppClient[];
+
+// The vendor client doesn't retain the `phoneNumberId` it was created with, so
+// carry the line alongside the client. Every creation site knows the line, and
+// the required field makes "client without a line" a compile error.
+export interface LineClient {
+  client: WhatsAppClient;
+  line: string;
+}
+export type WhatsAppClients = LineClient[];
 
 export const isCloudConfig = (
   config: WhatsAppConfig
@@ -29,7 +37,10 @@ export const userSchema = z.object({});
 
 export const spaceSchema = z.object({
   id: z.string(),
+  line: z.string().optional(),
 });
+
+export type WhatsAppSpace = z.infer<typeof spaceSchema>;
 
 export type WhatsAppMessage = SchemaMessage<
   typeof userSchema,

--- a/packages/whatsapp-business/test/auth.test.ts
+++ b/packages/whatsapp-business/test/auth.test.ts
@@ -271,6 +271,40 @@ describe("whatsapp cloud auth stream renewal", () => {
     await disposeCloudAuth(clients);
   });
 
+  it("drops a line removed from the project at runtime", async () => {
+    issueWhatsappBusinessTokens.mockImplementationOnce(async () => ({
+      auth: { "phone-1": "token-1", "phone-2": "token-1b" },
+      expiresIn: 0,
+    }));
+    issueWhatsappBusinessTokens.mockImplementationOnce(async () => ({
+      auth: { "phone-1": "token-2" },
+      expiresIn: 0,
+    }));
+
+    const clients = await createCloudClients("project-1", "secret-1");
+    expect(clients.map((c) => c.line)).toEqual(["phone-1", "phone-2"]);
+
+    const removedLineStream = clients[1]?.client.events.subscribe();
+    if (!removedLineStream) {
+      throw new Error("expected a WhatsApp event stream");
+    }
+    const iterator = removedLineStream[Symbol.asyncIterator]();
+    const pendingNext = iterator.next();
+
+    // expiresIn 0 → any proxy RPC refreshes first, pulling the new payload.
+    await clients[0]?.client.messages.markRead("wamid.1");
+
+    // The stale entry is gone, so outbound routing for spaces tagged with
+    // phone-2 falls back to an active line instead of a dead client.
+    expect(clients.map((c) => c.line)).toEqual(["phone-1"]);
+
+    // rawClients: raw0 = phone-1, raw1 = phone-2, raw2 = refreshed phone-1.
+    expect(rawClients[1]?.close).toHaveBeenCalledTimes(1);
+    expect((await pendingNext).done).toBe(true);
+
+    await disposeCloudAuth(clients);
+  });
+
   it("retries a failed scheduled refresh after the retry delay", async () => {
     vi.useFakeTimers();
 

--- a/packages/whatsapp-business/test/auth.test.ts
+++ b/packages/whatsapp-business/test/auth.test.ts
@@ -132,7 +132,8 @@ vi.doMock("@photon-ai/whatsapp-business", () => ({
   TypedEventStream: FakeTypedEventStream,
 }));
 
-const { createCloudClients, disposeCloudAuth } = await import("@/auth");
+const { createCloudClients, disposeCloudAuth, subscribeLineAdded } =
+  await import("@/auth");
 
 const waitFor = async (
   predicate: () => boolean,
@@ -168,7 +169,7 @@ describe("whatsapp cloud auth stream renewal", () => {
 
   it("opens a fresh subscription after token refresh even when the old SDK iterator does not return", async () => {
     const clients = await createCloudClients("project-1", "secret-1");
-    const eventStream = clients[0]?.events.subscribe();
+    const eventStream = clients[0]?.client.events.subscribe();
     if (!eventStream) {
       throw new Error("expected a WhatsApp event stream");
     }
@@ -181,7 +182,7 @@ describe("whatsapp cloud auth stream renewal", () => {
       "initial subscription did not start"
     );
 
-    await clients[0]?.messages.markRead("wamid.1");
+    await clients[0]?.client.messages.markRead("wamid.1");
 
     await waitFor(
       () => rawClients[1]?.events.subscribe.mock.calls.length === 1,
@@ -215,8 +216,8 @@ describe("whatsapp cloud auth stream renewal", () => {
     );
 
     const clients = await createCloudClients("project-1", "secret-1");
-    const firstMarkRead = clients[0]?.messages.markRead("wamid.1");
-    const secondMarkRead = clients[0]?.messages.markRead("wamid.2");
+    const firstMarkRead = clients[0]?.client.messages.markRead("wamid.1");
+    const secondMarkRead = clients[0]?.client.messages.markRead("wamid.2");
 
     await waitFor(
       () => issueWhatsappBusinessTokens.mock.calls.length === 2,
@@ -233,6 +234,40 @@ describe("whatsapp cloud auth stream renewal", () => {
     expect(rawClients[1]?.options.accessToken).toBe("token-2");
     expect(rawClients[1]?.messages.markRead).toHaveBeenCalledTimes(2);
 
+    await disposeCloudAuth(clients);
+  });
+
+  it("picks up a line added to the project at runtime", async () => {
+    issueWhatsappBusinessTokens.mockImplementationOnce(async () => ({
+      auth: { "phone-1": "token-1" },
+      expiresIn: 0,
+    }));
+    issueWhatsappBusinessTokens.mockImplementationOnce(async () => ({
+      auth: { "phone-1": "token-2", "phone-2": "token-2b" },
+      expiresIn: 0,
+    }));
+
+    const clients = await createCloudClients("project-1", "secret-1");
+    expect(clients.map((c) => c.line)).toEqual(["phone-1"]);
+
+    const added: string[] = [];
+    const unsubscribe = subscribeLineAdded(clients, (entry) => {
+      added.push(entry.line);
+    });
+
+    // expiresIn 0 → any proxy RPC refreshes first, pulling the new payload.
+    await clients[0]?.client.messages.markRead("wamid.1");
+
+    expect(clients.map((c) => c.line)).toEqual(["phone-1", "phone-2"]);
+    expect(added).toEqual(["phone-2"]);
+
+    // The late-added line's proxy routes RPCs to its own raw client
+    // (rawClients[2]: raw0 = initial phone-1, raw1 = refreshed phone-1,
+    // raw2 = phone-2).
+    await clients[1]?.client.messages.markRead("wamid.2");
+    expect(rawClients[2]?.messages.markRead).toHaveBeenCalledWith("wamid.2");
+
+    unsubscribe?.();
     await disposeCloudAuth(clients);
   });
 

--- a/packages/whatsapp-business/test/inbound-line.test.ts
+++ b/packages/whatsapp-business/test/inbound-line.test.ts
@@ -1,0 +1,106 @@
+import type { Content } from "@spectrum-ts/core";
+import { describe, expect, it, vi } from "vitest";
+import { messages, send } from "@/messages";
+import type { LineClient, WhatsAppMessage } from "@/types";
+
+// Drives the real inbound path — messages() -> clientStream -> toMessages —
+// with a fake client whose event stream yields one text message.
+const fakeInboundClient = (from: string): LineClient["client"] => {
+  const inbound = {
+    id: `wamid.${from}`,
+    from,
+    timestamp: new Date("2026-07-13T00:00:00.000Z"),
+    content: { type: "text", body: "hello" },
+  };
+  // `.filter(...)` result: an async-iterable with `close()`, matching what
+  // clientStream consumes.
+  const filtered = {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "message", message: inbound };
+    },
+    close: async () => undefined,
+  };
+  return {
+    events: { subscribe: () => ({ filter: () => filtered }) },
+  } as unknown as LineClient["client"];
+};
+
+const receiveOne = async (
+  entries: LineClient[]
+): Promise<WhatsAppMessage | undefined> => {
+  for await (const m of messages(entries)) {
+    return m;
+  }
+  return;
+};
+
+const fakeSendClient = () => {
+  const sendMock = vi.fn(async () => ({ messageId: "wamid.out" }));
+  const client = {
+    messages: { send: sendMock, markRead: vi.fn(async () => undefined) },
+  } as unknown as LineClient["client"];
+  return { client, sendMock };
+};
+
+const text: Content = { type: "text", text: "yo" } as Content;
+
+describe("whatsapp space.line", () => {
+  it("tags the inbound space with the client's line", async () => {
+    const received = await receiveOne([
+      { client: fakeInboundClient("15551234567"), line: "PHONE_NUMBER_ID_123" },
+    ]);
+    expect(received?.space.id).toBe("15551234567");
+    expect(received?.space.line).toBe("PHONE_NUMBER_ID_123");
+  });
+
+  it("tags each client's messages with its own line", async () => {
+    const seen = new Map<string, string | undefined>();
+    const entries: LineClient[] = [
+      { client: fakeInboundClient("15551110000"), line: "LINE_A" },
+      { client: fakeInboundClient("15552220000"), line: "LINE_B" },
+    ];
+    for await (const m of messages(entries)) {
+      seen.set(m.space.id, m.space.line);
+      if (seen.size === 2) {
+        break;
+      }
+    }
+    expect(seen.get("15551110000")).toBe("LINE_A");
+    expect(seen.get("15552220000")).toBe("LINE_B");
+  });
+
+  it("routes outbound to the client matching space.line", async () => {
+    const a = fakeSendClient();
+    const b = fakeSendClient();
+    const clients: LineClient[] = [
+      { client: a.client, line: "LINE_A" },
+      { client: b.client, line: "LINE_B" },
+    ];
+
+    const record = await send(clients, "15551234567", text, "LINE_B");
+
+    expect(b.sendMock).toHaveBeenCalledWith({
+      to: "15551234567",
+      text: "yo",
+    });
+    expect(a.sendMock).not.toHaveBeenCalled();
+    expect(record?.space).toEqual({ id: "15551234567", line: "LINE_B" });
+  });
+
+  it("falls back to the first line when space.line is absent or unknown", async () => {
+    const a = fakeSendClient();
+    const b = fakeSendClient();
+    const clients: LineClient[] = [
+      { client: a.client, line: "LINE_A" },
+      { client: b.client, line: "LINE_B" },
+    ];
+
+    const untagged = await send(clients, "15551234567", text);
+    const unknown = await send(clients, "15551234567", text, "LINE_GONE");
+
+    expect(a.sendMock).toHaveBeenCalledTimes(2);
+    expect(b.sendMock).not.toHaveBeenCalled();
+    expect(untagged?.space.line).toBe("LINE_A");
+    expect(unknown?.space.line).toBe("LINE_A");
+  });
+});

--- a/packages/whatsapp-business/test/messages.test.ts
+++ b/packages/whatsapp-business/test/messages.test.ts
@@ -13,7 +13,9 @@ const target = {
 describe("whatsapp send — read", () => {
   it("marks the conversation read up to the target via markRead", async () => {
     const markRead = vi.fn(() => Promise.resolve());
-    const clients = [{ messages: { markRead } }] as unknown as WhatsAppClients;
+    const clients = [
+      { client: { messages: { markRead } }, line: "LINE_A" },
+    ] as unknown as WhatsAppClients;
 
     const result = await send(clients, "15550001111", asRead({ target }));
 


### PR DESCRIPTION
Inbound messages' spaces now carry `line` (the phoneNumberId they arrived on), and outbound send/reply/reaction/markRead route to the matching line's client instead of always the first line, falling back to the primary line for untagged spaces.

Clients are carried as LineClient ({ client, line }) so line identity is part of the type. Cloud mode also picks up lines added to the project at runtime: a token refresh with a new phoneNumberId creates the client, exposes it for outbound routing, and feeds it into the live message stream via subscribeLineAdded.

next steps:
- merge this pr
- update spectrum-webhook

Entire-Checkpoint: 290a871b37ec

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes message routing and live stream merging for multi-line cloud auth; wrong line selection could misroute outbound traffic, but behavior is covered by new tests and preserves first-line fallback.
> 
> **Overview**
> Adds **multi-line WhatsApp Business** support: clients are `{ client, line }` (`phoneNumberId`), spaces carry optional **`line`**, and inbound messages tag the space with the line they arrived on.
> 
> **Outbound** send, reply, reaction, and read receipts use **`clientFor`** to hit the space’s line (fallback to the first line if untagged or the line was removed). Provider records include **`space.line`**.
> 
> In **cloud mode**, token refresh can **add** lines (`subscribeLineAdded` + dynamic message merge) or **remove** lines missing from the new auth payload (close subscriptions and splice the client list). Direct config wraps a single line the same way.
> 
> Tests cover runtime line add/remove in auth and inbound/outbound line tagging and routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8596d1a4914543f2d6c73e30b9b24bb9ef04027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for WhatsApp Business accounts with multiple lines, with line-aware client selection.
  * Automatically detects, activates, and begins streaming newly added lines after startup.
  * Supports line-tagged spaces and records the active line for messages, replies, reactions, and read receipts.
  * Extends outbound sending to optionally target a specific line.
* **Bug Fixes**
  * Automatically drops line activity when a line is removed at runtime.
  * Improves fallback routing when a requested line is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->