### PR TITLE
docs: generate type references with Vellum

### DIFF
--- a/docs/content.mdx.vel
+++ b/docs/content.mdx.vel
@@ -20,7 +20,7 @@ Use this section when you need to choose the right outbound content shape or und
     Send styled text that renders through each provider's native formatting model.
   </Card>
   <Card title="Attachments" icon="paperclip" href="/spectrum-ts/content/attachments">
-    Send files from paths or buffers with stable attachment IDs.
+    Send files from paths, URLs, or buffers with stable attachment IDs.
   </Card>
   <Card title="Voice" icon="audio-lines" href="/spectrum-ts/content/voice">
     Send voice notes with audio metadata and provider fallbacks.
@@ -29,9 +29,9 @@ Use this section when you need to choose the right outbound content shape or und
     Share contact cards from structured data, users, or vCards.
   </Card>
   <Card title="Rich links" icon="link" href="/spectrum-ts/content/rich-links">
-    Render URLs as rich previews with lazy Open Graph metadata.
+    Let each platform render URLs with its native preview behavior.
   </Card>
-  <Card title="App link cards" icon="panel-top" href="/spectrum-ts/content/app-link-cards">
+  <Card title="App link cards" icon="panel-top" href="/spectrum-ts/content/app">
     Present URLs as tappable app-style cards where providers support them.
   </Card>
   <Card title="Polls" icon="list-checks" href="/spectrum-ts/content/polls">

--- a/docs/content/app.mdx.vel
+++ b/docs/content/app.mdx.vel
@@ -3,11 +3,14 @@ title: "App"
 description: "Send and update a tappable app card, with optional live rendering on supported platforms."
 ---
 
+import { TypeTooltip } from "/snippets/type-tooltip.mdx";
+
 Use `app()` when you want to present a URL as a tappable card instead of an inline link.
 
 ## Send an app card
 
-Pass the destination URL to `app()` and send it like any other content:
+{% set appUrl = symbol("ts:spectrum-ts#AppUrl") %}
+The first argument is <TypeTooltip name="AppUrl" type={`{{ appUrl.signature }}`} />. {{ appUrl.doc.summary }}
 
 ```ts
 import { app } from "spectrum-ts";
@@ -19,7 +22,10 @@ On iMessage, the recipient gets a native mini-app card. On Slack, Telegram, What
 
 ## Show the app's live UI
 
-Pass `{ live: true }` as the second argument to ask supported platforms to render the installed app extension's live UI:
+{% set appOptions = symbol("ts:spectrum-ts#AppOptions") %}
+The second argument is <TypeTooltip name="AppOptions" type={`{{ appOptions.signature }}`} />.
+
+Set `live` to `true` to request live rendering:
 
 ```ts
 import { app } from "spectrum-ts";
@@ -30,6 +36,14 @@ await space.send(
   })
 );
 ```
+
+<Accordion title="AppOptions" description="{{ appOptions.doc.summary }}">
+  | Option | Type | Description |
+  |---|---|---|
+  {% for m in appOptions.members -%}
+  | `{{ m.name }}{% if m.optional %}?{% endif %}` | `{{ m.type.text | replace("\n", " ") | replace("    ", "") | replace("|", "\\|") | replace("<", "&lt;") | replace(">", "&gt;") }}` | {{ m.doc.summary }} |
+  {% endfor %}
+</Accordion>
 
 When `live` is omitted, iMessage shows the card's static URL preview. Platforms without a live app surface ignore the option and keep their normal URL fallback.
 

--- a/docs/content/attachments.mdx.vel
+++ b/docs/content/attachments.mdx.vel
@@ -1,9 +1,11 @@
 ---
 title: "Attachments"
-description: "Send files from paths or buffers with stable attachment IDs."
+description: "Send files from paths, URLs, or buffers with stable attachment IDs."
 ---
 
-Use `attachment()` to send files. Pass a file path or a `Buffer`. MIME types are detected from the file extension. Override with `options.mimeType` when you already have the bytes.
+import { TypeTooltip } from "/snippets/type-tooltip.mdx";
+
+Use `attachment()` to send files. Pass a file path, a `URL`, or a `Buffer`. MIME types are detected from the file extension. Override with `options.mimeType` when you already have the bytes.
 
 ```ts
 import { attachment } from "spectrum-ts";
@@ -34,7 +36,9 @@ await space.send(attachment(buffer, {
 }));
 ```
 
-The `Attachment` and `AttachmentInput` types are exported from the public API for use in your own type signatures:
+{% set attachmentType = symbol("ts:spectrum-ts#Attachment") %}
+{% set attachmentInput = symbol("ts:spectrum-ts#AttachmentInput") %}
+Use the resolved <TypeTooltip name="Attachment" type={`{{ attachmentType.signature }}`} /> and accepted <TypeTooltip name="AttachmentInput" type={`{{ attachmentInput.signature }}`} /> input types in your own signatures:
 
 ```ts
 import { type Attachment, type AttachmentInput } from "spectrum-ts";

--- a/docs/content/avatar.mdx.vel
+++ b/docs/content/avatar.mdx.vel
@@ -3,6 +3,8 @@ title: "Avatar"
 description: "Set or clear group chat avatars."
 ---
 
+import { TypeTooltip } from "/snippets/type-tooltip.mdx";
+
 Use `avatar()` to set or clear the chat avatar, also called a group icon. It is fire-and-forget: `space.send(avatar(...))` resolves to `undefined`.
 
 ```ts
@@ -18,9 +20,12 @@ await space.send(avatar(buffer, { mimeType: "image/jpeg" }));
 await space.send(avatar("clear"));
 ```
 
-`space.avatar(...)` is sugar for `space.send(avatar(...))`. Per-platform constraints, such as iMessage requiring remote mode and a group chat, surface as `UnsupportedError` from the provider's send action.
+{% set unsupportedError = symbol("ts:spectrum-ts#UnsupportedError") %}
+`space.avatar(...)` is sugar for `space.send(avatar(...))`. Per-platform constraints, such as iMessage requiring remote mode and a group chat, surface as an <TypeTooltip name="UnsupportedError" type={`{{ unsupportedError.signature }}`} /> from the provider's send action.
 
-Avatar is bidirectional: on platforms that report it (iMessage remote mode today), someone else changing the icon arrives as an inbound message with `content.type === "avatar"` — `action.kind === "set"` carries the fetched icon behind `action.read()` with its `mimeType`, and `"clear"` mirrors icon removal. Over the Spectrum webhook, a `set` arrives metadata-only (its `read()` throws); fetch the current icon via `space.getAvatar()` instead. `message.sender` is the user who changed it, or `undefined` when the platform recorded no actor.
+{% set avatarContent = symbol("ts:spectrum-ts#Avatar") %}
+{% set avatarData = symbol("ts:spectrum-ts#AvatarData") %}
+The <TypeTooltip name="Avatar" type={`{{ avatarContent.signature }}`} /> content is bidirectional: on platforms that report it (iMessage remote mode today), someone else changing the icon arrives as an inbound message with `content.type === "avatar"` — `action.kind === "set"` carries the fetched icon behind `action.read()` with its `mimeType`, and `"clear"` mirrors icon removal. Over the Spectrum webhook, a `set` arrives metadata-only (its `read()` throws); fetch the current icon via `space.getAvatar()` instead, which returns <TypeTooltip name="AvatarData" type={`{{ avatarData.signature }}`} /> with the image bytes and MIME type. `message.sender` is the user who changed it, or `undefined` when the platform recorded no actor.
 
 <Note>
   The string `"clear"` is a reserved sentinel. If you have a file literally named `clear` with no extension, pass `"./clear"` or load it as a `Buffer`.

--- a/docs/content/contacts.mdx.vel
+++ b/docs/content/contacts.mdx.vel
@@ -3,7 +3,12 @@ title: "Contacts"
 description: "Share contact cards from structured data, users, or vCards."
 ---
 
-Use `contact()` to share contact cards. The builder takes either a structured `ContactInput`, a vCard string, a `vcf` instance, or a known `User` paired with optional `ContactDetails`.
+import { TypeTooltip } from "/snippets/type-tooltip.mdx";
+
+{% set contactInput = symbol("ts:spectrum-ts#ContactInput") %}
+{% set user = symbol("ts:spectrum-ts#User") %}
+{% set contactDetails = symbol("ts:spectrum-ts#ContactDetails") %}
+Use `contact()` to share contact cards. The builder takes either a structured <TypeTooltip name="ContactInput" type={`{{ contactInput.signature }}`} />, a vCard string, a `vcf` instance, or a known <TypeTooltip name="User" type={`{{ user.signature }}`} /> paired with optional <TypeTooltip name="ContactDetails" type={`{{ contactDetails.signature }}`} />.
 
 <Tabs>
   <Tab title="Structured">
