### PR TITLE
feat(imessage): route inbound messages through Fusor

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1015,7 +1015,7 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
-    "nice-grpc": ["nice-grpc@2.1.16", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.5.0", "nice-grpc-common": "^2.0.3" } }, "sha512-Cl3Pn00212Hl8/U6bpgMxmhZj5lyv3nWoJov4cd3FjWarktrMHP4DNvSjCnDwkMWYx4W1tyscEia4JX6Y4GVCQ=="],
+    "nice-grpc": ["nice-grpc@2.1.15", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.5.0", "nice-grpc-common": "^2.0.3" } }, "sha512-agPIt7dtQASnN5p1X3c2S5amDhWRWRT0Jp62trmpMBKSbkm87l8bG2slqxSthlrGa4AnRPG8+lFf4y8nn+Pogw=="],
 
     "nice-grpc-common": ["nice-grpc-common@2.0.3", "", { "dependencies": { "ts-error": "^1.0.6" } }, "sha512-MEhnD3JMah0mgyivpb9hpRDbOBuXBxI/TVO+OK1h6rC97WM42HsPMR+zzRNQ0C5BqYJTw1nyWiQRD0DucO+pjQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1015,7 +1015,7 @@
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
-    "nice-grpc": ["nice-grpc@2.1.15", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.5.0", "nice-grpc-common": "^2.0.3" } }, "sha512-agPIt7dtQASnN5p1X3c2S5amDhWRWRT0Jp62trmpMBKSbkm87l8bG2slqxSthlrGa4AnRPG8+lFf4y8nn+Pogw=="],
+    "nice-grpc": ["nice-grpc@2.1.16", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.5.0", "nice-grpc-common": "^2.0.3" } }, "sha512-Cl3Pn00212Hl8/U6bpgMxmhZj5lyv3nWoJov4cd3FjWarktrMHP4DNvSjCnDwkMWYx4W1tyscEia4JX6Y4GVCQ=="],
 
     "nice-grpc-common": ["nice-grpc-common@2.0.3", "", { "dependencies": { "ts-error": "^1.0.6" } }, "sha512-MEhnD3JMah0mgyivpb9hpRDbOBuXBxI/TVO+OK1h6rC97WM42HsPMR+zzRNQ0C5BqYJTw1nyWiQRD0DucO+pjQ=="],
 

--- a/packages/core/src/fusor/core.ts
+++ b/packages/core/src/fusor/core.ts
@@ -9,10 +9,18 @@ import { errorAttrs } from "../utils/telemetry";
 import { createFusorTokenProvider, type FusorTokenProvider } from "./auth";
 import { FUSOR_MESSAGES_CHANNEL, isFusorEvent } from "./event";
 import { type ParsedHttpRequest, parseHttpRequest } from "./parse";
-import type { FusorMessagesReturn, FusorReply, FusorVerify } from "./types";
 import {
+  type FusorMessagesReturn,
+  type FusorReply,
+  FusorRetryableError,
+  FusorTerminalError,
+  type FusorVerify,
+} from "./types";
+import {
+  FusorWsError,
   type FusorWsSession,
   isWsAuthError,
+  isWsTerminalError,
   runFusorWsSession,
 } from "./websocket";
 
@@ -20,11 +28,44 @@ const DEFAULT_FUSOR_WS_URL =
   "wss://fusor-ws.spectrum.photon.codes/v1/subscribe";
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30_000;
+const RECONNECT_STABLE_MS = 30_000;
+// Event ids protect against transport redelivery at a new sequence (or an
+// overlapping reconnect). The safe sequence handles normal retained replay;
+// keep the id cache bounded so a long-lived SDK process cannot grow forever.
+const PROCESSED_EVENT_ID_CACHE_SIZE = 4096;
 
 const log = createLogger("spectrum.fusor");
 
 const errorText = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
+
+const isValidCursor = (value: unknown): value is number =>
+  Number.isSafeInteger(value) &&
+  (value as number) >= 0 &&
+  (value as number) < Number.MAX_SAFE_INTEGER;
+
+export interface FusorCursorScope {
+  readonly projectId: string;
+  readonly websocketEndpoint: string;
+}
+
+/**
+ * Optional persistence for the Fusor transport's normalization/enqueue cursor.
+ *
+ * A scope represents one logical stream consumer. Store implementations used
+ * by multiple processes must make saves monotonic (for example, max/CAS) so a
+ * lagging writer cannot regress a newer checkpoint. A successful save means
+ * provider verification/normalization and synchronous enqueue completed; it
+ * does not mean an application consumed an in-memory `spectrum.messages`
+ * record. A crash between save and consumption can therefore lose that queued
+ * record. Use a durable application sink for end-to-end delivery guarantees.
+ */
+export interface FusorCursorStore {
+  load(scope: FusorCursorScope): Promise<number | undefined>;
+  save(scope: FusorCursorScope, seq: number): Promise<void>;
+}
+
+export type FusorEventProvenance = "stream" | "webhook";
 
 export interface RegisteredFusorHandler<TPayload = unknown> {
   messages: (ctx: {
@@ -35,6 +76,8 @@ export interface RegisteredFusorHandler<TPayload = unknown> {
   // the Spectrum bootstrap to the per-(platform, channel) queue.
   pushEvent: (channel: string, data: unknown) => void;
   pushMessage: (record: ProviderMessageRecord) => void;
+  /** Exclude this handler from the synchronous webhook transport. */
+  streamOnly?: boolean;
   verify: FusorVerify<TPayload>;
 }
 
@@ -49,9 +92,16 @@ function toReplyBytes(body: string | Uint8Array | undefined): Uint8Array {
 }
 
 interface HandlerOutcome {
+  error?: unknown;
   errorReason?: string;
   ok: boolean;
   reply?: FusorReply;
+  retryable?: boolean;
+}
+
+interface ProcessEventOutcome {
+  reply: InboundReply;
+  retryableError?: Error;
 }
 
 function combineReplies(outcomes: HandlerOutcome[]): InboundReply {
@@ -131,34 +181,69 @@ function runHandlerOnce<TPayload>(
   deliver: (record: ProviderMessageRecord) => void = handler.pushMessage
 ): Promise<HandlerOutcome> {
   return (async () => {
+    let payload: TPayload;
     try {
-      const payload = await handler.verify(parsedRequest);
-      let reply: FusorReply | undefined;
-      let respondCalled = false;
-      let returned = false;
-      const respond = (next: FusorReply): void => {
-        if (returned) {
-          log.warn("fusor.respond called after handler returned; ignoring");
-          return;
-        }
-        if (respondCalled) {
-          log.debug("fusor.respond called more than once; last call wins");
-        }
-        respondCalled = true;
-        reply = next;
+      payload = await handler.verify(parsedRequest);
+    } catch (error) {
+      // Verification failures are normally deterministic input/auth failures.
+      // Providers whose verifier depends on a fallible remote service can opt
+      // into retained replay with FusorRetryableError.
+      return {
+        error,
+        errorReason: errorText(error),
+        ok: false,
+        retryable: error instanceof FusorRetryableError,
       };
+    }
+
+    let reply: FusorReply | undefined;
+    let respondCalled = false;
+    let returned = false;
+    const respond = (next: FusorReply): void => {
+      if (returned) {
+        log.warn("fusor.respond called after handler returned; ignoring");
+        return;
+      }
+      if (respondCalled) {
+        log.debug("fusor.respond called more than once; last call wins");
+      }
+      respondCalled = true;
+      reply = next;
+    };
+    try {
       const result = await handler.messages({ payload, respond });
       returned = true;
 
       routeHandlerResult(result, handler as RegisteredFusorHandler, deliver);
       return { ok: true, reply };
     } catch (error) {
-      return { ok: false, errorReason: errorText(error) };
+      // Message processing can perform I/O, so an unclassified exception is
+      // retryable by default. Providers must explicitly mark deterministic
+      // per-event rejection to prevent a poison event from blocking the stream.
+      return {
+        error,
+        errorReason: errorText(error),
+        ok: false,
+        retryable: !(error instanceof FusorTerminalError),
+      };
+    } finally {
+      // A handler that rejects has returned too; reject any later respond().
+      returned = true;
     }
   })();
 }
 
 export interface FusorCoreOptions {
+  /**
+   * Transport cursor hooks. Scope is always the resolved endpoint plus project;
+   * `save` must resolve before the in-memory checkpoint advances. This is an
+   * SDK normalization/enqueue checkpoint, not an application-consumption ack.
+   * Without a store, startSeq=0 subscribes at the live tail and cannot recover
+   * a bootstrap or process-restart gap.
+   */
+  cursorStore?: FusorCursorStore;
+  /** Internal lifecycle hook used to surface post-ready terminal failures. */
+  onTerminal?: (error: Error) => void;
   // Optional: only the streaming transport (start) needs cloud credentials to
   // mint a token. The webhook path (processEvent) routes registered handlers
   // without them, so a webhook-only Spectrum can construct a core with
@@ -177,10 +262,21 @@ export class FusorCore {
   private readonly options: FusorCoreOptions;
   private readonly websocketEndpoint: string;
   private readonly handlers = new Map<string, RegisteredFusorHandler[]>();
+  private readonly processedEventIds = new Map<string, number>();
+  // Global JetStream cursor of the last event whose provider normalization and
+  // synchronous enqueue/reply completed and whose optional external save
+  // succeeded. This is not an application-consumption acknowledgement. Without
+  // cursorStore it is process-local: startSeq=0 is a live tail and cannot
+  // recover bootstrap or process-restart gaps.
+  private lastProcessedSeq = 0;
   private tokenProvider?: FusorTokenProvider;
   private wsSession?: FusorWsSession;
   private connectionLoop?: Promise<void>;
-  private started = false;
+  private connectionLoopError?: unknown;
+  private firstReadyReject?: (error: Error) => void;
+  private firstReadyResolve?: () => void;
+  private startPromise?: Promise<void>;
+  private closePromise?: Promise<void>;
   private stopped = false;
   private stopResolve?: () => void;
   private readonly stoppedPromise: Promise<void>;
@@ -208,55 +304,172 @@ export class FusorCore {
     this.handlers.set(platform, list);
   }
 
-  async start(): Promise<void> {
+  start(): Promise<void> {
+    if (this.stopped) {
+      return Promise.reject(new Error("fusor: cannot start after close"));
+    }
+    if (this.startPromise) {
+      return this.startPromise;
+    }
     if (!(this.options.projectId && this.options.projectSecret)) {
-      throw new Error(
-        "fusor: streaming via spectrum.messages requires projectId and projectSecret"
+      return Promise.reject(
+        new Error(
+          "fusor: streaming via spectrum.messages requires projectId and projectSecret"
+        )
       );
     }
-    // Idempotent: a second start() must not spin up a duplicate token provider,
-    // channel, or connection loop. The flag is set synchronously before the
-    // first await so concurrent calls are guarded too.
-    if (this.started) {
-      return;
-    }
-    this.started = true;
-    this.tokenProvider = await createFusorTokenProvider(
+
+    this.startPromise = this.startOnce(
       this.options.projectId,
       this.options.projectSecret
     );
-    this.connectionLoop = this.runConnectionLoop().catch((error) => {
-      log.error("fusor connection loop crashed", errorAttrs(error), error);
-    });
+    return this.startPromise;
   }
 
-  // Streaming transport: the fusor.v1.json WebSocket plane. A session that
-  // runs to a clean end reconnects immediately; an errored session backs
-  // off exponentially (reset on the next clean run).
-  private async runConnectionLoop(): Promise<void> {
-    let attempt = 0;
-    while (!this.stopped) {
-      const wsRan = await this.tryWebsocketOnce();
+  private async startOnce(
+    projectId: string,
+    projectSecret: string
+  ): Promise<void> {
+    const scope = this.cursorScope(projectId);
+    if (this.options.cursorStore) {
+      const loaded = await this.options.cursorStore.load(scope);
+      if (loaded !== undefined && !isValidCursor(loaded)) {
+        throw new Error(
+          "fusor: cursor store returned an invalid cursor; expected a non-negative safe integer below Number.MAX_SAFE_INTEGER"
+        );
+      }
       if (this.stopped) {
         return;
       }
-      if (wsRan) {
-        attempt = 0;
-        continue;
-      }
+      this.lastProcessedSeq = loaded ?? 0;
+    }
 
+    const tokenProvider = await createFusorTokenProvider(
+      projectId,
+      projectSecret
+    );
+    if (this.stopped) {
+      await tokenProvider.dispose();
+      return;
+    }
+
+    this.tokenProvider = tokenProvider;
+    const firstReady = new Promise<void>((resolve, reject) => {
+      this.firstReadyResolve = resolve;
+      this.firstReadyReject = reject;
+    });
+    this.connectionLoop = this.runConnectionLoop().then(
+      () => {
+        this.rejectFirstReady(
+          new Error("fusor: stopped before websocket stream became ready")
+        );
+      },
+      async (error: unknown) => {
+        const normalizedError =
+          error instanceof Error ? error : new Error(String(error));
+        this.rejectFirstReady(normalizedError);
+        log.error("fusor connection loop crashed", errorAttrs(error), error);
+        if (this.stopped) {
+          // close() initiated this stop. Preserve handler/checkpoint/physical
+          // close failures so the shared shutdown promise cannot report success.
+          this.connectionLoopError ??= error;
+          return;
+        }
+        // A terminal transport invariant cannot be repaired by reconnecting.
+        // Publish the lifecycle transition so post-ready waitStopped() callers
+        // do not wait forever after start() has already returned.
+        this.stopped = true;
+        try {
+          this.options.onTerminal?.(normalizedError);
+        } catch (callbackError) {
+          log.error(
+            "fusor terminal callback failed",
+            errorAttrs(callbackError),
+            callbackError
+          );
+        }
+        const provider = this.tokenProvider;
+        this.tokenProvider = undefined;
+        try {
+          await provider?.dispose();
+        } catch (disposeError) {
+          log.error(
+            "fusor token provider disposal failed",
+            errorAttrs(disposeError),
+            disposeError
+          );
+        } finally {
+          this.stopResolve?.();
+          this.stopResolve = undefined;
+        }
+      }
+    );
+    await firstReady;
+  }
+
+  private resolveFirstReady(): void {
+    const resolve = this.firstReadyResolve;
+    this.firstReadyResolve = undefined;
+    this.firstReadyReject = undefined;
+    resolve?.();
+  }
+
+  private rejectFirstReady(error: Error): void {
+    const reject = this.firstReadyReject;
+    this.firstReadyResolve = undefined;
+    this.firstReadyReject = undefined;
+    reject?.(error);
+  }
+
+  private cursorScope(projectId: string): FusorCursorScope {
+    return {
+      projectId,
+      websocketEndpoint: this.websocketEndpoint,
+    };
+  }
+
+  // Streaming transport: the fusor.v1.json WebSocket plane. Retry backoff uses
+  // full jitter and resets after a connection stayed ready long enough to be
+  // considered stable, not only after a clean close (which remote sockets do
+  // not normally provide).
+  private async runConnectionLoop(): Promise<void> {
+    let attempt = 0;
+    while (!this.stopped) {
+      const wasStable = await this.tryWebsocketOnce();
+      if (this.stopped) {
+        return;
+      }
+      if (wasStable) {
+        attempt = 0;
+      }
       attempt += 1;
       await this.backoffSleep(this.backoffMs(attempt));
     }
   }
 
-  // True when the stream ran to a clean end; false when it errored (the
-  // loop then backs off before reconnecting).
+  // True when the session remained ready for the stability window. Terminal
+  // protocol/auth invariants escape this method and stop the loop; rejected
+  // credentials instead invalidate the cached token and retry.
   private async tryWebsocketOnce(): Promise<boolean> {
+    let readyAt: number | undefined;
+    let transportClosedAt: number | undefined;
     try {
-      await this.runWebsocketOnce();
-      return true;
+      await this.runWebsocketOnce(
+        () => {
+          readyAt ??= Date.now();
+          this.resolveFirstReady();
+        },
+        () => {
+          transportClosedAt ??= Date.now();
+        }
+      );
     } catch (error) {
+      if (this.stopped) {
+        throw error;
+      }
+      if (isWsTerminalError(error)) {
+        throw error;
+      }
       // Drop a stale token on auth failure so the next attempt mints a
       // fresh one instead of replaying the rejected token.
       if (isWsAuthError(error)) {
@@ -269,12 +482,20 @@ export class FusorCore {
           error
         );
       }
-      return false;
     }
+    return (
+      readyAt !== undefined &&
+      transportClosedAt !== undefined &&
+      transportClosedAt - readyAt >= RECONNECT_STABLE_MS
+    );
   }
 
   private backoffMs(attempt: number): number {
-    return Math.min(RECONNECT_BASE_MS * 2 ** (attempt - 1), RECONNECT_MAX_MS);
+    const ceiling = Math.min(
+      RECONNECT_BASE_MS * 2 ** (attempt - 1),
+      RECONNECT_MAX_MS
+    );
+    return Math.floor(Math.random() * (ceiling + 1));
   }
 
   // Cancelable sleep: close() clears the timer and resolves it so
@@ -290,22 +511,68 @@ export class FusorCore {
     this.reconnectResolve = undefined;
   }
 
-  private async runWebsocketOnce(): Promise<void> {
+  private async runWebsocketOnce(
+    onReady: () => void,
+    onTransportClose: () => void
+  ): Promise<void> {
     if (!this.tokenProvider) {
       throw new Error("fusor: token not initialized");
     }
     const token = await this.tokenProvider.getToken();
+    // close() may have run while an expired token was being refreshed. Do not
+    // create an untracked replacement socket after shutdown has begun.
+    if (this.stopped) {
+      return;
+    }
     const session = runFusorWsSession({
       url: this.websocketEndpoint,
       token,
-      onEvent: async (event, sendReply) => {
+      startSeq: this.lastProcessedSeq,
+      onReady,
+      onTransportClose,
+      onEvent: async (event, sendReply, seq) => {
         if (this.stopped) {
           return;
         }
-        const reply = await this.processEvent(event);
+        if (event.projectId !== this.options.projectId) {
+          throw new FusorWsError(
+            `fusor websocket delivered project ${event.projectId || "<empty>"} to ${this.options.projectId}`,
+            undefined,
+            "project_mismatch",
+            undefined,
+            false
+          );
+        }
+
+        const duplicateReason = this.processedReason(event.eventId, seq);
+        if (duplicateReason) {
+          // A duplicate event id at a later stream position is itself safe to
+          // cross: the original completed already, and ordered delivery means
+          // advancing to this duplicate cannot jump over unfinished work.
+          if (seq > this.lastProcessedSeq) {
+            await this.rememberProcessed(event.eventId, seq);
+          }
+          log.debug("fusor websocket duplicate suppressed", {
+            "spectrum.fusor.event_id": event.eventId,
+            "spectrum.fusor.seq": seq,
+            "spectrum.fusor.duplicate_reason": duplicateReason,
+          });
+          return;
+        }
+
+        const outcome = await this.processEventWithOutcome(event);
+        if (outcome.retryableError) {
+          throw outcome.retryableError;
+        }
         // The server answers unexpected replies with typed notices —
         // only reply when asked (sendReply is set iff replyExpected).
-        sendReply?.(reply);
+        sendReply?.(outcome.reply);
+        // This callback is serialized by runFusorWsSession. Checkpoint only
+        // after normalization/handler work (including a terminal error reply)
+        // and any reply send completed. Retrying every verifier/application
+        // error would poison this project-wide stream forever; only transport
+        // or durable-checkpoint failures reject the ordered callback.
+        await this.rememberProcessed(event.eventId, seq);
       },
     });
     this.wsSession = session;
@@ -313,6 +580,50 @@ export class FusorCore {
       await session.done;
     } finally {
       this.wsSession = undefined;
+    }
+  }
+
+  private processedReason(
+    eventId: string,
+    seq: number
+  ): "event_id" | "sequence" | undefined {
+    if (seq <= this.lastProcessedSeq) {
+      return "sequence";
+    }
+    if (eventId && this.processedEventIds.has(eventId)) {
+      return "event_id";
+    }
+    return;
+  }
+
+  private async rememberProcessed(eventId: string, seq: number): Promise<void> {
+    const cursorStore = this.options.cursorStore;
+    const projectId = this.options.projectId;
+    if (cursorStore) {
+      if (!projectId) {
+        throw new Error("fusor: cursor store requires projectId");
+      }
+      // The external checkpoint is the durable boundary. If it rejects, leave
+      // the process-local cursor untouched so a positive prior cursor replays
+      // this event on reconnect.
+      await cursorStore.save(this.cursorScope(projectId), seq);
+    }
+
+    this.lastProcessedSeq = seq;
+    if (!eventId) {
+      return;
+    }
+
+    // Map insertion order gives a tiny LRU: refresh a repeated id before
+    // evicting the oldest completed transport identity.
+    this.processedEventIds.delete(eventId);
+    this.processedEventIds.set(eventId, seq);
+    if (this.processedEventIds.size <= PROCESSED_EVENT_ID_CACHE_SIZE) {
+      return;
+    }
+    const oldest = this.processedEventIds.keys().next().value;
+    if (oldest !== undefined) {
+      this.processedEventIds.delete(oldest);
     }
   }
 
@@ -326,9 +637,23 @@ export class FusorCore {
   // request instead.
   async processEvent(
     event: RawInboundEvent,
-    deliver?: (record: ProviderMessageRecord) => void
+    deliver?: (record: ProviderMessageRecord) => void,
+    provenance: FusorEventProvenance = "stream"
   ): Promise<InboundReply> {
-    const handlers = this.handlers.get(event.platform) ?? [];
+    return (await this.processEventWithOutcome(event, deliver, provenance))
+      .reply;
+  }
+
+  private async processEventWithOutcome(
+    event: RawInboundEvent,
+    deliver?: (record: ProviderMessageRecord) => void,
+    provenance: FusorEventProvenance = "stream"
+  ): Promise<ProcessEventOutcome> {
+    const registeredHandlers = this.handlers.get(event.platform) ?? [];
+    const handlers =
+      provenance === "webhook"
+        ? registeredHandlers.filter((handler) => !handler.streamOnly)
+        : registeredHandlers;
     if (handlers.length === 0) {
       // Reply shape stays wire-compatible; only the local log gets the
       // install hint (since v5 the official providers are separate packages,
@@ -341,14 +666,17 @@ export class FusorCore {
         {
           "spectrum.fusor.platform": event.platform,
           "spectrum.fusor.event_id": event.eventId,
+          "spectrum.fusor.provenance": provenance,
         }
       );
       return {
-        eventId: event.eventId,
-        errorReason: `no handler for platform ${event.platform}`,
-        status: 0,
-        headers: {},
-        body: new Uint8Array(0),
+        reply: {
+          eventId: event.eventId,
+          errorReason: `no handler for platform ${event.platform}`,
+          status: 0,
+          headers: {},
+          body: new Uint8Array(0),
+        },
       };
     }
 
@@ -360,14 +688,17 @@ export class FusorCore {
       log.warn("fusor: failed to parse raw_request", {
         "spectrum.fusor.platform": event.platform,
         "spectrum.fusor.event_id": event.eventId,
+        "spectrum.fusor.provenance": provenance,
         ...errorAttrs(error),
       });
       return {
-        eventId: event.eventId,
-        errorReason,
-        status: 0,
-        headers: {},
-        body: new Uint8Array(0),
+        reply: {
+          eventId: event.eventId,
+          errorReason,
+          status: 0,
+          headers: {},
+          body: new Uint8Array(0),
+        },
       };
     }
 
@@ -377,13 +708,30 @@ export class FusorCore {
 
     const combined = combineReplies(outcomes);
     combined.eventId = event.eventId;
-    return combined;
+    const retryableFailure = outcomes.find(
+      (outcome) => !outcome.ok && outcome.retryable
+    );
+    return {
+      reply: combined,
+      ...(retryableFailure && {
+        retryableError: new FusorRetryableError(
+          `fusor handler failed transiently for event ${event.eventId}: ${retryableFailure.errorReason ?? "unknown error"}`,
+          retryableFailure.error instanceof Error
+            ? { cause: retryableFailure.error }
+            : undefined
+        ),
+      }),
+    };
   }
 
-  async close(): Promise<void> {
-    if (this.stopped) {
-      return;
+  close(): Promise<void> {
+    if (!this.closePromise) {
+      this.closePromise = this.closeOnce();
     }
+    return this.closePromise;
+  }
+
+  private async closeOnce(): Promise<void> {
     this.stopped = true;
     this.wsSession?.close();
     // Wake an in-progress reconnect backoff so the loop observes stopped and
@@ -394,13 +742,32 @@ export class FusorCore {
     }
     this.reconnectResolve?.();
     this.reconnectResolve = undefined;
-    if (this.tokenProvider) {
-      await this.tokenProvider.dispose();
+
+    try {
+      // Startup may be loading a cursor or minting the initial token. It owns
+      // disposing a provider created after stopped became true; wait for that
+      // branch before taking the final session/loop snapshot.
+      try {
+        await this.startPromise;
+      } catch {
+        // The start() caller observes initialization failures; shutdown still
+        // needs to reach its shared completion boundary.
+      }
+
+      this.wsSession?.close();
+      if (this.connectionLoop) {
+        await this.connectionLoop;
+      }
+      if (this.tokenProvider) {
+        await this.tokenProvider.dispose();
+      }
+      if (this.connectionLoopError !== undefined) {
+        throw this.connectionLoopError;
+      }
+    } finally {
+      this.stopResolve?.();
+      this.stopResolve = undefined;
     }
-    if (this.connectionLoop) {
-      await this.connectionLoop;
-    }
-    this.stopResolve?.();
   }
 
   async waitStopped(): Promise<void> {

--- a/packages/core/src/fusor/index.ts
+++ b/packages/core/src/fusor/index.ts
@@ -1,5 +1,6 @@
 import { FUSOR_BRAND, type FusorClient, type FusorVerify } from "./types";
 
+export type { FusorCursorScope, FusorCursorStore } from "./core";
 export { type FusorEvent, fusorEvent, isFusorEvent } from "./event";
 export type {
   FusorClient,
@@ -10,10 +11,16 @@ export type {
   FusorRespond,
   FusorVerify,
   FusorVerifyRequest,
+  HybridFusor,
+  HybridFusorCreateContext,
+  HybridFusorMessages,
+  HybridFusorMessagesCtx,
+  HybridFusorMessagesReturn,
   WebhookHandler,
   WebhookRawRequest,
   WebhookRawResult,
 } from "./types";
+export { FusorRetryableError, FusorTerminalError } from "./types";
 
 export function fusor<TPayload>(
   platform: string,

--- a/packages/core/src/fusor/types.ts
+++ b/packages/core/src/fusor/types.ts
@@ -12,6 +12,10 @@ export interface FusorVerifyRequest {
   rawBody: Uint8Array;
 }
 
+/**
+ * Verify and decode one provider request. Thrown errors reject that event as
+ * terminal unless wrapped in FusorRetryableError.
+ */
 export type FusorVerify<TPayload = unknown> = (
   req: FusorVerifyRequest
 ) => TPayload | Promise<TPayload>;
@@ -20,6 +24,28 @@ export interface FusorReply {
   body?: string | Uint8Array;
   headers?: Record<string, string>;
   status?: number;
+}
+
+/**
+ * Mark a provider verification or message-processing failure as safe to retry.
+ * Streaming delivery reconnects from the prior durable checkpoint.
+ */
+export class FusorRetryableError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "FusorRetryableError";
+  }
+}
+
+/**
+ * Mark a provider message-processing failure as deterministic for this event.
+ * Streaming delivery returns an error reply and advances its checkpoint.
+ */
+export class FusorTerminalError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "FusorTerminalError";
+  }
 }
 
 export type FusorRespond = (reply: FusorReply) => void;
@@ -45,9 +71,74 @@ export type FusorMessagesReturn =
   | (ProviderMessageRecord | FusorEvent)[]
   | undefined;
 
+/**
+ * Process one verified payload. Thrown errors retry streaming delivery unless
+ * wrapped in FusorTerminalError. Providers should keep side effects idempotent.
+ */
 export type FusorMessages<TPayload, TConfig = unknown> = (
   ctx: FusorMessagesCtx<TPayload, TConfig>
 ) => FusorMessagesReturn | Promise<FusorMessagesReturn>;
+
+/**
+ * Initialization context for a hybrid provider's optional Fusor transport.
+ *
+ * Hybrid providers retain their regular, long-lived SDK client for actions,
+ * outbound sends, regular event producers, and teardown. The Fusor binding is
+ * an additional inbound source only, so its initializer receives that client
+ * alongside the normal provider initialization context and may return
+ * `undefined` to keep using only the provider's regular message source.
+ */
+export interface HybridFusorCreateContext<TClient, TConfig = unknown> {
+  client: TClient;
+  config: TConfig;
+  projectConfig: ProjectData | undefined;
+  projectId: string | undefined;
+  projectSecret: string | undefined;
+  store: Store;
+}
+
+/** Runtime context for a hybrid provider's per-payload Fusor handler. */
+export interface HybridFusorMessagesCtx<TPayload, TClient, TConfig = unknown>
+  extends FusorMessagesCtx<TPayload, TConfig> {
+  /** The provider's regular lifecycle client, not the Fusor routing client. */
+  client: TClient;
+}
+
+/**
+ * Hybrid handlers emit only core message records. Custom event channels remain
+ * regular `events` producers backed by the provider's regular client.
+ */
+export type HybridFusorMessagesReturn =
+  | ProviderMessageRecord
+  | ProviderMessageRecord[]
+  | undefined;
+
+export type HybridFusorMessages<TPayload, TClient, TConfig = unknown> = (
+  ctx: HybridFusorMessagesCtx<TPayload, TClient, TConfig>
+) => HybridFusorMessagesReturn | Promise<HybridFusorMessagesReturn>;
+
+/**
+ * Optional Fusor inbound binding for a provider that also owns a regular SDK
+ * client. `create` is evaluated once during `Spectrum()` initialization;
+ * returning `undefined` leaves the provider entirely on its regular transport.
+ */
+export interface HybridFusor<TPayload, TClient, TConfig = unknown> {
+  create: (
+    ctx: HybridFusorCreateContext<TClient, TConfig>
+  ) =>
+    | FusorClient<TPayload>
+    | undefined
+    | Promise<FusorClient<TPayload> | undefined>;
+  messages: HybridFusorMessages<TPayload, TClient, TConfig>;
+  /**
+   * Restrict this binding to events received over Fusor's authenticated
+   * streaming transport. When enabled, a caller cannot invoke the binding by
+   * posting a raw Fusor protobuf envelope to `spectrum.webhook()`.
+   *
+   * @default false
+   */
+  streamOnly?: boolean;
+}
 
 export const FUSOR_BRAND: unique symbol = Symbol.for("spectrum.fusor.client");
 

--- a/packages/core/src/fusor/websocket.ts
+++ b/packages/core/src/fusor/websocket.ts
@@ -21,6 +21,7 @@ import { errorAttrs } from "../utils/telemetry";
 const log = createLogger("spectrum.fusor.ws");
 
 export const FUSOR_WS_SUBPROTOCOL = "fusor.v1.json";
+export const FUSOR_WS_MAX_PENDING_EVENTS = 1024;
 
 // Staleness watchdog: the server sends app-level heartbeat frames (the
 // cadence is advertised in `ready`); no frame of any kind for
@@ -29,16 +30,27 @@ export const FUSOR_WS_SUBPROTOCOL = "fusor.v1.json";
 // bounds how long we wait for the server to acknowledge the init.
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 const STALENESS_GRACE_MS = 5000;
+const LOCAL_CLOSE_TIMEOUT_MS = 2000;
 
 export class FusorWsError extends Error {
   readonly closeCode?: number;
   readonly errorCode?: string;
+  readonly reason?: string;
+  readonly retryable?: boolean;
 
-  constructor(message: string, closeCode?: number, errorCode?: string) {
+  constructor(
+    message: string,
+    closeCode?: number,
+    errorCode?: string,
+    reason?: string,
+    retryable?: boolean
+  ) {
     super(message);
     this.name = "FusorWsError";
     this.closeCode = closeCode;
     this.errorCode = errorCode;
+    this.reason = reason;
+    this.retryable = retryable;
   }
 }
 
@@ -50,6 +62,31 @@ export function isWsAuthError(error: unknown): boolean {
     error instanceof FusorWsError &&
     (error.closeCode === 4401 || error.errorCode === "unauthenticated")
   );
+}
+
+/** A server verifier invariant, not a rejected credential to re-mint. */
+export function isWsTerminalAuthError(error: unknown): boolean {
+  return (
+    error instanceof FusorWsError &&
+    error.errorCode === "unauthenticated" &&
+    error.reason === "jwt:not-initialized"
+  );
+}
+
+/** A fatal server/client protocol condition that reconnecting cannot repair. */
+export function isWsTerminalError(error: unknown): boolean {
+  if (!(error instanceof FusorWsError)) {
+    return false;
+  }
+  if (isWsTerminalAuthError(error)) {
+    return true;
+  }
+  // A rejected credential is the one retryable=false server response that the
+  // client can repair itself by minting a fresh token.
+  if (isWsAuthError(error)) {
+    return false;
+  }
+  return error.retryable === false || error.closeCode === 1009;
 }
 
 function decodeBase64(value: string): Uint8Array {
@@ -107,12 +144,21 @@ export interface FusorWsSessionOptions {
    * Called for every event frame, in arrival order. `sendReply` is set
    * only when the server flagged `replyExpected` — replying to anything
    * else earns a (non-fatal) `reply_unknown_event` notice from the
-   * server, so the core must not fire blind replies.
+   * server, so the core must not fire blind replies. `seq` is the global
+   * stream cursor for this delivery; callers must checkpoint it only after
+   * this promise resolves successfully.
    */
   onEvent: (
     event: RawInboundEvent,
-    sendReply: ((reply: InboundReply) => void) | undefined
+    sendReply: ((reply: InboundReply) => void) | undefined,
+    seq: number
   ) => Promise<void>;
+  /** Called once when the server acknowledges the subscription as ready. */
+  onReady?: () => void;
+  /** Called when the underlying transport reports that it has closed. */
+  onTransportClose?: () => void;
+  /** Last transport-completed global stream sequence; defaults to live tail. */
+  startSeq?: number;
   token: string;
   url: string;
 }
@@ -129,7 +175,11 @@ export function runFusorWsSession(
   const WebSocketCtor = globalThis.WebSocket;
   if (typeof WebSocketCtor !== "function") {
     throw new FusorWsError(
-      "global WebSocket is not available in this runtime — the fusor websocket transport needs Bun, Node >= 22, or a browser/worker environment"
+      "global WebSocket is not available in this runtime — the fusor websocket transport needs Bun, Node >= 22, or a browser/worker environment",
+      undefined,
+      "websocket_unavailable",
+      undefined,
+      false
     );
   }
 
@@ -138,20 +188,47 @@ export function runFusorWsSession(
   // error above can fire.
   const wsOpen = WebSocketCtor.OPEN;
 
+  // Optional for source compatibility with callers of the original session
+  // helper; the core always supplies its explicit safe checkpoint.
+  const startSeq = options.startSeq ?? 0;
+  if (
+    !Number.isSafeInteger(startSeq) ||
+    startSeq < 0 ||
+    startSeq >= Number.MAX_SAFE_INTEGER
+  ) {
+    throw new FusorWsError(
+      "fusor websocket startSeq must be a non-negative safe integer below Number.MAX_SAFE_INTEGER",
+      undefined,
+      "invalid_start_seq",
+      undefined,
+      false
+    );
+  }
+
   const ws = new WebSocketCtor(options.url, [FUSOR_WS_SUBPROTOCOL]);
 
   let settled = false;
   let closedByUs = false;
+  let closing = false;
+  let pendingLocalError: Error | undefined;
   // Last fatal `error` frame — the close event that follows carries only
   // a code, so this is what makes the rejection actionable.
-  let pendingError: { code: string; message: string; reason?: string } | null =
-    null;
+  let pendingError: {
+    code: string;
+    message: string;
+    reason?: string;
+    retryable?: boolean;
+  } | null = null;
+  let readyNotified = false;
+  let transportCloseNotified = false;
   let stalenessBudgetMs =
     2 * DEFAULT_HEARTBEAT_INTERVAL_MS + STALENESS_GRACE_MS;
   let watchdog: ReturnType<typeof setTimeout> | undefined;
+  let closeFailsafe: ReturnType<typeof setTimeout> | undefined;
   // Events are processed strictly in arrival order even though the
   // handler is async (same discipline as the server side).
   let tail: Promise<void> = Promise.resolve();
+  let pendingEventCount = 0;
 
   let resolveDone!: () => void;
   let rejectDone!: (error: Error) => void;
@@ -159,6 +236,11 @@ export function runFusorWsSession(
     resolveDone = resolve;
     rejectDone = reject;
   });
+  // `done` is also the processing-drain boundary. A transport close may race
+  // an async handler that already received an event; reconnecting before that
+  // handler settles could replay it concurrently or checkpoint past it. Mark
+  // the transport settled immediately (so no new frames are accepted), then
+  // resolve/reject only after the ordered handler tail has drained.
   const settle = (error?: Error): void => {
     if (settled) {
       return;
@@ -168,11 +250,71 @@ export function runFusorWsSession(
       clearTimeout(watchdog);
       watchdog = undefined;
     }
-    if (error) {
-      rejectDone(error);
-    } else {
-      resolveDone();
+    if (closeFailsafe) {
+      clearTimeout(closeFailsafe);
+      closeFailsafe = undefined;
     }
+    tail.then(
+      () => {
+        if (error) {
+          rejectDone(error);
+        } else {
+          resolveDone();
+        }
+      },
+      (handlerError: unknown) => {
+        rejectDone(
+          handlerError instanceof Error
+            ? handlerError
+            : new FusorWsError(String(handlerError))
+        );
+      }
+    );
+  };
+
+  const closeTransport = (error?: Error): void => {
+    if (settled || closing) {
+      return;
+    }
+    closing = true;
+    pendingLocalError = error;
+    try {
+      ws.close();
+    } catch {
+      // Already closing.
+    }
+    if (settled) {
+      return;
+    }
+    closeFailsafe = setTimeout(() => {
+      const timeoutError = new FusorWsError(
+        "fusor websocket close handshake timed out"
+      );
+      settle(
+        pendingLocalError
+          ? new FusorWsError(
+              `${pendingLocalError.message}; ${timeoutError.message}`,
+              pendingLocalError instanceof FusorWsError
+                ? pendingLocalError.closeCode
+                : undefined,
+              pendingLocalError instanceof FusorWsError
+                ? pendingLocalError.errorCode
+                : undefined,
+              pendingLocalError instanceof FusorWsError
+                ? pendingLocalError.reason
+                : undefined,
+              pendingLocalError instanceof FusorWsError
+                ? pendingLocalError.retryable
+                : undefined
+            )
+          : timeoutError
+      );
+    }, LOCAL_CLOSE_TIMEOUT_MS);
+    closeFailsafe.unref?.();
+  };
+
+  const failSession = (error: Error): void => {
+    closeTransport(error);
   };
 
   const armWatchdog = (): void => {
@@ -186,12 +328,7 @@ export function runFusorWsSession(
       log.warn("fusor ws: no frame within staleness budget; closing", {
         "spectrum.fusor.ws.staleness_budget_ms": stalenessBudgetMs,
       });
-      settle(new FusorWsError("websocket heartbeat timeout"));
-      try {
-        ws.close();
-      } catch {
-        // Already closing.
-      }
+      failSession(new FusorWsError("websocket heartbeat timeout"));
     }, stalenessBudgetMs);
     watchdog.unref?.();
   };
@@ -225,33 +362,94 @@ export function runFusorWsSession(
       "spectrum.fusor.ws.heartbeat_interval_ms":
         typeof interval === "number" ? interval : 0,
     });
+    if (!readyNotified) {
+      readyNotified = true;
+      options.onReady?.();
+    }
   };
 
   const handleEventFrame = (frame: Record<string, unknown>): void => {
+    if (pendingEventCount >= FUSOR_WS_MAX_PENDING_EVENTS) {
+      failSession(
+        new FusorWsError(
+          `fusor websocket pending-event limit (${FUSOR_WS_MAX_PENDING_EVENTS}) exceeded`,
+          undefined,
+          "client_backpressure",
+          undefined,
+          true
+        )
+      );
+      return;
+    }
     const eventFrame = frame as unknown as WsEventFrame;
+    const seq = eventFrame.seq;
+    if (
+      !Number.isSafeInteger(seq) ||
+      seq <= 0 ||
+      seq >= Number.MAX_SAFE_INTEGER
+    ) {
+      failSession(
+        new FusorWsError(
+          "fusor websocket event seq must be a positive safe integer below Number.MAX_SAFE_INTEGER",
+          undefined,
+          "event_invalid",
+          undefined,
+          false
+        )
+      );
+      return;
+    }
     let event: RawInboundEvent;
     try {
       event = toRawInboundEvent(eventFrame);
     } catch (error) {
       log.warn(
-        "fusor ws: undecodable event frame; skipping",
+        "fusor ws: undecodable event frame; failing session",
         errorAttrs(error),
         error
+      );
+      failSession(
+        new FusorWsError(
+          `fusor websocket event frame is undecodable: ${error instanceof Error ? error.message : String(error)}`,
+          undefined,
+          "event_invalid",
+          undefined,
+          false
+        )
       );
       return;
     }
     const sendReply = eventFrame.replyExpected
       ? sendReplyFor(event.eventId)
       : undefined;
-    tail = tail
-      .then(() => options.onEvent(event, sendReply))
-      .catch((error) => {
-        log.warn(
-          "fusor ws: event handler failed",
-          { "spectrum.fusor.ws.event_id": event.eventId, ...errorAttrs(error) },
-          error
-        );
-      });
+    // Do not recover this chain after a handler failure. Every later event was
+    // delivered after the failed one, so processing it and advancing the core
+    // cursor would skip the failed delivery. Failing the session reconnects
+    // from the last earlier safe cursor instead.
+    pendingEventCount += 1;
+    const next = tail.then(() => options.onEvent(event, sendReply, seq));
+    tail = next;
+    next.then(
+      () => {
+        pendingEventCount -= 1;
+      },
+      (error) => {
+        pendingEventCount -= 1;
+        if (!settled) {
+          log.warn(
+            "fusor ws: event handler failed",
+            {
+              "spectrum.fusor.ws.event_id": event.eventId,
+              ...errorAttrs(error),
+            },
+            error
+          );
+          failSession(
+            error instanceof Error ? error : new FusorWsError(String(error))
+          );
+        }
+      }
+    );
   };
 
   const handleErrorFrame = (frame: Record<string, unknown>): void => {
@@ -260,7 +458,13 @@ export function runFusorWsSession(
       typeof frame.message === "string" ? frame.message : "server error";
     const reason = typeof frame.reason === "string" ? frame.reason : undefined;
     if (frame.fatal === true) {
-      pendingError = { code, message, reason };
+      pendingError = {
+        code,
+        message,
+        reason,
+        retryable:
+          typeof frame.retryable === "boolean" ? frame.retryable : undefined,
+      };
     } else {
       // Typed non-fatal notice (reply_unknown_event, frame_invalid, …)
       // — the stream keeps running; surface it for debugging.
@@ -302,13 +506,28 @@ export function runFusorWsSession(
   };
 
   ws.onopen = () => {
+    if (settled || closing) {
+      try {
+        ws.close(1000);
+      } catch {
+        // Already closing.
+      }
+      return;
+    }
     armWatchdog();
     ws.send(
-      JSON.stringify({ type: "init", startSeq: 0, token: options.token })
+      JSON.stringify({
+        type: "init",
+        startSeq,
+        token: options.token,
+      })
     );
   };
 
   ws.onmessage = (messageEvent: MessageEvent) => {
+    if (settled || closing) {
+      return;
+    }
     armWatchdog();
     handleFrame(messageEvent.data);
   };
@@ -319,6 +538,14 @@ export function runFusorWsSession(
   };
 
   ws.onclose = (closeEvent: CloseEvent) => {
+    if (!transportCloseNotified) {
+      transportCloseNotified = true;
+      options.onTransportClose?.();
+    }
+    if (pendingLocalError) {
+      settle(pendingLocalError);
+      return;
+    }
     if (closedByUs) {
       settle();
       return;
@@ -330,7 +557,9 @@ export function runFusorWsSession(
       new FusorWsError(
         `fusor websocket closed (${closeEvent.code}): ${detail}`,
         closeEvent.code,
-        pendingError?.code ?? (closeEvent.reason || undefined)
+        pendingError?.code ?? (closeEvent.reason || undefined),
+        pendingError?.reason,
+        pendingError?.retryable
       )
     );
   };
@@ -341,16 +570,11 @@ export function runFusorWsSession(
   return {
     done,
     close() {
-      closedByUs = true;
-      try {
-        ws.close(1000);
-      } catch {
-        // Already closed.
+      if (closedByUs || closing) {
+        return;
       }
-      // Some runtimes skip the close event for never-opened sockets;
-      // don't let done hang on shutdown.
-      const failsafe = setTimeout(() => settle(), 2000);
-      failsafe.unref?.();
+      closedByUs = true;
+      closeTransport();
     },
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,8 @@ export { type Voice, voice } from "./content/voice";
 export { Emoji, type EmojiKey } from "./emoji";
 export type {
   FusorClient,
+  FusorCursorScope,
+  FusorCursorStore,
   FusorEvent,
   FusorMessages,
   FusorMessagesCtx,
@@ -81,11 +83,23 @@ export type {
   FusorRespond,
   FusorVerify,
   FusorVerifyRequest,
+  HybridFusor,
+  HybridFusorCreateContext,
+  HybridFusorMessages,
+  HybridFusorMessagesCtx,
+  HybridFusorMessagesReturn,
   WebhookHandler,
   WebhookRawRequest,
   WebhookRawResult,
 } from "./fusor";
-export { fusor, fusorEvent, isFusorClient, isFusorEvent } from "./fusor";
+export {
+  FusorRetryableError,
+  FusorTerminalError,
+  fusor,
+  fusorEvent,
+  isFusorClient,
+  isFusorEvent,
+} from "./fusor";
 export { definePlatform } from "./platform/define";
 export type {
   AnyPlatformDef,

--- a/packages/core/src/platform/define.ts
+++ b/packages/core/src/platform/define.ts
@@ -1,6 +1,6 @@
 import { createLogger, withSpan } from "@photon-ai/otel";
 import type z from "zod";
-import type { FusorClient, FusorMessages } from "../fusor/types";
+import type { FusorClient, FusorMessages, HybridFusor } from "../fusor/types";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
 import type { ProjectData } from "../utils/cloud";
@@ -311,22 +311,30 @@ function createPlatformInstance<
   ) as unknown as PlatformInstance<Def>;
 }
 
-// `definePlatform` has two call shapes, expressed as overloads:
+// `definePlatform` has three call shapes, expressed as overloads:
 //
-// 1. **Fusor mode** — `lifecycle.createClient` returns `fusor(name, verify)`
+// 1. **Regular mode** — `createClient` returns a normal SDK client and
+//    `messages` is a long-lived `EventProducer` (async-iterable) stream.
+// 2. **Hybrid Fusor mode** — `createClient` still returns the normal SDK
+//    client, while `fusor.create` optionally returns a separate branded
+//    `FusorClient`. `fusor.messages` handles those payloads and receives the
+//    regular client; the regular `messages` producer remains active alongside
+//    it for event classes that do not travel through Fusor.
+// 3. **Pure Fusor mode** — `lifecycle.createClient` returns
+//    `fusor(name, verify)`
 //    (a branded `FusorClient<TPayload>`). There is no long-lived SDK client;
 //    `messages` runs once per inbound webhook against an already-verified
 //    payload, returning the message(s) to emit on `spectrum.messages` (and
 //    optionally calling `respond(reply)` to shape the HTTP reply to fusor).
-// 2. **Regular mode** — `createClient` returns a normal SDK client and
-//    `messages` is a long-lived `EventProducer` (async-iterable) stream.
 //
 // Overloads (not one conditional signature): switching `messages`'s shape on
 // the resolved `_Client` via a conditional type breaks TS contextual typing of
 // `({ client, config })` for regular providers — the conditional collapses to
-// `unknown` before `_Client` resolves. Two concrete signatures sidestep that.
+// `unknown` before `_Client` resolves. Concrete overloads sidestep that.
 //
-// The REGULAR overload is listed first. Overload resolution defers
+// The REGULAR overload is listed first. Its `PlatformDef` carries
+// `fusor?: never`, so a hybrid definition skips it unambiguously. Overload
+// resolution otherwise defers
 // context-sensitive (unannotated-param) arrows during applicability, so a def
 // whose `createClient` and `messages` are both inline arrows — every regular
 // provider — matches the first applicable overload (regular). A fusor provider
@@ -401,6 +409,95 @@ export function definePlatform<
       _Actions
     >,
     "lifecycle" | "name"
+  > & { static?: _Static }
+): Platform<
+  PlatformDef<
+    _Name,
+    _ConfigSchema,
+    _UserSchema,
+    _SpaceSchema,
+    _SpaceParamsSchema,
+    _Client,
+    _ResolvedUser,
+    _ResolvedSpace,
+    _MessageSchema,
+    _MessageType,
+    _Events,
+    _SpaceActions,
+    _MessageActions,
+    _Actions
+  >
+> &
+  Readonly<_Static>;
+
+export function definePlatform<
+  _Name extends string,
+  _ConfigSchema extends z.ZodType<object>,
+  _UserSchema extends z.ZodType<object> | undefined,
+  _SpaceSchema extends z.ZodType<object> | undefined,
+  _SpaceParamsSchema extends z.ZodType<object> | undefined,
+  _Client,
+  _TPayload,
+  _ResolvedUser extends { id: string },
+  _ResolvedSpace extends { id: string },
+  _MessageSchema extends z.ZodType<object> | undefined = undefined,
+  _MessageType extends ProviderMessage<
+    _ResolvedUser,
+    _ResolvedSpace,
+    _MessageSchema extends z.ZodType<object>
+      ? z.infer<_MessageSchema>
+      : Record<never, never>
+  > = ProviderMessage<
+    _ResolvedUser,
+    _ResolvedSpace,
+    _MessageSchema extends z.ZodType<object>
+      ? z.infer<_MessageSchema>
+      : Record<never, never>
+  >,
+  _Events extends
+    | (Record<
+        string,
+        EventProducer<unknown, _Client, z.infer<_ConfigSchema>>
+      > & { messages?: never })
+    | undefined = undefined,
+  _Static extends Record<string, unknown> = Record<never, never>,
+  _SpaceActions extends Record<string, SpaceActionFn> = Record<never, never>,
+  _MessageActions extends Record<string, MessageActionFn> = Record<
+    never,
+    never
+  >,
+  _Actions extends Record<string, InstanceActionFn> = Record<never, never>,
+>(
+  name: _Name,
+  def: {
+    fusor: HybridFusor<_TPayload, _Client, z.infer<_ConfigSchema>>;
+    lifecycle: {
+      createClient: (
+        ctx: CreateClientContext<_ConfigSchema>
+      ) => Promise<_Client>;
+      destroyClient?: (ctx: {
+        client: NoInferValue<_Client>;
+        store: Store;
+      }) => Promise<void>;
+    };
+  } & Omit<
+    PlatformDef<
+      _Name,
+      _ConfigSchema,
+      _UserSchema,
+      _SpaceSchema,
+      _SpaceParamsSchema,
+      _Client,
+      _ResolvedUser,
+      _ResolvedSpace,
+      _MessageSchema,
+      _MessageType,
+      _Events,
+      _SpaceActions,
+      _MessageActions,
+      _Actions
+    >,
+    "fusor" | "lifecycle" | "name"
   > & { static?: _Static }
 ): Platform<
   PlatformDef<
@@ -507,11 +604,11 @@ export function definePlatform<
 > &
   Readonly<_Static>;
 
-// Implementation signature — intentionally loose so both overloads above are
+// Implementation signature — intentionally loose so all overloads above are
 // assignable to it. Callers only ever see the overloads; the body erases to
 // `AnyPlatformDef` and the overload return types restore precision at the call
-// site. The runtime is identical for both modes: fusor's `messages`/`events`
-// are read off `__definition` by FusorCore, never invoked here.
+// site. Fusor callbacks are read off `__definition` by the Spectrum bootstrap,
+// never invoked here.
 export function definePlatform(platformId: string, rawDef: unknown): unknown {
   assertValidPlatformId(platformId);
   const def = rawDef as AnyPlatformDef & {

--- a/packages/core/src/platform/types.ts
+++ b/packages/core/src/platform/types.ts
@@ -2,6 +2,7 @@ import type { Fn, Pipe, Tuples } from "hotscript";
 import type z from "zod";
 import type { AvatarData } from "../content/avatar";
 import type { Content } from "../content/types";
+import type { HybridFusor } from "../fusor/types";
 import type { Message } from "../types/message";
 import type { Space } from "../types/space";
 import type { User } from "../types/user";
@@ -358,6 +359,15 @@ export interface PlatformDef<
    */
   events?: _Events;
 
+  /**
+   * Hybrid Fusor inbound transport. This slot is supplied by the dedicated
+   * `definePlatform` hybrid overload; regular and pure-Fusor definitions leave
+   * it absent. It is `never` here so adding the slot cannot make the regular
+   * overload greedily accept a hybrid definition and lose its payload/client
+   * inference.
+   */
+  fusor?: never;
+
   lifecycle: {
     createClient: (ctx: CreateClientContext<_ConfigSchema>) => Promise<_Client>;
     destroyClient?: (ctx: {
@@ -510,6 +520,11 @@ export interface AnyPlatformDef {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard event
     [key: string]: ((ctx: any) => AsyncIterable<any>) | z.ZodType<object>;
   };
+
+  // Optional messages-only Fusor binding for a provider whose lifecycle client
+  // remains a regular SDK client. The concrete generics are restored by the
+  // hybrid `definePlatform` overload; this interface is the runtime erasure.
+  fusor?: HybridFusor<unknown, unknown, unknown>;
 
   lifecycle: {
     // biome-ignore lint/suspicious/noExplicitAny: wildcard lifecycle

--- a/packages/core/src/spectrum.ts
+++ b/packages/core/src/spectrum.ts
@@ -183,7 +183,17 @@ export interface SpectrumOptions {
 const spectrumOptionsSchema = z
   .object({
     flattenGroups: z.boolean().optional(),
-    fusorCursorStore: z.custom<FusorCursorStore>().optional(),
+    fusorCursorStore: z
+      .custom<FusorCursorStore>(
+        (value) =>
+          typeof value === "object" &&
+          value !== null &&
+          "load" in value &&
+          typeof value.load === "function" &&
+          "save" in value &&
+          typeof value.save === "function"
+      )
+      .optional(),
     logLevel: z.enum(["debug", "info", "warn", "error", "silent"]).optional(),
   })
   .optional();
@@ -781,7 +791,9 @@ export async function Spectrum<
     const key = `${platform}\0${channel}`;
     let broadcaster = eventBroadcasters.get(key);
     if (!broadcaster) {
-      broadcaster = broadcast(adaptIterable(queue.iterable));
+      broadcaster = broadcast(
+        adaptIterable(queue.iterable, undefined, ensureFusorStarted)
+      );
       eventBroadcasters.set(key, broadcaster);
     }
     return broadcaster;

--- a/packages/core/src/spectrum.ts
+++ b/packages/core/src/spectrum.ts
@@ -10,11 +10,16 @@ import { RawInboundEvent } from "@photon-ai/proto/photon/fusor/v1/inbound";
 import z from "zod";
 import { SPECTRUM_BUILD_ENV, SPECTRUM_SDK_VERSION } from "./build-env";
 import type { ContentInput } from "./content/types";
-import { FusorCore, type RegisteredFusorHandler } from "./fusor/core";
+import {
+  FusorCore,
+  type FusorCursorStore,
+  type RegisteredFusorHandler,
+} from "./fusor/core";
 import { isFusorClient } from "./fusor/index";
 import type {
   FusorClient,
   FusorMessages,
+  HybridFusorMessages,
   WebhookHandler,
   WebhookRawRequest,
   WebhookRawResult,
@@ -68,6 +73,7 @@ const PHOTON_OTEL_ENDPOINT = "https://otlp.photon.codes";
 // (uncancellable) provider is rescued by destroyClient (Phase 3), and the
 // residual stream close is awaited at the very end — so stop() never hangs.
 const STREAM_CLOSE_TIMEOUT_MS = 5000;
+const FUSOR_CLOSE_TIMEOUT_MS = 5000;
 
 const lifecycleLog = createLogger("spectrum.lifecycle");
 
@@ -152,6 +158,15 @@ export interface SpectrumOptions {
   flattenGroups?: boolean;
 
   /**
+   * Optional storage for Fusor's last verified, normalized, and synchronously
+   * enqueued stream sequence. This is a transport checkpoint, not an
+   * acknowledgement that application code consumed the in-memory message; a
+   * crash between those steps can lose that queued record. Use a durable
+   * application sink when end-to-end delivery guarantees are required.
+   */
+  fusorCursorStore?: FusorCursorStore;
+
+  /**
    * Minimum severity emitted by the SDK's structured logger (to both the
    * console and, when telemetry is on, OTLP). Applies process-wide. The
    * `LOG_LEVEL` environment variable still takes precedence.
@@ -168,6 +183,7 @@ export interface SpectrumOptions {
 const spectrumOptionsSchema = z
   .object({
     flattenGroups: z.boolean().optional(),
+    fusorCursorStore: z.custom<FusorCursorStore>().optional(),
     logLevel: z.enum(["debug", "info", "warn", "error", "silent"]).optional(),
   })
   .optional();
@@ -266,6 +282,184 @@ interface SpectrumFactoryOptions<Providers extends PlatformProviderConfig[]> {
   webhookSecret?: string;
 }
 
+interface ProviderInitializationContext {
+  config: unknown;
+  projectConfig: ProjectData | undefined;
+  projectId: string | undefined;
+  projectSecret: string | undefined;
+  store: Store;
+}
+
+interface RuntimeHybridFusorBinding {
+  client: FusorClient;
+  messages: HybridFusorMessages<unknown, unknown, unknown>;
+  streamOnly: boolean;
+}
+
+interface RuntimeFusorMessageSource {
+  mode: "hybrid" | "pure";
+  queue: AsyncQueue<ProviderMessageRecord>;
+}
+
+type FusorPlatformBinding =
+  | {
+      client: FusorClient;
+      messages: FusorMessages<unknown>;
+      mode: "pure";
+      name: string;
+      streamOnly: false;
+    }
+  | {
+      client: FusorClient;
+      messages: HybridFusorMessages<unknown, unknown, unknown>;
+      mode: "hybrid";
+      name: string;
+      streamOnly: boolean;
+    };
+
+async function initializeHybridFusorBinding(
+  bindings: Map<string, RuntimeHybridFusorBinding>,
+  definition: AnyPlatformDef,
+  client: unknown,
+  context: ProviderInitializationContext
+): Promise<void> {
+  const hybrid = definition.fusor;
+  if (!hybrid) {
+    return;
+  }
+  const fusorClient = await hybrid.create({ ...context, client });
+  if (fusorClient === undefined) {
+    return;
+  }
+  if (!isFusorClient(fusorClient)) {
+    throw new Error(
+      `Platform "${definition.name}" fusor.create() must return fusor(...) or undefined`
+    );
+  }
+  bindings.set(definition.name, {
+    client: fusorClient,
+    messages: hybrid.messages,
+    streamOnly: hybrid.streamOnly ?? false,
+  });
+}
+
+function collectFusorPlatformBindings(
+  platformStates: Map<string, PlatformRuntime>,
+  hybridBindings: Map<string, RuntimeHybridFusorBinding>
+): FusorPlatformBinding[] {
+  const bindings: FusorPlatformBinding[] = [];
+  for (const [name, state] of platformStates) {
+    const hybrid = hybridBindings.get(name);
+    if (hybrid) {
+      bindings.push({
+        name,
+        client: hybrid.client,
+        messages: hybrid.messages,
+        mode: "hybrid",
+        streamOnly: hybrid.streamOnly,
+      });
+      continue;
+    }
+    if (isFusorClient(state.client)) {
+      bindings.push({
+        name,
+        client: state.client,
+        messages: state.definition
+          .messages as unknown as FusorMessages<unknown>,
+        mode: "pure",
+        streamOnly: false,
+      });
+    }
+  }
+  return bindings;
+}
+
+function assertUniqueFusorRoutes(bindings: FusorPlatformBinding[]): void {
+  const ownerByRoute = new Map<string, string>();
+  for (const binding of bindings) {
+    const existingOwner = ownerByRoute.get(binding.client.platform);
+    if (existingOwner !== undefined) {
+      throw new Error(
+        `Fusor route "${binding.client.platform}" is registered by both "${existingOwner}" and "${binding.name}"`
+      );
+    }
+    ownerByRoute.set(binding.client.platform, binding.name);
+  }
+}
+
+async function waitForCloseWithin(
+  close: Promise<unknown>,
+  timeoutMs: number
+): Promise<boolean> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timedOut = await Promise.race([
+    close.then(() => false),
+    new Promise<true>((resolve) => {
+      timeout = setTimeout(() => resolve(true), timeoutMs);
+      timeout.unref();
+    }),
+  ]);
+  if (timeout) {
+    clearTimeout(timeout);
+  }
+  return !timedOut;
+}
+
+type DestroyableProvider = Pick<
+  PlatformRuntime,
+  "client" | "definition" | "store"
+>;
+
+async function destroyProvider(
+  state: DestroyableProvider,
+  phase: "rollback" | "stop"
+): Promise<void> {
+  const destroy = state.definition.lifecycle.destroyClient;
+  if (!destroy) {
+    return;
+  }
+  try {
+    await withSpan(
+      "spectrum.provider.destroy_client",
+      { "spectrum.provider": state.definition.name },
+      () => destroy({ client: state.client, store: state.store })
+    );
+  } catch (error) {
+    lifecycleLog.warn(
+      `spectrum: provider cleanup failed during ${phase}`,
+      {
+        "spectrum.lifecycle.platform": state.definition.name,
+        ...errorAttrs(error),
+      },
+      error
+    );
+  }
+}
+
+async function rollbackInitializedProviders(
+  states: Map<string, PlatformRuntime>
+): Promise<void> {
+  const initialized = Array.from(states.values()).reverse();
+  for (const state of initialized) {
+    await destroyProvider(state, "rollback");
+  }
+  states.clear();
+}
+
+function createFusorEventQueues(
+  binding: FusorPlatformBinding,
+  runtime: PlatformRuntime
+): Map<string, AsyncQueue<unknown>> {
+  const queues = new Map<string, AsyncQueue<unknown>>();
+  if (binding.mode === "hybrid") {
+    return queues;
+  }
+  for (const channel of Object.keys(runtime.definition.events ?? {})) {
+    queues.set(channel, createAsyncQueue<unknown>());
+  }
+  return queues;
+}
+
 export async function Spectrum<
   const Providers extends PlatformProviderConfig[],
 >(
@@ -326,13 +520,19 @@ export async function Spectrum<
 
   const platformStates = new Map<string, PlatformRuntime>();
 
-  // Per-platform fusor message queues (populated only for fusor-mode platforms).
-  // When set, the message stream pulls from this queue instead of calling
-  // `def.messages({ client, config, store })`.
-  const fusorMessageSources = new Map<
-    string,
-    AsyncQueue<ProviderMessageRecord>
-  >();
+  // Optional Fusor bindings for hybrid providers. These are deliberately kept
+  // separate from `PlatformRuntime.client`: the latter remains the provider's
+  // regular SDK client for every action, producer, record wrapper, and teardown.
+  const hybridFusorBindings = new Map<string, RuntimeHybridFusorBinding>();
+
+  // A Fusor wire route need not equal the provider's public Spectrum name
+  // (`imessage` vs `iMessage`). The synchronous webhook path needs this lookup
+  // to resolve records with the same regular runtime as streaming delivery.
+  const fusorRuntimeByRoute = new Map<string, PlatformRuntime>();
+
+  // Per-platform Fusor message queues. A pure-Fusor provider reads only this
+  // queue; a hybrid provider merges it with its regular `messages` producer.
+  const fusorMessageSources = new Map<string, RuntimeFusorMessageSource>();
 
   // Per-platform message broadcasters (lazy: created on first subscribe).
   const messageBroadcasters = new Map<string, Broadcaster<[Space, Message]>>();
@@ -349,6 +549,44 @@ export async function Spectrum<
   const customEventStreams = new Map<string, ManagedStream<unknown>>();
 
   let stopped = false;
+  let fusorCore: FusorCore | undefined;
+  let fusorStartPromise: Promise<void> | undefined;
+
+  // Open the Fusor WebSocket stream on demand — exactly once, when any
+  // message subscription that consumes a Fusor source begins iterating.
+  // Webhook-only setups never call this and therefore need no stream.
+  const ensureFusorStarted = (): Promise<void> => {
+    if (!fusorCore) {
+      return Promise.resolve();
+    }
+    fusorStartPromise ??= fusorCore.start();
+    return fusorStartPromise;
+  };
+
+  // Fail every Fusor queue on a terminal transport error so current and future
+  // subscribers observe it. Ordinary stop/rollback closes and drops them.
+  const closeFusorSources = (error?: unknown) => {
+    for (const source of fusorMessageSources.values()) {
+      if (error === undefined) {
+        source.queue.close();
+      } else {
+        source.queue.fail(error);
+      }
+    }
+    for (const queues of fusorEventSources.values()) {
+      for (const queue of queues.values()) {
+        if (error === undefined) {
+          queue.close();
+        } else {
+          queue.fail(error);
+        }
+      }
+    }
+    if (error === undefined) {
+      fusorMessageSources.clear();
+      fusorEventSources.clear();
+    }
+  };
 
   // Adapt any AsyncIterable into a ManagedStream, optionally projecting each
   // source value into zero or more output values via `project`. The pump is the
@@ -358,13 +596,15 @@ export async function Spectrum<
   // which is what lets `stop()` cancel a parked read instead of deadlocking.
   const adaptIterable = <TIn, TOut = TIn>(
     iterable: AsyncIterable<TIn>,
-    project?: (value: TIn, emit: (out: TOut) => Promise<void>) => Promise<void>
+    project?: (value: TIn, emit: (out: TOut) => Promise<void>) => Promise<void>,
+    beforeRead?: () => Promise<void>
   ): ManagedStream<TOut> =>
     stream<TOut>((emit, end) => {
       const iterator = iterable[Symbol.asyncIterator]();
 
       const pump = (async () => {
         try {
+          await beforeRead?.();
           let result = await iterator.next();
           while (!result.done) {
             if (project) {
@@ -456,14 +696,32 @@ export async function Spectrum<
   }): ManagedStream<[Space, Message]> => {
     const { client, config, definition, store } = state;
     const fusorSource = fusorMessageSources.get(definition.name);
-    const raw = fusorSource
-      ? fusorSource.iterable
-      : (definition.messages({
-          client,
-          config,
-          projectConfig,
-          store,
-        }) as unknown as AsyncIterable<ProviderMessageRecord>);
+    let raw: AsyncIterable<ProviderMessageRecord>;
+    if (!fusorSource) {
+      raw = definition.messages({
+        client,
+        config,
+        projectConfig,
+        store,
+      }) as unknown as AsyncIterable<ProviderMessageRecord>;
+    } else if (fusorSource.mode === "pure") {
+      // Legacy pure-Fusor provider: `definition.messages` is the per-payload
+      // callback, not an iterable, so its queue remains the sole raw source.
+      raw = fusorSource.queue.iterable;
+    } else {
+      // Hybrid provider: Fusor owns only one inbound lane. Keep the regular
+      // producer alive alongside it for event classes that still use the SDK.
+      const regular = definition.messages({
+        client,
+        config,
+        projectConfig,
+        store,
+      }) as unknown as AsyncIterable<ProviderMessageRecord>;
+      raw = mergeStreams([
+        adaptIterable(fusorSource.queue.iterable),
+        adaptIterable(regular),
+      ]);
+    }
 
     return adaptIterable<ProviderMessageRecord, [Space, Message]>(
       raw,
@@ -477,7 +735,8 @@ export async function Spectrum<
         for (const tuple of tuples) {
           await emit(tuple);
         }
-      }
+      },
+      fusorSource ? ensureFusorStarted : undefined
     );
   };
 
@@ -519,7 +778,7 @@ export async function Spectrum<
         `Spectrum instance has been stopped; cannot subscribe to "${platform}" event "${channel}"`
       );
     }
-    const key = `${platform} ${channel}`;
+    const key = `${platform}\0${channel}`;
     let broadcaster = eventBroadcasters.get(key);
     if (!broadcaster) {
       broadcaster = broadcast(adaptIterable(queue.iterable));
@@ -531,144 +790,178 @@ export async function Spectrum<
   // Initialize all provider clients eagerly. Each runtime exposes
   // `subscribeMessages()` that returns a fresh fanout consumer of the
   // platform's single upstream message stream.
-  await withSpan(
-    "spectrum.init",
-    {
-      "spectrum.provider_count": providers.length,
-      "spectrum.flatten_groups": flattenGroups,
-    },
-    async () => {
-      for (const provider of providers) {
-        const providerConfig = provider as PlatformProviderConfig;
-        const def = providerConfig.__definition;
-        const userConfig = def.config.parse(providerConfig.config);
-        const store = createStore();
+  try {
+    await withSpan(
+      "spectrum.init",
+      {
+        "spectrum.provider_count": providers.length,
+        "spectrum.flatten_groups": flattenGroups,
+      },
+      async () => {
+        for (const provider of providers) {
+          const providerConfig = provider as PlatformProviderConfig;
+          const def = providerConfig.__definition;
+          const userConfig = def.config.parse(providerConfig.config);
+          const store = createStore();
 
-        const client = await withSpan(
-          "spectrum.provider.create_client",
-          {
-            "spectrum.provider": def.name,
-          },
-          () =>
-            def.lifecycle.createClient({
-              config: userConfig,
-              projectId,
-              projectSecret,
-              projectConfig,
-              store,
-            })
-        );
+          const createContext = {
+            config: userConfig,
+            projectId,
+            projectSecret,
+            projectConfig,
+            store,
+          };
 
-        const state = {
-          client,
-          config: userConfig,
-          definition: def,
-          store,
-        };
+          const client = await withSpan(
+            "spectrum.provider.create_client",
+            {
+              "spectrum.provider": def.name,
+            },
+            () => def.lifecycle.createClient(createContext)
+          );
 
-        platformStates.set(def.name, {
-          ...state,
-          projectConfig,
-          subscribeMessages: () =>
-            getOrCreateMessageBroadcast(state).subscribe(),
-          // Fanout subscription to a fusor event channel. Returns undefined for
-          // regular platforms (no per-channel queue) — callers fall back to the
-          // producer path. Resolved lazily, after the fusor bootstrap below has
-          // created the per-(platform, channel) queues.
-          subscribeEvent: (channel: string) =>
-            getOrCreateEventBroadcast(def.name, channel)?.subscribe(),
-        });
+          try {
+            await initializeHybridFusorBinding(
+              hybridFusorBindings,
+              def,
+              client,
+              createContext
+            );
+          } catch (error) {
+            // The regular lifecycle client already exists but is not recorded
+            // in platformStates yet, so unwind it explicitly before the outer
+            // rollback handles every provider initialized earlier.
+            await destroyProvider(
+              { client, definition: def, store },
+              "rollback"
+            );
+            throw error;
+          }
+
+          const state = {
+            client,
+            config: userConfig,
+            definition: def,
+            store,
+          };
+
+          platformStates.set(def.name, {
+            ...state,
+            projectConfig,
+            subscribeMessages: () =>
+              getOrCreateMessageBroadcast(state).subscribe(),
+            // Fanout subscription to a fusor event channel. Returns undefined for
+            // regular platforms (no per-channel queue) — callers fall back to the
+            // producer path. Resolved lazily, after the fusor bootstrap below has
+            // created the per-(platform, channel) queues.
+            subscribeEvent: (channel: string) =>
+              getOrCreateEventBroadcast(def.name, channel)?.subscribe(),
+          });
+        }
       }
-    }
+    );
+  } catch (error) {
+    await rollbackInitializedProviders(platformStates);
+    hybridFusorBindings.clear();
+    await otelHandle?.shutdown().catch(ignoreCleanupError);
+    throw error;
+  }
+
+  // Bootstrap fusor: register legacy providers whose lifecycle client is a
+  // FusorClient plus enabled hybrid bindings whose separate `fusor.create`
+  // returned one. Both transports route through the same handlers. The
+  // WebSocket stream is NOT opened here — it starts lazily when a subscription
+  // begins consuming any Fusor-backed message source. spectrum.webhook()
+  // drives eligible handlers synchronously and never opens the stream.
+  const fusorPlatforms = collectFusorPlatformBindings(
+    platformStates,
+    hybridFusorBindings
   );
 
-  // Bootstrap fusor: if any provider's createClient returned a FusorClient,
-  // register a handler per platform so both transports can route to it. The
-  // gRPC stream is NOT opened here — it starts lazily on the first
-  // spectrum.messages subscription (ensureFusorStarted). spectrum.webhook()
-  // drives the same handlers synchronously and never opens the stream.
-  let fusorCore: FusorCore | undefined;
-  let fusorStartPromise: Promise<void> | undefined;
-  const fusorPlatforms: { name: string; client: FusorClient }[] = [];
-  for (const [name, state] of platformStates) {
-    if (isFusorClient(state.client)) {
-      fusorPlatforms.push({ name, client: state.client });
-    }
-  }
+  try {
+    // Detect collisions before allocating a core or any queues. A failure must
+    // unwind every regular lifecycle client created above.
+    assertUniqueFusorRoutes(fusorPlatforms);
 
-  if (fusorPlatforms.length > 0) {
-    fusorCore = new FusorCore({ projectId, projectSecret });
-    for (const { name, client } of fusorPlatforms) {
-      const queue = createAsyncQueue<ProviderMessageRecord>();
-      fusorMessageSources.set(name, queue);
+    if (fusorPlatforms.length > 0) {
+      fusorCore = new FusorCore({
+        cursorStore: runtimeOptions?.fusorCursorStore,
+        onTerminal: closeFusorSources,
+        projectId,
+        projectSecret,
+      });
+      for (const binding of fusorPlatforms) {
+        const { name, client } = binding;
+        const runtime = platformStates.get(name);
+        if (!runtime) {
+          throw new Error(`Missing runtime for Fusor provider "${name}"`);
+        }
 
-      const runtime = platformStates.get(name);
-      if (!runtime) {
-        continue;
+        const queue = createAsyncQueue<ProviderMessageRecord>();
+        fusorMessageSources.set(name, { mode: binding.mode, queue });
+
+        // One queue per declared event channel (schema-valued `events` keys).
+        // `pushEvent` routes a `fusorEvent(channel, data)` here; an undeclared
+        // channel (a typo in the handler) is warned and dropped rather than
+        // silently lost.
+        const eventQueues = createFusorEventQueues(binding, runtime);
+        fusorEventSources.set(name, eventQueues);
+
+        const handler: RegisteredFusorHandler = {
+          verify: client.verify,
+          streamOnly: binding.streamOnly,
+          // Enrich the transport-level `{ payload, respond }` ctx with the same
+          // runtime context every other platform callback receives, so fusor
+          // handlers can read config/store/projectConfig directly instead of
+          // smuggling state through the payload.
+          messages: async (ctx) => {
+            const common = {
+              ...ctx,
+              config: runtime.config,
+              store: runtime.store,
+              projectConfig: runtime.projectConfig,
+            };
+            if (binding.mode === "hybrid") {
+              return await binding.messages({
+                ...common,
+                client: runtime.client,
+              });
+            }
+            return await binding.messages(common);
+          },
+          pushMessage: (record) => queue.push(record),
+          pushEvent: (channel, data) => {
+            const eventQueue = eventQueues.get(channel);
+            if (!eventQueue) {
+              lifecycleLog.warn(
+                `spectrum: fusorEvent("${channel}", …) names a channel not declared in "${name}".events; dropping`,
+                {
+                  "spectrum.lifecycle.platform": name,
+                  "spectrum.lifecycle.channel": channel,
+                }
+              );
+              return;
+            }
+            eventQueue.push(data);
+          },
+        };
+        fusorRuntimeByRoute.set(client.platform, runtime);
+        fusorCore.register(client.platform, handler);
       }
-      const userMessages = runtime.definition
-        .messages as unknown as FusorMessages<unknown>;
-
-      // One queue per declared event channel (schema-valued `events` keys).
-      // `pushEvent` routes a `fusorEvent(channel, data)` here; an undeclared
-      // channel (a typo in the handler) is warned and dropped rather than
-      // silently lost.
-      const declaredEvents = (runtime.definition.events ?? {}) as Record<
-        string,
-        unknown
-      >;
-      const eventQueues = new Map<string, AsyncQueue<unknown>>();
-      for (const channel of Object.keys(declaredEvents)) {
-        eventQueues.set(channel, createAsyncQueue<unknown>());
-      }
-      fusorEventSources.set(name, eventQueues);
-
-      const handler: RegisteredFusorHandler = {
-        verify: client.verify,
-        // Enrich the transport-level `{ payload, respond }` ctx with the same
-        // runtime context every other platform callback receives, so fusor
-        // handlers can read config/store/projectConfig directly instead of
-        // smuggling state through the payload.
-        messages: async (ctx) =>
-          userMessages({
-            ...ctx,
-            config: runtime.config,
-            store: runtime.store,
-            projectConfig: runtime.projectConfig,
-          }),
-        pushMessage: (record) => queue.push(record),
-        pushEvent: (channel, data) => {
-          const eventQueue = eventQueues.get(channel);
-          if (!eventQueue) {
-            lifecycleLog.warn(
-              `spectrum: fusorEvent("${channel}", …) names a channel not declared in "${name}".events; dropping`,
-              {
-                "spectrum.lifecycle.platform": name,
-                "spectrum.lifecycle.channel": channel,
-              }
-            );
-            return;
-          }
-          eventQueue.push(data);
-        },
-      };
-      fusorCore.register(client.platform, handler);
     }
+  } catch (error) {
+    closeFusorSources();
+    if (fusorCore) {
+      const closing = fusorCore.close().catch(ignoreCleanupError);
+      await waitForCloseWithin(closing, FUSOR_CLOSE_TIMEOUT_MS);
+      fusorCore = undefined;
+    }
+    fusorRuntimeByRoute.clear();
+    await rollbackInitializedProviders(platformStates);
+    hybridFusorBindings.clear();
+    await otelHandle?.shutdown().catch(ignoreCleanupError);
+    throw error;
   }
-
-  // Open the fusor gRPC stream on demand — exactly once, on the first
-  // spectrum.messages subscription. Requires cloud credentials (enforced in
-  // FusorCore.start). Webhook-only setups never call this, so they never
-  // connect and don't need credentials.
-  const ensureFusorStarted = (): Promise<void> => {
-    if (!fusorCore) {
-      return Promise.resolve();
-    }
-    if (!fusorStartPromise) {
-      fusorStartPromise = fusorCore.start();
-    }
-    return fusorStartPromise;
-  };
 
   const providerNames = providers
     .map((p) => (p as PlatformProviderConfig).__definition.name)
@@ -714,10 +1007,6 @@ export async function Spectrum<
 
   const createMessagesStream = (): ManagedStream<[Space, Message]> =>
     stream<[Space, Message]>((emit, end) => {
-      // Open the fusor gRPC stream lazily on first subscription. A fatal connect
-      // failure (e.g. missing credentials) surfaces on this iterator. Non-async
-      // so subscribe stays non-blocking. Webhook-only setups never reach here.
-      ensureFusorStarted().catch((error) => end(error));
       const merged = mergeStreams(
         Array.from(platformStates.values(), (runtime) =>
           runtime.subscribeMessages()
@@ -814,22 +1103,6 @@ export async function Spectrum<
 
   const messagesStream = createMessagesStream();
 
-  // Close + drop every fusor queue (per-platform message queues and
-  // per-(platform, channel) event queues). Extracted from stopOnce to keep its
-  // cognitive complexity in check.
-  const closeFusorSources = () => {
-    for (const queue of fusorMessageSources.values()) {
-      queue.close();
-    }
-    fusorMessageSources.clear();
-    for (const queues of fusorEventSources.values()) {
-      for (const queue of queues.values()) {
-        queue.close();
-      }
-    }
-    fusorEventSources.clear();
-  };
-
   const stopOnce = async () => {
     if (stopped) {
       return;
@@ -878,39 +1151,29 @@ export async function Spectrum<
     let fusorCloseMs = 0;
     if (fusorCore) {
       const fusorCloseStart = performance.now();
-      // If a lazy gRPC start is in flight, let it finish wiring before teardown
-      // so close() doesn't race a half-built connection.
-      if (fusorStartPromise) {
-        await fusorStartPromise.catch(ignoreCleanupError);
-      }
-      await fusorCore.close().catch((error) => {
+      const closeAttempt = fusorCore.close().catch((error) => {
         lifecycleLog.warn("fusor core close failed", errorAttrs(error), error);
       });
+      const closed = await waitForCloseWithin(
+        closeAttempt,
+        FUSOR_CLOSE_TIMEOUT_MS
+      );
+      if (!closed) {
+        lifecycleLog.warn(
+          "fusor core close timed out; proceeding to provider teardown",
+          {
+            "spectrum.lifecycle.fusor_close_timeout_ms": FUSOR_CLOSE_TIMEOUT_MS,
+          }
+        );
+      }
       fusorCloseMs = Math.round(performance.now() - fusorCloseStart);
       closeFusorSources();
     }
 
     // Phase 3: destroy clients
-    const clientShutdowns: Promise<void>[] = [];
-    for (const state of platformStates.values()) {
-      const destroy = state.definition.lifecycle.destroyClient;
-      if (!destroy) {
-        continue;
-      }
-      clientShutdowns.push(
-        withSpan(
-          "spectrum.provider.destroy_client",
-          {
-            "spectrum.provider": state.definition.name,
-          },
-          () =>
-            destroy({
-              client: state.client,
-              store: state.store,
-            })
-        )
-      );
-    }
+    const clientShutdowns = Array.from(platformStates.values(), (state) =>
+      destroyProvider(state, "stop")
+    );
     const clientCloseStart = performance.now();
     await Promise.allSettled(clientShutdowns);
     const clientCloseMs = Math.round(performance.now() - clientCloseStart);
@@ -923,6 +1186,8 @@ export async function Spectrum<
     customEventStreams.clear();
     messageBroadcasters.clear();
     eventBroadcasters.clear();
+    hybridFusorBindings.clear();
+    fusorRuntimeByRoute.clear();
     platformStates.clear();
     lifecycleLog.info("Spectrum stopped", {
       "spectrum.lifecycle.providers": providerNames,
@@ -1066,9 +1331,13 @@ export async function Spectrum<
     handler: WebhookHandler
   ): Promise<WebhookRawResult> => {
     const collected: ProviderMessageRecord[] = [];
-    const reply = await core.processEvent(event, (record) => {
-      collected.push(record);
-    });
+    const reply = await core.processEvent(
+      event,
+      (record) => {
+        collected.push(record);
+      },
+      "webhook"
+    );
 
     // A verify/parse/no-handler failure is poison — 400 (a retry won't help).
     if (reply.errorReason) {
@@ -1094,7 +1363,9 @@ export async function Spectrum<
     // never surfaced as a 500 / fusor retry. On a long-running server the event
     // loop keeps this alive; on serverless, keeping it alive past the response is
     // the caller's responsibility (e.g. enqueue + process in a separate worker).
-    const runtime = platformStates.get(event.platform);
+    const runtime =
+      fusorRuntimeByRoute.get(event.platform) ??
+      platformStates.get(event.platform);
     if (runtime && collected.length > 0) {
       // Per-message handler throws are isolated + logged inside
       // deliverWebhookMessages; this safety net only fires on a message

--- a/packages/core/src/utils/cloud.ts
+++ b/packages/core/src/utils/cloud.ts
@@ -24,6 +24,8 @@ export interface DedicatedTokenData {
   auth: Record<string, string>;
   expiresIn: number;
   numbers: Record<string, string | null>;
+  /** Project-scoped bearer for Spectrum's virtual-resource proxy. */
+  proxyToken: string;
   type: "dedicated";
 }
 

--- a/packages/core/src/utils/stream.ts
+++ b/packages/core/src/utils/stream.ts
@@ -6,6 +6,7 @@ export interface ManagedStream<T> extends AsyncIterable<T> {
 
 export interface AsyncQueue<T> {
   close(): void;
+  fail(error: unknown): void;
   iterable: AsyncIterable<T>;
   push(value: T): void;
 }
@@ -17,16 +18,21 @@ export interface AsyncQueue<T> {
  */
 export function createAsyncQueue<T>(): AsyncQueue<T> {
   const buffer: T[] = [];
-  const resolvers: ((result: IteratorResult<T, undefined>) => void)[] = [];
+  const waiters: {
+    reject: (error: unknown) => void;
+    resolve: (result: IteratorResult<T, undefined>) => void;
+  }[] = [];
   let closed = false;
+  let failure: unknown;
+  let failed = false;
 
   const push = (value: T): void => {
     if (closed) {
       return;
     }
-    const resolver = resolvers.shift();
-    if (resolver) {
-      resolver({ value, done: false });
+    const waiter = waiters.shift();
+    if (waiter) {
+      waiter.resolve({ value, done: false });
     } else {
       buffer.push(value);
     }
@@ -37,9 +43,21 @@ export function createAsyncQueue<T>(): AsyncQueue<T> {
       return;
     }
     closed = true;
-    while (resolvers.length > 0) {
-      const resolver = resolvers.shift();
-      resolver?.({ value: undefined, done: true });
+    while (waiters.length > 0) {
+      const waiter = waiters.shift();
+      waiter?.resolve({ value: undefined, done: true });
+    }
+  };
+
+  const fail = (error: unknown): void => {
+    if (closed) {
+      return;
+    }
+    closed = true;
+    failed = true;
+    failure = error;
+    while (waiters.length > 0) {
+      waiters.shift()?.reject(error);
     }
   };
 
@@ -51,11 +69,14 @@ export function createAsyncQueue<T>(): AsyncQueue<T> {
             const value = buffer.shift() as T;
             return Promise.resolve({ value, done: false });
           }
+          if (failed) {
+            return Promise.reject(failure);
+          }
           if (closed) {
             return Promise.resolve({ value: undefined, done: true });
           }
-          return new Promise((resolve) => {
-            resolvers.push(resolve);
+          return new Promise((resolve, reject) => {
+            waiters.push({ reject, resolve });
           });
         },
         return(): Promise<IteratorResult<T, undefined>> {
@@ -66,7 +87,7 @@ export function createAsyncQueue<T>(): AsyncQueue<T> {
     },
   };
 
-  return { iterable, push, close };
+  return { iterable, push, close, fail };
 }
 
 type StreamCleanup = void | (() => void | Promise<void>);

--- a/packages/core/test/core/fusor/hybrid.test.ts
+++ b/packages/core/test/core/fusor/hybrid.test.ts
@@ -27,7 +27,7 @@ describe("hybrid Fusor providers", () => {
   it("routes a wire name to a differently named provider and gives the handler its regular runtime context", async () => {
     const seen = capture();
     const fixture = makeHybrid(seen, {
-      name: "iMessage Display",
+      name: "imessage_display",
       route: "imessage-wire",
     });
     const spectrum = await Spectrum({
@@ -53,8 +53,8 @@ describe("hybrid Fusor providers", () => {
     await delivered;
 
     expect(result.status).toBe(200);
-    expect(received?.[0].__platform).toBe("iMessage Display");
-    expect(received?.[1].platform).toBe("iMessage Display");
+    expect(received?.[0].__platform).toBe("imessage_display");
+    expect(received?.[1].platform).toBe("imessage_display");
     expect(received?.[1].id).toBe("fusor-from-webhook");
     expect(seen.createClient).toBe(fixture.client);
     expect(seen.createConfig).toEqual({ token: "hybrid-token" });
@@ -134,12 +134,12 @@ describe("hybrid Fusor providers", () => {
     const firstSeen = capture();
     const failingSeen = capture();
     const first = makeHybrid(firstSeen, {
-      name: "Initialized First",
+      name: "initialized_first",
       route: "initialized-first-wire",
     });
     const failing = makeHybrid(failingSeen, {
       createError: new Error("second binding failed"),
-      name: "Fails Second",
+      name: "fails_second",
       route: "fails-second-wire",
     });
 
@@ -158,11 +158,11 @@ describe("hybrid Fusor providers", () => {
     const firstSeen = capture();
     const secondSeen = capture();
     const first = makeHybrid(firstSeen, {
-      name: "Duplicate Route One",
+      name: "duplicate_route_one",
       route: "shared-wire-route",
     });
     const second = makeHybrid(secondSeen, {
-      name: "Duplicate Route Two",
+      name: "duplicate_route_two",
       route: "shared-wire-route",
     });
 
@@ -172,7 +172,7 @@ describe("hybrid Fusor providers", () => {
         providers: [first.provider, second.provider],
       })
     ).rejects.toThrow(
-      'Fusor route "shared-wire-route" is registered by both "Duplicate Route One" and "Duplicate Route Two"'
+      'Fusor route "shared-wire-route" is registered by both "duplicate_route_one" and "duplicate_route_two"'
     );
 
     expect(firstSeen.destroyedClient).toBe(first.client);
@@ -182,7 +182,7 @@ describe("hybrid Fusor providers", () => {
   it("keeps a stream-only binding off direct webhooks and starts Fusor from provider messages", async () => {
     const seen = capture();
     const fixture = makeHybrid(seen, {
-      name: "Stream Only Hybrid",
+      name: "stream_only_hybrid",
       route: "stream-only-wire",
       streamOnly: true,
     });
@@ -269,7 +269,7 @@ describe("hybrid Fusor providers", () => {
 
   it("keeps hybrid custom events on their regular producer", async () => {
     const seen = capture();
-    const fixture = makeHybrid(seen, { name: "Hybrid Events" });
+    const fixture = makeHybrid(seen, { name: "hybrid_events" });
     const spectrum = await Spectrum({
       ...baseConfig,
       providers: [fixture.provider],
@@ -284,7 +284,7 @@ describe("hybrid Fusor providers", () => {
 
     await expect(pending).resolves.toEqual({
       done: false,
-      value: { platform: "Hybrid Events", state: "ready" },
+      value: { platform: "hybrid_events", state: "ready" },
     });
     expect(seen.regularEventProducerCalls).toBe(1);
 
@@ -300,7 +300,7 @@ describe("hybrid Fusor providers", () => {
     try {
       const seen = capture();
       const fixture = makeHybrid(seen, {
-        name: "Blocked Fusor Close",
+        name: "blocked_fusor_close",
         route: "blocked-close-wire",
       });
       const spectrum = await Spectrum({

--- a/packages/core/test/core/fusor/hybrid.test.ts
+++ b/packages/core/test/core/fusor/hybrid.test.ts
@@ -1,0 +1,322 @@
+import { RawInboundEvent } from "@photon-ai/proto/photon/fusor/v1/inbound";
+import { stubCloud } from "@spectrum-ts/test-support/cloud";
+import {
+  encodeEvent,
+  type HybridCapture,
+  makeHybrid,
+} from "@spectrum-ts/test-support/fusor";
+import { baseConfig } from "@spectrum-ts/test-support/platform";
+import { describe, expect, it, vi } from "vitest";
+import { text } from "@/content/text";
+import { FusorCore } from "@/fusor/core";
+import { FUSOR_BRAND } from "@/fusor/types";
+import { Spectrum } from "@/spectrum";
+import type { Message } from "@/types/message";
+import type { Space } from "@/types/space";
+
+stubCloud();
+
+const NO_FUSOR_PROVIDER_ERROR = /no fusor provider is configured/;
+
+const capture = (): HybridCapture => ({
+  regularEventProducerCalls: 0,
+  regularMessagesCalls: 0,
+});
+
+describe("hybrid Fusor providers", () => {
+  it("routes a wire name to a differently named provider and gives the handler its regular runtime context", async () => {
+    const seen = capture();
+    const fixture = makeHybrid(seen, {
+      name: "iMessage Display",
+      route: "imessage-wire",
+    });
+    const spectrum = await Spectrum({
+      ...baseConfig,
+      providers: [fixture.provider],
+    });
+    const { promise: delivered, resolve: done } = Promise.withResolvers<void>();
+    let received: [Space, Message] | undefined;
+
+    const result = await spectrum.webhook(
+      {
+        headers: {},
+        body: encodeEvent(
+          "imessage-wire",
+          JSON.stringify({ text: "from-webhook" })
+        ),
+      },
+      (space, message) => {
+        received = [space, message];
+        done();
+      }
+    );
+    await delivered;
+
+    expect(result.status).toBe(200);
+    expect(received?.[0].__platform).toBe("iMessage Display");
+    expect(received?.[1].platform).toBe("iMessage Display");
+    expect(received?.[1].id).toBe("fusor-from-webhook");
+    expect(seen.createClient).toBe(fixture.client);
+    expect(seen.createConfig).toEqual({ token: "hybrid-token" });
+    expect(seen.handlerClient).toBe(fixture.client);
+    expect(seen.handlerConfig).toEqual({ token: "hybrid-token" });
+    expect(seen.handlerProjectConfig).toEqual({
+      id: "proj",
+      name: "Test Project",
+      profile: {},
+      slug: "test-project",
+    });
+    expect(seen.handlerStoreRoundTrip).toBe("from-webhook");
+    expect(seen.handlerStore).toBeDefined();
+
+    await spectrum.stop();
+    expect(seen.destroyedClient).toBe(fixture.client);
+  });
+
+  it("can disable Fusor at initialization and stay credential-free on the regular transport", async () => {
+    const seen = capture();
+    const fixture = makeHybrid(seen, {
+      enabled: false,
+      regularMessageId: "regular-only",
+    });
+    const startSpy = vi
+      .spyOn(FusorCore.prototype, "start")
+      .mockResolvedValue(undefined);
+    try {
+      const spectrum = await Spectrum({ providers: [fixture.provider] });
+      const iterator = spectrum.messages[Symbol.asyncIterator]();
+      const first = await iterator.next();
+
+      expect(first.done).toBe(false);
+      expect(first.value?.[1].id).toBe("regular-only");
+      expect(seen.createClient).toBe(fixture.client);
+      expect(seen.handlerClient).toBeUndefined();
+      expect(seen.regularMessagesCalls).toBe(1);
+      expect(startSpy).not.toHaveBeenCalled();
+
+      if (!first.value) {
+        throw new Error("expected a regular hybrid-provider message");
+      }
+      await first.value[0].send(text("outbound"));
+      expect(seen.sendClient).toBe(fixture.client);
+
+      await expect(
+        spectrum.webhook(
+          { headers: {}, body: new Uint8Array([0]) },
+          () => undefined
+        )
+      ).rejects.toThrow(NO_FUSOR_PROVIDER_ERROR);
+
+      await iterator.return?.();
+      await spectrum.stop();
+      expect(seen.destroyedClient).toBe(fixture.client);
+    } finally {
+      startSpy.mockRestore();
+    }
+  });
+
+  it("destroys the regular client when hybrid initialization fails", async () => {
+    const seen = capture();
+    const fixture = makeHybrid(seen, {
+      createError: new Error("binding failed"),
+    });
+
+    await expect(
+      Spectrum({
+        ...baseConfig,
+        providers: [fixture.provider],
+      })
+    ).rejects.toThrow("binding failed");
+    expect(seen.destroyedClient).toBe(fixture.client);
+  });
+
+  it("rolls back every earlier provider when a later hybrid binding fails", async () => {
+    const firstSeen = capture();
+    const failingSeen = capture();
+    const first = makeHybrid(firstSeen, {
+      name: "Initialized First",
+      route: "initialized-first-wire",
+    });
+    const failing = makeHybrid(failingSeen, {
+      createError: new Error("second binding failed"),
+      name: "Fails Second",
+      route: "fails-second-wire",
+    });
+
+    await expect(
+      Spectrum({
+        ...baseConfig,
+        providers: [first.provider, failing.provider],
+      })
+    ).rejects.toThrow("second binding failed");
+
+    expect(firstSeen.destroyedClient).toBe(first.client);
+    expect(failingSeen.destroyedClient).toBe(failing.client);
+  });
+
+  it("preflights duplicate Fusor routes and rolls back every provider", async () => {
+    const firstSeen = capture();
+    const secondSeen = capture();
+    const first = makeHybrid(firstSeen, {
+      name: "Duplicate Route One",
+      route: "shared-wire-route",
+    });
+    const second = makeHybrid(secondSeen, {
+      name: "Duplicate Route Two",
+      route: "shared-wire-route",
+    });
+
+    await expect(
+      Spectrum({
+        ...baseConfig,
+        providers: [first.provider, second.provider],
+      })
+    ).rejects.toThrow(
+      'Fusor route "shared-wire-route" is registered by both "Duplicate Route One" and "Duplicate Route Two"'
+    );
+
+    expect(firstSeen.destroyedClient).toBe(first.client);
+    expect(secondSeen.destroyedClient).toBe(second.client);
+  });
+
+  it("keeps a stream-only binding off direct webhooks and starts Fusor from provider messages", async () => {
+    const seen = capture();
+    const fixture = makeHybrid(seen, {
+      name: "Stream Only Hybrid",
+      route: "stream-only-wire",
+      streamOnly: true,
+    });
+    const event = RawInboundEvent.decode(
+      encodeEvent("stream-only-wire", JSON.stringify({ text: "authenticated" }))
+    );
+    const startSpy = vi
+      .spyOn(FusorCore.prototype, "start")
+      .mockImplementation(async function (this: FusorCore) {
+        await this.processEvent(event, undefined, "stream");
+      });
+    try {
+      const spectrum = await Spectrum({
+        ...baseConfig,
+        providers: [fixture.provider],
+      });
+      const webhookHandler = vi.fn();
+
+      const webhookResult = await spectrum.webhook(
+        { headers: {}, body: RawInboundEvent.encode(event).finish() },
+        webhookHandler
+      );
+
+      expect(webhookResult.status).toBe(400);
+      expect(webhookHandler).not.toHaveBeenCalled();
+      expect(seen.handlerClient).toBeUndefined();
+      expect(startSpy).not.toHaveBeenCalled();
+
+      const providerMessages = fixture.platform(spectrum).messages;
+      const iterator = providerMessages[Symbol.asyncIterator]();
+      const streamed = await iterator.next();
+
+      expect(streamed.done).toBe(false);
+      expect(streamed.value?.[1].id).toBe("fusor-authenticated");
+      expect(startSpy).toHaveBeenCalledTimes(1);
+      expect(seen.handlerClient).toBe(fixture.client);
+
+      await iterator.return?.();
+      await spectrum.stop();
+    } finally {
+      startSpy.mockRestore();
+    }
+  });
+
+  it("merges Fusor records with the provider's regular messages producer", async () => {
+    const seen = capture();
+    const fixture = makeHybrid(seen, {
+      regularMessageId: "regular-lane",
+      route: "hybrid-merge-wire",
+    });
+    // A hybrid's lifecycle client can be structurally branded by another
+    // integration. Runtime source selection must use the binding mode recorded
+    // at bootstrap, not re-infer the mode from this client object.
+    Object.defineProperty(fixture.client, FUSOR_BRAND, { value: true });
+    const event = RawInboundEvent.decode(
+      encodeEvent("hybrid-merge-wire", JSON.stringify({ text: "stream-lane" }))
+    );
+    const startSpy = vi
+      .spyOn(FusorCore.prototype, "start")
+      .mockImplementation(async function (this: FusorCore) {
+        await this.processEvent(event);
+      });
+    try {
+      const spectrum = await Spectrum({
+        ...baseConfig,
+        providers: [fixture.provider],
+      });
+      const iterator = spectrum.messages[Symbol.asyncIterator]();
+      const first = await iterator.next();
+      const second = await iterator.next();
+      const ids = [first.value?.[1].id, second.value?.[1].id].sort();
+
+      expect(ids).toEqual(["fusor-stream-lane", "regular-lane"]);
+      expect(startSpy).toHaveBeenCalledTimes(1);
+      expect(seen.regularMessagesCalls).toBe(1);
+      expect(seen.handlerClient).toBe(fixture.client);
+
+      await iterator.return?.();
+      await spectrum.stop();
+    } finally {
+      startSpy.mockRestore();
+    }
+  });
+
+  it("keeps hybrid custom events on their regular producer", async () => {
+    const seen = capture();
+    const fixture = makeHybrid(seen, { name: "Hybrid Events" });
+    const spectrum = await Spectrum({
+      ...baseConfig,
+      providers: [fixture.provider],
+    });
+    const iterator = (
+      spectrum as unknown as {
+        status: AsyncIterable<{ platform: string; state: string }>;
+      }
+    ).status[Symbol.asyncIterator]();
+    const pending = iterator.next();
+    fixture.pushEvent("ready");
+
+    await expect(pending).resolves.toEqual({
+      done: false,
+      value: { platform: "Hybrid Events", state: "ready" },
+    });
+    expect(seen.regularEventProducerCalls).toBe(1);
+
+    await iterator.return?.();
+    await spectrum.stop();
+  });
+
+  it("bounds Fusor close before tearing down provider clients", async () => {
+    vi.useFakeTimers();
+    const closeSpy = vi
+      .spyOn(FusorCore.prototype, "close")
+      .mockImplementation(() => new Promise<void>(() => undefined));
+    try {
+      const seen = capture();
+      const fixture = makeHybrid(seen, {
+        name: "Blocked Fusor Close",
+        route: "blocked-close-wire",
+      });
+      const spectrum = await Spectrum({
+        ...baseConfig,
+        providers: [fixture.provider],
+      });
+
+      const stopping = spectrum.stop();
+      await vi.advanceTimersByTimeAsync(5000);
+      await stopping;
+
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+      expect(seen.destroyedClient).toBe(fixture.client);
+    } finally {
+      closeSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/core/test/core/fusor/webhook.test.ts
+++ b/packages/core/test/core/fusor/webhook.test.ts
@@ -1,3 +1,4 @@
+import { RawInboundEvent } from "@photon-ai/proto/photon/fusor/v1/inbound";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
   CTX_PROBE_PLATFORM,
@@ -421,44 +422,139 @@ describe("spectrum.webhook", () => {
 });
 
 describe("fusor events", () => {
-  it("routes fusorEvent(channel) to spectrum.<channel>, not the message handler", async () => {
-    const spectrum = await Spectrum({
-      ...baseConfig,
-      providers: [makePresence().config({})],
-    });
-    // Attach to the presence stream before firing so the broadcaster is wired.
-    const presence = (
-      spectrum as unknown as { presence: AsyncIterable<unknown> }
-    ).presence[Symbol.asyncIterator]();
-    const firstPresence = presence.next();
-
-    let handlerCalls = 0;
-    const result = await spectrum.webhook(
-      {
-        headers: {},
-        body: encodeEvent(
-          PRESENCE_PLATFORM,
-          JSON.stringify({ type: "presence", user: "alice" })
-        ),
-      },
-      () => {
-        handlerCalls += 1;
-      }
+  it("starts a pure-Fusor custom event stream once when it is consumed", async () => {
+    const provider = makePresence();
+    const event = RawInboundEvent.decode(
+      encodeEvent(
+        PRESENCE_PLATFORM,
+        JSON.stringify({ type: "presence", user: "stream-user" }),
+        "evt-stream-presence"
+      )
     );
-    expect(result.status).toBe(200);
+    const startGate = Promise.withResolvers<void>();
+    const startSpy = vi
+      .spyOn(FusorCore.prototype, "start")
+      .mockImplementation(async function (this: FusorCore) {
+        await startGate.promise;
+        await this.processEvent(event);
+      });
 
-    const event = await firstPresence;
-    expect(event.done).toBe(false);
-    expect(event.value).toEqual({
-      user: "alice",
-      online: true,
-      platform: PRESENCE_PLATFORM,
-    });
-    // The event went to the channel, NOT the (messages-only) webhook handler.
-    expect(handlerCalls).toBe(0);
+    try {
+      const spectrum = await Spectrum({
+        ...baseConfig,
+        providers: [provider.config({})],
+      });
+      expect(startSpy).not.toHaveBeenCalled();
 
-    await presence.return?.();
-    await spectrum.stop();
+      const topLevel = (
+        spectrum as unknown as { presence: AsyncIterable<unknown> }
+      ).presence[Symbol.asyncIterator]();
+      const platformLevel = (
+        provider(spectrum) as unknown as { presence: AsyncIterable<unknown> }
+      ).presence[Symbol.asyncIterator]();
+      const topLevelEvent = topLevel.next();
+      const platformLevelEvent = platformLevel.next();
+      startGate.resolve();
+
+      const expected = {
+        user: "stream-user",
+        online: true,
+        platform: PRESENCE_PLATFORM,
+      };
+      await expect(topLevelEvent).resolves.toEqual({
+        done: false,
+        value: expected,
+      });
+      await expect(platformLevelEvent).resolves.toEqual({
+        done: false,
+        value: { user: "stream-user", online: true },
+      });
+      expect(startSpy).toHaveBeenCalledTimes(1);
+
+      await topLevel.return?.();
+      await platformLevel.return?.();
+      await spectrum.stop();
+    } finally {
+      startGate.resolve();
+      startSpy.mockRestore();
+    }
+  });
+
+  it("does not start Fusor for webhook-only custom event delivery", async () => {
+    const startSpy = vi
+      .spyOn(FusorCore.prototype, "start")
+      .mockResolvedValue(undefined);
+    try {
+      const spectrum = await Spectrum({
+        ...baseConfig,
+        providers: [makePresence().config({})],
+      });
+
+      const result = await spectrum.webhook(
+        {
+          headers: {},
+          body: encodeEvent(
+            PRESENCE_PLATFORM,
+            JSON.stringify({ type: "presence", user: "webhook-user" })
+          ),
+        },
+        () => undefined
+      );
+
+      expect(result.status).toBe(200);
+      expect(startSpy).not.toHaveBeenCalled();
+      await spectrum.stop();
+    } finally {
+      startSpy.mockRestore();
+    }
+  });
+
+  it("routes fusorEvent(channel) to spectrum.<channel>, not the message handler", async () => {
+    const startSpy = vi
+      .spyOn(FusorCore.prototype, "start")
+      .mockResolvedValue(undefined);
+    try {
+      const spectrum = await Spectrum({
+        ...baseConfig,
+        providers: [makePresence().config({})],
+      });
+      // Attach to the presence stream before firing so the broadcaster is wired.
+      const presence = (
+        spectrum as unknown as { presence: AsyncIterable<unknown> }
+      ).presence[Symbol.asyncIterator]();
+      const firstPresence = presence.next();
+
+      let handlerCalls = 0;
+      const result = await spectrum.webhook(
+        {
+          headers: {},
+          body: encodeEvent(
+            PRESENCE_PLATFORM,
+            JSON.stringify({ type: "presence", user: "alice" })
+          ),
+        },
+        () => {
+          handlerCalls += 1;
+        }
+      );
+      expect(result.status).toBe(200);
+
+      const event = await firstPresence;
+      expect(event.done).toBe(false);
+      expect(event.value).toEqual({
+        user: "alice",
+        online: true,
+        platform: PRESENCE_PLATFORM,
+      });
+      // The event went to the channel, NOT the (messages-only) webhook handler.
+      expect(handlerCalls).toBe(0);
+      expect(startSpy).toHaveBeenCalledTimes(1);
+
+      await presence.return?.();
+      await spectrum.stop();
+    } finally {
+      startSpy.mockRestore();
+    }
   });
 
   it("treats fusorEvent('messages', record) like a bare record", async () => {

--- a/packages/core/test/core/fusor/webhook.test.ts
+++ b/packages/core/test/core/fusor/webhook.test.ts
@@ -17,7 +17,7 @@ import {
 } from "@spectrum-ts/test-support/timing";
 import { describe, expect, it, vi } from "vitest";
 import { FusorCore } from "@/fusor/core";
-import { Spectrum } from "@/spectrum";
+import { Spectrum, type SpectrumInstance } from "@/spectrum";
 import type { Message } from "@/types/message";
 
 stubCloud();
@@ -438,22 +438,27 @@ describe("fusor events", () => {
         await startGate.promise;
         await this.processEvent(event);
       });
+    let spectrum: SpectrumInstance | undefined;
+    let topLevel: AsyncIterator<unknown> | undefined;
+    let platformLevel: AsyncIterator<unknown> | undefined;
+    let topLevelEvent: Promise<IteratorResult<unknown>> | undefined;
+    let platformLevelEvent: Promise<IteratorResult<unknown>> | undefined;
 
     try {
-      const spectrum = await Spectrum({
+      spectrum = await Spectrum({
         ...baseConfig,
         providers: [provider.config({})],
       });
       expect(startSpy).not.toHaveBeenCalled();
 
-      const topLevel = (
+      topLevel = (
         spectrum as unknown as { presence: AsyncIterable<unknown> }
       ).presence[Symbol.asyncIterator]();
-      const platformLevel = (
+      platformLevel = (
         provider(spectrum) as unknown as { presence: AsyncIterable<unknown> }
       ).presence[Symbol.asyncIterator]();
-      const topLevelEvent = topLevel.next();
-      const platformLevelEvent = platformLevel.next();
+      topLevelEvent = topLevel.next();
+      platformLevelEvent = platformLevel.next();
       startGate.resolve();
 
       const expected = {
@@ -470,12 +475,13 @@ describe("fusor events", () => {
         value: { user: "stream-user", online: true },
       });
       expect(startSpy).toHaveBeenCalledTimes(1);
-
-      await topLevel.return?.();
-      await platformLevel.return?.();
-      await spectrum.stop();
     } finally {
       startGate.resolve();
+      await settleSoon(topLevel?.return?.());
+      await settleSoon(platformLevel?.return?.());
+      await settleSoon(topLevelEvent?.catch(() => undefined));
+      await settleSoon(platformLevelEvent?.catch(() => undefined));
+      await settleSoon(spectrum?.stop());
       startSpy.mockRestore();
     }
   });
@@ -484,8 +490,9 @@ describe("fusor events", () => {
     const startSpy = vi
       .spyOn(FusorCore.prototype, "start")
       .mockResolvedValue(undefined);
+    let spectrum: SpectrumInstance | undefined;
     try {
-      const spectrum = await Spectrum({
+      spectrum = await Spectrum({
         ...baseConfig,
         providers: [makePresence().config({})],
       });
@@ -503,8 +510,8 @@ describe("fusor events", () => {
 
       expect(result.status).toBe(200);
       expect(startSpy).not.toHaveBeenCalled();
-      await spectrum.stop();
     } finally {
+      await settleSoon(spectrum?.stop());
       startSpy.mockRestore();
     }
   });
@@ -513,16 +520,19 @@ describe("fusor events", () => {
     const startSpy = vi
       .spyOn(FusorCore.prototype, "start")
       .mockResolvedValue(undefined);
+    let spectrum: SpectrumInstance | undefined;
+    let presence: AsyncIterator<unknown> | undefined;
+    let firstPresence: Promise<IteratorResult<unknown>> | undefined;
     try {
-      const spectrum = await Spectrum({
+      spectrum = await Spectrum({
         ...baseConfig,
         providers: [makePresence().config({})],
       });
       // Attach to the presence stream before firing so the broadcaster is wired.
-      const presence = (
+      presence = (
         spectrum as unknown as { presence: AsyncIterable<unknown> }
       ).presence[Symbol.asyncIterator]();
-      const firstPresence = presence.next();
+      firstPresence = presence.next();
 
       let handlerCalls = 0;
       const result = await spectrum.webhook(
@@ -549,10 +559,10 @@ describe("fusor events", () => {
       // The event went to the channel, NOT the (messages-only) webhook handler.
       expect(handlerCalls).toBe(0);
       expect(startSpy).toHaveBeenCalledTimes(1);
-
-      await presence.return?.();
-      await spectrum.stop();
     } finally {
+      await settleSoon(presence?.return?.());
+      await settleSoon(firstPresence?.catch(() => undefined));
+      await settleSoon(spectrum?.stop());
       startSpy.mockRestore();
     }
   });

--- a/packages/core/test/core/fusor/webhook.test.ts
+++ b/packages/core/test/core/fusor/webhook.test.ts
@@ -477,12 +477,20 @@ describe("fusor events", () => {
       expect(startSpy).toHaveBeenCalledTimes(1);
     } finally {
       startGate.resolve();
-      await settleSoon(topLevel?.return?.());
-      await settleSoon(platformLevel?.return?.());
-      await settleSoon(topLevelEvent?.catch(() => undefined));
-      await settleSoon(platformLevelEvent?.catch(() => undefined));
-      await settleSoon(spectrum?.stop());
-      startSpy.mockRestore();
+      try {
+        await Promise.all([
+          settleSoon(topLevel?.return?.()),
+          settleSoon(platformLevel?.return?.()),
+          settleSoon(topLevelEvent?.catch(() => undefined)),
+          settleSoon(platformLevelEvent?.catch(() => undefined)),
+        ]);
+      } finally {
+        try {
+          await spectrum?.stop();
+        } finally {
+          startSpy.mockRestore();
+        }
+      }
     }
   });
 
@@ -511,8 +519,11 @@ describe("fusor events", () => {
       expect(result.status).toBe(200);
       expect(startSpy).not.toHaveBeenCalled();
     } finally {
-      await settleSoon(spectrum?.stop());
-      startSpy.mockRestore();
+      try {
+        await spectrum?.stop();
+      } finally {
+        startSpy.mockRestore();
+      }
     }
   });
 
@@ -560,10 +571,18 @@ describe("fusor events", () => {
       expect(handlerCalls).toBe(0);
       expect(startSpy).toHaveBeenCalledTimes(1);
     } finally {
-      await settleSoon(presence?.return?.());
-      await settleSoon(firstPresence?.catch(() => undefined));
-      await settleSoon(spectrum?.stop());
-      startSpy.mockRestore();
+      try {
+        await Promise.all([
+          settleSoon(presence?.return?.()),
+          settleSoon(firstPresence?.catch(() => undefined)),
+        ]);
+      } finally {
+        try {
+          await spectrum?.stop();
+        } finally {
+          startSpy.mockRestore();
+        }
+      }
     }
   });
 

--- a/packages/core/test/core/fusor/websocket.test.ts
+++ b/packages/core/test/core/fusor/websocket.test.ts
@@ -7,8 +7,17 @@ import { setTimeout as sleep } from "node:timers/promises";
 import { NO_MESSAGE_WAIT_MS } from "@spectrum-ts/test-support/timing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
-import { FusorCore, type RegisteredFusorHandler } from "@/fusor/core";
-import type { FusorMessagesReturn } from "@/fusor/types";
+import {
+  FusorCore,
+  type FusorCursorStore,
+  type RegisteredFusorHandler,
+} from "@/fusor/core";
+import {
+  type FusorMessagesReturn,
+  FusorRetryableError,
+  FusorTerminalError,
+} from "@/fusor/types";
+import { FUSOR_WS_MAX_PENDING_EVENTS } from "@/fusor/websocket";
 import { cloud } from "@/utils/cloud";
 
 const PLATFORM = "tg";
@@ -18,6 +27,12 @@ const WAIT_POLL_MS = 10;
 // close() must return promptly: above the 2s never-opened-socket
 // failsafe, far below the 30s max reconnect backoff.
 const CLOSE_PROMPTLY_MS = 3000;
+const CANNOT_START_RE = /cannot start after close/;
+const INVALID_CURSOR_RE = /invalid cursor/;
+const JWT_NOT_INITIALIZED_RE = /jwt:not-initialized/;
+const PROTOCOL_VIOLATION_RE = /protocol_violation/;
+const PROJECT_MISMATCH_RE = /project_mismatch|other-project/;
+const STOPPED_BEFORE_READY_RE = /stopped before websocket stream became ready/;
 
 const httpBytes = (json: string): string =>
   `POST /${PLATFORM} HTTP/1.1\r\ncontent-type: application/json\r\n\r\n${json}`;
@@ -27,9 +42,14 @@ type Frame = Record<string, unknown> & { type: string };
 
 interface WsServerScript {
   /** Close the connection right after onInit frames (code + reason). */
-  closeAfterInit?: (
-    connection: number
-  ) => { code: number; reason: string } | undefined;
+  closeAfterInit?: (connection: number) =>
+    | {
+        beforeClose?: () => void;
+        code: number;
+        delayMs?: number;
+        reason: string;
+      }
+    | undefined;
   /** Called per connection with the parsed init frame; returns frames to send. */
   onInit: (init: Frame, connection: number) => Frame[];
 }
@@ -50,11 +70,29 @@ async function makeFusorWsServer(script: WsServerScript) {
       if (frame.type === "init") {
         inits.push(frame);
         for (const out of script.onInit(frame, connection)) {
+          // Match retained-stream semantics: startSeq is the last completed
+          // sequence, so a conforming server only sends newer positions.
+          if (
+            out.type === "event" &&
+            typeof out.seq === "number" &&
+            typeof frame.startSeq === "number" &&
+            out.seq <= frame.startSeq
+          ) {
+            continue;
+          }
           ws.send(JSON.stringify(out));
         }
         const close = script.closeAfterInit?.(connection);
         if (close) {
-          ws.close(close.code, close.reason);
+          const closeSocket = () => {
+            close.beforeClose?.();
+            ws.close(close.code, close.reason);
+          };
+          if (close.delayMs === undefined) {
+            closeSocket();
+          } else {
+            setTimeout(closeSocket, close.delayMs);
+          }
         }
         return;
       }
@@ -70,6 +108,7 @@ async function makeFusorWsServer(script: WsServerScript) {
     inits,
     replies,
     connectionCount: () => connections,
+    activeConnectionCount: () => wss.clients.size,
     // Fire-and-forget, matching the old Bun.serve stop(true): under Bun's ws
     // shim the close callback never fires once clients were terminated
     // server-side, so awaiting it would deadlock the afterEach cleanup.
@@ -133,7 +172,8 @@ async function waitFor(
 
 const cleanups: (() => void | Promise<void>)[] = [];
 afterEach(async () => {
-  for (const cleanup of cleanups.splice(0)) {
+  // Core shutdown first, then server teardown, then token mock restoration.
+  for (const cleanup of cleanups.splice(0).reverse()) {
     await cleanup();
   }
 });
@@ -188,6 +228,417 @@ describe("fusor websocket streaming", () => {
     );
   });
 
+  it("reconnects from the last completed sequence and suppresses duplicate event ids across valid gaps", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: (_init, connection) => {
+        const ready = {
+          type: "ready",
+          projectId: "proj",
+          heartbeatIntervalMs: 30_000,
+        };
+        if (connection === 1) {
+          return [ready, eventFrame("evt-a", '{"text":"first"}', false, 10)];
+        }
+        if (connection === 2) {
+          return [
+            ready,
+            // Same completed event id delivered at a newer position.
+            eventFrame("evt-a", '{"text":"id replay"}', false, 11),
+            // Gaps are valid for a filtered global stream and must not block it.
+            eventFrame("evt-b", '{"text":"after gap"}', false, 20),
+          ];
+        }
+        return [ready];
+      },
+      closeAfterInit: (connection) =>
+        connection <= 2 ? { code: 1012, reason: "restart" } : undefined,
+    });
+    cleanups.push(server.stop);
+
+    const capture = { payloads: [] as unknown[] };
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+    });
+    cleanups.push(() => core.close());
+    core.register(PLATFORM, makeHandler(capture));
+    await core.start();
+
+    await waitFor(() => server.inits.length === 3, 15_000);
+    expect(server.inits.map((init) => init.startSeq)).toEqual([0, 10, 20]);
+
+    await sleep(NO_MESSAGE_WAIT_MS);
+    expect(capture.payloads).toEqual([
+      { text: "first" },
+      { text: "after gap" },
+    ]);
+  });
+
+  it("resets full-jitter backoff after a stable ready connection", async () => {
+    let clockMs = 0;
+    const dateSpy = vi.spyOn(Date, "now").mockImplementation(() => clockMs);
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.999);
+    cleanups.push(() => dateSpy.mockRestore());
+    cleanups.push(() => randomSpy.mockRestore());
+
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const connectedAt: number[] = [];
+    const server = await makeFusorWsServer({
+      onInit: (_init, connection) => {
+        connectedAt.push(performance.now());
+        return connection === 1
+          ? []
+          : [
+              {
+                type: "ready",
+                projectId: "proj",
+                heartbeatIntervalMs: 30_000,
+              },
+            ];
+      },
+      closeAfterInit: (connection) => {
+        if (connection === 1) {
+          return { code: 1012, reason: "initial failure" };
+        }
+        if (connection === 2) {
+          return {
+            beforeClose: () => {
+              clockMs = 30_001;
+            },
+            code: 1012,
+            delayMs: 20,
+            reason: "stable restart",
+          };
+        }
+        return;
+      },
+    });
+    cleanups.push(server.stop);
+
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+    });
+    cleanups.push(() => core.close());
+    core.register(PLATFORM, makeHandler({ payloads: [] }));
+    await core.start();
+
+    await waitFor(() => server.inits.length === 3, 100_000);
+    const secondAt = connectedAt[1];
+    const thirdAt = connectedAt[2];
+    expect(secondAt).toBeDefined();
+    expect(thirdAt).toBeDefined();
+    // random=0.999 puts full jitter near its ceiling. Resetting after the
+    // 30-second logical ready period makes the next ceiling ~1s; retaining the
+    // previous attempt would make it ~2s.
+    expect((thirdAt ?? 0) - (secondAt ?? 0)).toBeLessThan(1600);
+    expect(randomSpy).toHaveBeenCalled();
+  });
+
+  it("loads a scoped durable cursor and retries a failed save from the prior positive cursor", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: (_init, connection) =>
+        connection <= 2
+          ? [
+              {
+                type: "ready",
+                projectId: "proj",
+                heartbeatIntervalMs: 30_000,
+              },
+              eventFrame("evt-checkpoint", '{"text":"retry"}', false, 5),
+            ]
+          : [
+              {
+                type: "ready",
+                projectId: "proj",
+                heartbeatIntervalMs: 30_000,
+              },
+            ],
+      closeAfterInit: (connection) =>
+        connection === 2 ? { code: 1012, reason: "restart" } : undefined,
+    });
+    cleanups.push(server.stop);
+
+    const loads: { projectId: string; websocketEndpoint: string }[] = [];
+    const saves: {
+      projectId: string;
+      seq: number;
+      websocketEndpoint: string;
+    }[] = [];
+    let failSaveOnce = true;
+    const cursorStore: FusorCursorStore = {
+      load: async (scope) => {
+        loads.push({ ...scope });
+        return 4;
+      },
+      save: async (scope, seq) => {
+        saves.push({ ...scope, seq });
+        if (failSaveOnce) {
+          failSaveOnce = false;
+          throw new Error("cursor store unavailable");
+        }
+      },
+    };
+    const capture = { payloads: [] as unknown[] };
+    const core = new FusorCore({
+      cursorStore,
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+    });
+    cleanups.push(() => core.close());
+    core.register(PLATFORM, makeHandler(capture));
+    await core.start();
+
+    await waitFor(() => server.inits.length === 3, 15_000);
+    // The first durable save failed, so reconnect used the loaded positive
+    // cursor (4) and the real server can replay sequence 5. Only the successful
+    // second save moves the third connection to 5.
+    expect(server.inits.map((init) => init.startSeq)).toEqual([4, 4, 5]);
+    expect(loads).toEqual([
+      { projectId: "proj", websocketEndpoint: server.url },
+    ]);
+    expect(saves).toEqual([
+      { projectId: "proj", seq: 5, websocketEndpoint: server.url },
+      { projectId: "proj", seq: 5, websocketEndpoint: server.url },
+    ]);
+
+    await sleep(NO_MESSAGE_WAIT_MS);
+    // Durable side effects still need provider-level idempotency when the
+    // cursor store fails after handler completion.
+    expect(capture.payloads).toEqual([{ text: "retry" }, { text: "retry" }]);
+  });
+
+  it("rejects an invalid durable cursor before minting a token", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "unused",
+      expiresIn: 900,
+    });
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const scopes: { projectId: string; websocketEndpoint: string }[] = [];
+    const core = new FusorCore({
+      cursorStore: {
+        load: async (scope) => {
+          scopes.push({ ...scope });
+          return Number.MAX_SAFE_INTEGER;
+        },
+        save: async () => undefined,
+      },
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: "ws://cursor.invalid/v1/subscribe",
+    });
+    cleanups.push(() => core.close());
+
+    await expect(core.start()).rejects.toThrow(INVALID_CURSOR_RE);
+    expect(scopes).toEqual([
+      {
+        projectId: "proj",
+        websocketEndpoint: "ws://cursor.invalid/v1/subscribe",
+      },
+    ]);
+    expect(tokenSpy).not.toHaveBeenCalled();
+  });
+
+  it("checkpoints an explicitly terminal handler error instead of poisoning later events", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: (_init, connection) =>
+        connection === 1
+          ? [
+              {
+                type: "ready",
+                projectId: "proj",
+                heartbeatIntervalMs: 30_000,
+              },
+              eventFrame("evt-invalid", '{"text":"invalid"}', false, 1),
+              eventFrame("evt-after", '{"text":"after"}', false, 2),
+            ]
+          : [
+              {
+                type: "ready",
+                projectId: "proj",
+                heartbeatIntervalMs: 30_000,
+              },
+            ],
+      closeAfterInit: (connection) =>
+        connection === 1 ? { code: 1012, reason: "restart" } : undefined,
+    });
+    cleanups.push(server.stop);
+
+    const capture = { payloads: [] as unknown[] };
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+    });
+    cleanups.push(() => core.close());
+    const handler = makeHandler(capture);
+    const messages = handler.messages;
+    handler.messages = (context) => {
+      if (context.payload.text === "invalid") {
+        throw new FusorTerminalError("unsupported payload");
+      }
+      return messages(context);
+    };
+    core.register(PLATFORM, handler);
+    await core.start();
+
+    await waitFor(() => server.inits.length === 2, 10_000);
+    // `0` is a live-tail sentinel, not a replay position. The invalid event is
+    // completed with an error reply and checkpointed in order; the client does
+    // not claim it could recover a failed first delivery by reconnecting at 0.
+    expect(server.inits.map((init) => init.startSeq)).toEqual([0, 2]);
+    expect(capture.payloads).toEqual([{ text: "after" }]);
+  });
+
+  it("retries an explicitly transient verifier failure before checkpointing", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: (_init, connection) =>
+        connection <= 2
+          ? [
+              {
+                type: "ready",
+                projectId: "proj",
+                heartbeatIntervalMs: 30_000,
+              },
+              eventFrame("evt-retry", '{"text":"retry"}', false, 1),
+            ]
+          : [
+              {
+                type: "ready",
+                projectId: "proj",
+                heartbeatIntervalMs: 30_000,
+              },
+            ],
+      closeAfterInit: (connection) =>
+        connection === 2 ? { code: 1012, reason: "restart" } : undefined,
+    });
+    cleanups.push(server.stop);
+
+    let verifyAttempts = 0;
+    const capture = { payloads: [] as unknown[] };
+    const handler = makeHandler(capture);
+    const verify = handler.verify;
+    handler.verify = (request) => {
+      verifyAttempts += 1;
+      if (verifyAttempts === 1) {
+        throw new FusorRetryableError("JWKS temporarily unavailable");
+      }
+      return verify(request);
+    };
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+    });
+    cleanups.push(() => core.close());
+    core.register(PLATFORM, handler);
+    await core.start();
+
+    await waitFor(() => server.inits.length === 3, 15_000);
+    expect(server.inits.map((init) => init.startSeq)).toEqual([0, 0, 1]);
+    expect(verifyAttempts).toBe(2);
+    expect(capture.payloads).toEqual([{ text: "retry" }]);
+  });
+
+  it("bounds pending event work and reconnects from the last drained cursor", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: (_init, connection) => {
+        const ready = {
+          type: "ready",
+          projectId: "proj",
+          heartbeatIntervalMs: 30_000,
+        };
+        if (connection !== 1) {
+          return [ready];
+        }
+        return [
+          ready,
+          ...Array.from(
+            { length: FUSOR_WS_MAX_PENDING_EVENTS + 1 },
+            (_, index) =>
+              eventFrame(
+                `evt-backpressure-${index + 1}`,
+                '{"text":"queued"}',
+                false,
+                index + 1
+              )
+          ),
+        ];
+      },
+    });
+    cleanups.push(server.stop);
+
+    const handlerGate = Promise.withResolvers<void>();
+    let handled = 0;
+    const handler = makeHandler({ payloads: [] });
+    handler.messages = async () => {
+      handled += 1;
+      if (handled === 1) {
+        await handlerGate.promise;
+      }
+      return [];
+    };
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+    });
+    cleanups.push(async () => {
+      handlerGate.resolve();
+      await core.close();
+    });
+    core.register(PLATFORM, handler);
+    await core.start();
+
+    await waitFor(() => server.activeConnectionCount() === 0, 10_000);
+    handlerGate.resolve();
+    await waitFor(() => server.inits.length === 2, 15_000);
+    expect(server.inits.map((init) => init.startSeq)).toEqual([
+      0,
+      FUSOR_WS_MAX_PENDING_EVENTS,
+    ]);
+    expect(handled).toBe(FUSOR_WS_MAX_PENDING_EVENTS);
+  });
+
   it("invalidates the token on a 4401 close and reconnects with a fresh one", async () => {
     let minted = 0;
     const tokenSpy = vi
@@ -235,6 +686,236 @@ describe("fusor websocket streaming", () => {
     expect(server.inits[1]?.token).toBe("t2");
   });
 
+  it("does not retry the jwt:not-initialized authentication invariant", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: () => [
+        {
+          type: "error",
+          code: "unauthenticated",
+          reason: "jwt:not-initialized",
+          message: "JWT verifier is unavailable",
+          fatal: true,
+          retryable: false,
+        },
+      ],
+      closeAfterInit: () => ({ code: 4401, reason: "unauthenticated" }),
+    });
+    cleanups.push(server.stop);
+
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+    });
+    cleanups.push(() => core.close());
+    core.register(PLATFORM, makeHandler({ payloads: [] }));
+    await expect(core.start()).rejects.toThrow(JWT_NOT_INITIALIZED_RE);
+
+    await waitFor(() => server.inits.length === 1);
+    await core.waitStopped();
+    await expect(core.start()).rejects.toThrow(CANNOT_START_RE);
+    // Longer than the first retry ceiling: a generic 4401 would already have
+    // minted a replacement credential and opened connection two.
+    await sleep(1200);
+    expect(server.inits).toHaveLength(1);
+    expect(tokenSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry a fatal non-auth protocol error", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: () => [
+        {
+          type: "error",
+          code: "protocol_violation",
+          message: "invalid init contract",
+          fatal: true,
+          retryable: false,
+        },
+      ],
+      closeAfterInit: () => ({ code: 4400, reason: "protocol_violation" }),
+    });
+    cleanups.push(server.stop);
+
+    const onTerminal = vi.fn();
+    const core = new FusorCore({
+      onTerminal,
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+    });
+    cleanups.push(() => core.close());
+    core.register(PLATFORM, makeHandler({ payloads: [] }));
+
+    await expect(core.start()).rejects.toThrow(PROTOCOL_VIOLATION_RE);
+    await core.waitStopped();
+    expect(onTerminal).toHaveBeenCalledTimes(1);
+    expect(onTerminal.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        message: expect.stringMatching(PROTOCOL_VIOLATION_RE),
+      })
+    );
+    await sleep(1200);
+    expect(server.inits).toHaveLength(1);
+    expect(tokenSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops and surfaces a cross-project event after ready", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    cleanups.push(() => tokenSpy.mockRestore());
+    const mismatched = eventFrame("cross-project", '{"text":"nope"}', false);
+    mismatched.event = {
+      ...(mismatched.event as Record<string, unknown>),
+      projectId: "other-project",
+    };
+    const server = await makeFusorWsServer({
+      onInit: () => [
+        { type: "ready", projectId: "proj", heartbeatIntervalMs: 30_000 },
+        mismatched,
+      ],
+    });
+    cleanups.push(server.stop);
+    const terminal = Promise.withResolvers<Error>();
+    const core = new FusorCore({
+      onTerminal: (error) => terminal.resolve(error),
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+    });
+    cleanups.push(() => core.close());
+    const payloads: unknown[] = [];
+    core.register(PLATFORM, makeHandler({ payloads }));
+
+    await core.start();
+    await expect(terminal.promise).resolves.toEqual(
+      expect.objectContaining({
+        message: expect.stringMatching(PROJECT_MISMATCH_RE),
+      })
+    );
+    await core.waitStopped();
+    expect(payloads).toEqual([]);
+    expect(server.inits).toHaveLength(1);
+  });
+
+  it("close() shares completion and cancels startup while the initial token is pending", async () => {
+    const tokenResult = { token: "t1", expiresIn: 900 };
+    const tokenGate = Promise.withResolvers<typeof tokenResult>();
+    const tokenSpy = vi
+      .spyOn(cloud, "issueFusorToken")
+      .mockReturnValue(tokenGate.promise);
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: () => [
+        { type: "ready", projectId: "proj", heartbeatIntervalMs: 30_000 },
+      ],
+    });
+    cleanups.push(server.stop);
+
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+    });
+    cleanups.push(async () => {
+      tokenGate.resolve(tokenResult);
+      await core.close();
+    });
+
+    const startPromise = core.start();
+    await waitFor(() => tokenSpy.mock.calls.length === 1);
+    const firstClose = core.close();
+    const concurrentClose = core.close();
+    expect(concurrentClose).toBe(firstClose);
+
+    let closeSettled = false;
+    firstClose.then(() => {
+      closeSettled = true;
+    });
+    await sleep(NO_MESSAGE_WAIT_MS);
+    expect(closeSettled).toBe(false);
+
+    tokenGate.resolve(tokenResult);
+    await startPromise;
+    await firstClose;
+    expect(server.connectionCount()).toBe(0);
+  });
+
+  it("close() does not open a replacement socket after token refresh resolves", async () => {
+    const refreshResult = { token: "t2", expiresIn: 900 };
+    const refreshGate = Promise.withResolvers<typeof refreshResult>();
+    let mintCount = 0;
+    const tokenSpy = vi
+      .spyOn(cloud, "issueFusorToken")
+      .mockImplementation(async () => {
+        mintCount += 1;
+        if (mintCount === 1) {
+          return { token: "t1", expiresIn: 900 };
+        }
+        return await refreshGate.promise;
+      });
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: () => [
+        {
+          type: "error",
+          code: "unauthenticated",
+          reason: "jwt:expired",
+          message: "JWT expired",
+          fatal: true,
+          retryable: false,
+        },
+      ],
+      closeAfterInit: () => ({ code: 4401, reason: "unauthenticated" }),
+    });
+    cleanups.push(server.stop);
+
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+    });
+    cleanups.push(async () => {
+      refreshGate.resolve(refreshResult);
+      await core.close();
+    });
+    core.register(PLATFORM, makeHandler({ payloads: [] }));
+    const startRejection = expect(core.start()).rejects.toThrow(
+      STOPPED_BEFORE_READY_RE
+    );
+
+    await waitFor(() => tokenSpy.mock.calls.length === 2, 10_000);
+    const closePromise = core.close();
+    let closeSettled = false;
+    closePromise.then(() => {
+      closeSettled = true;
+    });
+    await sleep(NO_MESSAGE_WAIT_MS);
+    expect(closeSettled).toBe(false);
+
+    refreshGate.resolve(refreshResult);
+    await startRejection;
+    await closePromise;
+    await sleep(NO_MESSAGE_WAIT_MS);
+    expect(server.inits).toHaveLength(1);
+    expect(server.connectionCount()).toBe(1);
+  });
+
   it("close() tears down an active websocket session promptly", async () => {
     const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
       token: "t1",
@@ -261,5 +942,109 @@ describe("fusor websocket streaming", () => {
     const start = Date.now();
     await core.close();
     expect(Date.now() - start).toBeLessThan(CLOSE_PROMPTLY_MS);
+    await waitFor(() => server.activeConnectionCount() === 0);
+    expect(server.activeConnectionCount()).toBe(0);
+  });
+
+  it("surfaces a durable checkpoint failure that races shutdown", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: () => [
+        { type: "ready", projectId: "proj", heartbeatIntervalMs: 30_000 },
+        eventFrame("evt-checkpoint-close", '{"text":"save"}', false, 1),
+      ],
+    });
+    cleanups.push(server.stop);
+
+    const saveGate = Promise.withResolvers<void>();
+    let saveStarted = false;
+    const core = new FusorCore({
+      cursorStore: {
+        load: async () => 0,
+        save: async () => {
+          saveStarted = true;
+          await saveGate.promise;
+        },
+      },
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+    });
+    cleanups.push(async () => {
+      saveGate.reject(new Error("cursor store unavailable"));
+      await core.close().catch(() => undefined);
+    });
+    core.register(PLATFORM, makeHandler({ payloads: [] }));
+    await core.start();
+    await waitFor(() => saveStarted);
+
+    const closePromise = core.close();
+    saveGate.reject(new Error("cursor store unavailable"));
+    await expect(closePromise).rejects.toThrow("cursor store unavailable");
+  });
+
+  it("close() waits for an in-flight ordered handler", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: () => [
+        { type: "ready", projectId: "proj", heartbeatIntervalMs: 30_000 },
+        eventFrame("evt-slow", '{"text":"slow"}', false, 1),
+      ],
+    });
+    cleanups.push(server.stop);
+
+    let releaseHandler: (() => void) | undefined;
+    const handlerGate = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    let handlerStarted = false;
+    const capture = { payloads: [] as unknown[] };
+    const handler = makeHandler(capture);
+    const messages = handler.messages;
+    handler.messages = async (context) => {
+      handlerStarted = true;
+      await handlerGate;
+      return messages(context);
+    };
+
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+    });
+    core.register(PLATFORM, handler);
+
+    let closePromise: Promise<void> | undefined;
+    let closeSettled = false;
+    try {
+      await core.start();
+      await waitFor(() => handlerStarted);
+
+      const sharedClose = core.close();
+      expect(core.close()).toBe(sharedClose);
+      closePromise = sharedClose.then(() => {
+        closeSettled = true;
+      });
+      await sleep(NO_MESSAGE_WAIT_MS);
+      expect(closeSettled).toBe(false);
+
+      releaseHandler?.();
+      await closePromise;
+      expect(closeSettled).toBe(true);
+      expect(capture.payloads).toEqual([{ text: "slow" }]);
+    } finally {
+      releaseHandler?.();
+      await (closePromise ?? core.close());
+    }
   });
 });

--- a/packages/core/test/core/fusor/websocket.test.ts
+++ b/packages/core/test/core/fusor/websocket.test.ts
@@ -161,9 +161,9 @@ async function waitFor(
   cond: () => boolean,
   timeoutMs = WAIT_TIMEOUT_MS
 ): Promise<void> {
-  const start = Date.now();
+  const start = performance.now();
   while (!cond()) {
-    if (Date.now() - start > timeoutMs) {
+    if (performance.now() - start > timeoutMs) {
       throw new Error("waitFor timed out");
     }
     await sleep(WAIT_POLL_MS);

--- a/packages/core/test/core/spectrum.options.test.ts
+++ b/packages/core/test/core/spectrum.options.test.ts
@@ -1,6 +1,10 @@
 import { makeManagedProvider } from "@spectrum-ts/test-support/platform";
 import { describe, expect, it } from "vitest";
-import { Spectrum, type SpectrumOptions } from "@/spectrum";
+import {
+  Spectrum,
+  type SpectrumInstance,
+  type SpectrumOptions,
+} from "@/spectrum";
 
 const provider = () => makeManagedProvider("managed").config({});
 
@@ -23,16 +27,19 @@ describe("Spectrum() runtime options", () => {
   });
 
   it("accepts a Fusor cursor store with callable load and save methods", async () => {
-    const app = await Spectrum({
-      providers: [provider()],
-      options: {
-        fusorCursorStore: {
-          load: async () => undefined,
-          save: async () => undefined,
+    let app: SpectrumInstance | undefined;
+    try {
+      app = await Spectrum({
+        providers: [provider()],
+        options: {
+          fusorCursorStore: {
+            load: async () => undefined,
+            save: async () => undefined,
+          },
         },
-      },
-    });
-
-    await app.stop();
+      });
+    } finally {
+      await app?.stop();
+    }
   });
 });

--- a/packages/core/test/core/spectrum.options.test.ts
+++ b/packages/core/test/core/spectrum.options.test.ts
@@ -1,0 +1,38 @@
+import { makeManagedProvider } from "@spectrum-ts/test-support/platform";
+import { describe, expect, it } from "vitest";
+import { Spectrum, type SpectrumOptions } from "@/spectrum";
+
+const provider = () => makeManagedProvider("managed").config({});
+
+describe("Spectrum() runtime options", () => {
+  it.each([
+    { load: async () => undefined },
+    { save: async () => undefined },
+    { load: "not callable", save: async () => undefined },
+    { load: async () => undefined, save: "not callable" },
+  ])("rejects an invalid Fusor cursor store: %o", async (fusorCursorStore) => {
+    await expect(
+      Spectrum({
+        providers: [provider()],
+        options: {
+          fusorCursorStore:
+            fusorCursorStore as unknown as SpectrumOptions["fusorCursorStore"],
+        },
+      })
+    ).rejects.toThrow();
+  });
+
+  it("accepts a Fusor cursor store with callable load and save methods", async () => {
+    const app = await Spectrum({
+      providers: [provider()],
+      options: {
+        fusorCursorStore: {
+          load: async () => undefined,
+          save: async () => undefined,
+        },
+      },
+    });
+
+    await app.stop();
+  });
+});

--- a/packages/core/test/utils/stream.test.ts
+++ b/packages/core/test/utils/stream.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { createAsyncQueue } from "@/utils/stream";
+
+describe("async queue", () => {
+  it("surfaces a terminal failure to a parked and future reader", async () => {
+    const queue = createAsyncQueue<number>();
+    const iterator = queue.iterable[Symbol.asyncIterator]();
+    const pending = iterator.next();
+    const failure = new Error("terminal transport failure");
+
+    queue.fail(failure);
+
+    await expect(pending).rejects.toBe(failure);
+    await expect(iterator.next()).rejects.toBe(failure);
+  });
+
+  it("drains buffered values before surfacing a terminal failure", async () => {
+    const queue = createAsyncQueue<number>();
+    queue.push(1);
+    queue.fail(new Error("failed after enqueue"));
+    const iterator = queue.iterable[Symbol.asyncIterator]();
+
+    await expect(iterator.next()).resolves.toEqual({ done: false, value: 1 });
+    await expect(iterator.next()).rejects.toThrow("failed after enqueue");
+  });
+});

--- a/packages/imessage/README.md
+++ b/packages/imessage/README.md
@@ -25,8 +25,10 @@ iMessage clients for outbound actions, reactions, polls, and group events, so
 cloud apps still maintain supplemental direct gRPC streams; received-message
 duplicates on those streams are ignored. Synthetic iMessage envelopes are
 stream-only and are never accepted through the public `spectrum.webhook()`
-path. Explicit `clients` configurations remain entirely on direct gRPC inbound
-transport, so self-hosted endpoints keep their existing behavior.
+path. In cloud mode Fusor is authoritative for received messages, so Fusor
+connectivity is required even while the supplemental direct streams are
+healthy. Explicit `clients` configurations remain entirely on direct gRPC
+inbound transport, so self-hosted endpoints keep their existing behavior.
 
 In auto-discovered dedicated mode, native chats and resources continue to use
 their dedicated server directly. Spectrum Cloud also supplies one

--- a/packages/imessage/README.md
+++ b/packages/imessage/README.md
@@ -19,6 +19,15 @@ const spectrum = Spectrum({
 });
 ```
 
+With Spectrum Cloud credentials, inbound received messages arrive through
+Fusor's authenticated WebSocket transport. The provider keeps its Advanced
+iMessage clients for outbound actions, reactions, polls, and group events, so
+cloud apps still maintain supplemental direct gRPC streams; received-message
+duplicates on those streams are ignored. Synthetic iMessage envelopes are
+stream-only and are never accepted through the public `spectrum.webhook()`
+path. Explicit `clients` configurations remain entirely on direct gRPC inbound
+transport, so self-hosted endpoints keep their existing behavior.
+
 This package also exports the iMessage-specific content helpers `effect`, `read`, `background`, `customizedMiniApp`, and `nativeContactCard`.
 
 `nativeContactCard()` shares the bot account's own contact card (Apple's "Share Name and Photo") with a chat — remote mode only:

--- a/packages/imessage/README.md
+++ b/packages/imessage/README.md
@@ -28,6 +28,16 @@ stream-only and are never accepted through the public `spectrum.webhook()`
 path. Explicit `clients` configurations remain entirely on direct gRPC inbound
 transport, so self-hosted endpoints keep their existing behavior.
 
+In auto-discovered dedicated mode, native chats and resources continue to use
+their dedicated server directly. Spectrum Cloud also supplies one
+project-scoped proxy token, which all of the dedicated lines share for
+virtualized `spc-msg-*` and `spc-att-*` resources delivered by Fusor. Replies,
+reactions, edits, unsends, message/attachment reads, and mini-app updates are
+routed through that proxy only when their resource id is virtual; the proxy
+resolves the owning instance and native GUID server-side. A dedicated token
+response without `proxyToken` is rejected rather than leaking a virtual GUID
+to an instance server. Shared and explicitly configured clients are unchanged.
+
 This package also exports the iMessage-specific content helpers `effect`, `read`, `background`, `customizedMiniApp`, and `nativeContactCard`.
 
 `nativeContactCard()` shares the bot account's own contact card (Apple's "Share Name and Photo") with a chat — remote mode only:

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -1,4 +1,7 @@
-import { createGrpcClient } from "@photon-ai/advanced-imessage/grpc";
+import {
+  type AdvancedIMessage,
+  createGrpcClient,
+} from "@photon-ai/advanced-imessage/grpc";
 import {
   cloud,
   type DedicatedTokenData,
@@ -19,6 +22,38 @@ interface CloudAuth {
 
 const cloudAuthState = new WeakMap<RemoteClient[], CloudAuth>();
 
+const proxyAddress = (): string =>
+  process.env.SPECTRUM_IMESSAGE_ADDRESS ?? "imessage.spectrum.photon.codes:443";
+
+const requireProxyToken = (data: DedicatedTokenData): string => {
+  if (!data.proxyToken) {
+    throw new Error(
+      "Dedicated iMessage token response is missing proxyToken; virtual spc-* resources cannot be routed through Spectrum"
+    );
+  }
+  return data.proxyToken;
+};
+
+const requireSharedToken = (data: SharedTokenData): string => {
+  if (!data.token) {
+    throw new Error("Shared iMessage token response is missing token");
+  }
+  return data.token;
+};
+
+const requireInstanceToken = (
+  data: DedicatedTokenData,
+  instanceId: string
+): string => {
+  const token = data.auth[instanceId];
+  if (!token) {
+    throw new Error(
+      `Dedicated iMessage token response is missing auth for instance ${instanceId}`
+    );
+  }
+  return token;
+};
+
 const requirePhone = (data: DedicatedTokenData, instanceId: string): string => {
   const phone = data.numbers?.[instanceId];
   if (!phone) {
@@ -32,16 +67,34 @@ export async function createCloudClients(
   projectSecret: string
 ): Promise<RemoteClient[]> {
   let tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
+  if (tokenData.type === "dedicated") {
+    requireProxyToken(tokenData);
+  } else {
+    requireSharedToken(tokenData);
+  }
+  const tokenMode = tokenData.type;
   let lastRefreshAt = Date.now();
 
-  // The instanceId stays paired with each entry in this closure so renewal
-  // can rewrite `entry.phone` in place without leaking instanceId onto the
-  // public RemoteClient shape. Empty in shared mode.
+  // Keep the instanceId paired with each entry so renewal can validate the
+  // complete direct credential set. Stream routing captures the initial phone,
+  // so a line/topology change must rebuild the Spectrum client. Empty in
+  // shared mode.
   const records: { entry: RemoteClient; instanceId: string }[] = [];
 
-  const syncPhones = (data: DedicatedTokenData) => {
+  const validateDedicatedRecords = (data: DedicatedTokenData): void => {
     for (const { entry, instanceId } of records) {
-      entry.phone = requirePhone(data, instanceId);
+      requireInstanceToken(data, instanceId);
+      const phone = requirePhone(data, instanceId);
+      if (phone !== entry.phone) {
+        throw new Error(
+          `iMessage token refresh changed the phone for instance ${instanceId}; recreate the Spectrum client`
+        );
+      }
+    }
+    if (Object.keys(data.auth).length !== records.length) {
+      throw new Error(
+        "iMessage token refresh changed the dedicated instance set; recreate the Spectrum client"
+      );
     }
   };
 
@@ -49,11 +102,25 @@ export async function createCloudClients(
     expiresInSeconds: () => tokenData.expiresIn,
     name: "imessage",
     refresh: async () => {
-      tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
-      lastRefreshAt = Date.now();
-      if (tokenData.type === "dedicated") {
-        syncPhones(tokenData);
+      const refreshed = await cloud.issueImessageTokens(
+        projectId,
+        projectSecret
+      );
+      if (refreshed.type !== tokenMode) {
+        throw new Error(
+          `iMessage token refresh changed mode from ${tokenMode} to ${refreshed.type}; recreate the Spectrum client`
+        );
       }
+      if (refreshed.type === "dedicated") {
+        requireProxyToken(refreshed);
+        validateDedicatedRecords(refreshed);
+      } else {
+        requireSharedToken(refreshed);
+      }
+      // Commit only a fully validated credential set. A malformed refresh
+      // leaves the last known-good tokens and routing together.
+      tokenData = refreshed;
+      lastRefreshAt = Date.now();
     },
   });
 
@@ -71,14 +138,11 @@ export async function createCloudClients(
   const cloudAuth: CloudAuth = { dispose: renewal.dispose, forceRefresh };
 
   if (tokenData.type === "shared") {
-    const address =
-      process.env.SPECTRUM_IMESSAGE_ADDRESS ??
-      "imessage.spectrum.photon.codes:443";
     const entries: RemoteClient[] = [
       {
         phone: SHARED_PHONE,
         client: createGrpcClient({
-          address,
+          address: proxyAddress(),
           // Auto-retry transient unary failures so a brief server blip during
           // an outbound action (send/react/reply) doesn't surface as an
           // uncaught error. `autoIdempotency` attaches an x-idempotency-key to
@@ -88,7 +152,13 @@ export async function createCloudClients(
           tls: true,
           token: async () => {
             await renewal.refreshIfNeeded();
-            return (tokenData as SharedTokenData).token;
+            const data = tokenData;
+            if (data.type !== "shared") {
+              throw new Error(
+                "Shared iMessage token refresh returned dedicated credentials"
+              );
+            }
+            return requireSharedToken(data);
           },
         }),
       },
@@ -100,23 +170,67 @@ export async function createCloudClients(
   }
 
   const dedicated = tokenData;
-  for (const [instanceId, token] of Object.entries(dedicated.auth)) {
-    const entry: RemoteClient = {
+  const dedicatedEntries = Object.keys(dedicated.auth).map((instanceId) => {
+    requireInstanceToken(dedicated, instanceId);
+    return {
       instanceId,
       phone: requirePhone(dedicated, instanceId),
-      client: createGrpcClient({
+    };
+  });
+  if (dedicatedEntries.length === 0) {
+    const entries: RemoteClient[] = [];
+    cloudAuthState.set(entries, cloudAuth);
+    return entries;
+  }
+  const openedClients: AdvancedIMessage[] = [];
+  try {
+    const resourceClient = createGrpcClient({
+      address: proxyAddress(),
+      autoIdempotency: true,
+      retry: true,
+      tls: true,
+      token: async () => {
+        await renewal.refreshIfNeeded();
+        const data = tokenData;
+        if (data.type !== "dedicated") {
+          throw new Error(
+            "Dedicated iMessage token refresh returned shared credentials"
+          );
+        }
+        return requireProxyToken(data);
+      },
+    });
+    openedClients.push(resourceClient);
+    for (const { instanceId, phone } of dedicatedEntries) {
+      const directClient = createGrpcClient({
         address: `${instanceId}.imsg.photon.codes:443`,
         autoIdempotency: true,
         retry: true,
         tls: true,
         token: async () => {
           await renewal.refreshIfNeeded();
-          const data = tokenData as DedicatedTokenData;
-          return data.auth[instanceId] ?? token;
+          const data = tokenData;
+          if (data.type !== "dedicated") {
+            throw new Error(
+              "Dedicated iMessage token refresh returned shared credentials"
+            );
+          }
+          return requireInstanceToken(data, instanceId);
         },
-      }),
-    };
-    records.push({ entry, instanceId });
+      });
+      openedClients.push(directClient);
+      const entry: RemoteClient = {
+        client: directClient,
+        instanceId,
+        phone,
+        resourceClient,
+      };
+      records.push({ entry, instanceId });
+    }
+  } catch (error) {
+    renewal.dispose();
+    await Promise.allSettled(openedClients.map((client) => client.close()));
+    throw error;
   }
   const entries = records.map((r) => r.entry);
 

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -102,6 +102,7 @@ export async function createCloudClients(
   const dedicated = tokenData;
   for (const [instanceId, token] of Object.entries(dedicated.auth)) {
     const entry: RemoteClient = {
+      instanceId,
       phone: requirePhone(dedicated, instanceId),
       client: createGrpcClient({
         address: `${instanceId}.imsg.photon.codes:443`,

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -85,6 +85,9 @@ import { toSpectrumMiniApp } from "./remote/app";
 import { getRemoteAttachment } from "./remote/attachments";
 import {
   availablePhones,
+  clientForAttachmentResource,
+  clientForMessageResource,
+  clientForMiniAppSession,
   clientForPhone,
   isSharedMode,
   randomPhone,
@@ -160,7 +163,11 @@ const handleEdit = async (
     }
     const url = await content.content.url();
     const layout = await content.content.layout();
-    const remote = clientForPhone(client, space.phone);
+    const remote = clientForMiniAppSession(
+      client,
+      space.phone,
+      miniAppCardSession
+    );
     const record = cacheRemoteOutbound(
       remote,
       space,
@@ -182,7 +189,11 @@ const handleEdit = async (
         "customized mini app card edits require a miniAppCardSession from the original send"
       );
     }
-    const remote = clientForPhone(client, space.phone);
+    const remote = clientForMiniAppSession(
+      client,
+      space.phone,
+      miniAppCardSession
+    );
     const record = cacheRemoteOutbound(
       remote,
       space,
@@ -205,7 +216,11 @@ const handleEdit = async (
       `only text content can be edited (got "${content.content.type}")`
     );
   }
-  const remote = clientForPhone(client, space.phone);
+  const remote = clientForMessageResource(
+    client,
+    space.phone,
+    content.target.id
+  );
   await remoteEditMessage(remote, space.id, content.target.id, content.content);
 };
 
@@ -222,21 +237,31 @@ const handleUnsend = async (
       "iMessage polls cannot be unsent"
     );
   }
-  const remote = clientForPhone(client, space.phone);
   const targetContent = content.target.content;
   if (targetContent.type === "reaction") {
     // Tapbacks are removed via `setReaction(..., false)` against the
     // original message, not by retracting the tapback message — so pass
     // the reaction's own target (the message that was reacted to). Same
     // unknown-cast widen as the reaction send branch.
+    const reactionTarget = targetContent.target as unknown as IMessageMessage;
+    const remote = clientForMessageResource(
+      client,
+      space.phone,
+      reactionTarget.parentId ?? reactionTarget.id
+    );
     await remoteUnsendReaction(
       remote,
       space.id,
-      targetContent.target as unknown as IMessageMessage,
+      reactionTarget,
       targetContent.emoji
     );
     return;
   }
+  const remote = clientForMessageResource(
+    client,
+    space.phone,
+    content.target.id
+  );
   await remoteUnsendMessage(remote, space.id, content.target.id);
 };
 
@@ -449,7 +474,7 @@ const handleProviderControlSignal = async (
 const remoteForMessageTarget = (
   client: IMessageClient,
   space: { phone: string },
-  target: { content: { type: string } },
+  target: { content: { type: string }; id: string; parentId?: string },
   action: string,
   pollNoun: string
 ): AdvancedIMessage => {
@@ -460,7 +485,11 @@ const remoteForMessageTarget = (
       `iMessage polls do not support ${pollNoun}`
     );
   }
-  return clientForPhone(client, space.phone);
+  return clientForMessageResource(
+    client,
+    space.phone,
+    target.parentId ?? target.id
+  );
 };
 
 export const imessage = definePlatform(IMESSAGE_PLATFORM, {
@@ -519,7 +548,14 @@ export const imessage = definePlatform(IMESSAGE_PLATFORM, {
 
     destroyClient: async ({ client }) => {
       await disposeCloudAuth(client);
-      await Promise.all(client.map((entry) => entry.client.close()));
+      const uniqueClients = new Set<AdvancedIMessage>();
+      for (const entry of client) {
+        uniqueClients.add(entry.client);
+        if (entry.resourceClient) {
+          uniqueClients.add(entry.resourceClient);
+        }
+      }
+      await Promise.all(Array.from(uniqueClients, (remote) => remote.close()));
     },
   },
 
@@ -727,7 +763,7 @@ export const imessage = definePlatform(IMESSAGE_PLATFORM, {
 
   actions: {
     getMessage: async ({ client }, space, messageId) => {
-      const remote = clientForPhone(client, space.phone);
+      const remote = clientForMessageResource(client, space.phone, messageId);
       return remoteGetMessage(remote, space.id, messageId, space.phone);
     },
     // List a remote group chat's current participants. Remote + group only;
@@ -793,7 +829,7 @@ export const imessage = definePlatform(IMESSAGE_PLATFORM, {
           `imessage.getAttachment requires a phone in multi-phone mode. Available: ${availablePhones(client).join(", ")}`
         );
       })();
-      const remote = clientForPhone(client, routedPhone);
+      const remote = clientForAttachmentResource(client, routedPhone, guid);
       return withSpan(
         "spectrum.imessage.getAttachment",
         {

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -12,6 +12,7 @@ import {
   type Content,
   definePlatform,
   type Edit,
+  fusor,
   type RemoveMember,
   type Rename,
   type Space,
@@ -88,6 +89,10 @@ import {
   isSharedMode,
   randomPhone,
 } from "./remote/client";
+import {
+  handleImessageFusorMessages,
+  verifyImessageFusorRequest,
+} from "./remote/fusor";
 import { chatTypeFromGuid, dmChatGuid } from "./remote/ids";
 import { cacheMessage } from "./remote/inbound";
 import {
@@ -461,6 +466,17 @@ const remoteForMessageTarget = (
 export const imessage = definePlatform(IMESSAGE_PLATFORM, {
   config: configSchema,
 
+  fusor: {
+    streamOnly: true,
+    create: ({ config, projectId, projectSecret }) => {
+      if (config.clients || !(projectId && projectSecret)) {
+        return;
+      }
+      return fusor("imessage", verifyImessageFusorRequest);
+    },
+    messages: handleImessageFusorMessages,
+  },
+
   static: {
     effect: {
       message: messageEffects,
@@ -601,8 +617,8 @@ export const imessage = definePlatform(IMESSAGE_PLATFORM, {
     schema: messageSchema,
   },
 
-  messages: ({ client, projectConfig }) =>
-    remoteMessages(client, projectConfig),
+  messages: ({ client, config, projectConfig }) =>
+    remoteMessages(client, projectConfig, config.clients !== undefined),
 
   send: async ({ space, content, client }) => {
     if (content.type === "reply") {

--- a/packages/imessage/src/remote/api.ts
+++ b/packages/imessage/src/remote/api.ts
@@ -56,8 +56,10 @@ import {
 
 export const messages = (
   clients: RemoteClient[],
-  projectConfig: ProjectData | undefined
-): ManagedStream<IMessageMessage> => remoteMessages(clients, projectConfig);
+  projectConfig: ProjectData | undefined,
+  includeReceived = true
+): ManagedStream<IMessageMessage> =>
+  remoteMessages(clients, projectConfig, includeReceived);
 
 export const setBackground = async (
   remote: AdvancedIMessage,

--- a/packages/imessage/src/remote/client.ts
+++ b/packages/imessage/src/remote/client.ts
@@ -1,5 +1,6 @@
 import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import { type RemoteClient, SHARED_PHONE } from "../types";
+import { parseChildId } from "./ids";
 
 export const isSharedMode = (clients: RemoteClient[]): boolean =>
   clients.length === 1 && clients[0]?.phone === SHARED_PHONE;
@@ -7,10 +8,10 @@ export const isSharedMode = (clients: RemoteClient[]): boolean =>
 export const availablePhones = (clients: RemoteClient[]): string[] =>
   clients.map((c) => c.phone);
 
-export const clientForPhone = (
+const entryForPhone = (
   clients: RemoteClient[],
   phone: string
-): AdvancedIMessage => {
+): RemoteClient => {
   // Shared mode: a single client serves every conversation regardless of
   // the phone arg, since the SDK exposes no per-number routing in this mode.
   if (isSharedMode(clients)) {
@@ -18,17 +19,90 @@ export const clientForPhone = (
     if (!entry) {
       throw new Error("No iMessage clients configured");
     }
-    return entry.client;
+    return entry;
   }
-  const entry = clients.find((c) => c.phone === phone);
+  const entry = clients.find((candidate) => candidate.phone === phone);
   if (!entry) {
     const list = availablePhones(clients).join(", ") || "<none>";
     throw new Error(
       `No iMessage client serves phone ${phone}. Available: ${list}`
     );
   }
-  return entry.client;
+  return entry;
 };
+
+export const clientForPhone = (
+  clients: RemoteClient[],
+  phone: string
+): AdvancedIMessage => entryForPhone(clients, phone).client;
+
+const virtualMessageGuid = (id: string): string =>
+  parseChildId(id)?.parentGuid ?? id;
+
+export const isVirtualMessageResource = (id: string): boolean => {
+  const guid = virtualMessageGuid(id);
+  return guid.startsWith("spc-msg-") && guid.length > "spc-msg-".length;
+};
+
+export const isVirtualAttachmentResource = (guid: string): boolean =>
+  guid.startsWith("spc-att-") && guid.length > "spc-att-".length;
+
+const virtualResourceClient = (
+  entry: RemoteClient,
+  resource: string
+): AdvancedIMessage => {
+  // Shared and explicitly configured clients already point at the caller's
+  // intended server. Only auto-discovered dedicated entries have an
+  // `instanceId` and therefore need the project-scoped Spectrum proxy.
+  if (!entry.instanceId) {
+    return entry.client;
+  }
+  if (!entry.resourceClient) {
+    throw new Error(
+      `Cannot access virtual iMessage resource ${resource}: the dedicated cloud token response did not provide a Spectrum proxy token`
+    );
+  }
+  return entry.resourceClient;
+};
+
+export const clientForMessageResource = (
+  clients: RemoteClient[],
+  phone: string,
+  messageId: string
+): AdvancedIMessage => {
+  const entry = entryForPhone(clients, phone);
+  return isVirtualMessageResource(messageId)
+    ? virtualResourceClient(entry, messageId)
+    : entry.client;
+};
+
+export const clientForAttachmentResource = (
+  clients: RemoteClient[],
+  phone: string,
+  attachmentGuid: string
+): AdvancedIMessage => {
+  const entry = entryForPhone(clients, phone);
+  return isVirtualAttachmentResource(attachmentGuid)
+    ? virtualResourceClient(entry, attachmentGuid)
+    : entry.client;
+};
+
+export const clientForMiniAppSession = (
+  clients: RemoteClient[],
+  phone: string,
+  session: { messageGuid: string; targetMessageGuid: string }
+): AdvancedIMessage => {
+  const entry = entryForPhone(clients, phone);
+  return isVirtualMessageResource(session.messageGuid) ||
+    isVirtualMessageResource(session.targetMessageGuid)
+    ? virtualResourceClient(entry, session.messageGuid)
+    : entry.client;
+};
+
+export const resourceClientForEntry = (
+  entry: RemoteClient,
+  resource: string
+): AdvancedIMessage => virtualResourceClient(entry, resource);
 
 export const randomPhone = (clients: RemoteClient[]): string => {
   if (clients.length === 0) {

--- a/packages/imessage/src/remote/fusor.ts
+++ b/packages/imessage/src/remote/fusor.ts
@@ -234,17 +234,18 @@ export const handleImessageFusorMessages: HybridFusorMessages<
 > = async ({ client, payload, projectConfig }) => {
   const selected = selectClient(client, payload);
   const phone = selected.phone === SHARED_PHONE ? SHARED_PHONE : selected.phone;
-  if (projectConfig?.profile?.imessageSynced === true) {
-    getContactShareTracker(selected.client).maybeShare(payload.event.chatGuid);
-  }
   const resourceClient = resourceClientForEntry(
     selected,
     payload.event.message.guid
   );
-  return await toInboundMessages(
+  const messages = await toInboundMessages(
     resourceClient,
     getMessageCache(resourceClient),
     payload.event,
     phone
   );
+  if (projectConfig?.profile?.imessageSynced === true) {
+    getContactShareTracker(selected.client).maybeShare(payload.event.chatGuid);
+  }
+  return messages;
 };

--- a/packages/imessage/src/remote/fusor.ts
+++ b/packages/imessage/src/remote/fusor.ts
@@ -1,7 +1,7 @@
 import {
   decodeCatchUpEvent,
   type MessageEvent,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import {
   FusorTerminalError,
   type FusorVerifyRequest,
@@ -11,7 +11,7 @@ import type z from "zod";
 import { getMessageCache } from "../cache";
 import type { IMessageClient, RemoteClient } from "../types";
 import { type configSchema, SHARED_PHONE } from "../types";
-import { isSharedMode } from "./client";
+import { isSharedMode, resourceClientForEntry } from "./client";
 import { getContactShareTracker } from "./contact-share";
 import { type ReceivedEvent, toInboundMessages } from "./inbound";
 
@@ -237,9 +237,13 @@ export const handleImessageFusorMessages: HybridFusorMessages<
   if (projectConfig?.profile?.imessageSynced === true) {
     getContactShareTracker(selected.client).maybeShare(payload.event.chatGuid);
   }
+  const resourceClient = resourceClientForEntry(
+    selected,
+    payload.event.message.guid
+  );
   return await toInboundMessages(
-    selected.client,
-    getMessageCache(selected.client),
+    resourceClient,
+    getMessageCache(resourceClient),
     payload.event,
     phone
   );

--- a/packages/imessage/src/remote/fusor.ts
+++ b/packages/imessage/src/remote/fusor.ts
@@ -1,0 +1,246 @@
+import {
+  decodeCatchUpEvent,
+  type MessageEvent,
+} from "@photon-ai/advanced-imessage";
+import {
+  FusorTerminalError,
+  type FusorVerifyRequest,
+  type HybridFusorMessages,
+} from "@spectrum-ts/core";
+import type z from "zod";
+import { getMessageCache } from "../cache";
+import type { IMessageClient, RemoteClient } from "../types";
+import { type configSchema, SHARED_PHONE } from "../types";
+import { isSharedMode } from "./client";
+import { getContactShareTracker } from "./contact-share";
+import { type ReceivedEvent, toInboundMessages } from "./inbound";
+
+const EVENT_PATH = "/imessage/events/messageChanged";
+const PROTOBUF_CONTENT_TYPE = "application/x-protobuf";
+const TRANSFORM_VERSIONS = new Set(["1", "2"]);
+const SOURCE = "spectrum-imessage";
+const POSITIVE_INTEGER_RE = /^[1-9]\d*$/;
+
+const header = (request: FusorVerifyRequest, name: string): string =>
+  request.headers[name] ?? "";
+
+const requireHeader = (request: FusorVerifyRequest, name: string): string => {
+  const value = header(request, name);
+  if (!value) {
+    throw new Error(`Invalid iMessage Fusor event: missing ${name}`);
+  }
+  return value;
+};
+
+const assertVirtualGuid = (
+  value: string | undefined,
+  prefix: "spc-att-" | "spc-msg-",
+  field: string
+): void => {
+  if (
+    value !== undefined &&
+    (!value.startsWith(prefix) || value.length === prefix.length)
+  ) {
+    throw new Error(
+      `Invalid iMessage Fusor event: ${field} is not a virtual resource`
+    );
+  }
+};
+
+const assertVirtualAttachment = (
+  attachment: ReceivedEvent["message"]["content"]["attachments"][number],
+  field: string
+): void => {
+  assertVirtualGuid(attachment.guid, "spc-att-", `${field}.guid`);
+  assertVirtualGuid(
+    attachment.originalGuid,
+    "spc-att-",
+    `${field}.originalGuid`
+  );
+};
+
+export const assertVirtualImessageResources = (event: ReceivedEvent): void => {
+  const message = event.message;
+  assertVirtualGuid(message.guid, "spc-msg-", "message.guid");
+  assertVirtualGuid(
+    message.threadOriginatorGuid,
+    "spc-msg-",
+    "message.threadOriginatorGuid"
+  );
+  assertVirtualGuid(
+    message.replyTargetGuid,
+    "spc-msg-",
+    "message.replyTargetGuid"
+  );
+  assertVirtualGuid(
+    message.reactionTargetGuid,
+    "spc-msg-",
+    "message.reactionTargetGuid"
+  );
+  for (const [index, attachment] of message.content.attachments.entries()) {
+    assertVirtualAttachment(
+      attachment,
+      `message.content.attachments[${index}]`
+    );
+  }
+  for (const [index, reaction] of message.appliedReactions.entries()) {
+    assertVirtualGuid(
+      reaction.messageGuid,
+      "spc-msg-",
+      `message.appliedReactions[${index}].messageGuid`
+    );
+  }
+  for (const [index, placed] of message.placedStickers.entries()) {
+    assertVirtualGuid(
+      placed.messageGuid,
+      "spc-msg-",
+      `message.placedStickers[${index}].messageGuid`
+    );
+    if (placed.sticker) {
+      assertVirtualAttachment(
+        placed.sticker,
+        `message.placedStickers[${index}].sticker`
+      );
+    }
+  }
+};
+
+export interface ImessageFusorPayload {
+  event: ReceivedEvent;
+  instanceId?: string;
+  transformVersion: "1" | "2";
+}
+
+/** Verify and decode a trusted transform-v1 or transform-v2 fan-in request. */
+export const verifyImessageFusorRequest = (
+  request: FusorVerifyRequest
+): ImessageFusorPayload => {
+  if (request.method !== "POST" || request.path !== EVENT_PATH) {
+    throw new Error("Invalid iMessage Fusor event route");
+  }
+  const contentType = header(request, "content-type")
+    .split(";", 1)[0]
+    ?.trim()
+    .toLowerCase();
+  if (contentType !== PROTOBUF_CONTENT_TYPE) {
+    throw new Error("Invalid iMessage Fusor event content type");
+  }
+  if (header(request, "x-fusor-source") !== SOURCE) {
+    throw new Error("Invalid iMessage Fusor event source");
+  }
+  if (header(request, "x-fusor-imessage-event-type") !== "messageChanged") {
+    throw new Error("Invalid iMessage Fusor event type");
+  }
+  const transformVersion = header(
+    request,
+    "x-fusor-imessage-transform-version"
+  );
+  if (!TRANSFORM_VERSIONS.has(transformVersion)) {
+    throw new Error("Unsupported iMessage Fusor transform version");
+  }
+
+  const instanceId =
+    transformVersion === "2"
+      ? requireHeader(request, "x-fusor-imessage-instance-id")
+      : header(request, "x-fusor-imessage-instance-id") || undefined;
+  const logId = requireHeader(request, "x-fusor-imessage-log-id");
+  if (!POSITIVE_INTEGER_RE.test(logId)) {
+    throw new Error("Invalid iMessage Fusor source log id");
+  }
+
+  const decoded = decodeCatchUpEvent(request.rawBody);
+  if (decoded?.type !== "message.received") {
+    throw new Error("Invalid iMessage Fusor event payload");
+  }
+  const event = decoded as Extract<MessageEvent, { type: "message.received" }>;
+  if (event.isFromMe || event.message.isFromMe) {
+    throw new Error("Invalid iMessage Fusor event: outbound message");
+  }
+  if (String(event.sequence) !== logId) {
+    throw new Error("Invalid iMessage Fusor event: sequence mismatch");
+  }
+  assertVirtualImessageResources(event);
+
+  return {
+    event,
+    instanceId,
+    transformVersion: transformVersion as "1" | "2",
+  };
+};
+
+const destinationPhone = (destinationCallerId: string | undefined): string => {
+  if (!destinationCallerId) {
+    return "";
+  }
+  return destinationCallerId.startsWith("p:")
+    ? destinationCallerId.slice(2)
+    : destinationCallerId;
+};
+
+const selectClient = (
+  clients: IMessageClient,
+  payload: ImessageFusorPayload
+): RemoteClient => {
+  if (isSharedMode(clients)) {
+    const shared = clients[0];
+    if (!shared) {
+      throw new FusorTerminalError("No shared iMessage client configured");
+    }
+    return shared;
+  }
+
+  if (payload.instanceId) {
+    const selected = clients.find(
+      (entry) => entry.instanceId === payload.instanceId
+    );
+    if (!selected) {
+      throw new FusorTerminalError(
+        `No iMessage client serves Fusor instance ${payload.instanceId}`
+      );
+    }
+    const phone = destinationPhone(payload.event.message.destinationCallerId);
+    if (phone && phone !== selected.phone) {
+      throw new FusorTerminalError(
+        `Fusor instance ${payload.instanceId} does not serve destination ${phone}`
+      );
+    }
+    return selected;
+  }
+
+  // Retained transform-v1 frames predate the trusted instance header. Prefer
+  // their destination caller id whenever present: a frame for a removed line
+  // must not be silently reassigned to the sole line configured today.
+  const phone = destinationPhone(payload.event.message.destinationCallerId);
+  if (phone) {
+    const matches = clients.filter((entry) => entry.phone === phone);
+    if (matches.length === 1) {
+      return matches[0] as RemoteClient;
+    }
+  } else if (clients.length === 1) {
+    // The only safe fallback is a truly destination-less legacy frame with one
+    // possible recipient.
+    return clients[0] as RemoteClient;
+  }
+
+  throw new FusorTerminalError(
+    "Cannot route transform-v1 iMessage Fusor event to one dedicated client"
+  );
+};
+
+export const handleImessageFusorMessages: HybridFusorMessages<
+  ImessageFusorPayload,
+  IMessageClient,
+  z.infer<typeof configSchema>
+> = async ({ client, payload, projectConfig }) => {
+  const selected = selectClient(client, payload);
+  const phone = selected.phone === SHARED_PHONE ? SHARED_PHONE : selected.phone;
+  if (projectConfig?.profile?.imessageSynced === true) {
+    getContactShareTracker(selected.client).maybeShare(payload.event.chatGuid);
+  }
+  return await toInboundMessages(
+    selected.client,
+    getMessageCache(selected.client),
+    payload.event,
+    phone
+  );
+};

--- a/packages/imessage/src/remote/fusor.ts
+++ b/packages/imessage/src/remote/fusor.ts
@@ -17,7 +17,7 @@ import { type ReceivedEvent, toInboundMessages } from "./inbound";
 
 const EVENT_PATH = "/imessage/events/messageChanged";
 const PROTOBUF_CONTENT_TYPE = "application/x-protobuf";
-const TRANSFORM_VERSIONS = new Set(["1", "2"]);
+const TRANSFORM_VERSIONS = new Set(["1", "2", "3"]);
 const SOURCE = "spectrum-imessage";
 const POSITIVE_INTEGER_RE = /^[1-9]\d*$/;
 
@@ -108,10 +108,10 @@ export const assertVirtualImessageResources = (event: ReceivedEvent): void => {
 export interface ImessageFusorPayload {
   event: ReceivedEvent;
   instanceId?: string;
-  transformVersion: "1" | "2";
+  transformVersion: "1" | "2" | "3";
 }
 
-/** Verify and decode a trusted transform-v1 or transform-v2 fan-in request. */
+/** Verify and decode a supported, trusted iMessage fan-in request. */
 export const verifyImessageFusorRequest = (
   request: FusorVerifyRequest
 ): ImessageFusorPayload => {
@@ -140,7 +140,7 @@ export const verifyImessageFusorRequest = (
   }
 
   const instanceId =
-    transformVersion === "2"
+    transformVersion === "2" || transformVersion === "3"
       ? requireHeader(request, "x-fusor-imessage-instance-id")
       : header(request, "x-fusor-imessage-instance-id") || undefined;
   const logId = requireHeader(request, "x-fusor-imessage-log-id");
@@ -164,7 +164,7 @@ export const verifyImessageFusorRequest = (
   return {
     event,
     instanceId,
-    transformVersion: transformVersion as "1" | "2",
+    transformVersion: transformVersion as "1" | "2" | "3",
   };
 };
 

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -115,7 +115,7 @@ const toMessageItem = async (
   onInbound?: OnInboundMessage
 ): Promise<ResumableStreamItem<IMessageMessage>> => {
   if (event.type === "message.received") {
-    if (!includeReceived || event.message.isFromMe) {
+    if (!includeReceived || event.isFromMe || event.message.isFromMe) {
       return { cursor, id: event.message.guid, values: [] };
     }
 

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -111,10 +111,11 @@ const toMessageItem = async (
   event: MessageEvent,
   phone: string,
   cursor: string,
+  includeReceived: boolean,
   onInbound?: OnInboundMessage
 ): Promise<ResumableStreamItem<IMessageMessage>> => {
   if (event.type === "message.received") {
-    if (event.message.isFromMe) {
+    if (!includeReceived || event.message.isFromMe) {
       return { cursor, id: event.message.guid, values: [] };
     }
 
@@ -282,6 +283,7 @@ const withClose = <T extends MessageEvent | PollEvent | GroupEvent>(
 const messageStream = (
   client: AdvancedIMessage,
   phone: string,
+  includeReceived: boolean,
   onInbound?: OnInboundMessage,
   recover?: () => Promise<void>
 ): ManagedStream<IMessageMessage> =>
@@ -295,7 +297,14 @@ const messageStream = (
         streamLabel("messages", phone),
         String(event.sequence),
         () =>
-          toMessageItem(client, event, phone, String(event.sequence), onInbound)
+          toMessageItem(
+            client,
+            event,
+            phone,
+            String(event.sequence),
+            includeReceived,
+            onInbound
+          )
       ),
     processMissed: (event) =>
       event.type === "catchup.complete"
@@ -309,6 +318,7 @@ const messageStream = (
                 event,
                 phone,
                 String(event.sequence),
+                includeReceived,
                 onInbound
               )
           ),
@@ -381,11 +391,12 @@ const clientStream = (
   pollCache: PollCache,
   phone: string,
   includeGroupEvents: boolean,
+  includeReceived: boolean,
   onInbound?: OnInboundMessage,
   recover?: () => Promise<void>
 ): ManagedStream<IMessageMessage> => {
   const streams: ManagedStream<IMessageMessage>[] = [
-    messageStream(client, phone, onInbound, recover),
+    messageStream(client, phone, includeReceived, onInbound, recover),
     pollStream(client, pollCache, phone, recover),
   ];
 
@@ -398,7 +409,8 @@ const clientStream = (
 
 export const messages = (
   clients: RemoteClient[],
-  projectConfig?: ProjectData | undefined
+  projectConfig?: ProjectData | undefined,
+  includeReceived = true
 ): ManagedStream<IMessageMessage> => {
   const pollCache = getPollCache(clients);
   // When the project profile opts in to iMessage sync, push the bot's contact
@@ -422,6 +434,7 @@ export const messages = (
         pollCache,
         entry.phone,
         includeGroupEvents,
+        includeReceived,
         tracker ? (chatGuid) => tracker.maybeShare(chatGuid) : undefined,
         recover
       );

--- a/packages/imessage/src/types.ts
+++ b/packages/imessage/src/types.ts
@@ -7,6 +7,11 @@ export interface RemoteClient {
   /** Cloud instance routing key; absent for explicit and shared clients. */
   instanceId?: string;
   phone: string;
+  /**
+   * Spectrum proxy used only for project-scoped `spc-*` resources. All
+   * auto-discovered dedicated entries share the same client instance.
+   */
+  resourceClient?: AdvancedIMessage;
 }
 
 export type IMessageClient = RemoteClient[];

--- a/packages/imessage/src/types.ts
+++ b/packages/imessage/src/types.ts
@@ -4,6 +4,8 @@ import z from "zod";
 
 export interface RemoteClient {
   client: AdvancedIMessage;
+  /** Cloud instance routing key; absent for explicit and shared clients. */
+  instanceId?: string;
   phone: string;
 }
 

--- a/packages/imessage/test/auth.test.ts
+++ b/packages/imessage/test/auth.test.ts
@@ -1,29 +1,31 @@
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-interface FakeDedicatedTokenData {
-  auth: Record<string, string>;
-  expiresIn: number;
-  numbers: Record<string, string | null>;
-  type: "dedicated";
+interface GrpcClientOptions {
+  address: string;
+  token: string | (() => Promise<string>);
 }
 
-interface FakeClientOptions {
-  token: () => Promise<string>;
+interface FakeClient {
+  close: ReturnType<typeof vi.fn>;
+  options: GrpcClientOptions;
 }
 
-const initialTokenData: FakeDedicatedTokenData = {
-  auth: { "instance-1": "token-1" },
-  expiresIn: 3600,
-  numbers: { "instance-1": "+15550000001" },
-  type: "dedicated",
+const issuedClients: FakeClient[] = [];
+const MISSING_PROXY_TOKEN_ERROR = /missing proxyToken/;
+const MISSING_INSTANCE_AUTH_ERROR = /missing auth for instance instance-2/;
+const MISSING_INSTANCE_PHONE_ERROR = /instance-2 has no phone/;
+const makeFakeClient = (options: GrpcClientOptions): AdvancedIMessage => {
+  const client: FakeClient = {
+    close: vi.fn(() => Promise.resolve()),
+    options,
+  };
+  issuedClients.push(client);
+  return client as unknown as AdvancedIMessage;
 };
+const createGrpcClient = vi.fn(makeFakeClient);
 
-const issueImessageTokens = vi.fn(() => Promise.resolve(initialTokenData));
-const clientOptions: FakeClientOptions[] = [];
-const createGrpcClient = vi.fn((options: FakeClientOptions) => {
-  clientOptions.push(options);
-  return {};
-});
+const issueImessageTokens = vi.fn();
 
 vi.doMock("@spectrum-ts/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@spectrum-ts/core")>();
@@ -33,36 +35,63 @@ vi.doMock("@spectrum-ts/core", async (importOriginal) => {
   };
 });
 
-vi.doMock("@photon-ai/advanced-imessage/grpc", () => ({ createGrpcClient }));
+vi.doMock("@photon-ai/advanced-imessage/grpc", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@photon-ai/advanced-imessage/grpc")>();
+  return { ...actual, createGrpcClient };
+});
 
 const { createCloudClients, disposeCloudAuth, getCloudRecover } = await import(
   "@/auth"
 );
+const { imessage } = await import("@/index");
 
-describe("imessage cloud auth", () => {
+const dedicatedTokens = (
+  proxyToken: string,
+  expiresIn = 3600
+): {
+  auth: Record<string, string>;
+  expiresIn: number;
+  numbers: Record<string, string>;
+  proxyToken: string;
+  type: "dedicated";
+} => ({
+  auth: { "instance-1": "direct-1", "instance-2": "direct-2" },
+  expiresIn,
+  numbers: {
+    "instance-1": "+15550100",
+    "instance-2": "+15550101",
+  },
+  proxyToken,
+  type: "dedicated",
+});
+
+const resolveToken = async (token: GrpcClientOptions["token"]) =>
+  typeof token === "function" ? await token() : token;
+
+describe("iMessage cloud resource client auth", () => {
   beforeEach(() => {
+    issuedClients.length = 0;
+    createGrpcClient.mockReset();
+    createGrpcClient.mockImplementation(makeFakeClient);
     issueImessageTokens.mockReset();
-    issueImessageTokens.mockResolvedValue(initialTokenData);
-    createGrpcClient.mockClear();
-    clientOptions.length = 0;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
-  it("coalesces forced recovery and updates dedicated clients in place", async () => {
+  it("coalesces forced recovery and updates all dedicated tokens", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
     let resolveRefresh:
-      | ((
-          value: FakeDedicatedTokenData | PromiseLike<FakeDedicatedTokenData>
-        ) => void)
+      | ((value: ReturnType<typeof dedicatedTokens>) => void)
       | undefined;
-    issueImessageTokens.mockResolvedValueOnce(initialTokenData);
+    issueImessageTokens.mockResolvedValueOnce(dedicatedTokens("proxy-1"));
     issueImessageTokens.mockImplementationOnce(
       () =>
-        new Promise<FakeDedicatedTokenData>((resolve) => {
+        new Promise<ReturnType<typeof dedicatedTokens>>((resolve) => {
           resolveRefresh = resolve;
         })
     );
@@ -79,18 +108,252 @@ describe("imessage cloud auth", () => {
     expect(issueImessageTokens).toHaveBeenCalledTimes(2);
 
     resolveRefresh?.({
-      auth: { "instance-1": "token-2" },
-      expiresIn: 3600,
-      numbers: { "instance-1": "+15550000002" },
-      type: "dedicated",
+      ...dedicatedTokens("proxy-2"),
+      auth: {
+        "instance-1": "direct-1-refreshed",
+        "instance-2": "direct-2-refreshed",
+      },
     });
     await Promise.all([first, second]);
 
     expect(issueImessageTokens).toHaveBeenCalledTimes(2);
-    expect(clients[0]?.phone).toBe("+15550000002");
-    expect(await clientOptions[0]?.token()).toBe("token-2");
+    expect(await resolveToken(issuedClients[0]?.options.token ?? "")).toBe(
+      "proxy-2"
+    );
+    expect(await resolveToken(issuedClients[1]?.options.token ?? "")).toBe(
+      "direct-1-refreshed"
+    );
 
     await disposeCloudAuth(clients);
     expect(getCloudRecover(clients)).toBeUndefined();
+  });
+
+  it("shares one project proxy across all dedicated instance clients", async () => {
+    issueImessageTokens.mockResolvedValue(dedicatedTokens("proxy-1"));
+
+    const clients = await createCloudClients("project-1", "secret-1");
+
+    expect(clients).toHaveLength(2);
+    expect(createGrpcClient).toHaveBeenCalledTimes(3);
+    expect(issuedClients.map((entry) => entry.options.address)).toEqual([
+      "imessage.spectrum.photon.codes:443",
+      "instance-1.imsg.photon.codes:443",
+      "instance-2.imsg.photon.codes:443",
+    ]);
+    expect(clients[0]?.resourceClient).toBe(clients[1]?.resourceClient);
+    expect(clients[0]?.resourceClient).toBe(
+      issuedClients[0] as unknown as AdvancedIMessage
+    );
+    expect(await resolveToken(issuedClients[0]?.options.token ?? "")).toBe(
+      "proxy-1"
+    );
+    expect(await resolveToken(issuedClients[1]?.options.token ?? "")).toBe(
+      "direct-1"
+    );
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("reads the latest proxy token after a cloud refresh", async () => {
+    issueImessageTokens
+      .mockResolvedValueOnce(dedicatedTokens("proxy-1", 0))
+      .mockResolvedValue(dedicatedTokens("proxy-2"));
+    const clients = await createCloudClients("project-1", "secret-1");
+
+    expect(await resolveToken(issuedClients[0]?.options.token ?? "")).toBe(
+      "proxy-2"
+    );
+    expect(issueImessageTokens).toHaveBeenCalledTimes(2);
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("rejects a dedicated response without a project proxy token", async () => {
+    issueImessageTokens.mockResolvedValue(dedicatedTokens(""));
+
+    await expect(createCloudClients("project-1", "secret-1")).rejects.toThrow(
+      MISSING_PROXY_TOKEN_ERROR
+    );
+    expect(createGrpcClient).not.toHaveBeenCalled();
+  });
+
+  it("validates every dedicated line before opening any channel", async () => {
+    issueImessageTokens.mockResolvedValue({
+      ...dedicatedTokens("proxy-1"),
+      numbers: { "instance-1": "+15550100" },
+    });
+
+    await expect(createCloudClients("project-1", "secret-1")).rejects.toThrow(
+      MISSING_INSTANCE_PHONE_ERROR
+    );
+    expect(createGrpcClient).not.toHaveBeenCalled();
+  });
+
+  it("closes channels already opened when later client construction fails", async () => {
+    issueImessageTokens.mockResolvedValue(dedicatedTokens("proxy-1"));
+    createGrpcClient
+      .mockImplementationOnce(makeFakeClient)
+      .mockImplementationOnce(() => {
+        throw new Error("direct channel construction failed");
+      });
+
+    await expect(createCloudClients("project-1", "secret-1")).rejects.toThrow(
+      "direct channel construction failed"
+    );
+
+    expect(issuedClients).toHaveLength(1);
+    expect(issuedClients[0]?.close).toHaveBeenCalledOnce();
+  });
+
+  it("does not add a second client in shared mode", async () => {
+    issueImessageTokens.mockResolvedValue({
+      expiresIn: 3600,
+      token: "shared-token",
+      type: "shared",
+    });
+
+    const clients = await createCloudClients("project-1", "secret-1");
+
+    expect(clients).toHaveLength(1);
+    expect(clients[0]?.resourceClient).toBeUndefined();
+    expect(createGrpcClient).toHaveBeenCalledTimes(1);
+    expect(await resolveToken(issuedClients[0]?.options.token ?? "")).toBe(
+      "shared-token"
+    );
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("rejects a shared-to-dedicated refresh without corrupting the last good token", async () => {
+    issueImessageTokens
+      .mockResolvedValueOnce({
+        expiresIn: 0,
+        token: "shared-1",
+        type: "shared",
+      })
+      .mockResolvedValueOnce(dedicatedTokens("proxy-wrong-mode"))
+      .mockResolvedValueOnce({
+        expiresIn: 3600,
+        token: "shared-2",
+        type: "shared",
+      });
+    const clients = await createCloudClients("project-1", "secret-1");
+    const token = issuedClients[0]?.options.token ?? "";
+
+    await expect(resolveToken(token)).rejects.toThrow(
+      "changed mode from shared to dedicated"
+    );
+    await expect(resolveToken(token)).resolves.toBe("shared-2");
+    expect(issueImessageTokens).toHaveBeenCalledTimes(3);
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("commits a dedicated refresh only after every existing line validates", async () => {
+    issueImessageTokens
+      .mockResolvedValueOnce(dedicatedTokens("proxy-1", 0))
+      .mockResolvedValueOnce({
+        ...dedicatedTokens("proxy-invalid"),
+        auth: { "instance-1": "direct-invalid" },
+      })
+      .mockResolvedValueOnce({
+        ...dedicatedTokens("proxy-2"),
+        auth: {
+          "instance-1": "direct-1-refreshed",
+          "instance-2": "direct-2-refreshed",
+        },
+      });
+    const clients = await createCloudClients("project-1", "secret-1");
+    const proxyToken = issuedClients[0]?.options.token ?? "";
+
+    await expect(resolveToken(proxyToken)).rejects.toThrow(
+      MISSING_INSTANCE_AUTH_ERROR
+    );
+    expect(clients.map((entry) => entry.phone)).toEqual([
+      "+15550100",
+      "+15550101",
+    ]);
+
+    await expect(resolveToken(proxyToken)).resolves.toBe("proxy-2");
+    expect(clients.map((entry) => entry.phone)).toEqual([
+      "+15550100",
+      "+15550101",
+    ]);
+    await expect(
+      resolveToken(issuedClients[1]?.options.token ?? "")
+    ).resolves.toBe("direct-1-refreshed");
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("rejects line topology or phone changes that require rebuilding streams", async () => {
+    issueImessageTokens
+      .mockResolvedValueOnce(dedicatedTokens("proxy-1", 0))
+      .mockResolvedValueOnce({
+        ...dedicatedTokens("proxy-phone-change"),
+        numbers: {
+          "instance-1": "+15550110",
+          "instance-2": "+15550101",
+        },
+      })
+      .mockResolvedValueOnce({
+        ...dedicatedTokens("proxy-added-line"),
+        auth: {
+          "instance-1": "direct-1",
+          "instance-2": "direct-2",
+          "instance-3": "direct-3",
+        },
+        numbers: {
+          "instance-1": "+15550100",
+          "instance-2": "+15550101",
+          "instance-3": "+15550102",
+        },
+      })
+      .mockResolvedValueOnce(dedicatedTokens("proxy-2"));
+    const clients = await createCloudClients("project-1", "secret-1");
+    const proxyToken = issuedClients[0]?.options.token ?? "";
+
+    await expect(resolveToken(proxyToken)).rejects.toThrow(
+      "changed the phone for instance instance-1"
+    );
+    await expect(resolveToken(proxyToken)).rejects.toThrow(
+      "changed the dedicated instance set"
+    );
+    await expect(resolveToken(proxyToken)).resolves.toBe("proxy-2");
+    expect(clients.map((entry) => entry.phone)).toEqual([
+      "+15550100",
+      "+15550101",
+    ]);
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("does not create an orphan proxy client when no dedicated line resolves", async () => {
+    issueImessageTokens.mockResolvedValue({
+      ...dedicatedTokens("proxy-1"),
+      auth: {},
+      numbers: {},
+    });
+
+    const clients = await createCloudClients("project-1", "secret-1");
+
+    expect(clients).toEqual([]);
+    expect(createGrpcClient).not.toHaveBeenCalled();
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("closes a shared dedicated resource client exactly once", async () => {
+    issueImessageTokens.mockResolvedValue(dedicatedTokens("proxy-1"));
+    const clients = await createCloudClients("project-1", "secret-1");
+    const destroyClient = imessage.config({}).__definition.lifecycle
+      .destroyClient;
+
+    await destroyClient?.({ client: clients } as never);
+
+    expect(issuedClients).toHaveLength(3);
+    for (const issued of issuedClients) {
+      expect(issued.close).toHaveBeenCalledTimes(1);
+    }
   });
 });

--- a/packages/imessage/test/remote/client.test.ts
+++ b/packages/imessage/test/remote/client.test.ts
@@ -1,0 +1,127 @@
+import type {
+  AdvancedIMessage,
+  MiniAppCardSession,
+} from "@photon-ai/advanced-imessage/grpc";
+import { describe, expect, it } from "vitest";
+import {
+  clientForAttachmentResource,
+  clientForMessageResource,
+  clientForMiniAppSession,
+  isVirtualAttachmentResource,
+  isVirtualMessageResource,
+} from "@/remote/client";
+import type { RemoteClient } from "@/types";
+import { SHARED_PHONE } from "@/types";
+
+const MISSING_PROXY_CLIENT_ERROR = /did not provide a Spectrum proxy token/;
+
+const remote = (name: string): AdvancedIMessage =>
+  ({ name }) as unknown as AdvancedIMessage;
+
+const dedicated = (): {
+  direct: AdvancedIMessage;
+  entry: RemoteClient;
+  proxy: AdvancedIMessage;
+} => {
+  const direct = remote("direct");
+  const proxy = remote("proxy");
+  return {
+    direct,
+    entry: {
+      client: direct,
+      instanceId: "instance-1",
+      phone: "+15550100",
+      resourceClient: proxy,
+    },
+    proxy,
+  };
+};
+
+describe("iMessage virtual resource client routing", () => {
+  it("recognizes message parents, child ids, and attachment resources", () => {
+    expect(isVirtualMessageResource("spc-msg-parent")).toBe(true);
+    expect(isVirtualMessageResource("p:3/spc-msg-parent")).toBe(true);
+    expect(isVirtualMessageResource("p:3/native-parent")).toBe(false);
+    expect(isVirtualMessageResource("spc-msg-")).toBe(false);
+    expect(isVirtualAttachmentResource("spc-att-photo")).toBe(true);
+    expect(isVirtualAttachmentResource("spc-att-")).toBe(false);
+  });
+
+  it("keeps native dedicated resources on their instance client", () => {
+    const { direct, entry } = dedicated();
+
+    expect(
+      clientForMessageResource([entry], entry.phone, "native-message")
+    ).toBe(direct);
+    expect(
+      clientForAttachmentResource([entry], entry.phone, "native-attachment")
+    ).toBe(direct);
+  });
+
+  it("routes virtual messages, child ids, attachments, and sessions to the shared proxy", () => {
+    const { entry, proxy } = dedicated();
+    const virtualSession = {
+      chatGuid: "any;-;+15551234",
+      messageGuid: "spc-msg-card",
+      sessionId: "session-1",
+      targetMessageGuid: "spc-msg-target",
+    } satisfies MiniAppCardSession;
+
+    expect(
+      clientForMessageResource([entry], entry.phone, "spc-msg-parent")
+    ).toBe(proxy);
+    expect(
+      clientForMessageResource([entry], entry.phone, "p:2/spc-msg-parent")
+    ).toBe(proxy);
+    expect(
+      clientForAttachmentResource([entry], entry.phone, "spc-att-photo")
+    ).toBe(proxy);
+    expect(clientForMiniAppSession([entry], entry.phone, virtualSession)).toBe(
+      proxy
+    );
+  });
+
+  it("keeps native mini-app sessions on the dedicated instance", () => {
+    const { direct, entry } = dedicated();
+    const session = {
+      chatGuid: "any;-;+15551234",
+      messageGuid: "native-card",
+      sessionId: "session-1",
+      targetMessageGuid: "native-target",
+    } satisfies MiniAppCardSession;
+
+    expect(clientForMiniAppSession([entry], entry.phone, session)).toBe(direct);
+  });
+
+  it("leaves shared and explicitly configured clients unchanged", () => {
+    const shared = remote("shared");
+    const explicit = remote("explicit");
+
+    expect(
+      clientForMessageResource(
+        [{ client: shared, phone: SHARED_PHONE }],
+        SHARED_PHONE,
+        "spc-msg-shared"
+      )
+    ).toBe(shared);
+    expect(
+      clientForAttachmentResource(
+        [{ client: explicit, phone: "+15550100" }],
+        "+15550100",
+        "spc-att-explicit"
+      )
+    ).toBe(explicit);
+  });
+
+  it("fails clearly instead of sending a virtual id to a dedicated server", () => {
+    const entry: RemoteClient = {
+      client: remote("direct"),
+      instanceId: "instance-1",
+      phone: "+15550100",
+    };
+
+    expect(() =>
+      clientForMessageResource([entry], entry.phone, "spc-msg-missing")
+    ).toThrow(MISSING_PROXY_CLIENT_ERROR);
+  });
+});

--- a/packages/imessage/test/remote/fusor.test.ts
+++ b/packages/imessage/test/remote/fusor.test.ts
@@ -47,6 +47,14 @@ const v1Request = () => {
   });
 };
 
+const v3Request = () =>
+  request({
+    headers: {
+      ...request().headers,
+      "x-fusor-imessage-transform-version": "3",
+    },
+  });
+
 const client = (): AdvancedIMessage =>
   ({
     messages: {
@@ -103,7 +111,7 @@ describe("iMessage Fusor transport", () => {
       request({
         headers: {
           ...request().headers,
-          "x-fusor-imessage-transform-version": "3",
+          "x-fusor-imessage-transform-version": "4",
         },
       }),
     ],
@@ -132,6 +140,28 @@ describe("iMessage Fusor transport", () => {
     expect(payload.instanceId).toBeUndefined();
     expect(payload.transformVersion).toBe("1");
     expect(payload.event.message.destinationCallerId).toBe("p:+15550001111");
+  });
+
+  it("accepts Spectrum-materialized transform-v3 frames", () => {
+    const payload = verifyImessageFusorRequest(v3Request());
+
+    expect(payload.instanceId).toBe("instance-1");
+    expect(payload.transformVersion).toBe("3");
+    expect(payload.event.sequence).toBe(42);
+  });
+
+  it("requires an instance header on transform-v3 frames", () => {
+    const base = v3Request();
+
+    expect(() =>
+      verifyImessageFusorRequest({
+        ...base,
+        headers: {
+          ...base.headers,
+          "x-fusor-imessage-instance-id": "",
+        },
+      })
+    ).toThrow("missing x-fusor-imessage-instance-id");
   });
 
   it("routes a dedicated event by its trusted instance id", async () => {

--- a/packages/imessage/test/remote/fusor.test.ts
+++ b/packages/imessage/test/remote/fusor.test.ts
@@ -1,6 +1,6 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import { FusorTerminalError } from "@spectrum-ts/core";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   assertVirtualImessageResources,
   handleImessageFusorMessages,
@@ -166,6 +166,7 @@ describe("iMessage Fusor transport", () => {
 
   it("routes a dedicated event by its trusted instance id", async () => {
     const selected = client();
+    const resourceClient = client();
     const other = client();
     const payload = verifyImessageFusorRequest(request());
 
@@ -176,6 +177,7 @@ describe("iMessage Fusor transport", () => {
           client: selected,
           instanceId: "instance-1",
           phone: "+15550001111",
+          resourceClient,
         },
       ],
       config: {},
@@ -195,6 +197,127 @@ describe("iMessage Fusor transport", () => {
         phone: "+15550001111",
       },
     });
+  });
+
+  it("binds virtual inbound attachment reads to the Spectrum resource client", async () => {
+    const directDownload = vi.fn();
+    const resourceDownload = vi.fn(() => ({
+      async *[Symbol.asyncIterator]() {
+        yield { data: Uint8Array.from([1, 2, 3]), type: "primaryChunk" };
+      },
+      close: () => Promise.resolve(),
+    }));
+    const direct = {
+      attachments: { downloadStream: directDownload },
+    } as unknown as AdvancedIMessage;
+    const resourceClient = {
+      attachments: { downloadStream: resourceDownload },
+      messages: { get: () => Promise.reject(new Error("not expected")) },
+    } as unknown as AdvancedIMessage;
+    const decoded = verifyImessageFusorRequest(request());
+    const payload = {
+      ...decoded,
+      event: {
+        ...decoded.event,
+        message: {
+          ...decoded.event.message,
+          content: {
+            ...decoded.event.message.content,
+            attachments: [
+              {
+                fileName: "photo.png",
+                guid: "spc-att-photo",
+                isHidden: false,
+                isOutgoing: false,
+                isSticker: false,
+                mimeType: "image/png",
+                totalBytes: 3,
+                transferState: 0,
+                uti: "public.png",
+              },
+            ],
+            text: "\uFFFC",
+          },
+        },
+      },
+    } as unknown as typeof decoded;
+
+    const records = await handleImessageFusorMessages({
+      client: [
+        {
+          client: direct,
+          instanceId: "instance-1",
+          phone: "+15550001111",
+          resourceClient,
+        },
+      ],
+      config: {},
+      payload,
+      projectConfig: undefined,
+      respond: () => undefined,
+      store: {} as never,
+    });
+    const record = Array.isArray(records) ? records[0] : records;
+    if (record?.content.type !== "attachment") {
+      throw new Error("expected an attachment record");
+    }
+
+    await expect(record.content.read()).resolves.toEqual(
+      Buffer.from([1, 2, 3])
+    );
+    expect(resourceDownload).toHaveBeenCalledWith("spc-att-photo");
+    expect(directDownload).not.toHaveBeenCalled();
+  });
+
+  it("resolves virtual reply targets through the Spectrum resource client", async () => {
+    const decoded = verifyImessageFusorRequest(request());
+    const getDirect = vi.fn(() => Promise.reject(new Error("wrong client")));
+    const getResource = vi.fn(() =>
+      Promise.resolve({
+        ...decoded.event.message,
+        content: {
+          ...decoded.event.message.content,
+          text: "original message",
+        },
+        guid: "spc-msg-reply-target",
+      })
+    );
+    const payload = {
+      ...decoded,
+      event: {
+        ...decoded.event,
+        message: {
+          ...decoded.event.message,
+          replyTargetGuid: "spc-msg-reply-target",
+        },
+      },
+    } as typeof decoded;
+
+    const records = await handleImessageFusorMessages({
+      client: [
+        {
+          client: {
+            messages: { get: getDirect },
+          } as unknown as AdvancedIMessage,
+          instanceId: "instance-1",
+          phone: "+15550001111",
+          resourceClient: {
+            messages: { get: getResource },
+          } as unknown as AdvancedIMessage,
+        },
+      ],
+      config: {},
+      payload,
+      projectConfig: undefined,
+      respond: () => undefined,
+      store: {} as never,
+    });
+
+    expect(Array.isArray(records) ? records[0]?.content.type : undefined).toBe(
+      "reply"
+    );
+    expect(getResource).toHaveBeenCalledWith("spc-msg-reply-target");
+    expect(getDirect).not.toHaveBeenCalled();
   });
 
   it("rejects a v2 instance whose configured phone disagrees with the payload", async () => {

--- a/packages/imessage/test/remote/fusor.test.ts
+++ b/packages/imessage/test/remote/fusor.test.ts
@@ -199,6 +199,86 @@ describe("iMessage Fusor transport", () => {
     });
   });
 
+  it("shares the event chat after a synced inbound conversion succeeds", async () => {
+    const shareContactInfo = vi.fn(() => Promise.resolve());
+    const direct = {
+      chats: { shareContactInfo },
+    } as unknown as AdvancedIMessage;
+    const resourceClient = client();
+    const payload = verifyImessageFusorRequest(request());
+
+    const records = await handleImessageFusorMessages({
+      client: [
+        {
+          client: direct,
+          instanceId: "instance-1",
+          phone: "+15550001111",
+          resourceClient,
+        },
+      ],
+      config: {},
+      payload,
+      projectConfig: {
+        id: "project-1",
+        name: "Project",
+        profile: { imessageSynced: true },
+        slug: "project",
+      },
+      respond: () => undefined,
+      store: {} as never,
+    });
+
+    expect(records).toHaveLength(1);
+    expect(shareContactInfo).toHaveBeenCalledOnce();
+    expect(shareContactInfo).toHaveBeenCalledWith(payload.event.chatGuid);
+  });
+
+  it("does not share a synced event whose inbound conversion fails", async () => {
+    const shareContactInfo = vi.fn(() => Promise.resolve());
+    const direct = {
+      chats: { shareContactInfo },
+    } as unknown as AdvancedIMessage;
+    const decoded = verifyImessageFusorRequest(request());
+    const payload = {
+      ...decoded,
+      event: {
+        ...decoded.event,
+        message: {
+          ...decoded.event.message,
+          content: {
+            ...decoded.event.message.content,
+            attachments: undefined,
+          },
+        },
+      },
+    } as unknown as typeof decoded;
+
+    await expect(
+      handleImessageFusorMessages({
+        client: [
+          {
+            client: direct,
+            instanceId: "instance-1",
+            phone: "+15550001111",
+            resourceClient: client(),
+          },
+        ],
+        config: {},
+        payload,
+        projectConfig: {
+          id: "project-1",
+          name: "Project",
+          profile: { imessageSynced: true },
+          slug: "project",
+        },
+        respond: () => undefined,
+        store: {} as never,
+      })
+    ).rejects.toThrow();
+
+    expect(shareContactInfo).not.toHaveBeenCalled();
+  });
+
   it("binds virtual inbound attachment reads to the Spectrum resource client", async () => {
     const directDownload = vi.fn();
     const resourceDownload = vi.fn(() => ({

--- a/packages/imessage/test/remote/fusor.test.ts
+++ b/packages/imessage/test/remote/fusor.test.ts
@@ -1,0 +1,311 @@
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import { FusorTerminalError } from "@spectrum-ts/core";
+import { describe, expect, it } from "vitest";
+import {
+  assertVirtualImessageResources,
+  handleImessageFusorMessages,
+  verifyImessageFusorRequest,
+} from "@/remote/fusor";
+import { SHARED_PHONE } from "@/types";
+
+// Encoded with advanced-imessage's v1 CatchUpEventsResponse codec. This is a
+// small companion to fusor-fanin-imessage's exhaustive transformed golden and
+// deliberately contains only project-scoped virtual message resources.
+const RECEIVED_FRAME = Uint8Array.from(
+  Buffer.from(
+    "CCpSuwEKF2lNZXNzYWdlOy07KzE1NTUxMjM0NTY3EgwIi9vg0gYQgIS42QEaFAoMKzE1NTUxMjM0NTY3EAEaAlVTUnwKegoUc3BjLW1zZy1tZXNzYWdlLWd1aWQSEgoQaGVsbG8gZnJvbSBmdXNvclIMCIvb4NIGEICEuNkBogEUCgwrMTU1NTEyMzQ1NjcQARoCVVPaBA5wOisxNTU1MDAwMTExMeIFF2lNZXNzYWdlOy07KzE1NTUxMjM0NTY3",
+    "base64"
+  )
+);
+
+const request = (
+  overrides: Partial<Parameters<typeof verifyImessageFusorRequest>[0]> = {}
+) => ({
+  method: "POST",
+  path: "/imessage/events/messageChanged",
+  headers: {
+    "content-type": "application/x-protobuf",
+    "x-fusor-imessage-event-type": "messageChanged",
+    "x-fusor-imessage-instance-id": "instance-1",
+    "x-fusor-imessage-log-id": "42",
+    "x-fusor-imessage-transform-version": "2",
+    "x-fusor-source": "spectrum-imessage",
+  },
+  rawBody: RECEIVED_FRAME,
+  ...overrides,
+});
+
+const v1Request = () => {
+  const base = request();
+  const { "x-fusor-imessage-instance-id": _instanceId, ...headers } =
+    base.headers;
+  return request({
+    headers: {
+      ...headers,
+      "x-fusor-imessage-transform-version": "1",
+    },
+  });
+};
+
+const client = (): AdvancedIMessage =>
+  ({
+    messages: {
+      get: () => Promise.reject(new Error("not expected")),
+    },
+  }) as unknown as AdvancedIMessage;
+
+describe("iMessage Fusor transport", () => {
+  it("verifies and decodes the versioned fan-in contract", () => {
+    const payload = verifyImessageFusorRequest(request());
+
+    expect(payload.instanceId).toBe("instance-1");
+    expect(payload.transformVersion).toBe("2");
+    expect(payload.event).toMatchObject({
+      chatGuid: "iMessage;-;+15551234567",
+      isFromMe: false,
+      message: {
+        content: { text: "hello from fusor" },
+        destinationCallerId: "p:+15550001111",
+        guid: "spc-msg-message-guid",
+        isFromMe: false,
+      },
+      sequence: 42,
+      type: "message.received",
+    });
+  });
+
+  it.each([
+    ["method", request({ method: "GET" })],
+    ["path", request({ path: "/imessage/events/other" })],
+    [
+      "content type",
+      request({
+        headers: { ...request().headers, "content-type": "application/json" },
+      }),
+    ],
+    [
+      "source",
+      request({
+        headers: { ...request().headers, "x-fusor-source": "public-ingress" },
+      }),
+    ],
+    [
+      "event type",
+      request({
+        headers: {
+          ...request().headers,
+          "x-fusor-imessage-event-type": "pollChanged",
+        },
+      }),
+    ],
+    [
+      "transform version",
+      request({
+        headers: {
+          ...request().headers,
+          "x-fusor-imessage-transform-version": "3",
+        },
+      }),
+    ],
+    [
+      "instance",
+      request({
+        headers: {
+          ...request().headers,
+          "x-fusor-imessage-instance-id": "",
+        },
+      }),
+    ],
+    [
+      "sequence",
+      request({
+        headers: { ...request().headers, "x-fusor-imessage-log-id": "43" },
+      }),
+    ],
+  ])("rejects an invalid %s contract", (_name, input) => {
+    expect(() => verifyImessageFusorRequest(input)).toThrow();
+  });
+
+  it("accepts retained transform-v1 frames without an instance header", () => {
+    const payload = verifyImessageFusorRequest(v1Request());
+
+    expect(payload.instanceId).toBeUndefined();
+    expect(payload.transformVersion).toBe("1");
+    expect(payload.event.message.destinationCallerId).toBe("p:+15550001111");
+  });
+
+  it("routes a dedicated event by its trusted instance id", async () => {
+    const selected = client();
+    const other = client();
+    const payload = verifyImessageFusorRequest(request());
+
+    const records = await handleImessageFusorMessages({
+      client: [
+        { client: other, instanceId: "instance-2", phone: "+15550002222" },
+        {
+          client: selected,
+          instanceId: "instance-1",
+          phone: "+15550001111",
+        },
+      ],
+      config: {},
+      payload,
+      projectConfig: undefined,
+      respond: () => undefined,
+      store: {} as never,
+    });
+
+    expect(records).toHaveLength(1);
+    const record = Array.isArray(records) ? records[0] : records;
+    expect(record).toMatchObject({
+      content: { text: "hello from fusor", type: "text" },
+      id: "spc-msg-message-guid",
+      space: {
+        id: "iMessage;-;+15551234567",
+        phone: "+15550001111",
+      },
+    });
+  });
+
+  it("rejects a v2 instance whose configured phone disagrees with the payload", async () => {
+    const payload = verifyImessageFusorRequest(request());
+
+    await expect(
+      handleImessageFusorMessages({
+        client: [
+          {
+            client: client(),
+            instanceId: "instance-1",
+            phone: "+15550002222",
+          },
+        ],
+        config: {},
+        payload,
+        projectConfig: undefined,
+        respond: () => undefined,
+        store: {} as never,
+      })
+    ).rejects.toMatchObject({
+      name: "FusorTerminalError",
+      message:
+        "Fusor instance instance-1 does not serve destination +15550001111",
+    });
+  });
+
+  it("uses the sole client in shared mode", async () => {
+    const payload = verifyImessageFusorRequest(v1Request());
+    const records = await handleImessageFusorMessages({
+      client: [{ client: client(), phone: SHARED_PHONE }],
+      config: {},
+      payload,
+      projectConfig: undefined,
+      respond: () => undefined,
+      store: {} as never,
+    });
+
+    const record = Array.isArray(records) ? records[0] : records;
+    expect(record?.space).toMatchObject({ phone: SHARED_PHONE });
+  });
+
+  it("routes a retained transform-v1 frame by its destination phone", async () => {
+    const selected = client();
+    const payload = verifyImessageFusorRequest(v1Request());
+    const records = await handleImessageFusorMessages({
+      client: [
+        { client: client(), phone: "+15550002222" },
+        { client: selected, phone: "+15550001111" },
+      ],
+      config: {},
+      payload,
+      projectConfig: undefined,
+      respond: () => undefined,
+      store: {} as never,
+    });
+
+    const record = Array.isArray(records) ? records[0] : records;
+    expect(record?.space).toMatchObject({ phone: "+15550001111" });
+  });
+
+  it("does not reassign a retained v1 frame for a removed line", async () => {
+    const payload = verifyImessageFusorRequest(v1Request());
+
+    await expect(
+      handleImessageFusorMessages({
+        client: [{ client: client(), phone: "+15550002222" }],
+        config: {},
+        payload,
+        projectConfig: undefined,
+        respond: () => undefined,
+        store: {} as never,
+      })
+    ).rejects.toMatchObject({
+      name: "FusorTerminalError",
+      message:
+        "Cannot route transform-v1 iMessage Fusor event to one dedicated client",
+    });
+  });
+
+  it("uses the sole dedicated client for a destination-less v1 frame", async () => {
+    const decoded = verifyImessageFusorRequest(v1Request());
+    const { destinationCallerId: _destinationCallerId, ...message } =
+      decoded.event.message;
+    const payload = {
+      ...decoded,
+      event: { ...decoded.event, message },
+    } as typeof decoded;
+    const records = await handleImessageFusorMessages({
+      client: [{ client: client(), phone: "+15550002222" }],
+      config: {},
+      payload,
+      projectConfig: undefined,
+      respond: () => undefined,
+      store: {} as never,
+    });
+
+    const record = Array.isArray(records) ? records[0] : records;
+    expect(record?.space).toMatchObject({ phone: "+15550002222" });
+  });
+
+  it("rejects an event for an unconfigured dedicated instance", async () => {
+    const payload = verifyImessageFusorRequest(request());
+
+    await expect(
+      handleImessageFusorMessages({
+        client: [
+          {
+            client: client(),
+            instanceId: "instance-2",
+            phone: "+15550002222",
+          },
+        ],
+        config: {},
+        payload,
+        projectConfig: undefined,
+        respond: () => undefined,
+        store: {} as never,
+      })
+    ).rejects.toBeInstanceOf(FusorTerminalError);
+  });
+
+  it("rejects empty and nested unvirtualized resource ids", () => {
+    const { event } = verifyImessageFusorRequest(request());
+    const emptyGuidEvent = {
+      ...event,
+      message: { ...event.message, guid: "spc-msg-" },
+    } as typeof event;
+    expect(() => assertVirtualImessageResources(emptyGuidEvent)).toThrow(
+      "message.guid"
+    );
+
+    const nestedEvent = {
+      ...event,
+      message: {
+        ...event.message,
+        appliedReactions: [{ messageGuid: "backend-message-guid" }],
+      },
+    } as unknown as typeof event;
+    expect(() => assertVirtualImessageResources(nestedEvent)).toThrow(
+      "message.appliedReactions[0].messageGuid"
+    );
+  });
+});

--- a/packages/imessage/test/remote/stream.test.ts
+++ b/packages/imessage/test/remote/stream.test.ts
@@ -1,3 +1,4 @@
+import type { MessageEvent } from "@photon-ai/advanced-imessage";
 import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import { flush, settleSoon } from "@spectrum-ts/test-support/timing";
 import { describe, expect, it, vi } from "vitest";
@@ -37,8 +38,46 @@ const idleEventStream = () => {
   };
 };
 
-const remoteClient = (phone: string) => {
-  const subscribeToMessages = vi.fn(idleEventStream);
+const oneEventStream = <T>(event: T) => {
+  let closed = false;
+  let emitted = false;
+  let resolveNext: ((result: IteratorResult<T, undefined>) => void) | undefined;
+
+  const close = (): Promise<void> => {
+    closed = true;
+    resolveNext?.({ done: true, value: undefined });
+    resolveNext = undefined;
+    return Promise.resolve();
+  };
+
+  return {
+    close,
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<T, undefined>> {
+          if (closed) {
+            return Promise.resolve({ done: true, value: undefined });
+          }
+          if (!emitted) {
+            emitted = true;
+            return Promise.resolve({ done: false, value: event });
+          }
+          return new Promise((resolve) => {
+            resolveNext = resolve;
+          });
+        },
+        return(): Promise<IteratorResult<T, undefined>> {
+          return close().then(() => ({ done: true, value: undefined }));
+        },
+      };
+    },
+  };
+};
+
+const remoteClient = (phone: string, messageEvent?: MessageEvent) => {
+  const subscribeToMessages = vi.fn(() =>
+    messageEvent ? oneEventStream(messageEvent) : idleEventStream()
+  );
   const subscribeToPolls = vi.fn(idleEventStream);
   const subscribeToGroups = vi.fn(idleEventStream);
   const entry: RemoteClient = {
@@ -225,4 +264,41 @@ describe("remote iMessage streams", () => {
     await stream.close();
     await settleSoon(iterator.next());
   }, 15_000);
+
+  it("suppresses direct received messages when Fusor owns that lane", async () => {
+    const received = {
+      type: "message.received",
+      sequence: 1,
+      chatGuid: "iMessage;-;+15551234567",
+      isFromMe: false,
+      occurredAt: new Date("2026-07-16T01:02:03.456Z"),
+      message: {
+        guid: "message-guid",
+        chatGuids: ["iMessage;-;+15551234567"],
+        content: {
+          attachments: [],
+          formatting: [],
+          mentions: [],
+          text: "direct duplicate",
+        },
+        dateCreated: new Date("2026-07-16T01:02:03.456Z"),
+        isFromMe: false,
+      },
+    } as unknown as MessageEvent;
+    const dedicated = remoteClient("+15550100", received);
+    const stream = messages([dedicated.entry], undefined, false);
+    let settled = false;
+    const pending = stream[Symbol.asyncIterator]()
+      .next()
+      .finally(() => {
+        settled = true;
+      });
+
+    await flush();
+    expect(settled).toBe(false);
+    expect(dedicated.subscribeToMessages).toHaveBeenCalledTimes(1);
+
+    await stream.close();
+    await settleSoon(pending);
+  });
 });

--- a/packages/imessage/test/remote/stream.test.ts
+++ b/packages/imessage/test/remote/stream.test.ts
@@ -1,5 +1,7 @@
-import type { MessageEvent } from "@photon-ai/advanced-imessage";
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
+import type {
+  AdvancedIMessage,
+  MessageEvent,
+} from "@photon-ai/advanced-imessage/grpc";
 import { flush, settleSoon } from "@spectrum-ts/test-support/timing";
 import { describe, expect, it, vi } from "vitest";
 import { messages } from "@/remote/stream";

--- a/packages/imessage/test/remote/stream.test.ts
+++ b/packages/imessage/test/remote/stream.test.ts
@@ -303,4 +303,40 @@ describe("remote iMessage streams", () => {
     await stream.close();
     await settleSoon(pending);
   });
+
+  it("suppresses event-level self messages when the nested flag is false", async () => {
+    const selfMessage = {
+      type: "message.received",
+      sequence: 1,
+      chatGuid: "iMessage;-;+15551234567",
+      isFromMe: true,
+      occurredAt: new Date("2026-07-16T01:02:03.456Z"),
+      message: {
+        guid: "self-message-guid",
+        chatGuids: ["iMessage;-;+15551234567"],
+        content: {
+          attachments: [],
+          formatting: [],
+          mentions: [],
+          text: "outbound message",
+        },
+        dateCreated: new Date("2026-07-16T01:02:03.456Z"),
+        isFromMe: false,
+      },
+    } as unknown as MessageEvent;
+    const dedicated = remoteClient("+15550100", selfMessage);
+    const stream = messages([dedicated.entry]);
+    let settled = false;
+    const pending = stream[Symbol.asyncIterator]()
+      .next()
+      .finally(() => {
+        settled = true;
+      });
+
+    await flush();
+    expect(settled).toBe(false);
+
+    await stream.close();
+    await settleSoon(pending);
+  });
 });

--- a/packages/imessage/test/resource-actions.test.ts
+++ b/packages/imessage/test/resource-actions.test.ts
@@ -1,0 +1,325 @@
+import type {
+  AdvancedIMessage,
+  MiniAppCardSession,
+  Message as SDKMessage,
+} from "@photon-ai/advanced-imessage/grpc";
+import type { Content } from "@spectrum-ts/core";
+import { describe, expect, it, vi } from "vitest";
+import { imessage } from "@/index";
+import type { IMessageMessage, RemoteClient } from "@/types";
+
+const PHONE = "+15550100";
+const CHILD_ID_PREFIX = /^p:(\d+)\//;
+const SPACE = { id: "any;-;+15551234", phone: PHONE, type: "dm" } as const;
+const ctx = { config: {} as never, store: undefined as never };
+const def = imessage.config({}).__definition;
+
+const sdkMessage = (guid: string): SDKMessage =>
+  ({ dateCreated: new Date(0), guid }) as SDKMessage;
+
+const clients = (
+  direct: AdvancedIMessage,
+  resourceClient: AdvancedIMessage
+): RemoteClient[] => [
+  {
+    client: direct,
+    instanceId: "instance-1",
+    phone: PHONE,
+    resourceClient,
+  },
+];
+
+const target = (id: string, parentId?: string): IMessageMessage =>
+  ({
+    content: { text: "hello", type: "text" },
+    id,
+    parentId,
+    partIndex: parentId ? Number(id.match(CHILD_ID_PREFIX)?.[1]) : undefined,
+    sender: { id: "+15551234" },
+    space: SPACE,
+    timestamp: new Date(0),
+  }) as IMessageMessage;
+
+const appContent = (): Content =>
+  ({
+    layout: () => Promise.resolve({ caption: "Updated" }),
+    type: "app",
+    url: () => Promise.resolve("https://example.com/card"),
+  }) as unknown as Content;
+
+describe("iMessage dedicated virtual resource actions", () => {
+  it("routes replies and reactions for virtual child messages through Spectrum", async () => {
+    const directSend = vi.fn();
+    const directReaction = vi.fn();
+    const proxySend = vi.fn(() => Promise.resolve(sdkMessage("reply-guid")));
+    const proxyReaction = vi.fn(() =>
+      Promise.resolve(sdkMessage("reaction-guid"))
+    );
+    const direct = {
+      messages: { sendText: directSend, setReaction: directReaction },
+    } as unknown as AdvancedIMessage;
+    const proxy = {
+      messages: { sendText: proxySend, setReaction: proxyReaction },
+    } as unknown as AdvancedIMessage;
+    const virtualTarget = target("p:2/spc-msg-parent", "spc-msg-parent");
+
+    await def.send({
+      ...ctx,
+      client: clients(direct, proxy),
+      content: {
+        content: { text: "reply", type: "text" },
+        target: virtualTarget,
+        type: "reply",
+      } as never,
+      space: SPACE,
+    });
+    await def.send({
+      ...ctx,
+      client: clients(direct, proxy),
+      content: {
+        emoji: "👍",
+        target: virtualTarget,
+        type: "reaction",
+      } as never,
+      space: SPACE,
+    });
+
+    expect(proxySend).toHaveBeenCalledWith(
+      SPACE.id,
+      "reply",
+      expect.objectContaining({
+        replyTo: { guid: "spc-msg-parent", partIndex: 2 },
+      })
+    );
+    expect(proxyReaction).toHaveBeenCalledWith(
+      SPACE.id,
+      "spc-msg-parent",
+      { kind: "like" },
+      true,
+      { partIndex: 2 }
+    );
+    expect(directSend).not.toHaveBeenCalled();
+    expect(directReaction).not.toHaveBeenCalled();
+  });
+
+  it("routes edit, unsend, and reaction removal by virtual message id", async () => {
+    const directEdit = vi.fn();
+    const directUnsend = vi.fn();
+    const directReaction = vi.fn();
+    const proxyEdit = vi.fn(() => Promise.resolve(sdkMessage("edited")));
+    const proxyUnsend = vi.fn(() => Promise.resolve());
+    const proxyReaction = vi.fn(() =>
+      Promise.resolve(sdkMessage("reaction-guid"))
+    );
+    const direct = {
+      messages: {
+        edit: directEdit,
+        setReaction: directReaction,
+        unsend: directUnsend,
+      },
+    } as unknown as AdvancedIMessage;
+    const proxy = {
+      messages: {
+        edit: proxyEdit,
+        setReaction: proxyReaction,
+        unsend: proxyUnsend,
+      },
+    } as unknown as AdvancedIMessage;
+    const virtualTarget = target("p:4/spc-msg-parent", "spc-msg-parent");
+
+    await def.send({
+      ...ctx,
+      client: clients(direct, proxy),
+      content: {
+        content: { text: "edited", type: "text" },
+        target: virtualTarget,
+        type: "edit",
+      } as never,
+      space: SPACE,
+    });
+    await def.send({
+      ...ctx,
+      client: clients(direct, proxy),
+      content: { target: virtualTarget, type: "unsend" } as never,
+      space: SPACE,
+    });
+    await def.send({
+      ...ctx,
+      client: clients(direct, proxy),
+      content: {
+        target: {
+          content: {
+            emoji: "👍",
+            target: virtualTarget,
+            type: "reaction",
+          },
+          id: "reaction-record",
+        },
+        type: "unsend",
+      } as never,
+      space: SPACE,
+    });
+
+    expect(proxyEdit).toHaveBeenCalledWith(
+      SPACE.id,
+      "spc-msg-parent",
+      "edited",
+      { partIndex: 4 }
+    );
+    expect(proxyUnsend).toHaveBeenCalledWith(SPACE.id, "spc-msg-parent", {
+      partIndex: 4,
+    });
+    expect(proxyReaction).toHaveBeenCalledWith(
+      SPACE.id,
+      "spc-msg-parent",
+      { kind: "like" },
+      false,
+      { partIndex: 4 }
+    );
+    expect(directEdit).not.toHaveBeenCalled();
+    expect(directUnsend).not.toHaveBeenCalled();
+    expect(directReaction).not.toHaveBeenCalled();
+  });
+
+  it("routes getMessage and getAttachment through Spectrum for virtual ids", async () => {
+    const directGetMessage = vi.fn();
+    const directGetAttachment = vi.fn();
+    const proxyGetMessage = vi.fn(() =>
+      Promise.resolve({
+        chatGuids: [SPACE.id],
+        content: {
+          attachments: [
+            {
+              fileName: "photo.png",
+              guid: "spc-att-photo",
+              isHidden: false,
+              isOutgoing: false,
+              isSticker: false,
+              mimeType: "image/png",
+              totalBytes: 123,
+              transferState: 0,
+              uti: "public.png",
+            },
+          ],
+          formatting: [],
+          mentions: [],
+          text: "hi \uFFFC",
+        },
+        dateCreated: new Date(0),
+        guid: "spc-msg-parent",
+        isFromMe: false,
+      })
+    );
+    const proxyGetAttachment = vi.fn(() =>
+      Promise.resolve({
+        fileName: "photo.png",
+        guid: "spc-att-photo",
+        mimeType: "image/png",
+        totalBytes: 123,
+      })
+    );
+    const direct = {
+      attachments: { get: directGetAttachment },
+      messages: { get: directGetMessage },
+    } as unknown as AdvancedIMessage;
+    const proxy = {
+      attachments: { get: proxyGetAttachment },
+      messages: { get: proxyGetMessage },
+    } as unknown as AdvancedIMessage;
+    const entries = clients(direct, proxy);
+    const getMessage = def.actions?.getMessage;
+    const getAttachment = def.actions?.getAttachment;
+    if (!(getMessage && getAttachment)) {
+      throw new Error("iMessage resource actions are missing");
+    }
+
+    const message = await getMessage(
+      { ...ctx, client: entries },
+      { ...SPACE, __platform: "iMessage" },
+      "p:1/spc-msg-parent"
+    );
+    const attachment = await getAttachment(
+      { ...ctx, client: entries },
+      "spc-att-photo",
+      PHONE
+    );
+
+    expect(message).toMatchObject({
+      id: "p:1/spc-msg-parent",
+      parentId: "spc-msg-parent",
+    });
+    expect(attachment).toMatchObject({ id: "spc-att-photo" });
+    expect(proxyGetMessage).toHaveBeenCalledWith("spc-msg-parent");
+    expect(proxyGetAttachment).toHaveBeenCalledWith("spc-att-photo");
+    expect(directGetMessage).not.toHaveBeenCalled();
+    expect(directGetAttachment).not.toHaveBeenCalled();
+  });
+
+  it("routes virtual mini-app sessions through Spectrum", async () => {
+    const session = {
+      chatGuid: SPACE.id,
+      messageGuid: "spc-msg-card",
+      sessionId: "session-1",
+      targetMessageGuid: "spc-msg-target",
+    } satisfies MiniAppCardSession;
+    const directUpdate = vi.fn();
+    const proxyUpdate = vi.fn(() =>
+      Promise.resolve({
+        dateCreated: new Date(0),
+        guid: "spc-msg-updated",
+        miniAppCardSession: session,
+      })
+    );
+    const direct = {
+      messages: { updateCustomizedMiniApp: directUpdate },
+    } as unknown as AdvancedIMessage;
+    const proxy = {
+      messages: { updateCustomizedMiniApp: proxyUpdate },
+    } as unknown as AdvancedIMessage;
+
+    await def.send({
+      ...ctx,
+      client: clients(direct, proxy),
+      content: {
+        content: appContent(),
+        target: {
+          ...target("spc-msg-card"),
+          miniAppCardSession: session,
+        },
+        type: "edit",
+      } as never,
+      space: SPACE,
+    });
+
+    expect(proxyUpdate).toHaveBeenCalledWith(
+      session,
+      expect.objectContaining({ url: "https://example.com/card" })
+    );
+    expect(directUpdate).not.toHaveBeenCalled();
+  });
+
+  it("keeps ordinary native message operations on the dedicated instance", async () => {
+    const directUnsend = vi.fn(() => Promise.resolve());
+    const proxyUnsend = vi.fn();
+    const direct = {
+      messages: { unsend: directUnsend },
+    } as unknown as AdvancedIMessage;
+    const proxy = {
+      messages: { unsend: proxyUnsend },
+    } as unknown as AdvancedIMessage;
+
+    await def.send({
+      ...ctx,
+      client: clients(direct, proxy),
+      content: { target: target("native-message"), type: "unsend" } as never,
+      space: SPACE,
+    });
+
+    expect(directUnsend).toHaveBeenCalledWith(
+      SPACE.id,
+      "native-message",
+      undefined
+    );
+    expect(proxyUnsend).not.toHaveBeenCalled();
+  });
+});

--- a/packages/test-support/src/fusor.ts
+++ b/packages/test-support/src/fusor.ts
@@ -1,7 +1,14 @@
 import { RawInboundEvent } from "@photon-ai/proto/photon/fusor/v1/inbound";
-import type { Content, FusorMessages, ProjectData } from "@spectrum-ts/core";
+import type {
+  Content,
+  FusorMessages,
+  HybridFusorMessages,
+  ProjectData,
+  Store,
+} from "@spectrum-ts/core";
 import { definePlatform, fusor, fusorEvent } from "@spectrum-ts/core";
 import z from "zod";
+import { makeQueue, record } from "./platform";
 
 // A minimal fusor-mode provider standing in for a real platform (Slack-ish).
 // Its verify() parses the inner HTTP body to a typed payload; messages() turns
@@ -244,3 +251,132 @@ export const makeCtxProbe = (capture: CtxProbeCapture) =>
     messages: ctxProbeMessages(capture),
     send: () => Promise.resolve(undefined),
   });
+
+// ---------------------------------------------------------------------------
+// Hybrid Fusor provider — regular lifecycle client + optional Fusor messages
+// ---------------------------------------------------------------------------
+
+export interface HybridClient {
+  id: string;
+  kind: "regular";
+}
+
+export interface HybridPayload {
+  text: string;
+}
+
+const hybridConfig = z.object({ token: z.string() });
+type HybridConfig = z.infer<typeof hybridConfig>;
+
+export interface HybridCapture {
+  createClient?: HybridClient;
+  createConfig?: HybridConfig;
+  destroyedClient?: HybridClient;
+  handlerClient?: HybridClient;
+  handlerConfig?: HybridConfig;
+  handlerProjectConfig?: ProjectData | undefined;
+  handlerStore?: Store;
+  handlerStoreRoundTrip?: string;
+  regularEventProducerCalls: number;
+  regularMessagesCalls: number;
+  sendClient?: HybridClient;
+}
+
+export interface HybridOptions {
+  createError?: Error;
+  enabled?: boolean;
+  name?: string;
+  regularMessageId?: string;
+  route?: string;
+  streamOnly?: boolean;
+}
+
+export const makeHybrid = (
+  capture: HybridCapture,
+  opts: HybridOptions = {}
+) => {
+  const name = opts.name ?? "Hybrid Display";
+  const route = opts.route ?? "hybrid-wire";
+  const client: HybridClient = { id: `${name}-client`, kind: "regular" };
+  const regularMessages = makeQueue<ReturnType<typeof record>>();
+  const regularEvents = makeQueue<{ state: string }>();
+  if (opts.regularMessageId) {
+    regularMessages.push(record(opts.regularMessageId));
+  }
+
+  const hybridMessages: HybridFusorMessages<
+    HybridPayload,
+    HybridClient,
+    HybridConfig
+  > = ({ client: handlerClient, config, payload, projectConfig, store }) => {
+    capture.handlerClient = handlerClient;
+    capture.handlerConfig = config;
+    capture.handlerProjectConfig = projectConfig;
+    capture.handlerStore = store;
+    store.set("hybrid.lastText", payload.text);
+    capture.handlerStoreRoundTrip = store.string("hybrid.lastText");
+    return {
+      ...record(`fusor-${payload.text}`),
+      content: { type: "text", text: payload.text },
+    };
+  };
+
+  const platform = definePlatform(name, {
+    config: hybridConfig,
+    lifecycle: {
+      createClient: () => Promise.resolve(client),
+      destroyClient: ({ client: destroyedClient }) => {
+        capture.destroyedClient = destroyedClient;
+        regularMessages.close();
+        regularEvents.close();
+        return Promise.resolve();
+      },
+    },
+    fusor: {
+      streamOnly: opts.streamOnly,
+      create: ({ client: createClient, config }) => {
+        capture.createClient = createClient;
+        capture.createConfig = config;
+        if (opts.createError) {
+          throw opts.createError;
+        }
+        return opts.enabled === false
+          ? undefined
+          : fusor<HybridPayload>(route, (req) => {
+              const body = JSON.parse(
+                new TextDecoder().decode(req.rawBody)
+              ) as { text?: string };
+              return { text: body.text ?? "" };
+            });
+      },
+      messages: hybridMessages,
+    },
+    user: { resolve: ({ input }) => Promise.resolve({ id: input.userID }) },
+    space: {
+      create: ({ input }) =>
+        Promise.resolve({ id: input.users[0]?.id ?? "space" }),
+    },
+    events: {
+      status: () => {
+        capture.regularEventProducerCalls += 1;
+        return regularEvents.iter;
+      },
+    },
+    messages: () => {
+      capture.regularMessagesCalls += 1;
+      return regularMessages.iter;
+    },
+    send: ({ client: sendClient }) => {
+      capture.sendClient = sendClient;
+      return Promise.resolve(record("hybrid-sent"));
+    },
+  });
+
+  return {
+    client,
+    platform,
+    provider: platform.config({ token: "hybrid-token" }),
+    pushEvent: (state: string) => regularEvents.push({ state }),
+    pushRegularMessage: (id: string) => regularMessages.push(record(id)),
+  };
+};

--- a/packages/test-support/src/fusor.ts
+++ b/packages/test-support/src/fusor.ts
@@ -295,7 +295,7 @@ export const makeHybrid = (
   capture: HybridCapture,
   opts: HybridOptions = {}
 ) => {
-  const name = opts.name ?? "Hybrid Display";
+  const name = opts.name ?? "hybrid_display";
   const route = opts.route ?? "hybrid-wire";
   const client: HybridClient = { id: `${name}-client`, kind: "regular" };
   const regularMessages = makeQueue<ReturnType<typeof record>>();


### PR DESCRIPTION
## Summary

- add hybrid Spectrum transport: inbound iMessage messages arrive through one project-scoped Fusor WebSocket while the transitional direct lane supplies supplemental events
- add durable cursor persistence, sequence/event deduplication, bounded retries, lazy startup, and clean shutdown to the shared Fusor client
- decode and validate legacy transform v1 plus trusted transform v2/v3 iMessage envelopes
- preserve explicit-client and shared-line behavior, self-event filtering, and native voice-message support

Linear: [ENG-1979](https://linear.app/photonhq/issue/ENG-1979/route-spectrum-ts-imessage-inbound-messages-through-fusor)

## Security and lifecycle

- transform v2/v3 require the trusted source-instance header and validate the destination line
- malformed or cross-project events fail terminally without wedging the project stream
- setup failures close already-opened channels; shutdown remains bounded and idempotent
- webhook-only consumers do not start the WebSocket accidentally

## Stack and rollout

- rebuilt on current `main` at `5277841`, including the Advanced iMessage v2 gRPC transport from #212
- #210 deliberately supersedes this PR's transitional dedicated transform-v3/proxy behavior with transform v4, native IDs, and the Fusor HTTP gateway
- merge in order #195 → #210 → #211; after each squash merge, restack the next PR onto the new `main` and retarget it before merging
- do not publish an intermediate SDK release

## Validation

- Core Node: 35 files / 321 tests
- Core Bun: 35 files / 321 tests
- iMessage Node: 19 files / 193 tests
- iMessage Bun: 19 files / 193 tests
- scoped typecheck, Ultracite, Core/iMessage builds, and Node import smokes pass
- `git diff --check`
- the user's untracked `smoke.ts` remained untouched and is not part of this PR

No runtime stack was manually applied or synced.
