### PR TITLE
fix(whatsapp-business): surface inbound media captions as group content

### DIFF
--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -246,8 +246,28 @@ const waContactToSpectrum = (card: ContactCard): Content => {
   return asContact(input);
 };
 
-const stubMessage = (id: string, content: Content): SpectrumMessage =>
-  ({ id, content }) as unknown as SpectrumMessage;
+// Inbound group items are raw provider records that core's
+// wrapProviderMessage inflates into full Messages. They must carry
+// sender/space/timestamp — cloud webhook delivery serializes those per item
+// and crashes on a missing sender.
+const groupItem = (
+  msg: InboundMessage,
+  index: number,
+  content: Content
+): SpectrumMessage =>
+  ({
+    id: `${msg.id}:${index}`,
+    content,
+    sender: { id: msg.from },
+    space: { id: msg.from },
+    timestamp: msg.timestamp,
+  }) as unknown as SpectrumMessage;
+
+// Group items and multi-contact parts carry synthetic ids (`<wamid>:<index>`,
+// cf. toMessages) that the Cloud API doesn't know. Strip the suffix so
+// targeted actions (reply/react/read) hit the real parent message. Safe:
+// wamids are `wamid.` + base64, which never contains ":".
+const parentWamid = (id: string): string => id.split(":")[0] ?? id;
 
 const toMessages = (
   client: WhatsAppClient,
@@ -291,10 +311,7 @@ const mapContent = (client: WhatsAppClient, msg: InboundMessage): Content => {
       }
 
       return asGroup({
-        items: [
-          stubMessage(`${msg.id}:0`, media),
-          stubMessage(`${msg.id}:1`, asText(caption)),
-        ],
+        items: [groupItem(msg, 0, media), groupItem(msg, 1, asText(caption))],
       });
     }
     case "sticker":
@@ -559,7 +576,7 @@ export const send = async (
     return await replyToMessage(
       clients,
       spaceId,
-      content.target.id,
+      parentWamid(content.target.id),
       content.content
     );
   }