@@ -42,11 +47,13 @@ Use `contact()` to share contact cards. The builder takes either a structured `C
   </Tab>
 </Tabs>
 
-`fromVCard(vcf)` parses a vCard string into a `ContactInput`. `toVCard(contact)` serializes a resolved `Contact` back to vCard.
+{% set contactType = symbol("ts:spectrum-ts#Contact") %}
+`fromVCard(vcf)` parses a vCard string into a <TypeTooltip name="ContactInput" type={`{{ contactInput.signature }}`} />. `toVCard(contact)` serializes a resolved <TypeTooltip name="Contact" type={`{{ contactType.signature }}`} /> back to vCard.
 
 <Accordion title="ContactInput" description="The fields you can populate on a contact card. All fields are optional except where the receiving platform requires at least one identifying field.">
   | Field | Type | Description |
   |---|---|---|
+  | `user` | <TypeTooltip name="User" type={`{{ user.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} /> | Resolved provider user reference. |
   | `name` | `{ formatted?, first?, last?, middle?, prefix?, suffix? }` | Structured display name. |
   | `phones` | `Array<{ value, type? }>` | Phone numbers. `type` is `"mobile" \| "home" \| "work" \| "other"`. |
   | `emails` | `Array<{ value, type? }>` | Email addresses. `type` is `"home" \| "work" \| "other"`. |

--- a/docs/content/edits.mdx.vel
+++ b/docs/content/edits.mdx.vel
@@ -12,7 +12,7 @@ const sent = await space.send("Draft");
 await space.send(edit(text("Final version"), sent));
 ```
 
-`edit()` cannot wrap `edit`, `reply`, `reaction`, `group`, `typing`, `rename`, `avatar`, or `unsend` content.
+`edit()` cannot wrap `edit`, `reply`, `reaction`, `group`, `typing`, `rename`, `avatar`, `addMember`, `removeMember`, `leaveSpace`, `unsend`, or `read` content.
 
 Provider constraints surface at send time. For example, a provider may reject edits after its native edit window closes.
 

--- a/docs/content/groups.mdx.vel
+++ b/docs/content/groups.mdx.vel
@@ -3,9 +3,12 @@ title: "Groups"
 description: "Bundle multiple messages into one logical visual group."
 ---
 
+import { TypeTooltip } from "/snippets/type-tooltip.mdx";
+
 Use `group()` to bundle multiple messages into one logical unit, such as an album of images or a multi-attachment reply.
 
-Each item is delivered as its own `Message`, but the items ship together so the receiving platform can render them as a single visual group when supported.
+{% set messageType = symbol("ts:spectrum-ts#Message") %}
+Each item is delivered as its own <TypeTooltip name="Message" type={`{{ messageType.signature }}`} /> envelope, but the items ship together so the receiving platform can render them as a single visual group when supported.
 
 ```ts
 import { group, attachment } from "spectrum-ts";

--- a/docs/content/markdown.mdx.vel
+++ b/docs/content/markdown.mdx.vel
@@ -3,6 +3,8 @@ title: "Markdown"
 description: "Send styled text that renders through each provider's native formatting model."
 ---
 
+import { TypeTooltip } from "/snippets/type-tooltip.mdx";
+
 Use `markdown()` when you want to send styled text written in standard markdown. Spectrum supports CommonMark plus GFM tables and strikethrough.
 
 Each platform renders markdown to its native format. Telegram uses `parse_mode: "HTML"`. iMessage in remote mode uses UTF-16 styled text formatting ranges. Platforms without native markdown support receive readable plain text through the send pipeline's automatic fallback.
@@ -15,7 +17,8 @@ await space.send(markdown("**Bold** and _italic_ text."));
 
 ## Streaming markdown
 
-`markdown()` accepts a stream source, just like `text()`. Markdown streams render progressively on platforms with native support. Everywhere else, the accumulated text falls back through the markdown pipeline instead of surfacing raw `**` markers.
+{% set streamTextSource = symbol("ts:spectrum-ts#StreamTextSource") %}
+`markdown()` accepts a <TypeTooltip name="StreamTextSource" type={`{{ streamTextSource.signature }}`} />, just like `text()`. Markdown streams render progressively on platforms with native support. Everywhere else, the accumulated text falls back through the markdown pipeline instead of surfacing raw `**` markers.
 
 ```ts
 import { markdown } from "spectrum-ts";

--- a/docs/content/membership.mdx.vel
+++ b/docs/content/membership.mdx.vel
@@ -3,6 +3,8 @@ title: "Membership"
 description: "Add or remove group members and leave chats through the content pipeline."
 ---
 
+import { TypeTooltip } from "/snippets/type-tooltip.mdx";
+
 Use `addMember()` and `removeMember()` to manage a group chat's members, and `leaveSpace()` to make the agent's own account leave the chat. All three are fire-and-forget: `space.send(...)` resolves to `undefined`.
 
 ```ts
@@ -16,19 +18,24 @@ await space.send(leaveSpace());
 `space.add(users)`, `space.remove(users)`, and `space.leave()` are sugar for the canonical forms above.
 
 ```ts
-await space.add(alice);                       // a resolved User
-await space.add(["+15551234567", bob]);       // ids and Users mix; batches land in one provider call
+await space.add(alice);
+await space.add(["+15551234567", bob]);
 await space.remove("+15551234567");
 await space.leave();
 ```
 
-`addMember()` and `removeMember()` accept a single `User` or id string, or an array of either. Ids use the same platform handle format `space.create` accepts (for iMessage: an E.164 phone number or email); they are passed to the provider verbatim, with no resolution step. Both return a `ContentBuilder` that validates when it builds — an empty member list rejects at `space.send(...)` time, not at construction.
+{% set memberInput = symbol("ts:spectrum-ts#MemberInput") %}
+{% set user = symbol("ts:spectrum-ts#User") %}
+{% set contentBuilder = symbol("ts:spectrum-ts#ContentBuilder") %}
+`addMember()` and `removeMember()` accept <TypeTooltip name="MemberInput" type={`{{ memberInput.signature }}`} />: a <TypeTooltip name="User" type={`{{ user.signature }}`} /> resolved by the current platform or a raw id, either alone or in a batch. Ids use the same platform handle format `space.create` accepts (for iMessage: an E.164 phone number or email); they are passed to the provider verbatim, with no resolution step. Both return a <TypeTooltip name="ContentBuilder" type={`{{ contentBuilder.signature }}`} /> that validates when it builds — an empty member list rejects at `space.send(...)` time, not at construction.
 
-Per-platform constraints surface as `UnsupportedError` from the provider's send action. iMessage requires remote mode and a group chat — a DM cannot be converted into a group, so on a DM the error points you at creating a group via `space.create` instead.
+{% set unsupportedError = symbol("ts:spectrum-ts#UnsupportedError") %}
+Per-platform constraints surface as an <TypeTooltip name="UnsupportedError" type={`{{ unsupportedError.signature }}`} /> from the provider's send action. iMessage requires remote mode and a group chat — a DM cannot be converted into a group, so on a DM the error points you at creating a group via `space.create` instead.
 
 ## Inbound membership events
 
-On platforms that report membership changes (iMessage remote mode today), the same content types arrive as inbound messages on `app.messages` — what you send is what you observe when someone else does it:
+{% set messageType = symbol("ts:spectrum-ts#Message") %}
+On platforms that report membership changes (iMessage remote mode today), the same content types arrive as inbound <TypeTooltip name="Message" type={`{{ messageType.signature }}`} /> values on `app.messages` — what you send is what you observe when someone else does it:
 
 ```ts
 for await (const [space, message] of app.messages) {

--- a/docs/content/rename.mdx.vel
+++ b/docs/content/rename.mdx.vel
@@ -3,6 +3,8 @@ title: "Rename"
 description: "Rename chats through the content pipeline."
 ---
 
+import { TypeTooltip } from "/snippets/type-tooltip.mdx";
+
 Use `rename()` to rename the current chat. It is fire-and-forget: `space.send(rename(...))` resolves to `undefined`.
 
 ```ts
@@ -13,6 +15,8 @@ await space.send(rename("New Chat Name"));
 
 `space.rename(displayName)` is sugar for `space.send(rename(displayName))`. The builder throws at construction time if `displayName` is empty.
 
-Per-platform constraints, such as iMessage requiring remote mode and a group chat, surface as `UnsupportedError` from the provider's send action.
+{% set unsupportedError = symbol("ts:spectrum-ts#UnsupportedError") %}
+Per-platform constraints, such as iMessage requiring remote mode and a group chat, surface as an <TypeTooltip name="UnsupportedError" type={`{{ unsupportedError.signature }}`} /> from the provider's send action.
 
-Rename is bidirectional: on platforms that report it (iMessage remote mode today), someone else renaming the chat arrives as an inbound message with `content.type === "rename"` and the new `displayName`. `message.sender` is the user who renamed the chat, or `undefined` when the platform recorded no actor.
+{% set renameContent = symbol("ts:spectrum-ts#Rename") %}
+The <TypeTooltip name="Rename" type={`{{ renameContent.signature }}`} /> content is bidirectional: on platforms that report it (iMessage remote mode today), someone else renaming the chat arrives as an inbound message with `content.type === "rename"` and the new `displayName`. `message.sender` is the user who renamed the chat, or `undefined` when the platform recorded no actor.

--- a/docs/content/replies.mdx.vel
+++ b/docs/content/replies.mdx.vel
@@ -11,7 +11,7 @@ import { reply, text } from "spectrum-ts";
 await space.send(reply(text("Got it"), message));
 ```
 
-`reply()` cannot wrap `reply`, `edit`, `reaction`, `group`, `typing`, `rename`, `avatar`, or `unsend` content.
+`reply()` cannot wrap `reply`, `edit`, `reaction`, `group`, `typing`, `rename`, `avatar`, `addMember`, `removeMember`, `leaveSpace`, `unsend`, or `read` content.
 
 ## Reply sugar
 

--- a/docs/content/rich-links.mdx.vel
+++ b/docs/content/rich-links.mdx.vel
@@ -1,9 +1,12 @@
 ---
 title: "Rich links"
-description: "Render URLs as rich previews with lazy Open Graph metadata."
+description: "Let each platform render a URL with its native rich-link preview."
 ---
 
-Use `richlink()` to render a URL as a rich preview card with title, summary, and cover image. Spectrum scrapes Open Graph metadata at send time. Pass just the URL and the builder fills in the rest.
+import { TypeTooltip } from "/snippets/type-tooltip.mdx";
+
+{% set richlinkType = symbol("ts:spectrum-ts#Richlink") %}
+Use `richlink()` to build <TypeTooltip name="Richlink" type={`{{ richlinkType.signature }}`} /> content from a URL. Spectrum carries only the URL. It does not fetch Open Graph metadata.
 
 ```ts
 import { richlink } from "spectrum-ts";
@@ -11,13 +14,4 @@ import { richlink } from "spectrum-ts";
 await space.send(richlink("https://example.com/article"));
 ```
 
-`title()`, `summary()`, and `cover()` are lazy async accessors. The metadata fetch happens only if the receiving platform needs it. Platforms without rich-link support fall back to the URL as plain text.
-
-<Accordion title="Richlink" description="Resolved rich-link content with lazy metadata accessors.">
-  | Field | Type | Description |
-  |---|---|---|
-  | `url` | `string` | The original URL. |
-  | `title()` | `() => Promise<string \| undefined>` | OG title. |
-  | `summary()` | `() => Promise<string \| undefined>` | OG description. |
-  | `cover()` | `() => Promise<{ mimeType?, read(), stream() } \| undefined>` | OG image. |
-</Accordion>
+Each provider asks its native client to render or unfurl the URL. Platforms without rich-link support fall back to plain text.

--- a/docs/content/text.mdx.vel
+++ b/docs/content/text.mdx.vel
@@ -3,6 +3,8 @@ title: "Text"
 description: "Send plain text and stream text through Spectrum."
 ---
 
+import { TypeTooltip } from "/snippets/type-tooltip.mdx";
+
 Use `text()` for plain outbound text. You can also pass a plain string anywhere Spectrum accepts content.
 
 ```ts
@@ -16,7 +18,8 @@ await space.send("Hello, world.");
 
 ## Streaming text
 
-Both `text()` and `markdown()` accept a streaming source: an AI SDK result, an `AsyncIterable`, or a `ReadableStream`.
+{% set streamTextSource = symbol("ts:spectrum-ts#StreamTextSource") %}
+Both `text()` and `markdown()` accept a <TypeTooltip name="StreamTextSource" type={`{{ streamTextSource.signature }}`} />: an AI SDK result, an `AsyncIterable`, or a `ReadableStream`.
 
 On platforms that support it, text streams live. iMessage in remote mode sends the first chunk as a real message and edits in place as more text arrives. Telegram private chats animate a native draft preview. Platforms without streaming support wait for the stream to finish and send the full text as one message.
 
@@ -55,4 +58,13 @@ On platforms that support it, text streams live. iMessage in remote mode sends t
   </Tab>
 </Tabs>
 
-A stream can only be sent once. Pass `options.extract` for any chunk shape the built-in auto-detection doesn't recognize.
+A stream can only be sent once.
+
+{% set textStreamOptions = symbol("ts:spectrum-ts#TextStreamOptions") %}
+<Accordion title="TextStreamOptions" description="{{ textStreamOptions.doc.summary }}">
+  | Option | Type | Description |
+  |---|---|---|
+  {% for m in textStreamOptions.members -%}
+  | `{{ m.name }}{% if m.optional %}?{% endif %}` | `{{ m.type.text | replace("\n", " ") | replace("    ", "") | replace("|", "\\|") | replace("<", "&lt;") | replace(">", "&gt;") }}` | {{ m.doc.summary }} |
+  {% endfor %}
+</Accordion>

--- a/docs/content/voice.mdx.vel
+++ b/docs/content/voice.mdx.vel
@@ -3,7 +3,7 @@ title: "Voice"
 description: "Send voice notes with audio metadata and provider fallbacks."
 ---
 
-Use `voice()` to send a voice note. It uses the same input shape as `attachment`: a path or a `Buffer` plus optional metadata.
+Use `voice()` to send a voice note. It uses the same input shape as `attachment`: a path, a `URL`, or a `Buffer` plus optional metadata.
 
 <Note>
   This page covers audio clips sent inside messages. To place or receive a live

--- a/docs/custom-events-and-lifecycle.mdx.vel
+++ b/docs/custom-events-and-lifecycle.mdx.vel
@@ -3,6 +3,8 @@ title: "Custom Events and Lifecycle"
 description: "Platform-specific event streams and graceful shutdown"
 ---
 
+import { TypeTooltip } from "/snippets/type-tooltip.mdx";
+
 ## Custom events
 
 Platform providers can emit events beyond messages — typing indicators, read receipts, delivery status, whatever the provider chooses to surface. Spectrum exposes each event as a flat async iterable on the app instance:
@@ -36,15 +38,16 @@ Use the flat form on `app` when you want a merged feed across platforms; use the
 
 ### Fusor custom events
 
-Fusor-backed providers can emit non-message events (presence, read receipts, delivery status) into typed event streams using `fusorEvent`. Inside a Fusor `messages` handler, yield a `fusorEvent(name, data)` alongside regular messages to push events into `app.<name>` streams:
+{% set fusorEventType = symbol("ts:spectrum-ts#FusorEvent") %}
+Fusor-backed providers can emit non-message events (presence, read receipts, delivery status) into typed event streams using `fusorEvent`. The helper returns a <TypeTooltip name="FusorEvent" type={`{{ fusorEventType.signature }}`} /> envelope. Return a `fusorEvent(name, data)` from a Fusor `messages` handler to push it into an `app.<name>` stream:
 
 ```ts
 import { fusorEvent } from "spectrum-ts";
 
-yield fusorEvent("presence", { userId: update.userId, online: true });
+return fusorEvent("presence", { userId: update.userId, online: true });
 ```
 
-Events emitted this way are available as `app.presence` (merged across providers) or `narrowedInstance.presence` (scoped to the emitting provider). The event name and data shape are fully typed based on the provider's event declarations.
+Return an array when one webhook delivery produces both messages and custom events. Events emitted this way are available as `app.presence` (merged across providers) or `narrowedInstance.presence` (scoped to the emitting provider). Provider event declarations type the resulting streams. The `fusorEvent` helper itself accepts any name and data, so an undeclared event name produces a runtime warning.
 
 ## Lifecycle
 

--- a/docs/custom-platforms.mdx.vel
+++ b/docs/custom-platforms.mdx.vel
@@ -5,17 +5,16 @@ description: "Use definePlatform to plug a new messaging platform into Spectrum"
 
 import { TypeTooltip } from "/snippets/type-tooltip.mdx";
 
-{% set pd = symbol("ts:spectrum-ts#PlatformDef") %}
-{% set ep = symbol("ts:spectrum-ts#EventProducer") %}
-{% set schemaMsg = symbol("ts:spectrum-ts#SchemaMessage") %}
-
+{% set spaceType = symbol("ts:spectrum-ts#Space") %}
+{% set messageType = symbol("ts:spectrum-ts#Message") %}
 `definePlatform` is the entry point for building your own provider. It takes a name and a definition object, and returns a callable that:
 
 - exposes a `.config()` method for registering the provider on `Spectrum()`
-- accepts a Spectrum instance, space, or message for [narrowing](/spectrum-ts/platform-narrowing)
-- carries any `static` properties you declare (like iMessage's `tapbacks`)
+- accepts the app, a <TypeTooltip name="Space" type={`{{ spaceType.signature }}`} />, or a <TypeTooltip name="Message" type={`{{ messageType.signature }}`} /> for [narrowing](/spectrum-ts/platform-narrowing)
+- carries any `static` properties you declare (like iMessage's effect constants)
 
-The full definition shape is <TypeTooltip name="PlatformDef" type={`{{ pd.signature }}`} />.
+{% set pd = symbol("ts:spectrum-ts#PlatformDef") %}
+The core definition shape is <TypeTooltip name="PlatformDef" type={`{{ pd.signature }}`} />. You pass `name` as the first argument to `definePlatform`. The optional `static` object is an additional `definePlatform` input whose properties are copied onto the returned provider.
 
 ## Shape
 
@@ -87,31 +86,44 @@ export const myPlatform = definePlatform("my-platform", {
 
 ## Field reference
 
-| Field | Required | Description |
-|---|---|---|
-| `config` | Yes | A Zod schema that validates the object passed to `platform.config()`. If every field is optional, `platform.config()` can be called with no arguments. |
-| `user.resolve` | Yes | Resolves a user from a string ID. Returns at minimum `{ id: string }`. |
-| `user.schema` | No | Optional Zod schema for extra user properties. |
-| `space.create` | Yes | Creates a conversation from participants. Receives an array of users plus optional params. |
-| `space.get` | No | Hydrates a space from a known platform space ID. When omitted, the framework builds `{ id }` and validates it against `space.schema`. Providers whose schema requires more fields must implement this. |
-| `space.schema` | No | Optional Zod schema for the resolved space. |
-| `space.params` | No | Zod schema for additional space parameters — surfaces as the second arg to `platform(app).space.create()` and `platform(app).space.get()`. |
-| `space.actions` | No | A map of content-builder factories that become sugar methods on the resolved space. Each `space.<name>(...args)` delegates to `space.send(factory(...args))`. Names that collide with built-in `Space` methods (`send`, `edit`, `unsend`, `read`, `startTyping`, `stopTyping`, `responding`, `getMessage`, `getMembers`, `getAvatar`, `rename`, `avatar`, `add`, `remove`, `leave`) are skipped at runtime with a warning. |
-| `lifecycle.createClient` | Yes | Creates the platform client. Receives `config`, `projectId`, `projectSecret` (both may be `undefined`), and `store`. |
-| `lifecycle.destroyClient` | No | Tears down the client on shutdown. Omit if no cleanup is needed. |
-| `messages` | Yes | Async generator that yields incoming messages. |
-| `send` | Yes | Dispatches a content item to a space. All content types — text, markdown, attachments, reactions, replies, edits, unsends, typing indicators — flow through this single action. Return a `ProviderMessageRecord` for content that produces a message (including reactions — the record is the unsend handle), or `undefined` for fire-and-forget signals (typing, edits, unsends). |
-| `actions.getMessage` | No | Fetches a message by ID from a space. Receives `(ctx, space, messageId)` where `ctx` is `{ client, config, store }`. Powers `space.getMessage(id)`. When omitted, `space.getMessage()` throws `UnsupportedError`. |
-| `actions.getMembers` | No | Lists a space's current participants. Receives `(ctx, space)` and returns raw `{ id, ...extras }` records; `space.getMembers()` tags each with `__platform`. When omitted, `space.getMembers()` throws `UnsupportedError`. |
-| `actions.getAvatar` | No | Downloads the space's avatar. Receives `(ctx, space)` and returns `{ data: Buffer, mimeType }` — or `undefined` when no avatar is set. Powers `space.getAvatar()`. When omitted, `space.getAvatar()` throws `UnsupportedError`. |
-| `actions.[custom]` | No | Platform-specific methods projected onto the platform instance. Each receives `(ctx, ...args)` where `ctx` is `{ client, config, store }`; the public signature drops `ctx`. Names that collide with reserved instance keys (`user`, `space`, `messages`, plus any event names) are skipped at runtime with a warning. |
-| `events.[custom]` | No | Additional async generators for platform-specific events — exposed on `app.[eventName]`. |
-| `message.schema` | No | Zod schema for extra properties on incoming messages. |
-| `static` | No | Constants attached to the platform object (e.g. tapback names). |
+{% set providerMessageRecord = symbol("ts:spectrum-ts/authoring#ProviderMessageRecord") %}
+Return a <TypeTooltip name="ProviderMessageRecord" type={`{{ providerMessageRecord.signature }}`} /> from `send` when the content produces a message. Return `undefined` for fire-and-forget signals.
+
+<AccordionGroup>
+  <Accordion title="PlatformDef" description="{{ pd.doc.summary }}">
+    | Field | Type | Required | Description |
+    |---|---|---|---|
+    {% for m in pd.members -%}
+    | `{{ m.name }}` | `{{ m.type.text | replace("\n", " ") | replace("    ", "") | replace("|", "\\|") | replace("<", "&lt;") | replace(">", "&gt;") }}` | {% if m.optional %}No{% else %}Yes{% endif %} | {% if m.doc.summary %}{{ m.doc.summary }}{% else %}-{% endif %} |
+    {% endfor %}
+  </Accordion>
+  <Accordion title="Nested definition fields" description="Configure platform resolution, lifecycle hooks, schemas, and actions.">
+    | Field | Required | Description |
+    |---|---|---|
+    | `user.resolve` | Yes | Resolves a user from a string ID. Returns at minimum `{ id: string }`. |
+    | `user.schema` | No | Adds provider-specific user properties with a Zod schema. |
+    | `space.create` | Yes | Creates a conversation from participants. Receives an array of users plus optional params. |
+    | `space.get` | No | Hydrates a space from a known provider ID. When omitted, Spectrum builds `{ id }` and validates it against `space.schema`. Providers whose schemas require more fields must implement this method. |
+    | `space.schema` | No | Adds provider-specific properties to resolved spaces with a Zod schema. |
+    | `space.params` | No | Adds provider-specific parameters to `platform(app).space.create()` and `platform(app).space.get()` with a Zod schema. |
+    | `space.actions` | No | Adds async methods to resolved spaces. Spectrum binds each method's first parameter to the space, so callers pass only the remaining arguments. Reserved universal method names are skipped with a warning. |
+    | `lifecycle.createClient` | Yes | Creates the provider client. Receives `config`, `projectConfig`, `projectId`, `projectSecret`, and `store`. |
+    | `lifecycle.destroyClient` | No | Tears down the client on shutdown. Omit it when the client needs no cleanup. |
+    | `message.schema` | No | Adds provider-specific properties to incoming messages with a Zod schema. |
+    | `message.actions` | No | Adds async methods to narrowed messages. Spectrum binds each method's first parameter to the message, so callers pass only the remaining arguments. |
+    | `actions.getMessage` | No | Fetches a message by ID and powers `space.getMessage(id)`. Spectrum injects `{ client, config, store }` as the first argument. |
+    | `actions.getMembers` | No | Lists a space's participants and powers `space.getMembers()`. Spectrum injects `{ client, config, store }` as the first argument. |
+    | `actions.getAvatar` | No | Downloads a space's avatar and powers `space.getAvatar()`. Spectrum injects `{ client, config, store }` as the first argument. |
+    | `actions.getDisplayName` | No | Reads a space's title and powers `space.getDisplayName()`. Spectrum injects `{ client, config, store }` as the first argument. |
+    | `actions.[custom]` | No | Adds a provider-specific method to the narrowed provider instance. Spectrum injects `{ client, config, store }` as the first argument. |
+    | `events.[custom]` | No | Adds an event stream exposed on `app.[eventName]` and the narrowed provider instance. |
+    | `static` | No | Copies constants onto the provider returned by `definePlatform`. |
+  </Accordion>
+</AccordionGroup>
 
 ## Message direction
 
-Records yielded from `messages` are wrapped as inbound, and records returned from `send` are wrapped as outbound. When a provider knows the actual direction of a record, it can set `direction` on the raw record and Spectrum will use it instead of the wrapping context:
+Records yielded from `messages` are wrapped as inbound <TypeTooltip name="Message" type={`{{ messageType.signature }}`} /> values. Records returned from `send` are wrapped as outbound messages. When a provider knows a record's actual direction, it can set `direction` on the raw record and Spectrum uses it instead of the wrapping context:
 
 ```ts
 yield {
@@ -135,7 +147,8 @@ This matters for nested records like reaction targets: the outer reaction is inb
 
 ## Event producers
 
-Every event generator receives `{ client, config, store }` and returns an `AsyncIterable`. The signature is <TypeTooltip name="EventProducer" type={`{{ ep.signature }}`} />.
+{% set ep = symbol("ts:spectrum-ts#EventProducer") %}
+Every event generator receives `{ client, config, projectConfig, store }` and returns an `AsyncIterable`. The signature is <TypeTooltip name="EventProducer" type={`{{ ep.signature }}`} />.
 
 The core `messages` stream lives at the top level of the definition. Optional custom event streams (presence, read receipts, etc.) live inside `events`:
 
@@ -168,6 +181,7 @@ message: {
 },
 ```
 
+{% set schemaMsg = symbol("ts:spectrum-ts#SchemaMessage") %}
 Use <TypeTooltip name="SchemaMessage" type={`{{ schemaMsg.signature }}`} /> when you need the message shape in your own types.
 
 ## Instance actions
@@ -176,7 +190,8 @@ Methods declared in `actions` are projected onto the platform instance returned 
 
 Two tiers share the `actions` slot:
 
-- **Platform-wise actions** (`getMessage`, `getMembers`, `getAvatar`) — framework-recognized names. Always present on every platform instance. When omitted, the framework wires a default that throws `UnsupportedError`.
+{% set unsupportedError = symbol("ts:spectrum-ts#UnsupportedError") %}
+- **Platform-wise actions** (`getMessage`, `getMembers`, `getAvatar`, `getDisplayName`) — framework-recognized names. Always present on every platform instance. When omitted, the framework wires a default that throws an <TypeTooltip name="UnsupportedError" type={`{{ unsupportedError.signature }}`} />.
 - **Platform-specific actions** — free-form keys for platform ergonomics (e.g. iMessage's `getAttachment`). Only present when declared.
 
 ```ts
@@ -194,19 +209,19 @@ export const myPlatform = definePlatform("my-platform", {
 
 const mine = myPlatform(app);
 
-// Platform-wise — always available, throws UnsupportedError if not overridden
 const msg = await mine.getMessage(space, "msg-123");
 
-// Platform-specific — available because declared above
 const thread = await mine.lookupThread("thread-456");
 ```
 
 ## Fusor-backed providers
 
-When your platform receives inbound messages through webhooks (rather than a persistent connection), use `fusor(...)` as the client in `lifecycle.createClient`. A Fusor client handles webhook signature verification and delivers parsed payloads to your `messages` handler:
+{% set fusorMessages = symbol("ts:spectrum-ts#FusorMessages") %}
+{% set fusorMessagesCtx = symbol("ts:spectrum-ts#FusorMessagesCtx") %}
+When your platform receives inbound messages through webhooks (rather than a persistent connection), use `fusor(...)` as the client in `lifecycle.createClient`. A Fusor client handles webhook signature verification and delivers parsed payloads to a <TypeTooltip name="FusorMessages" type={`{{ fusorMessages.signature }}`} /> handler:
 
 ```ts
-import { definePlatform, fusor, fusorEvent } from "spectrum-ts";
+import { definePlatform, fusor } from "spectrum-ts";
 import z from "zod";
 
 export const myWebhookPlatform = definePlatform("my-webhook-platform", {
@@ -222,9 +237,9 @@ export const myWebhookPlatform = definePlatform("my-webhook-platform", {
       }),
   },
 
-  messages: async function* ({ payload, config, respond }) {
+  messages: async ({ payload, respond }) => {
     respond({ status: 200 });
-    yield {
+    return {
       id: payload.id,
       content: { type: "text", text: payload.text },
       sender: { id: payload.userId },
@@ -247,7 +262,15 @@ export const myWebhookPlatform = definePlatform("my-webhook-platform", {
 });
 ```
 
-The Fusor overload of `definePlatform` replaces the top-level `messages` async generator with a per-webhook-delivery handler that receives `{ payload, config, respond }`. Call `respond()` to set the HTTP response sent back to the webhook caller.
+The Fusor overload of `definePlatform` replaces the top-level `messages` async generator with a per-webhook-delivery handler. It receives a <TypeTooltip name="FusorMessagesCtx" type={`{{ fusorMessagesCtx.signature }}`} />. Call `respond()` to set the HTTP response sent back to the webhook caller.
+
+<Accordion title="FusorMessagesCtx" description="Context passed to a Fusor message handler for one webhook delivery.">
+  | Field | Type | Description |
+  |---|---|---|
+  {% for m in fusorMessagesCtx.members -%}
+  | `{{ m.name }}` | `{{ m.type.text | replace("\n", " ") | replace("    ", "") | replace("|", "\\|") | replace("<", "&lt;") | replace(">", "&gt;") }}` | {% if m.doc.summary %}{{ m.doc.summary }}{% else %}-{% endif %} |
+  {% endfor %}
+</Accordion>
 
 ## Registering your platform
 

--- a/docs/getting-started.mdx.vel
+++ b/docs/getting-started.mdx.vel
@@ -5,6 +5,10 @@ description: "Install spectrum-ts and send your first message across platforms"
 
 import { TypeTooltip } from "/snippets/type-tooltip.mdx";
 
+{% set message = symbol("ts:spectrum-ts#Message") %}
+{% set space = symbol("ts:spectrum-ts#Space") %}
+{% set user = symbol("ts:spectrum-ts#User") %}
+
 `spectrum-ts` is a unified messaging SDK for TypeScript. Write your logic once, deliver it across every platform — iMessage, WhatsApp Business, your terminal, or a custom platform you build yourself.
 
 ## Installation
@@ -63,12 +67,12 @@ Spectrum is built around four primitives:
 
 | Primitive | What it represents |
 |---|---|
-| **Message** | An incoming piece of content — text, attachments, or structured data — from any platform. |
-| **Space** | A conversation context. A DM, a group chat, a terminal session. You send messages *into* a space. |
-| **User** | A participant on a platform, identified by a platform-specific ID. |
+| <TypeTooltip name="Message" type={`{{ message.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} /> | An incoming piece of content — text, attachments, or structured data — from any platform. |
+| <TypeTooltip name="Space" type={`{{ space.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} /> | A conversation context. A DM, a group chat, a terminal session. You send messages *into* a space. |
+| <TypeTooltip name="User" type={`{{ user.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} /> | A participant on a platform, identified by a platform-specific ID. |
 | **Platform provider** | A platform adapter (iMessage, terminal, WhatsApp, or your own) that translates platform-specific protocols into Spectrum's unified interface. |
 
-Every message arrives as a `[Space, Message]` tuple. The space gives you the ability to respond; the message gives you the content and metadata.
+Every message arrives as a tuple containing a <TypeTooltip name="Space" type={`{{ space.signature }}`} /> and a <TypeTooltip name="Message" type={`{{ message.signature }}`} />. The space gives you the ability to respond; the message gives you the content and metadata.
 
 ## Quickstart
 
@@ -106,7 +110,7 @@ const app = await Spectrum({
 
 for await (const [space, message] of app.messages) {
   if (message.content.type === "text") {
-    console.log(`[${message.platform}] ${message.sender.id}: ${message.content.text}`);
+    console.log(`[${message.platform}] ${message.sender?.id ?? "unknown"}: ${message.content.text}`);
     await space.send("hello world");
   }
 }
@@ -129,12 +133,14 @@ const app = await Spectrum({
 `Spectrum()` returns a <TypeTooltip name="SpectrumInstance" type={`{{ spectrumInstance.signature }}`} /> — an object that merges a message stream with platform-specific custom event streams.
 
 ```ts
-app.messages                 // AsyncIterable<[Space, Message]>
+app.messages
 await app.send(space, ...)   // send into a space
 await app.responding(space, fn)  // run fn with a typing indicator
 await app.webhook(req, handler)  // handle an inbound webhook delivery
 await app.stop()             // graceful shutdown
 ```
+
+`app.messages` is an `AsyncIterable` of tuples containing a <TypeTooltip name="Space" type={`{{ space.signature }}`} /> and a <TypeTooltip name="Message" type={`{{ message.signature }}`} />.
 
 Custom events emitted by providers are exposed as flat async iterables on the same object — see [Custom events and lifecycle](/spectrum-ts/custom-events-and-lifecycle).
 

--- a/docs/messages.mdx.vel
+++ b/docs/messages.mdx.vel
@@ -6,9 +6,11 @@ description: "Receive, narrow, and act on incoming messages"
 import { TypeTooltip } from "/snippets/type-tooltip.mdx";
 
 {% set message = symbol("ts:spectrum-ts#Message") %}
+{% set space = symbol("ts:spectrum-ts#Space") %}
 {% set content = symbol("ts:spectrum-ts#Content") %}
+{% set poll = symbol("ts:spectrum-ts#Poll") %}
 
-Every incoming message arrives through `app.messages` as a `[Space, Message]` tuple. The space is already bound to the originating conversation — you don't need to resolve it yourself to reply.
+Every incoming message arrives through `app.messages` as a tuple containing a <TypeTooltip name="Space" type={`{{ space.signature }}`} /> and a <TypeTooltip name="Message" type={`{{ message.signature }}`} />. The space is already bound to the originating conversation — you don't need to resolve it yourself to reply.
 
 ## Receiving messages
 
@@ -24,60 +26,17 @@ Messages from every configured provider merge into this single stream. The order
 
 Every message conforms to <TypeTooltip name="Message" type={`{{ message.signature }}`} />.
 
-<table>
-  <thead>
-    <tr>
-      <th>Field</th>
-      <th>Description</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>id</code></td>
-      <td>Platform-assigned message identifier.</td>
-    </tr>
-    <tr>
-      <td><code>content</code></td>
-      <td>Discriminated union on <code>type</code> — see <a href="#narrowing-content">Narrowing content</a> for the full set of variants.</td>
-    </tr>
-    <tr>
-      <td><code>sender</code></td>
-      <td>The <TypeTooltip name="User" type={`{{ symbol("ts:spectrum-ts#User").signature }}`} /> who sent the message — <code>undefined</code> for events with no attributable author (e.g. a group-management event whose platform recorded no actor).</td>
-    </tr>
-    <tr>
-      <td><code>space</code></td>
-      <td>The <TypeTooltip name="Space" type={`{{ symbol("ts:spectrum-ts#Space").signature }}`} /> the message was sent into.</td>
-    </tr>
-    <tr>
-      <td><code>platform</code></td>
-      <td>Name of the provider that delivered the message (e.g. <code>"iMessage"</code>, <code>"terminal"</code>).</td>
-    </tr>
-    <tr>
-      <td><code>timestamp</code></td>
-      <td><code>Date</code> of when the message was sent.</td>
-    </tr>
-    <tr>
-      <td><code>react(reaction)</code></td>
-      <td>React to this message. Returns the reaction <code>Message</code> — keep it as the handle to <code>unsend()</code> later. No-op on platforms that don't support reactions.</td>
-    </tr>
-    <tr>
-      <td><code>reply(...content)</code></td>
-      <td>Reply threaded to this message. Falls back silently on platforms without thread support.</td>
-    </tr>
-    <tr>
-      <td><code>edit(newContent)</code></td>
-      <td>Rewrite the content of this outbound message. Fire-and-forget.</td>
-    </tr>
-    <tr>
-      <td><code>unsend()</code></td>
-      <td>Retract this outbound message. Fire-and-forget.</td>
-    </tr>
-  </tbody>
-</table>
+<Accordion title="Message" description="{{ message.doc.summary }}">
+  | Member | Description |
+  |---|---|
+  {% for m in message.members -%}
+  | `{{ m.signature | replace("\n", " ") | replace("    ", "") | replace("|", "\\|") | replace("<", "&lt;") | replace(">", "&gt;") }}` | {{ m.doc.summary | replace("\n", " ") | replace("|", "\\|") }} |
+  {% endfor %}
+</Accordion>
 
 ## Narrowing content
 
-`Content` is a discriminated union. Narrow on `message.content.type` before accessing fields:
+<TypeTooltip name="Content" type={`{{ content.signature }}`} /> is a discriminated union. Narrow on `message.content.type` before accessing fields:
 
 ```ts
 for await (const [space, message] of app.messages) {
@@ -98,7 +57,7 @@ for await (const [space, message] of app.messages) {
       console.log(message.content.name?.formatted, message.content.phones);
       break;
     case "richlink":
-      console.log(message.content.url, await message.content.title());
+      console.log(message.content.url);
       break;
     case "reaction":
       console.log(`${message.content.emoji} on ${message.content.target.id}`);
@@ -122,29 +81,32 @@ for await (const [space, message] of app.messages) {
 }
 ```
 
-<Accordion title="Content" description="The incoming content variants that every Message carries. Most platforms only emit a subset — narrow defensively.">
+<Accordion title="Content" description="{{ content.doc.summary }}">
   | Type | Fields |
   |---|---|
   | `"text"` | `text: string` |
   | `"markdown"` | `markdown: string` — outbound-only styled text |
   | `"attachment"` | `id: string`, `name: string`, `mimeType: string`, `size?: number`, `read()`, `stream()` |
   | `"voice"` | `name?: string`, `mimeType: string`, `duration?: number`, `size?: number`, `read()`, `stream()` |
-  | `"contact"` | `name?`, `phones?`, `emails?`, `addresses?`, `org?`, `urls?`, `birthday?`, `note?`, `photo?`, `user?` |
-  | `"richlink"` | `url: string`, `title()`, `summary()`, `cover()` |
-  | `"reaction"` | `emoji: string`, `target: Message` |
+  | `"contact"` | `name?`, `phones?`, `emails?`, `addresses?`, `org?`, `urls?`, `birthday?`, `note?`, `photo?`, `user?`, `raw?` |
+  | `"richlink"` | `url: string` |
+  | `"effect"` | `content`, `effect: string` — iMessage effect wrapping text, markdown, or an attachment |
+  | `"reaction"` | `emoji: string`, `target:` <TypeTooltip name="Message" type={`{{ message.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} /> |
   | `"poll"` | `title: string`, `options: { title: string }[]` |
-  | `"poll_option"` | `option: { title }`, `poll: Poll`, `selected: boolean`, `title: string` — sent as a vote |
-  | `"group"` | `items: Message[]` — bundled multi-message unit |
+  | `"poll_option"` | `option: { title }`, `poll:` <TypeTooltip name="Poll" type={`{{ poll.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} />, `selected: boolean`, `title: string` — sent as a vote |
+  | `"group"` | `items:` <TypeTooltip name="Message" type={`{{ message.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} />`[]` — bundled multi-message unit |
   | `"rename"` | `displayName: string` — the chat was renamed |
   | `"avatar"` | `action: { kind: "set", read(), mimeType } \| { kind: "clear" }` — group icon set or cleared |
   | `"addMember"` | `members: string[]` — members added; `sender` is who added them |
   | `"removeMember"` | `members: string[]` — members removed; `sender` is who removed them |
   | `"leaveSpace"` | *(no fields)* — `sender` is the member who left |
-  | `"reply"` | `content: Content`, `target: Message` — threaded reply wrapping inner content |
-  | `"edit"` | `content: Content`, `target: Message` — rewrite of a previously-sent message |
-  | `"unsend"` | `target: Message` — retraction of a previously-sent message |
+  | `"reply"` | `content:` <TypeTooltip name="Content" type={`{{ content.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} />, `target:` <TypeTooltip name="Message" type={`{{ message.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} /> — threaded reply wrapping inner content |
+  | `"edit"` | `content:` <TypeTooltip name="Content" type={`{{ content.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} />, `target:` <TypeTooltip name="Message" type={`{{ message.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} /> — rewrite of a previously-sent message |
+  | `"unsend"` | `target:` <TypeTooltip name="Message" type={`{{ message.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} /> — retraction of a previously-sent message |
+  | `"read"` | `target:` <TypeTooltip name="Message" type={`{{ message.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} /> — mark the conversation read through the target message |
   | `"typing"` | `state: "start" \| "stop"` — typing indicator signal |
-  | `"streamText"` | `stream: () => AsyncIterable<string>` — streaming text content |
+  | `"streamText"` | `stream: () => AsyncIterable<string>`, `format?: "plain" \| "markdown"` — streaming text content |
+  | `"app"` | `url()`, `layout()`, `live?: boolean` — app-style link card |
   | `"custom"` | `raw: unknown` — platform-specific structured data |
 </Accordion>
 
@@ -154,13 +116,11 @@ Group-management events (`rename`, `avatar`, `addMember`, `removeMember`, `leave
 
 ## Filtering out your own messages
 
-On platforms where your account also receives its own sends, guard with a platform-specific check — for example, iMessage carries an `isFromMe` flag on the raw message extra you can expose through a provider `message.schema`.
-
-For unified logic, compare the sender to a known identity:
+Every <TypeTooltip name="Message" type={`{{ message.signature }}`} /> carries a `direction`. Skip outbound messages when you only want user input:
 
 ```ts
 for await (const [space, message] of app.messages) {
-  if (message.sender?.id === myAccountId) continue;
+  if (message.direction === "outbound") continue;
   // handle incoming
 }
 ```
@@ -171,9 +131,9 @@ Every message is its own context. You can reply, react, or send new content into
 
 ```ts
 for await (const [space, message] of app.messages) {
-  await message.react("love");              // react
-  await message.reply("Got it");            // threaded reply
-  await space.send("Here's more context");  // fresh send into the space
+  await message.react("❤️");
+  await message.reply("Got it");
+  await space.send("Here's more context");
 }
 ```
 

--- a/docs/platform-narrowing.mdx.vel
+++ b/docs/platform-narrowing.mdx.vel
@@ -6,12 +6,15 @@ description: "Recover platform-specific types and actions from unified Spectrum 
 import { TypeTooltip } from "/snippets/type-tooltip.mdx";
 
 {% set pi = symbol("ts:spectrum-ts#PlatformInstance") %}
+{% set spectrumInstance = symbol("ts:spectrum-ts#SpectrumInstance") %}
+{% set space = symbol("ts:spectrum-ts#Space") %}
+{% set message = symbol("ts:spectrum-ts#Message") %}
 
 Every platform provider exports a callable — `imessage`, `terminal`, `whatsappBusiness`, `telegram` — that **narrows** generic Spectrum types into platform-specific ones. The same function handles three different inputs.
 
 ## Narrowing the app
 
-Pass a `Spectrum` instance to get a <TypeTooltip name="PlatformInstance" type={`{{ pi.signature }}`} /> for that platform. The instance gives you `user()` and `space.create()` / `space.get()` resolvers, plus access to any custom events the provider emits.
+Pass a <TypeTooltip name="SpectrumInstance" type={`{{ spectrumInstance.signature }}`} /> to get a <TypeTooltip name="PlatformInstance" type={`{{ pi.signature }}`} /> for that platform. The platform instance gives you `user()` and `space.create()` / `space.get()` resolvers, plus access to any custom events the provider emits.
 
 ```ts
 import { imessage } from "spectrum-ts/providers/imessage";
@@ -24,7 +27,7 @@ const space = await im.space.create(user);
 await space.send("Hello from a new conversation.");
 ```
 
-If the platform isn't registered in `providers`, the type of `imessage(app)` resolves to `never` — the call is a compile-time error.
+If the platform isn't registered in the `platforms` array, the type of `imessage(app)` resolves to `never` — the call is a compile-time error.
 
 ## Narrowing a space
 
@@ -72,4 +75,4 @@ Some platforms support an additional `params` argument for extra space creation 
 
 ## Why narrowing matters
 
-The generic `Space` and `Message` interfaces are deliberately small — just enough to send, react, and reply across every platform. Narrowing is the escape hatch for everything else: typed access to iMessage chat types, WhatsApp phone numbers, or any extra field your [custom platform](/spectrum-ts/custom-platforms) exposes.
+The generic <TypeTooltip name="Space" type={`{{ space.signature }}`} /> and <TypeTooltip name="Message" type={`{{ message.signature }}`} /> interfaces are deliberately small — just enough to send, react, and reply across every platform. Narrowing is the escape hatch for everything else: typed access to iMessage chat types, WhatsApp phone numbers, or any extra field your [custom platform](/spectrum-ts/custom-platforms) exposes.

--- a/docs/providers.mdx.vel
+++ b/docs/providers.mdx.vel
@@ -32,7 +32,7 @@ roadmap.
     Use the Telegram Bot API with Fusor webhooks, media, reactions, replies, typing, and edits.
   </Card>
   <Card title="Slack" icon="hash" href="/spectrum-ts/providers/slack">
-    Connect one or more Slack workspaces with text, media, reactions, threads, typing, and edits.
+    Connect one or more Slack workspaces with text, media, reactions, threads, and inbound edit events.
   </Card>
 </CardGroup>
 

--- a/docs/providers/imessage.mdx.vel
+++ b/docs/providers/imessage.mdx.vel
@@ -123,7 +123,7 @@ optional dependencies, install `better-sqlite3` explicitly.
 | Existing DMs and group chats | Yes | Yes |
 | Create a DM | Yes | Deterministic local reference |
 | Create a group | Dedicated lines only | No |
-| Reactions, replies, effects, and unsend | Yes | No |
+| Reactions, replies, edits, unsend, read receipts, and effects | Yes | No |
 | Streaming text and typing indicators | Yes | Typing is a no-op; streaming is unsupported |
 | Rename, avatar, membership, and group events | Dedicated lines only | No |
 | Backgrounds, mini-app cards, and native contact-card sharing | Yes | No |

--- a/docs/providers/imessage/connection-and-routing.mdx.vel
+++ b/docs/providers/imessage/connection-and-routing.mdx.vel
@@ -4,6 +4,8 @@ sidebarTitle: "Connection and routing"
 description: "Configure cloud or local iMessage packages, lines, spaces, and per-phone routing."
 ---
 
+import { TypeTooltip } from "/snippets/type-tooltip.mdx";
+
 Use this page to choose an iMessage package and understand how Spectrum routes
 iMessage conversations. Cloud and local iMessage are separate packages; the
 choice is made by the import, not by a config flag.
@@ -59,9 +61,10 @@ choice is made by the import, not by a config flag.
     <Note>
       Local iMessage supports receiving and sending text, attachments, and
       contacts. Universal app content degrades to its URL. Reactions, threaded
-      replies, effects, group creation, streaming text, chat backgrounds,
-      renaming, avatars, contact-card sharing, and membership operations are
-      unavailable. Typing signals are accepted as a no-op.
+      replies, edits, unsend, read receipts, effects, group creation, streaming
+      text, chat backgrounds, renaming, avatars, contact-card sharing, and
+      membership operations are unavailable. Typing signals are accepted as a
+      no-op.
     </Note>
   </Tab>
 </Tabs>
@@ -137,7 +140,7 @@ These fields are also available on `message.sender` after narrowing:
 for await (const [space, message] of app.messages) {
   if (message.platform !== "iMessage") continue;
   const imMsg = imessage(message);
-  console.log(imMsg.sender.service);
+  console.log(imMsg.sender?.service);
 }
 ```
 
@@ -169,7 +172,8 @@ DM creation works with the cloud package. The local package can construct a
 deterministic DM reference, but it cannot create a group because the local
 Messages database does not expose chat creation.
 
-Group creation requires a dedicated line. In shared-pool mode, passing multiple users to `space.create()` throws an `UnsupportedError`. You can use `space.get(chatGuid)` to reference an existing group, but shared mode still does not receive membership or metadata changes from the group-event stream.
+{% set unsupportedError = symbol("ts:spectrum-ts#UnsupportedError") %}
+Group creation requires a dedicated line. In shared-pool mode, passing multiple users to `space.create()` throws an <TypeTooltip name="UnsupportedError" type={`{{ unsupportedError.signature }}`} />. You can use `space.get(chatGuid)` to reference an existing group, but shared mode still does not receive membership or metadata changes from the group-event stream.
 
 ### Per-phone routing
 

--- a/docs/providers/imessage/messaging-features.mdx.vel
+++ b/docs/providers/imessage/messaging-features.mdx.vel
@@ -4,6 +4,8 @@ sidebarTitle: "Messaging features"
 description: "Use iMessage effects, chat metadata, mini-app cards, contact cards, attachments, and tapbacks."
 ---
 
+import { TypeTooltip } from "/snippets/type-tooltip.mdx";
+
 Use these provider-specific helpers after choosing the cloud or local package
 on the [iMessage provider](/spectrum-ts/providers/imessage) page. Unless noted,
 the rich operations on this page require the cloud package.
@@ -22,33 +24,32 @@ await space.send(effect(attachment("/path/to/photo.jpg"), imessage.effect.messag
 
 The wrapped content can be a string, `markdown(...)`, or any `attachment(...)`. Effects only apply on iMessage. Other platforms see the inner content unchanged.
 
+{% set unsupportedError = symbol("ts:spectrum-ts#UnsupportedError") %}
 <Note>
   Sending effects requires the cloud `@spectrum-ts/imessage` package. The local
   package exports the helper for API consistency but rejects effect sends with
-  an `UnsupportedError`.
+  an <TypeTooltip name="UnsupportedError" type={`{{ unsupportedError.signature }}`} />.
 </Note>
 
+{% set messageEffect = symbol("ts:@photon-ai/advanced-imessage#MessageEffect") %}
 <AccordionGroup>
   <Accordion title="Bubble effects" description="Animate the sent message bubble.">
     | Constant | Value |
     |---|---|
-    | `imessage.effect.message.slam` | `"com.apple.MobileSMS.expressivesend.impact"` |
-    | `imessage.effect.message.loud` | `"com.apple.MobileSMS.expressivesend.loud"` |
-    | `imessage.effect.message.gentle` | `"com.apple.MobileSMS.expressivesend.gentle"` |
-    | `imessage.effect.message.invisible` | `"com.apple.MobileSMS.expressivesend.invisibleink"` |
+    {% for v in messageEffect.variants -%}
+    {% if v.name == "slam" or v.name == "loud" or v.name == "gentle" or v.name == "invisible" -%}
+    | `imessage.effect.message.{{ v.name }}` | `{{ v.value.text }}` |
+    {% endif -%}
+    {% endfor %}
   </Accordion>
   <Accordion title="Screen effects" description="Play a full-screen animation on the recipient's device when the message arrives.">
     | Constant | Value |
     |---|---|
-    | `imessage.effect.message.confetti` | `"com.apple.messages.effect.CKConfettiEffect"` |
-    | `imessage.effect.message.fireworks` | `"com.apple.messages.effect.CKFireworksEffect"` |
-    | `imessage.effect.message.balloons` | `"com.apple.messages.effect.CKBalloonEffect"` |
-    | `imessage.effect.message.heart` | `"com.apple.messages.effect.CKHeartEffect"` |
-    | `imessage.effect.message.lasers` | `"com.apple.messages.effect.CKLasersEffect"` |
-    | `imessage.effect.message.celebration` | `"com.apple.messages.effect.CKHappyBirthdayEffect"` |
-    | `imessage.effect.message.sparkles` | `"com.apple.messages.effect.CKSparklesEffect"` |
-    | `imessage.effect.message.spotlight` | `"com.apple.messages.effect.CKSpotlightEffect"` |
-    | `imessage.effect.message.echo` | `"com.apple.messages.effect.CKEchoEffect"` |
+    {% for v in messageEffect.variants -%}
+    {% if v.name != "slam" and v.name != "loud" and v.name != "gentle" and v.name != "invisible" -%}
+    | `imessage.effect.message.{{ v.name }}` | `{{ v.value.text }}` |
+    {% endif -%}
+    {% endfor %}
   </Accordion>
 </AccordionGroup>
 
@@ -68,7 +69,7 @@ await space.send(rename("Book Club"));
 
 Renaming requires `@spectrum-ts/imessage` and only works on group chats. With
 `@spectrum-ts/imessage-local`, or on a DM, `rename()` throws an
-`UnsupportedError`.
+<TypeTooltip name="UnsupportedError" type={`{{ unsupportedError.signature }}`} />.
 
 ## Group avatars
 
@@ -87,7 +88,8 @@ await space.avatar("clear");
 await space.send(avatar("./icon.png"));
 ```
 
-Read the current icon back with `space.getAvatar()` — it resolves `{ data, mimeType }` (or `undefined` when the group has no icon), and the result round-trips into the setter:
+{% set avatarData = symbol("ts:spectrum-ts#AvatarData") %}
+Read the current icon back with `space.getAvatar()`. It resolves to <TypeTooltip name="AvatarData" type={`{{ avatarData.signature }}`} /> or `undefined` when the group has no icon. The result round-trips into the setter:
 
 ```ts
 const icon = await space.getAvatar();
@@ -98,7 +100,7 @@ if (icon) {
 
 Group avatars require `@spectrum-ts/imessage` and only work on group chats.
 With `@spectrum-ts/imessage-local`, or on a DM, `avatar()` and `getAvatar()`
-throw an `UnsupportedError`.
+throw an <TypeTooltip name="UnsupportedError" type={`{{ unsupportedError.signature }}`} />.
 
 ## Group membership
 
@@ -137,7 +139,7 @@ for (const member of detailed) {
 
 Membership management requires `@spectrum-ts/imessage` and only works on group
 chats. With `@spectrum-ts/imessage-local`, or on a DM, it throws an
-`UnsupportedError` — a DM cannot be converted into a group, so create a new
+<TypeTooltip name="UnsupportedError" type={`{{ unsupportedError.signature }}`} /> — a DM cannot be converted into a group, so create a new
 group with `space.create` instead. `getMembers()` has the same constraints.
 
 ## Inbound group events
@@ -222,7 +224,7 @@ Background UI may not appear in these cases:
 
 <Note>
   Chat backgrounds require `@spectrum-ts/imessage`. With
-  `@spectrum-ts/imessage-local`, `background()` throws an `UnsupportedError`.
+  `@spectrum-ts/imessage-local`, `background()` throws an <TypeTooltip name="UnsupportedError" type={`{{ unsupportedError.signature }}`} />.
 </Note>
 
 <Note>
@@ -269,31 +271,26 @@ const sent = await space.send(customizedMiniApp({
 
 The recipient must have the matching iMessage extension installed. Omit `live`, or set it to `false`, to keep the static layout preview.
 
+{% set customizedMiniAppInput = symbol("ts:spectrum-ts/providers/imessage#CustomizedMiniAppInput") %}
+{% set customizedMiniAppLayout = symbol("ts:spectrum-ts/providers/imessage#CustomizedMiniAppLayout") %}
+{% set customizedMiniAppMessage = symbol("ts:@photon-ai/advanced-imessage#CustomizedMiniAppMessage") %}
+{% set miniAppLayout = symbol("ts:@photon-ai/advanced-imessage#MiniAppLayout") %}
+`customizedMiniApp()` accepts a <TypeTooltip name="CustomizedMiniAppInput" type={`{{ customizedMiniAppInput.signature }}`} />. Its `layout` field uses <TypeTooltip name="CustomizedMiniAppLayout" type={`{{ customizedMiniAppLayout.signature }}`} />.
+
 <AccordionGroup>
   <Accordion title="CustomizedMiniAppInput" description="Fields for building a mini-app card.">
     | Field | Type | Description |
     |---|---|---|
-    | `appName` | `string` | Display name of the owning app, shown by Messages fallback UI. |
-    | `appStoreId` | `number` (optional) | Apple App Store numeric ID. Omit for unpublished extensions. |
-    | `extensionBundleId` | `string` | Bundle identifier of the iMessage extension target. |
-    | `layout` | `CustomizedMiniAppLayout` | Visible card layout. See below. |
-    | `live` | `boolean` (optional) | Render the installed extension's live UI when `true`. Omit for the static layout preview. |
-    | `teamId` | `string` | 10-character uppercase alphanumeric Apple Team ID. |
-    | `url` | `string` | Absolute URL delivered to the installed extension on tap. |
+    {% for m in customizedMiniAppMessage.members -%}
+    | `{{ m.name }}` | `{{ m.type.text | replace("\n", " ") | replace("    ", "") | replace("|", "\\|") | replace("<", "&lt;") | replace(">", "&gt;") }}`{% if m.optional %} (optional){% endif %} | {{ m.doc.summary }} |
+    {% endfor %}
   </Accordion>
-  <Accordion title="CustomizedMiniAppLayout" description="Visible layout of a mini-app card. Mirrors Apple's MSMessageTemplateLayout.">
+  <Accordion title="CustomizedMiniAppLayout" description="{{ miniAppLayout.doc.summary }}">
     | Field | Type | Description |
     |---|---|---|
-    | `caption` | `string` (optional) | Primary caption text. |
-    | `subcaption` | `string` (optional) | Secondary caption text. |
-    | `trailingCaption` | `string` (optional) | Right-aligned primary text. |
-    | `trailingSubcaption` | `string` (optional) | Right-aligned secondary text. |
-    | `image` | `Uint8Array` (optional) | Image data for the card. Must be set with `imageTitle`. |
-    | `imageTitle` | `string` (optional) | Title for the image. Must be set with `image`. |
-    | `imageSubtitle` | `string` (optional) | Subtitle for the image. Requires `image`. |
-    | `summary` | `string` (optional) | Fallback text for surfaces that can't render the card, such as notifications and lock screen. |
-
-    At least one of `caption`, `subcaption`, `trailingCaption`, `trailingSubcaption`, or `image` must be set.
+    {% for m in miniAppLayout.members -%}
+    | `{{ m.name }}` | `{{ m.type.text | replace("\n", " ") | replace("    ", "") | replace("|", "\\|") | replace("<", "&lt;") | replace(">", "&gt;") }}`{% if m.optional %} (optional){% endif %} | {{ m.doc.summary }} |
+    {% endfor %}
   </Accordion>
 </AccordionGroup>
 
@@ -334,7 +331,7 @@ await space.send(edit(customizedMiniApp({
 <Note>
   Mini-app cards require `@spectrum-ts/imessage`. With
   `@spectrum-ts/imessage-local`, `customizedMiniApp()` throws an
-  `UnsupportedError`.
+  <TypeTooltip name="UnsupportedError" type={`{{ unsupportedError.signature }}`} />.
 </Note>
 
 ## Native contact card sharing
@@ -364,12 +361,13 @@ This shares the bot's own contact card as it appears in iMessage. Recipients can
 <Note>
   Native contact card sharing requires `@spectrum-ts/imessage`. With
   `@spectrum-ts/imessage-local`, `nativeContactCard()` throws an
-  `UnsupportedError`.
+  <TypeTooltip name="UnsupportedError" type={`{{ unsupportedError.signature }}`} />.
 </Note>
 
 ## Fetching attachments
 
-Retrieve an attachment by its iMessage GUID using `getAttachment` on the narrowed platform instance. The returned `Attachment` is lazy. `.read()` and `.stream()` each trigger an independent download, so cache `.read()` if you need the bytes more than once.
+{% set attachmentType = symbol("ts:spectrum-ts#Attachment") %}
+Retrieve an attachment by its iMessage GUID using `getAttachment` on the narrowed platform instance. The returned <TypeTooltip name="Attachment" type={`{{ attachmentType.signature }}`} /> is lazy. `.read()` and `.stream()` each trigger an independent download, so cache `.read()` if you need the bytes more than once.
 
 ```ts
 import { imessage } from "spectrum-ts/providers/imessage";
@@ -393,22 +391,24 @@ When only one phone is configured, or in shared-pool mode, the phone parameter i
 
 <Note>
   `getAttachment` requires `@spectrum-ts/imessage`. With
-  `@spectrum-ts/imessage-local`, it throws an `UnsupportedError`. Local inbound
+  `@spectrum-ts/imessage-local`, it throws an <TypeTooltip name="UnsupportedError" type={`{{ unsupportedError.signature }}`} />. Local inbound
   attachments are still available through each incoming message's content.
 </Note>
 
 ## Tapback reactions
 
-iMessage converts six universal `Emoji` aliases into native tapbacks:
+{% set emoji = symbol("ts:spectrum-ts#Emoji") %}
+iMessage converts six universal <TypeTooltip name="Emoji" type={`{{ emoji.signature }}`} /> aliases into native tapbacks:
 
-| Constant | Value |
-|---|---|
-| `Emoji.love` | `"❤️"` |
-| `Emoji.like` | `"👍"` |
-| `Emoji.dislike` | `"👎"` |
-| `Emoji.laugh` | `"😂"` |
-| `Emoji.emphasize` | `"‼️"` |
-| `Emoji.question` | `"❓"` |
+<Accordion title="Emoji" description="{{ emoji.doc.summary }}">
+  | Constant | Value |
+  |---|---|
+  {% for v in emoji.variants -%}
+  {% if v.name == "love" or v.name == "like" or v.name == "dislike" or v.name == "laugh" or v.name == "emphasize" or v.name == "question" -%}
+  | `Emoji.{{ v.name }}` | `{{ v.value.text }}` |
+  {% endif -%}
+  {% endfor %}
+</Accordion>
 
 ```ts
 import { Emoji } from "spectrum-ts";

--- a/docs/providers/slack.mdx.vel
+++ b/docs/providers/slack.mdx.vel
@@ -7,7 +7,7 @@ description: "Send and receive messages through the Slack API."
 import { slack } from "spectrum-ts/providers/slack";
 ```
 
-The Slack provider connects your agent to Slack workspaces through the Slack API. It supports multi-workspace installations, text and media messaging, reactions, threaded replies, typing indicators, and edits.
+The Slack provider connects your agent to Slack workspaces through the Slack API. It supports multi-workspace installations, text and media messaging, reactions, threaded replies, and inbound edit events. Typing indicators are accepted as a no-op.
 
 ## Explore Slack
 

--- a/docs/providers/slack/conversations-and-events.mdx.vel
+++ b/docs/providers/slack/conversations-and-events.mdx.vel
@@ -50,5 +50,5 @@ Narrowed Slack messages expose additional fields:
 | Media, files, and images | Send and receive |
 | Reactions | Send and receive |
 | Threaded replies | Send and receive |
-| Typing indicators | Send |
-| Message edits | Send and receive |
+| Typing indicators | Accepted as a no-op |
+| Message edits | Receive only |

--- a/docs/providers/telegram.mdx.vel
+++ b/docs/providers/telegram.mdx.vel
@@ -7,7 +7,8 @@ description: "Send and receive messages through the Telegram Bot API."
 import { telegram } from "spectrum-ts/providers/telegram";
 ```
 
-The Telegram provider connects your agent to the Telegram Bot API. Inbound messages are delivered through Fusor webhooks. Outbound messages use the Bot API directly. The provider supports text, media, reactions, replies, typing indicators, edits, and lazy media downloads.
+{% set telegram = symbol("ts:spectrum-ts/providers/telegram#telegram") %}
+{{ telegram.doc.summary }} It connects your agent to the Telegram Bot API. Inbound messages are delivered through Fusor webhooks. Outbound messages use the Bot API directly. The provider supports text, media, reactions, replies, typing indicators, edits, and lazy media downloads.
 
 ## Explore Telegram
 

--- a/docs/providers/telegram/conversations-and-features.mdx.vel
+++ b/docs/providers/telegram/conversations-and-features.mdx.vel
@@ -8,7 +8,7 @@ Use [platform narrowing](/spectrum-ts/platform-narrowing) when you need Telegram
 
 ## Starting a conversation
 
-Resolve a user by their Telegram user ID and open a space. You can also pass a `chatId` parameter to target a specific Telegram chat:
+Resolve a user by their Telegram user ID to open their private chat. Telegram bots cannot create groups. Use `space.get(chatId)` for an existing group, supergroup, or channel, and stringify numeric Telegram chat IDs.
 
 ```ts
 const tg = telegram(app);
@@ -16,6 +16,9 @@ const user = await tg.user("123456789");
 const space = await tg.space.create(user);
 
 await space.send("Hello from Spectrum.");
+
+const group = await tg.space.get(process.env.TELEGRAM_CHAT_ID!);
+await group.send("Hello, existing group.");
 ```
 
 ## Supported features
@@ -30,4 +33,4 @@ await space.send("Hello from Spectrum.");
 | Threaded replies | Send and receive |
 | Typing indicators | Send |
 | Message edits | Send and receive, including text and markdown |
-| Custom Bot API calls | Via platform-specific actions |
+| Custom Bot API calls | Send with `custom({ method, params })` content |

--- a/docs/providers/terminal/interactions.mdx.vel
+++ b/docs/providers/terminal/interactions.mdx.vel
@@ -25,7 +25,7 @@ Reactions ride the same `app.messages` stream as text. They arrive as a `reactio
 ```ts
 for await (const [space, message] of app.messages) {
   if (message.content.type === "reaction") {
-    console.log(`${message.sender.id} reacted ${message.content.emoji}`);
+    console.log(`${message.sender?.id ?? "unknown"} reacted ${message.content.emoji}`);
     continue;
   }
   if (message.content.type === "text") {

--- a/docs/reactions-and-replies.mdx.vel
+++ b/docs/reactions-and-replies.mdx.vel
@@ -3,6 +3,11 @@ title: "Reactions and Replies"
 description: "React to incoming messages and send threaded replies"
 ---
 
+import { TypeTooltip } from "/snippets/type-tooltip.mdx";
+
+{% set message = symbol("ts:spectrum-ts#Message") %}
+{% set emoji = symbol("ts:spectrum-ts#Emoji") %}
+
 Both `react` and `reply` live directly on an incoming message. They no-op silently on platforms that don't support the feature — no `try/catch` required.
 
 Spectrum also exports first-class `reaction()`, `reply()`, and `unsend()` content builders that you can pass directly to `space.send(...)` — the sugar methods on `message` delegate through the same `send` pipeline.
@@ -12,23 +17,23 @@ Spectrum also exports first-class `reaction()`, `reply()`, and `unsend()` conten
 <Tabs>
   <Tab title="Sugar (message.react)">
     ```ts
-    const sent = await message.react("love");
+    const sent = await message.react("❤️");
     ```
   </Tab>
   <Tab title="Canonical (space.send)">
     ```ts
     import { reaction } from "spectrum-ts";
 
-    const sent = await space.send(reaction("love", message));
+    const sent = await space.send(reaction("❤️", message));
     ```
   </Tab>
 </Tabs>
 
 Both forms are equivalent — `message.react(emoji)` delegates to `space.send(reaction(emoji, message))` internally.
 
-Reactions resolve to a `Message` — keep it as the handle to `unsend()` later. Resolves `undefined` only when the platform does not support reactions.
+Reactions resolve to a <TypeTooltip name="Message" type={`{{ message.signature }}`} /> — keep it as the handle to `unsend()` later. Resolves `undefined` only when the platform does not support reactions.
 
-Use the universal `Emoji` aliases for iMessage's native tapbacks:
+Use the universal <TypeTooltip name="Emoji" type={`{{ emoji.signature }}`} /> aliases for iMessage's native tapbacks:
 
 ```ts
 import { Emoji } from "spectrum-ts";
@@ -38,16 +43,17 @@ await message.react(Emoji.laugh);
 
 `reaction()` rejects reaction messages as targets — reacting to a reaction throws at build time.
 
-Available tapbacks:
+The iMessage tapback aliases are:
 
-| Constant | Value |
-|---|---|
-| `Emoji.love` | `"❤️"` |
-| `Emoji.like` | `"👍"` |
-| `Emoji.dislike` | `"👎"` |
-| `Emoji.laugh` | `"😂"` |
-| `Emoji.emphasize` | `"‼️"` |
-| `Emoji.question` | `"❓"` |
+<Accordion title="Emoji" description="{{ emoji.doc.summary }}">
+  | Constant | Value |
+  |---|---|
+  {% for v in emoji.variants -%}
+  {% if v.name == "love" or v.name == "like" or v.name == "dislike" or v.name == "laugh" or v.name == "emphasize" or v.name == "question" -%}
+  | `Emoji.{{ v.name }}` | `{{ v.value.text }}` |
+  {% endif -%}
+  {% endfor %}
+</Accordion>
 
 ## Threaded replies
 
@@ -75,7 +81,7 @@ Both forms are equivalent — `message.reply(content)` wraps each content item i
 
 On platforms with thread support (iMessage, WhatsApp Business), this sends a threaded reply. On platforms without, the call resolves as a no-op — **the reply is not downgraded to a regular send**. If you need guaranteed delivery, use `space.send(...)` instead.
 
-`reply()` cannot wrap `reply`, `edit`, `reaction`, `group`, `typing`, `rename`, `avatar`, or `unsend` content — the builder throws at construction time.
+`reply()` cannot wrap `reply`, `edit`, `reaction`, `group`, `typing`, `rename`, `avatar`, `addMember`, `removeMember`, `leaveSpace`, `unsend`, or `read` content — the builder throws at construction time.
 
 ## Editing messages
 
@@ -83,7 +89,7 @@ On platforms with thread support (iMessage, WhatsApp Business), this sends a thr
   <Tab title="Sugar (message.edit)">
     ```ts
     const sent = await space.send("Draft");
-    await sent.edit("Final version");
+    await sent?.edit("Final version");
     ```
   </Tab>
   <Tab title="Canonical (space.send)">
@@ -98,7 +104,7 @@ On platforms with thread support (iMessage, WhatsApp Business), this sends a thr
 
 `edit()` takes new content and the outbound message to rewrite. Edits are fire-and-forget — `space.send(edit(...))` resolves to `undefined`.
 
-`edit()` cannot wrap `edit`, `reply`, `reaction`, `group`, `typing`, `rename`, `avatar`, or `unsend` content.
+`edit()` cannot wrap `edit`, `reply`, `reaction`, `group`, `typing`, `rename`, `avatar`, `addMember`, `removeMember`, `leaveSpace`, `unsend`, or `read` content.
 
 ## Unsending messages
 
@@ -106,7 +112,7 @@ On platforms with thread support (iMessage, WhatsApp Business), this sends a thr
   <Tab title="Sugar (message.unsend)">
     ```ts
     const sent = await space.send("Oops");
-    await sent.unsend();
+    await sent?.unsend();
     ```
   </Tab>
   <Tab title="Sugar (space.unsend)">
@@ -127,10 +133,10 @@ On platforms with thread support (iMessage, WhatsApp Business), this sends a thr
 
 Unsends retract a previously-sent outbound message. Fire-and-forget — the result is always `undefined`. Only outbound messages can be unsent; the builder throws at build time for inbound targets.
 
-Reactions can also be unsent — keep the `Message` returned by `react()` and pass it to `unsend()`:
+Reactions can also be unsent — keep the <TypeTooltip name="Message" type={`{{ message.signature }}`} /> returned by `react()` and pass it to `unsend()`:
 
 ```ts
-const reaction = await message.react("love");
+const reaction = await message.react("❤️");
 await reaction?.unsend();
 ```
 

--- a/docs/spaces-and-users.mdx.vel
+++ b/docs/spaces-and-users.mdx.vel
@@ -7,6 +7,7 @@ import { TypeTooltip } from "/snippets/type-tooltip.mdx";
 
 {% set space = symbol("ts:spectrum-ts#Space") %}
 {% set user = symbol("ts:spectrum-ts#User") %}
+{% set unsupportedError = symbol("ts:spectrum-ts#UnsupportedError") %}
 
 A **space** is a conversation — a DM, a group chat, a terminal session. A **user** is a participant identified by a platform-specific ID. Both carry a `__platform` tag so the narrowing functions from [platform narrowing](/spectrum-ts/platform-narrowing) can recover their platform-specific shapes.
 
@@ -14,22 +15,15 @@ A **space** is a conversation — a DM, a group chat, a terminal session. A **us
 
 Every <TypeTooltip name="Space" type={`{{ space.signature }}`} /> exposes the same interface regardless of platform:
 
-| Method | Description |
-|---|---|
-| `send(...content)` | Send one or more content items into the conversation. |
-| `edit(message, newContent)` | Rewrite a previously-sent message. Sugar for `send(edit(newContent, message))`. |
-| `unsend(message)` | Retract a previously-sent message. Sugar for `send(unsend(message))`. |
-| `startTyping()` | Show a typing indicator. No-op if the platform doesn't support it. |
-| `stopTyping()` | Hide the typing indicator. |
-| `responding(fn)` | Start a typing indicator, run `fn`, and stop the indicator when it completes — even if `fn` throws. |
-| `getMessage(id)` | Fetch a message by ID from the conversation. Throws `UnsupportedError` on platforms that don't support it. |
-| `getMembers()` | List the chat's current participants as `User`s, excluding the agent's own account where identifiable. Throws `UnsupportedError` on platforms that can't list members. |
-| `getAvatar()` | Download the chat avatar (group icon) as `{ data, mimeType }`. Resolves `undefined` when none is set; throws `UnsupportedError` on platforms that can't fetch avatars. |
-| `rename(displayName)` | Rename the chat. Sugar for `send(rename(displayName))`. |
-| `avatar(input, options?)` | Set or clear the chat avatar. Sugar for `send(avatar(input, options?))`. |
-| `add(users)` | Add members to the chat. Sugar for `send(addMember(users))`. |
-| `remove(users)` | Remove members from the chat. Sugar for `send(removeMember(users))`. |
-| `leave()` | Leave the chat with the agent's own account. Sugar for `send(leaveSpace())`. |
+<Accordion title="Space" description="{{ space.doc.summary }}">
+  | Member | Description |
+  |---|---|
+  {% for m in space.members -%}
+  | `{{ m.signature | replace("\n", " ") | replace("    ", "") | replace("|", "\\|") | replace("<", "&lt;") | replace(">", "&gt;") }}` | {{ m.doc.summary | replace("\n", " ") | replace("|", "\\|") }} |
+  {% endfor %}
+</Accordion>
+
+Provider-specific constraints surface as an <TypeTooltip name="UnsupportedError" type={`{{ unsupportedError.signature }}`} />.
 
 ```ts
 for await (const [space, message] of app.messages) {
@@ -39,14 +33,15 @@ for await (const [space, message] of app.messages) {
 
 ## User
 
-Users are minimal: an ID and a platform tag.
+Every <TypeTooltip name="User" type={`{{ user.signature }}`} /> has a platform-specific ID and platform tag.
 
-```ts
-interface User {
-  readonly id: string;
-  readonly __platform: string;
-}
-```
+<Accordion title="User" description="{{ user.doc.summary }}">
+  | Field | Description |
+  |---|---|
+  {% for m in user.members -%}
+  | `{{ m.signature | replace("\n", " ") | replace("    ", "") | replace("|", "\\|") | replace("<", "&lt;") | replace(">", "&gt;") }}` | {{ m.doc.summary | replace("\n", " ") | replace("|", "\\|") }} |
+  {% endfor %}
+</Accordion>
 
 Resolve a user from a platform-specific identifier through a narrowed platform instance:
 
@@ -115,4 +110,4 @@ const existing = await im.space.get("any;-;+15551111111");
 await existing.send("Hello again.");
 ```
 
-The returned space is the platform-specific type — so you can read extra fields like `type: "dm" | "group"` on iMessage — but it also satisfies the generic `Space` interface, so `send()`, `startTyping()`, and friends are always available.
+The returned space is the platform-specific type — so you can read extra fields like `type: "dm" | "group"` on iMessage — but it also satisfies the generic <TypeTooltip name="Space" type={`{{ space.signature }}`} /> interface, so `send()`, `startTyping()`, and friends are always available.

--- a/docs/webhooks.mdx.vel
+++ b/docs/webhooks.mdx.vel
@@ -5,6 +5,12 @@ description: "Receive messages via HTTP instead of a long-lived process"
 
 import { TypeTooltip } from "/snippets/type-tooltip.mdx";
 
+{% set message = symbol("ts:spectrum-ts#Message") %}
+{% set space = symbol("ts:spectrum-ts#Space") %}
+{% set honoOptions = symbol("ts:@spectrum-ts/hono#SpectrumPluginOptions") %}
+{% set expressOptions = symbol("ts:@spectrum-ts/express#SpectrumPluginOptions") %}
+{% set elysiaOptions = symbol("ts:@spectrum-ts/elysia#SpectrumPluginOptions") %}
+
 `app.webhook()` lets you receive messages through HTTP `POST` requests instead of the `app.messages` stream. It handles two webhook formats through the same method:
 
 | | Native Spectrum webhook | Fusor webhook |
@@ -75,7 +81,7 @@ Pass the raw body bytes. The HMAC is computed over the exact bytes on the wire. 
 
 ## Framework adapters
 
-First-party adapters mount the endpoint for you and handle raw-body parsing correctly. Each is an optional subpath import — install the framework as a peer dependency only if you use it.
+First-party adapters mount the endpoint for you and handle raw-body parsing correctly. Install the adapter package and its framework only when you use it.
 
 <Tabs>
   <Tab title="Hono">
@@ -83,7 +89,7 @@ First-party adapters mount the endpoint for you and handle raw-body parsing corr
     import { Hono } from "hono";
     import { Spectrum } from "spectrum-ts";
     import { imessage } from "spectrum-ts/providers/imessage";
-    import { spectrum } from "spectrum-ts/hono";
+    import { spectrum } from "@spectrum-ts/hono";
 
     const app = await Spectrum({
       projectId: process.env.PROJECT_ID!,
@@ -106,13 +112,21 @@ First-party adapters mount the endpoint for you and handle raw-body parsing corr
 
     export default server;
     ```
+
+    <Accordion title="SpectrumPluginOptions" description="{{ honoOptions.doc.summary }}">
+      | Option | Type | Default | Description |
+      |---|---|---|---|
+      {% for m in honoOptions.members -%}
+      | `{{ m.name }}{% if m.optional %}?{% endif %}` | `{{ m.type.text | replace("\n", " ") | replace("    ", "") | replace("|", "\\|") | replace("<", "&lt;") | replace(">", "&gt;") }}` | {% if m.doc.customTags["@default"] %}`{{ m.doc.customTags["@default"][0] }}`{% else %}—{% endif %} | {{ m.doc.summary | replace("\n", " ") | replace("|", "\\|") }} |
+      {% endfor %}
+    </Accordion>
   </Tab>
   <Tab title="Express">
     ```ts
     import express from "express";
     import { Spectrum } from "spectrum-ts";
     import { imessage } from "spectrum-ts/providers/imessage";
-    import { spectrum } from "spectrum-ts/express";
+    import { spectrum } from "@spectrum-ts/express";
 
     const app = await Spectrum({
       projectId: process.env.PROJECT_ID!,
@@ -139,13 +153,21 @@ First-party adapters mount the endpoint for you and handle raw-body parsing corr
     ```
 
     Mount the adapter **before** any global `express.json()`. A global JSON parser consumes the body stream first, breaking signature verification.
+
+    <Accordion title="SpectrumPluginOptions" description="{{ expressOptions.doc.summary }}">
+      | Option | Type | Default | Description |
+      |---|---|---|---|
+      {% for m in expressOptions.members -%}
+      | `{{ m.name }}{% if m.optional %}?{% endif %}` | `{{ m.type.text | replace("\n", " ") | replace("    ", "") | replace("|", "\\|") | replace("<", "&lt;") | replace(">", "&gt;") }}` | {% if m.doc.customTags["@default"] %}`{{ m.doc.customTags["@default"][0] }}`{% else %}—{% endif %} | {{ m.doc.summary | replace("\n", " ") | replace("|", "\\|") }} |
+      {% endfor %}
+    </Accordion>
   </Tab>
   <Tab title="Elysia">
     ```ts
     import { Elysia } from "elysia";
     import { Spectrum } from "spectrum-ts";
     import { imessage } from "spectrum-ts/providers/imessage";
-    import { spectrum } from "spectrum-ts/elysia";
+    import { spectrum } from "@spectrum-ts/elysia";
 
     const app = await Spectrum({
       projectId: process.env.PROJECT_ID!,
@@ -167,21 +189,21 @@ First-party adapters mount the endpoint for you and handle raw-body parsing corr
       )
       .listen(3000);
     ```
+
+    <Accordion title="SpectrumPluginOptions" description="{{ elysiaOptions.doc.summary }}">
+      | Option | Type | Default | Description |
+      |---|---|---|---|
+      {% for m in elysiaOptions.members -%}
+      | `{{ m.name }}{% if m.optional %}?{% endif %}` | `{{ m.type.text | replace("\n", " ") | replace("    ", "") | replace("|", "\\|") | replace("<", "&lt;") | replace(">", "&gt;") }}` | {% if m.doc.customTags["@default"] %}`{{ m.doc.customTags["@default"][0] }}`{% else %}—{% endif %} | {{ m.doc.summary | replace("\n", " ") | replace("|", "\\|") }} |
+      {% endfor %}
+    </Accordion>
   </Tab>
 </Tabs>
-
-All three adapters accept the same options:
-
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `app` | `Spectrum` instance | — | The instance returned by `await Spectrum({...})`. |
-| `onMessage` | `(space, message) => void \| Promise<void>` | — | Invoked once per inbound message, fire-and-forget. |
-| `path` | `string` | `"/spectrum/webhook"` | Route the endpoint is mounted on. |
 
 ## What the SDK handles
 
 - **Signature verification.** Native webhooks are verified with `HMAC-SHA256` over `v0:<timestamp>:<rawBody>`, with a 5-minute replay window. Bad signature returns `401`, missing headers return `400`.
-- **Payload deserialization.** Native webhook JSON is deserialized into normal `Message` / `Space` objects, including reactions and grouped items.
+- **Payload deserialization.** Native webhook JSON is deserialized into normal <TypeTooltip name="Message" type={`{{ message.signature }}`} /> and <TypeTooltip name="Space" type={`{{ space.signature }}`} /> objects, including reactions and grouped items.
 - **Attachment rehydration.** Native webhooks carry attachment metadata only. `read()` and `stream()` fetch the bytes lazily via the platform.
 - **Format detection.** Native vs Fusor is detected per request by payload shape — JSON for native, protobuf for Fusor.
 


### PR DESCRIPTION
## What

- Replace source-backed handwritten type references with Vellum-generated signatures, member tables, variants, and inline tooltips.
- Cover core Spectrum types, provider-specific types, framework adapter options, iMessage effects, mini-app layouts, and tapbacks.
- Keep manual tables only where the extractor falls through or where the table adds editorial structure.
- Align examples and behavior notes with Spectrum v11, including current content APIs, provider constraints, adapter imports, and direction filtering.

## Why

The documentation templates duplicated declarations from the TypeScript packages. Those copies could drift when Spectrum was released, and several pages still described pre-v11 behavior.

## Impact

Documentation templates only. No runtime or package source changes are included. The downstream docs site will render the reference content from the installed package declarations through Vellum.

## Root cause

Spectrum's initial documentation used handwritten tables and prose for types that are now extractable by Vellum. Package upgrades therefore required manual synchronization and left stale API details behind.

## Checks

Validation was run through the downstream documentation site with this template set:

- Vellum extraction and render: 753 symbols across 68 templates
- Documentation snippet typecheck: 127 snippets passed
- Mintlify validation
- Mintlify broken-link check: zero broken links
- `git diff --check`

Linear: [ENG-1974](https://linear.app/photonhq/issue/ENG-1974/generate-spectrum-api-references-with-vellum)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786717535&installation_id=127326493&pr_number=193&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F193&signature=b608f91735577a8bc53702c0460dd83b3c05452630fc3e5e419143eda3f986a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to Mintlify/Vellum templates; no runtime or package source is modified in this PR.
> 
> **Overview**
> **Spectrum TS docs templates** now pull **signatures, member tables, and variant lists** from installed package declarations via Vellum (`symbol(...)`, `<TypeTooltip>`, member loops) instead of maintaining duplicate handwritten API tables across core types, content builders, `definePlatform`, iMessage effects/mini-apps, and Hono/Express/Elysia plugin options.
> 
> **Behavior and examples** are brought in line with current APIs: **rich links** are URL-only (no Open Graph scraping); **attachments/voice** accept **`URL`**; **`reply`/`edit`** forbid membership, **`read`**, and related control content; inbound filtering uses **`message.direction === "outbound"`** and optional **`message.sender`**; **Content** docs add **`effect`**, **`app`**, **`read`**, and **`streamText.format`**; **Slack** is documented as **receive-only edits** and **no-op typing**; **Fusor** handlers **`return`** messages/events (including arrays) rather than **`yield`**; webhook adapters import **`@spectrum-ts/hono`** (and siblings), not **`spectrum-ts/hono`**.
> 
> Navigation tweaks include the **app link cards** hub path **`/content/app`** and refreshed provider capability wording (e.g. cloud iMessage **edits/unsend/read receipts**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2403f93252ddf9762479d9ae164fbeb1f6d12e07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved API documentation with interactive type references and dynamically generated option, field, and content tables.
  * Clarified supported inputs for attachments and voice content, including URLs.
  * Updated rich-link behavior to explain native platform URL previews.
  * Expanded guidance for messages, replies, edits, memberships, contacts, webhooks, and custom platforms.
  * Refined provider capability documentation for iMessage, Slack, Telegram, and terminal interactions.
  * Corrected examples for safer sender handling and updated event-handling patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->