### PR TITLE
fix(whatsapp-business) - removing reactions kill streams

### DIFF
--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -55,6 +55,7 @@ export { renameSchema } from "./content/rename";
 export { asReply, replySchema } from "./content/reply";
 export { asRichlink } from "./content/richlink";
 export { asText } from "./content/text";
+export { asUnsend } from "./content/unsend";
 export { asVoice } from "./content/voice";
 export type {
   ProviderMessageRecord,

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -622,6 +622,23 @@ export const send = async (
     await primary(clients).messages.markRead(parentWamid(content.target.id));
     return;
   }
+  if (content.type === "unsend") {
+    // The Cloud API can only retract reactions — resend the reaction with
+    // emoji: "" at the reacted message. Regular business messages cannot be
+    // deleted, so any other target stays unsupported.
+    const unsent = content.target.content;
+    if (unsent.type !== "reaction") {
+      throw UnsupportedError.content(content.type);
+    }
+    await primary(clients).messages.send({
+      to: spaceId,
+      reaction: {
+        messageId: parentWamid(unsent.target.id),
+        emoji: "",
+      },
+    });
+    return;
+  }
   const client = primary(clients);
   switch (content.type) {
     case "text":

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -28,6 +28,7 @@ import {
   asPollOption,
   asReaction,
   asText,
+  asUnsend,
   createLogger,
   errorAttrs,
   type ProviderMessageRecord,
@@ -321,12 +322,24 @@ const mapContent = (client: WhatsAppClient, msg: InboundMessage): Content => {
       return asCustom({ whatsapp_type: "location", ...content.location });
     case "reaction": {
       // Meta signals REMOVING a reaction as a reaction event whose emoji is
-      // the protobuf default "" which is not a valid `reaction` content (asReaction
-      // requires a non-empty emoji).
+      // the protobuf default "" — not valid `reaction` content (asReaction
+      // requires a non-empty emoji), and Meta doesn't say which emoji was
+      // removed (one reaction per user per message). Surface the portable
+      // `unsend` arm: the retracted "message" is the sender's reaction on
+      // the target, identified by the same synthetic `<id>:reaction:<user>`
+      // convention Slack uses for reaction messages.
       if (!content.reaction.emoji) {
-        return asCustom({
-          whatsapp_type: "reaction-removed",
-          messageId: content.reaction.messageId,
+        const reactedId = content.reaction.messageId;
+        const removedReaction = {
+          id: `${reactedId}:reaction:${msg.from}`,
+          content: asCustom({
+            whatsapp_type: "reaction-removed",
+            messageId: reactedId,
+            stub: true,
+          }),
+        };
+        return asUnsend({
+          target: removedReaction as Parameters<typeof asUnsend>[0]["target"],
         });
       }
       // WhatsApp reaction events carry only the target message id; synthesize

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -29,6 +29,7 @@ import {
   asReaction,
   asText,
   createLogger,
+  errorAttrs,
   type ProviderMessageRecord,
   tracedFetch,
 } from "@spectrum-ts/core/authoring";
@@ -319,6 +320,15 @@ const mapContent = (client: WhatsAppClient, msg: InboundMessage): Content => {
     case "location":
       return asCustom({ whatsapp_type: "location", ...content.location });
     case "reaction": {
+      // Meta signals REMOVING a reaction as a reaction event whose emoji is
+      // the protobuf default "" which is not a valid `reaction` content (asReaction
+      // requires a non-empty emoji).
+      if (!content.reaction.emoji) {
+        return asCustom({
+          whatsapp_type: "reaction-removed",
+          messageId: content.reaction.messageId,
+        });
+      }
       // WhatsApp reaction events carry only the target message id; synthesize
       // a minimal target Message shape. Core's wrapProviderMessage inflates
       // this into a full Message with react/reply methods at emit time.
@@ -547,7 +557,24 @@ const clientStream = (
     const pump = (async () => {
       try {
         for await (const event of eventStream) {
-          for (const m of toMessages(client, event.message)) {
+          // One unmappable event must not kill the live stream: a mapping
+          // throw here ends the merged stream for the whole project, and
+          // nothing downstream restarts it. Skip the event and keep pumping.
+          let mapped: WhatsAppMessage[];
+          try {
+            mapped = toMessages(client, event.message);
+          } catch (error) {
+            streamLog.warn(
+              "skipping unmappable whatsapp message event",
+              {
+                "spectrum.whatsapp.message_id": event.message.id,
+                ...errorAttrs(error),
+              },
+              error instanceof Error ? error : undefined
+            );
+            continue;
+          }
+          for (const m of mapped) {
             await emit(m);
           }
         }

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -322,12 +322,11 @@ const mapContent = (client: WhatsAppClient, msg: InboundMessage): Content => {
       return asCustom({ whatsapp_type: "location", ...content.location });
     case "reaction": {
       // Meta signals REMOVING a reaction as a reaction event whose emoji is
-      // the protobuf default "" — not valid `reaction` content (asReaction
+      // the protobuf default "" which is not a valid `reaction` content (asReaction
       // requires a non-empty emoji), and Meta doesn't say which emoji was
-      // removed (one reaction per user per message). Surface the portable
+      // removed (one reaction per user per message). Instead, we surface a
       // `unsend` arm: the retracted "message" is the sender's reaction on
-      // the target, identified by the same synthetic `<id>:reaction:<user>`
-      // convention Slack uses for reaction messages.
+      // the target, identified by the same synthetic `<id>:reaction:<user>`.
       if (!content.reaction.emoji) {
         const reactedId = content.reaction.messageId;
         const removedReaction = {

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -93,12 +93,10 @@ const cachePoll = (
   }
 };
 
-// Inbound reaction adds, keyed by (reacted message, reactor) — unique because
-// WhatsApp allows one reaction per user per message. A removal event carries
-// no emoji and no reaction wamid, so this cache is the only way to report
-// which emoji was taken out; best-effort by design (restart/eviction means a
-// removal can miss, falling back to a stub target).
-type CachedReaction = { id: string; emoji: string };
+interface CachedReaction {
+  emoji: string;
+  id: string;
+}
 const MAX_REACTION_CACHE_SIZE = 1000;
 const reactionCaches = new WeakMap<
   WhatsAppClient,
@@ -355,6 +353,53 @@ const toMessages = (
   ];
 };
 
+// Meta signals REMOVING a reaction as a reaction event whose emoji is the
+// protobuf default "" which is not a valid `reaction` content (asReaction
+// requires a non-empty emoji), and Meta doesn't say which emoji was removed
+// (one reaction per user per message).
+const mapReactionContent = (
+  client: WhatsAppClient,
+  msg: InboundMessage,
+  reaction: { messageId: string; emoji: string }
+): Content => {
+  const reactedId = reaction.messageId;
+  if (!reaction.emoji) {
+    const cached = takeCachedReaction(client, reactedId, msg.from);
+    const removedReaction = cached
+      ? {
+          id: cached.id,
+          content: asReaction({
+            emoji: cached.emoji,
+            target: reactionTargetStub(reactedId) as Parameters<
+              typeof asReaction
+            >[0]["target"],
+          }),
+        }
+      : {
+          id: `${reactedId}:reaction:${msg.from}`,
+          content: asCustom({
+            whatsapp_type: "reaction-removed",
+            messageId: reactedId,
+            stub: true,
+          }),
+        };
+    return asUnsend({
+      target: removedReaction as Parameters<typeof asUnsend>[0]["target"],
+    });
+  }
+  // Remember the add so a later removal can report which emoji left.
+  cacheReaction(client, reactedId, msg.from, {
+    id: msg.id,
+    emoji: reaction.emoji,
+  });
+  return asReaction({
+    emoji: reaction.emoji,
+    target: reactionTargetStub(reactedId) as Parameters<
+      typeof asReaction
+    >[0]["target"],
+  });
+};
+
 const mapContent = (client: WhatsAppClient, msg: InboundMessage): Content => {
   const { content } = msg;
   switch (content.type) {
@@ -378,51 +423,8 @@ const mapContent = (client: WhatsAppClient, msg: InboundMessage): Content => {
       return asCustom({ whatsapp_type: "sticker", ...content.sticker });
     case "location":
       return asCustom({ whatsapp_type: "location", ...content.location });
-    case "reaction": {
-      const reactedId = content.reaction.messageId;
-      // Meta signals REMOVING a reaction as a reaction event whose emoji is
-      // the protobuf default "" which is not a valid `reaction` content
-      // (asReaction requires a non-empty emoji), and Meta doesn't say which
-      // emoji was removed (one reaction per user per message). Instead, we
-      // surface a `unsend` arm whose target is the reaction being retracted:
-      // the cached original when the add was seen (real wamid + the emoji
-      // being taken out), else a synthetic `<id>:reaction:<user>` stub.
-      if (!content.reaction.emoji) {
-        const cached = takeCachedReaction(client, reactedId, msg.from);
-        const removedReaction = cached
-          ? {
-              id: cached.id,
-              content: asReaction({
-                emoji: cached.emoji,
-                target: reactionTargetStub(reactedId) as Parameters<
-                  typeof asReaction
-                >[0]["target"],
-              }),
-            }
-          : {
-              id: `${reactedId}:reaction:${msg.from}`,
-              content: asCustom({
-                whatsapp_type: "reaction-removed",
-                messageId: reactedId,
-                stub: true,
-              }),
-            };
-        return asUnsend({
-          target: removedReaction as Parameters<typeof asUnsend>[0]["target"],
-        });
-      }
-      // Remember the add so a later removal can report which emoji left.
-      cacheReaction(client, reactedId, msg.from, {
-        id: msg.id,
-        emoji: content.reaction.emoji,
-      });
-      return asReaction({
-        emoji: content.reaction.emoji,
-        target: reactionTargetStub(reactedId) as Parameters<
-          typeof asReaction
-        >[0]["target"],
-      });
-    }
+    case "reaction":
+      return mapReactionContent(client, msg, content.reaction);
     case "interactive": {
       const inter = content.interactive;
       if (inter.type === "button_reply" || inter.type === "list_reply") {

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -129,21 +129,13 @@ const cacheReaction = (
   }
 };
 
-const takeCachedReaction = (
+const getCachedReaction = (
   client: WhatsAppClient,
   reactedId: string,
   from: string
-): CachedReaction | undefined => {
-  const cache = reactionCaches.get(client);
-  const key = reactionCacheKey(reactedId, from);
-  const entry = cache?.get(key);
-  cache?.delete(key);
-  return entry;
-};
+): CachedReaction | undefined =>
+  reactionCaches.get(client)?.get(reactionCacheKey(reactedId, from));
 
-// WhatsApp reaction events carry only the target message id; synthesize a
-// minimal target Message shape. Core's wrapProviderMessage inflates this
-// into a full Message with react/reply methods at emit time.
 const reactionTargetStub = (reactedId: string) => ({
   id: reactedId,
   content: asCustom({ whatsapp_type: "reaction-target", stub: true }),
@@ -364,7 +356,7 @@ const mapReactionContent = (
 ): Content => {
   const reactedId = reaction.messageId;
   if (!reaction.emoji) {
-    const cached = takeCachedReaction(client, reactedId, msg.from);
+    const cached = getCachedReaction(client, reactedId, msg.from);
     const removedReaction = cached
       ? {
           id: cached.id,

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -93,6 +93,64 @@ const cachePoll = (
   }
 };
 
+// Inbound reaction adds, keyed by (reacted message, reactor) — unique because
+// WhatsApp allows one reaction per user per message. A removal event carries
+// no emoji and no reaction wamid, so this cache is the only way to report
+// which emoji was taken out; best-effort by design (restart/eviction means a
+// removal can miss, falling back to a stub target).
+type CachedReaction = { id: string; emoji: string };
+const MAX_REACTION_CACHE_SIZE = 1000;
+const reactionCaches = new WeakMap<
+  WhatsAppClient,
+  Map<string, CachedReaction>
+>();
+
+const reactionCacheKey = (reactedId: string, from: string): string =>
+  `${reactedId}:${from}`;
+
+const cacheReaction = (
+  client: WhatsAppClient,
+  reactedId: string,
+  from: string,
+  entry: CachedReaction
+): void => {
+  let cache = reactionCaches.get(client);
+  if (!cache) {
+    cache = new Map<string, CachedReaction>();
+    reactionCaches.set(client, cache);
+  }
+  const key = reactionCacheKey(reactedId, from);
+  // Delete-then-set keeps a re-reaction fresh in LRU order.
+  cache.delete(key);
+  cache.set(key, entry);
+  if (cache.size > MAX_REACTION_CACHE_SIZE) {
+    const first = cache.keys().next().value;
+    if (first !== undefined) {
+      cache.delete(first);
+    }
+  }
+};
+
+const takeCachedReaction = (
+  client: WhatsAppClient,
+  reactedId: string,
+  from: string
+): CachedReaction | undefined => {
+  const cache = reactionCaches.get(client);
+  const key = reactionCacheKey(reactedId, from);
+  const entry = cache?.get(key);
+  cache?.delete(key);
+  return entry;
+};
+
+// WhatsApp reaction events carry only the target message id; synthesize a
+// minimal target Message shape. Core's wrapProviderMessage inflates this
+// into a full Message with react/reply methods at emit time.
+const reactionTargetStub = (reactedId: string) => ({
+  id: reactedId,
+  content: asCustom({ whatsapp_type: "reaction-target", stub: true }),
+});
+
 const optionIndexFromId = (id: string): number | undefined => {
   if (!id.startsWith(OPTION_ID_PREFIX)) {
     return;
@@ -321,36 +379,48 @@ const mapContent = (client: WhatsAppClient, msg: InboundMessage): Content => {
     case "location":
       return asCustom({ whatsapp_type: "location", ...content.location });
     case "reaction": {
+      const reactedId = content.reaction.messageId;
       // Meta signals REMOVING a reaction as a reaction event whose emoji is
-      // the protobuf default "" which is not a valid `reaction` content (asReaction
-      // requires a non-empty emoji), and Meta doesn't say which emoji was
-      // removed (one reaction per user per message). Instead, we surface a
-      // `unsend` arm: the retracted "message" is the sender's reaction on
-      // the target, identified by the same synthetic `<id>:reaction:<user>`.
+      // the protobuf default "" which is not a valid `reaction` content
+      // (asReaction requires a non-empty emoji), and Meta doesn't say which
+      // emoji was removed (one reaction per user per message). Instead, we
+      // surface a `unsend` arm whose target is the reaction being retracted:
+      // the cached original when the add was seen (real wamid + the emoji
+      // being taken out), else a synthetic `<id>:reaction:<user>` stub.
       if (!content.reaction.emoji) {
-        const reactedId = content.reaction.messageId;
-        const removedReaction = {
-          id: `${reactedId}:reaction:${msg.from}`,
-          content: asCustom({
-            whatsapp_type: "reaction-removed",
-            messageId: reactedId,
-            stub: true,
-          }),
-        };
+        const cached = takeCachedReaction(client, reactedId, msg.from);
+        const removedReaction = cached
+          ? {
+              id: cached.id,
+              content: asReaction({
+                emoji: cached.emoji,
+                target: reactionTargetStub(reactedId) as Parameters<
+                  typeof asReaction
+                >[0]["target"],
+              }),
+            }
+          : {
+              id: `${reactedId}:reaction:${msg.from}`,
+              content: asCustom({
+                whatsapp_type: "reaction-removed",
+                messageId: reactedId,
+                stub: true,
+              }),
+            };
         return asUnsend({
           target: removedReaction as Parameters<typeof asUnsend>[0]["target"],
         });
       }
-      // WhatsApp reaction events carry only the target message id; synthesize
-      // a minimal target Message shape. Core's wrapProviderMessage inflates
-      // this into a full Message with react/reply methods at emit time.
-      const stubTarget = {
-        id: content.reaction.messageId,
-        content: asCustom({ whatsapp_type: "reaction-target", stub: true }),
-      };
+      // Remember the add so a later removal can report which emoji left.
+      cacheReaction(client, reactedId, msg.from, {
+        id: msg.id,
+        emoji: content.reaction.emoji,
+      });
       return asReaction({
         emoji: content.reaction.emoji,
-        target: stubTarget as Parameters<typeof asReaction>[0]["target"],
+        target: reactionTargetStub(reactedId) as Parameters<
+          typeof asReaction
+        >[0]["target"],
       });
     }
     case "interactive": {

--- a/packages/whatsapp-business/test/reaction-removal.test.ts
+++ b/packages/whatsapp-business/test/reaction-removal.test.ts
@@ -81,6 +81,29 @@ describe("whatsapp reaction removal", () => {
     });
   });
 
+  it("a duplicate removal webhook emits the same unsend target, not a stub", async () => {
+    // Meta delivery is at-least-once — a retried removal must not degrade
+    // to the synthetic stub shape, or consumers can't dedupe by target id.
+    const received = await receiveAll(
+      fakeClient([
+        reactionEvent("\u{1F44D}", "wamid.REACT1"),
+        reactionEvent("", "wamid.REMOVE1"),
+        reactionEvent("", "wamid.REMOVE1-RETRY"),
+      ])
+    );
+
+    expect(received).toHaveLength(3);
+    for (const removal of [received[1], received[2]]) {
+      expect(removal?.content).toMatchObject({
+        type: "unsend",
+        target: {
+          id: "wamid.REACT1",
+          content: { type: "reaction", emoji: "\u{1F44D}" },
+        },
+      });
+    }
+  });
+
   it("a re-reaction updates which emoji a later removal reports", async () => {
     const received = await receiveAll(
       fakeClient([

--- a/packages/whatsapp-business/test/reaction-removal.test.ts
+++ b/packages/whatsapp-business/test/reaction-removal.test.ts
@@ -23,8 +23,8 @@ const fakeClient = (inbounds: unknown[]): WhatsAppClient => {
   } as unknown as WhatsAppClient;
 };
 
-const reactionEvent = (emoji: string) => ({
-  id: "wamid.REACT1",
+const reactionEvent = (emoji: string, id = "wamid.REACT1") => ({
+  id,
   from: "15551234567",
   timestamp: new Date("2026-07-16T00:00:00.000Z"),
   content: {
@@ -62,7 +62,44 @@ describe("whatsapp reaction removal", () => {
     });
   });
 
-  it("surfaces an empty-emoji reaction (removal) as portable unsend content, not a throw", async () => {
+  it("surfaces a removal whose add was seen as unsend of the real reaction", async () => {
+    const received = await receiveAll(
+      fakeClient([
+        reactionEvent("\u{1F44D}", "wamid.REACT1"),
+        reactionEvent("", "wamid.REMOVE1"),
+      ])
+    );
+
+    expect(received).toHaveLength(2);
+    expect(received[1]?.content).toMatchObject({
+      type: "unsend",
+      target: {
+        // The cached original: its own wamid and the emoji being taken out.
+        id: "wamid.REACT1",
+        content: { type: "reaction", emoji: "\u{1F44D}" },
+      },
+    });
+  });
+
+  it("a re-reaction updates which emoji a later removal reports", async () => {
+    const received = await receiveAll(
+      fakeClient([
+        reactionEvent("\u{1F44D}", "wamid.REACT1"),
+        reactionEvent("\u{2764}\u{FE0F}", "wamid.REACT2"),
+        reactionEvent("", "wamid.REMOVE1"),
+      ])
+    );
+
+    expect(received[2]?.content).toMatchObject({
+      type: "unsend",
+      target: {
+        id: "wamid.REACT2",
+        content: { type: "reaction", emoji: "\u{2764}\u{FE0F}" },
+      },
+    });
+  });
+
+  it("surfaces a removal with no cached add as unsend of a stub, not a throw", async () => {
     const [received] = await receiveAll(fakeClient([reactionEvent("")]));
 
     expect(received?.content).toMatchObject({

--- a/packages/whatsapp-business/test/reaction-removal.test.ts
+++ b/packages/whatsapp-business/test/reaction-removal.test.ts
@@ -1,0 +1,98 @@
+import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
+import { describe, expect, it } from "vitest";
+import { messages } from "@/messages";
+import type { WhatsAppMessage } from "@/types";
+
+// Drives the real inbound path — messages() -> clientStream -> toMessages —
+// with a fake client whose event stream yields the given raw messages.
+// Meta represents removing a reaction as a reaction event whose emoji is the
+// protobuf default "" — before this fix that threw a ZodError inside the
+// stream pump and killed the project's entire messages stream (2026-07-16
+// production incident).
+const fakeClient = (inbounds: unknown[]): WhatsAppClient => {
+  const filtered = {
+    async *[Symbol.asyncIterator]() {
+      for (const inbound of inbounds) {
+        yield { type: "message", message: inbound };
+      }
+    },
+    close: async () => undefined,
+  };
+  return {
+    events: { subscribe: () => ({ filter: () => filtered }) },
+  } as unknown as WhatsAppClient;
+};
+
+const reactionEvent = (emoji: string) => ({
+  id: "wamid.REACT1",
+  from: "15551234567",
+  timestamp: new Date("2026-07-16T00:00:00.000Z"),
+  content: {
+    type: "reaction",
+    reaction: { messageId: "wamid.TARGET1", emoji },
+  },
+});
+
+const textEvent = (id: string, body: string) => ({
+  id,
+  from: "15551234567",
+  timestamp: new Date("2026-07-16T00:00:00.000Z"),
+  content: { type: "text", body },
+});
+
+const receiveAll = async (
+  client: WhatsAppClient
+): Promise<WhatsAppMessage[]> => {
+  const received: WhatsAppMessage[] = [];
+  for await (const m of messages([client])) {
+    received.push(m);
+  }
+  return received;
+};
+
+describe("whatsapp reaction removal", () => {
+  it("surfaces an emoji reaction as reaction content", async () => {
+    const [received] = await receiveAll(
+      fakeClient([reactionEvent("\u{1F44D}")])
+    );
+
+    expect(received?.content).toMatchObject({
+      type: "reaction",
+      emoji: "\u{1F44D}",
+    });
+  });
+
+  it("surfaces an empty-emoji reaction (removal) as a custom arm, not a throw", async () => {
+    const [received] = await receiveAll(fakeClient([reactionEvent("")]));
+
+    expect(received?.content).toMatchObject({
+      type: "custom",
+      raw: {
+        whatsapp_type: "reaction-removed",
+        messageId: "wamid.TARGET1",
+      },
+    });
+  });
+
+  it("keeps the stream alive when one event is unmappable", async () => {
+    // An event whose content shape crashes toMessages entirely (media with
+    // no payload) must be skipped — the messages after it still flow.
+    const poison = {
+      id: "wamid.POISON1",
+      from: "15551234567",
+      timestamp: new Date("2026-07-16T00:00:00.000Z"),
+      content: { type: "image" },
+    };
+
+    const received = await receiveAll(
+      fakeClient([poison, textEvent("wamid.OK1", "still alive")])
+    );
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.id).toBe("wamid.OK1");
+    expect(received[0]?.content).toMatchObject({
+      type: "text",
+      text: "still alive",
+    });
+  });
+});

--- a/packages/whatsapp-business/test/reaction-removal.test.ts
+++ b/packages/whatsapp-business/test/reaction-removal.test.ts
@@ -62,14 +62,24 @@ describe("whatsapp reaction removal", () => {
     });
   });
 
-  it("surfaces an empty-emoji reaction (removal) as a custom arm, not a throw", async () => {
+  it("surfaces an empty-emoji reaction (removal) as portable unsend content, not a throw", async () => {
     const [received] = await receiveAll(fakeClient([reactionEvent("")]));
 
     expect(received?.content).toMatchObject({
-      type: "custom",
-      raw: {
-        whatsapp_type: "reaction-removed",
-        messageId: "wamid.TARGET1",
+      type: "unsend",
+      target: {
+        // Synthetic reaction-message identity, mirroring Slack's
+        // `<id>:reaction:<user>` convention. parentWamid strips the suffix
+        // if a targeted action ever addresses it.
+        id: "wamid.TARGET1:reaction:15551234567",
+        content: {
+          type: "custom",
+          raw: {
+            whatsapp_type: "reaction-removed",
+            messageId: "wamid.TARGET1",
+            stub: true,
+          },
+        },
       },
     });
   });

--- a/packages/whatsapp-business/test/unsend-reaction.test.ts
+++ b/packages/whatsapp-business/test/unsend-reaction.test.ts
@@ -1,0 +1,64 @@
+import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
+import type { Content } from "@spectrum-ts/core";
+import { describe, expect, it, vi } from "vitest";
+import { send } from "@/messages";
+
+// Meta's Cloud API retracts a reaction by re-sending it with emoji: "" at the
+// reacted message. Regular business messages cannot be deleted, so unsend is
+// supported for reaction messages only.
+
+const UNSEND_UNSUPPORTED = /unsend/;
+
+const fakeSendClient = () => {
+  const sendMock = vi.fn(async () => ({ messageId: "wamid.NEW" }));
+  const client = {
+    messages: { send: sendMock },
+  } as unknown as WhatsAppClient;
+  return { client, sendMock };
+};
+
+const unsendOf = (targetContent: unknown): Content =>
+  ({
+    type: "unsend",
+    target: {
+      id: "wamid.SENT1",
+      direction: "outbound",
+      content: targetContent,
+    },
+  }) as unknown as Content;
+
+describe("whatsapp outbound unsend", () => {
+  it("retracts a reaction by sending an empty emoji at the reacted message", async () => {
+    const { client, sendMock } = fakeSendClient();
+
+    const result = await send(
+      [client],
+      "15551234567",
+      unsendOf({
+        type: "reaction",
+        emoji: "\u{1F44D}",
+        // Synthetic group-item suffix must be stripped for the Cloud API.
+        target: {
+          id: "wamid.TARGET1:0",
+          content: { type: "text", text: "hi" },
+        },
+      })
+    );
+
+    expect(result).toBeUndefined();
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledWith({
+      to: "15551234567",
+      reaction: { messageId: "wamid.TARGET1", emoji: "" },
+    });
+  });
+
+  it("rejects unsend of a non-reaction message as unsupported", async () => {
+    const { client, sendMock } = fakeSendClient();
+
+    await expect(
+      send([client], "15551234567", unsendOf({ type: "text", text: "oops" }))
+    ).rejects.toThrow(UNSEND_UNSUPPORTED);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
fixes the 2026-07-16 production incident where a WhatsApp reaction-removal event killed a project's entire inbound messages stream, and adds unsending reactions.

## Tests

- `test/reaction-removal.test.ts` — drives the real `messages()` path with a fake client: emoji reactions pass through, empty-emoji removals become the custom arm, and a poison event no longer stops subsequent messages. Both regression tests reproduced the production ZodError before the fix.
- `test/unsend-reaction.test.ts` — asserts the exact removal payload (including group-item suffix stripping) and that non-reaction unsends reject without an API call.
- 24/24 package tests pass; typecheck and biome clean.

## Followups
- bump spectrum-ts version + update internal service.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live inbound stream error handling and reaction semantics that downstream consumers rely on; outbound unsend is limited to reactions but still touches the send path.
> 
> **Overview**
> Fixes the production failure where Meta’s **empty-emoji reaction removal** events failed validation and **terminated the whole inbound `messages()` stream**.
> 
> Inbound **reaction** handling now maps adds through a per-client **LRU cache** (so removals can reference the original reaction id/emoji, including re-reactions and duplicate webhooks) and maps removals to **`unsend`**—either against the cached reaction or a **`reaction-removed` custom stub** when no prior add was seen. **`asUnsend`** is re-exported from core authoring for providers.
> 
> The live stream pump **catches mapping errors per event**, logs with `errorAttrs`, and continues so one bad webhook cannot stop the project stream.
> 
> Outbound **`unsend`** is supported **only for reaction targets**, implemented as Cloud API `reaction` with **`emoji: ""`** (with `parentWamid` on the reacted message); other unsend targets still throw **`UnsupportedError`**.
> 
> Vitest covers inbound removal/cache/stub/resilience and outbound unsend payload plus non-reaction rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9b34ef1a0dc4006eeb0749e9e1855e640dc58e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786825833&installation_id=127326493&pr_number=196&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F196&signature=de754e56c3e88adea89f5f818326e2281f0e4d05b506475702b82a58be43feef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for removing WhatsApp reactions via reaction-removal “unsend” handling.
  * Added outbound “unsend” support for retracting only reaction targets.
  * Exposed `asUnsend` through the core authoring surface.
* **Bug Fixes**
  * Hardened the WhatsApp live event stream to skip unmappable inbound events without stopping.
* **Tests**
  * Added Vitest coverage for reaction add/removal mapping, stream resilience, and outbound unsend behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->