@@ -575,7 +592,7 @@ export const send = async (
   if (content.type === "read") {
     // Cumulative receipt: the Cloud API marks `target` and every earlier
     // message in the conversation as read (blue ticks for the sender).
-    await primary(clients).messages.markRead(content.target.id);
+    await primary(clients).messages.markRead(parentWamid(content.target.id));
     return;
   }
   const client = primary(clients);
@@ -659,7 +676,10 @@ const reactToMessage = async (
   // record carries a genuine handle (usable by a future unsend).
   const result = await primary(clients).messages.send({
     to: spaceId,
-    reaction: { messageId: content.target.id, emoji: content.emoji },
+    reaction: {
+      messageId: parentWamid(content.target.id),
+      emoji: content.emoji,
+    },
   });
   return toRecord(result, spaceId, content);
 };

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -16,6 +16,7 @@ import {
   type ContactName as SpectrumContactName,
   type ContactOrg as SpectrumContactOrg,
   type ContactPhone as SpectrumContactPhone,
+  type Message as SpectrumMessage,
   stream,
   UnsupportedError,
 } from "@spectrum-ts/core";
@@ -23,6 +24,7 @@ import {
   asAttachment,
   asContact,
   asCustom,
+  asGroup,
   asPollOption,
   asReaction,
   asText,
@@ -244,6 +246,9 @@ const waContactToSpectrum = (card: ContactCard): Content => {
   return asContact(input);
 };
 
+const stubMessage = (id: string, content: Content): SpectrumMessage =>
+  ({ id, content }) as unknown as SpectrumMessage;
+
 const toMessages = (
   client: WhatsAppClient,
   msg: InboundMessage
@@ -278,8 +283,20 @@ const mapContent = (client: WhatsAppClient, msg: InboundMessage): Content => {
     case "image":
     case "video":
     case "audio":
-    case "document":
-      return lazyMedia(client, content.media);
+    case "document": {
+      const media = lazyMedia(client, content.media);
+      const caption = content.media.caption?.trim();
+      if (!caption) {
+        return media;
+      }
+
+      return asGroup({
+        items: [
+          stubMessage(`${msg.id}:0`, media),
+          stubMessage(`${msg.id}:1`, asText(caption)),
+        ],
+      });
+    }
     case "sticker":
       return asCustom({ whatsapp_type: "sticker", ...content.sticker });
     case "location":

--- a/packages/whatsapp-business/test/caption-group-actions.test.ts
+++ b/packages/whatsapp-business/test/caption-group-actions.test.ts
@@ -1,0 +1,82 @@
+import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
+import type { Content, Message } from "@spectrum-ts/core";
+import { asRead } from "@spectrum-ts/core/authoring";
+import { describe, expect, it, vi } from "vitest";
+import { send } from "@/messages";
+
+// Group items carry synthetic ids (`<wamid>:<index>`); the Cloud API only
+// knows the parent wamid, so targeted actions must strip the suffix.
+const itemTarget = {
+  id: "wamid.CAPTION1:1",
+  content: { type: "text", text: "how many pieces left?" },
+  direction: "inbound",
+} as unknown as Message;
+
+const fakeSendClient = () => {
+  const sendMock = vi.fn(async () => ({ messageId: "wamid.out" }));
+  const markRead = vi.fn(async () => undefined);
+  const client = {
+    messages: { send: sendMock, markRead },
+  } as unknown as WhatsAppClient;
+  return { client, sendMock, markRead };
+};
+
+describe("actions targeting captioned-media group items", () => {
+  it("replies with the parent wamid, not the synthetic item id", async () => {
+    const { client, sendMock } = fakeSendClient();
+    const reply = {
+      type: "reply",
+      target: itemTarget,
+      content: { type: "text", text: "three" },
+    } as unknown as Content;
+
+    await send([client], "15551234567", reply);
+
+    expect(sendMock).toHaveBeenCalledWith({
+      to: "15551234567",
+      replyTo: "wamid.CAPTION1",
+      text: "three",
+    });
+  });
+
+  it("reacts with the parent wamid, not the synthetic item id", async () => {
+    const { client, sendMock } = fakeSendClient();
+    const reaction = {
+      type: "reaction",
+      target: itemTarget,
+      emoji: "👍",
+    } as unknown as Content;
+
+    await send([client], "15551234567", reaction);
+
+    expect(sendMock).toHaveBeenCalledWith({
+      to: "15551234567",
+      reaction: { messageId: "wamid.CAPTION1", emoji: "👍" },
+    });
+  });
+
+  it("marks read with the parent wamid, not the synthetic item id", async () => {
+    const { client, markRead } = fakeSendClient();
+
+    await send([client], "15551234567", asRead({ target: itemTarget }));
+
+    expect(markRead).toHaveBeenCalledWith("wamid.CAPTION1");
+  });
+
+  it("leaves plain wamids untouched", async () => {
+    const { client, sendMock } = fakeSendClient();
+    const reply = {
+      type: "reply",
+      target: { ...itemTarget, id: "wamid.PLAIN" },
+      content: { type: "text", text: "ok" },
+    } as unknown as Content;
+
+    await send([client], "15551234567", reply);
+
+    expect(sendMock).toHaveBeenCalledWith({
+      to: "15551234567",
+      replyTo: "wamid.PLAIN",
+      text: "ok",
+    });
+  });
+});

--- a/packages/whatsapp-business/test/caption-group.test.ts
+++ b/packages/whatsapp-business/test/caption-group.test.ts
@@ -52,6 +52,14 @@ describe("whatsapp inbound media caption", () => {
     }
     expect(content.items).toHaveLength(2);
 
+    // Each item must be a complete record — cloud webhook delivery
+    // serializes item.sender/item.timestamp and crashes on undefined.
+    for (const item of content.items) {
+      expect(item.sender).toEqual({ id: "15551234567" });
+      expect(item.timestamp).toEqual(new Date("2026-07-14T00:00:00.000Z"));
+      expect(item.space).toEqual({ id: "15551234567" });
+    }
+
     const [attachmentItem, textItem] = content.items;
     expect(attachmentItem?.id).toBe("wamid.CAPTION1:0");
     expect(attachmentItem?.content).toMatchObject({

--- a/packages/whatsapp-business/test/caption-group.test.ts
+++ b/packages/whatsapp-business/test/caption-group.test.ts
@@ -1,0 +1,95 @@
+import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
+import { describe, expect, it } from "vitest";
+import { messages } from "@/messages";
+import type { WhatsAppMessage } from "@/types";
+
+// Drives the real inbound path — messages() -> clientStream -> toMessages —
+// with a fake client whose event stream yields one media message.
+const fakeMediaClient = (media: {
+  id: string;
+  mimeType: string;
+  caption?: string;
+}): WhatsAppClient => {
+  const inbound = {
+    id: "wamid.CAPTION1",
+    from: "15551234567",
+    timestamp: new Date("2026-07-14T00:00:00.000Z"),
+    content: { type: "image", media },
+  };
+  const filtered = {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "message", message: inbound };
+    },
+    close: async () => undefined,
+  };
+  return {
+    events: { subscribe: () => ({ filter: () => filtered }) },
+  } as unknown as WhatsAppClient;
+};
+
+const receiveOne = async (
+  client: WhatsAppClient
+): Promise<WhatsAppMessage | undefined> => {
+  for await (const m of messages([client])) {
+    return m;
+  }
+  return;
+};
+
+describe("whatsapp inbound media caption", () => {
+  it("surfaces a captioned image as a group of [attachment, text]", async () => {
+    const received = await receiveOne(
+      fakeMediaClient({
+        id: "983666494500094",
+        mimeType: "image/jpeg",
+        caption: "how many pieces left?",
+      })
+    );
+
+    const content = received?.content;
+    if (content?.type !== "group") {
+      throw new Error(`expected group content, got ${content?.type}`);
+    }
+    expect(content.items).toHaveLength(2);
+
+    const [attachmentItem, textItem] = content.items;
+    expect(attachmentItem?.id).toBe("wamid.CAPTION1:0");
+    expect(attachmentItem?.content).toMatchObject({
+      type: "attachment",
+      id: "983666494500094",
+      name: "media-983666494500094",
+      mimeType: "image/jpeg",
+    });
+    expect(textItem?.id).toBe("wamid.CAPTION1:1");
+    expect(textItem?.content).toMatchObject({
+      type: "text",
+      text: "how many pieces left?",
+    });
+  });
+
+  it("keeps an uncaptioned image as a plain attachment", async () => {
+    const received = await receiveOne(
+      fakeMediaClient({ id: "983666494500094", mimeType: "image/jpeg" })
+    );
+
+    expect(received?.id).toBe("wamid.CAPTION1");
+    expect(received?.content).toMatchObject({
+      type: "attachment",
+      id: "983666494500094",
+      name: "media-983666494500094",
+      mimeType: "image/jpeg",
+    });
+  });
+
+  it("treats a whitespace-only caption as no caption", async () => {
+    const received = await receiveOne(
+      fakeMediaClient({
+        id: "983666494500094",
+        mimeType: "image/jpeg",
+        caption: "   ",
+      })
+    );
+
+    expect(received?.content).toMatchObject({ type: "attachment" });
+  });
+});


### PR DESCRIPTION
Meta delivers image+caption as a single message; mapContent dropped the caption entirely which loses the customer' text. Captioned media now maps to a group of [attachment, text] while uncaptioned media stays a plain attachment.

### Tests

New `packages/whatsapp-business/test/caption-group.test.ts`, driving the real `messages()` inbound stream with a fake client (same harness style as `inbound-line.test.ts`):

- **Captioned image → `group`** with an attachment item (`id`/`name`/`mimeType` preserved) and a text item carrying the caption. Failed before the fix (content came out as a bare `attachment`, reproducing the report), passes after.
- **Regression guards:** uncaptioned image and whitespace-only caption both remain a plain `attachment` with unchanged fields.

Full package suite passes (15 tests, 5 files); `tsc --noEmit` and `ultracite check` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786656103&installation_id=127326493&pr_number=192&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F192&signature=6e4d1f4eb5b68312a92c95e5754298a67189c865068925b2145597ba5beb314f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped WhatsApp Business message mapping and ID normalization with regression tests; no auth or persistence changes.
> 
> **Overview**
> Inbound **image/video/audio/document** messages with a non-empty caption now map to **`group` content** (`attachment` + `text`) instead of dropping the caption. Group items get synthetic ids (`<wamid>:<index>`) and full **sender/space/timestamp** so cloud webhook serialization does not fail.
> 
> **Reply, react, and read** outbound paths use **`parentWamid`** to strip the `:index` suffix before calling the Cloud API, so actions targeting a caption text item still reference the real parent message. Uncaptioned or whitespace-only captions stay a single **attachment**.
> 
> New tests cover the inbound `messages()` stream mapping and `send()` behavior for synthetic item targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f581e3edd09e9053406e5cd56433f02955f1062c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Captioned inbound WhatsApp media is now displayed as grouped content, combining the attachment and its caption.
  - Uncaptioned media continues to appear as a standalone attachment.

- **Bug Fixes**
  - Replies, reactions, and read receipts for grouped media items now correctly target the original WhatsApp message.
  - Whitespace-only captions are handled as if no caption were provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->