### PR TITLE
  fix(imessage): skip poison events instead of wedging the stream on mapping throws

### DIFF
--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -55,6 +55,7 @@ export { renameSchema } from "./content/rename";
 export { asReply, replySchema } from "./content/reply";
 export { asRichlink } from "./content/richlink";
 export { asText } from "./content/text";
+export { asUnsend } from "./content/unsend";
 export { asVoice } from "./content/voice";
 export type {
   ProviderMessageRecord,

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -14,6 +14,8 @@ import {
 } from "@spectrum-ts/core";
 import {
   type CloseableAsyncIterable,
+  createLogger,
+  errorAttrs,
   type ResumableStreamItem,
   resumableOrderedStream,
 } from "@spectrum-ts/core/authoring";
@@ -55,6 +57,46 @@ const isEventFromCurrentAccount = (
   (phone !== SHARED_PHONE &&
     event.actor?.address !== undefined &&
     event.actor.address === phone);
+
+const streamLog = createLogger("spectrum.imessage.stream");
+
+// Mapping does RPC work (message/attachment rebuilds), so its errors split
+// two ways. Client errors marked `retryable` are transient (network blip,
+// gateway restart): rethrow so resumableOrderedStream refetches the event
+// via catch-up and the message is delivered late rather than lost.
+const isRetryableMappingError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  (error as { retryable?: unknown }).retryable === true;
+
+// Everything else is deterministic (schema/shape throws, non-retryable
+// client errors) and must not wedge the stream: retrying would refetch the
+// same poison event forever and the cursor would never advance. Convert the
+// throw into an empty skip item — the same shape the isFromMe skips use —
+// so the cursor moves past the event.
+const skipUnmappable = async <T>(
+  label: string,
+  cursor: string,
+  map: () => Promise<ResumableStreamItem<T>>
+): Promise<ResumableStreamItem<T>> => {
+  try {
+    return await map();
+  } catch (error) {
+    if (isRetryableMappingError(error)) {
+      throw error;
+    }
+    streamLog.warn(
+      "skipping unmappable imessage event",
+      {
+        "spectrum.imessage.stream": label,
+        "spectrum.imessage.cursor": cursor,
+        ...errorAttrs(error),
+      },
+      error instanceof Error ? error : undefined
+    );
+    return { cursor, id: `unmappable:${cursor}`, values: [] };
+  }
+};
 
 /**
  * Side effect fired when a non-self `message.received` event is converted.
@@ -248,16 +290,26 @@ const messageStream = (
     label: streamLabel("messages", phone),
     recover,
     processLive: (event) =>
-      toMessageItem(client, event, phone, String(event.sequence), onInbound),
+      skipUnmappable(
+        streamLabel("messages", phone),
+        String(event.sequence),
+        () =>
+          toMessageItem(client, event, phone, String(event.sequence), onInbound)
+      ),
     processMissed: (event) =>
       event.type === "catchup.complete"
         ? Promise.resolve(toCatchUpCompleteItem(event))
-        : toMessageItem(
-            client,
-            event,
-            phone,
+        : skipUnmappable(
+            streamLabel("messages", phone),
             String(event.sequence),
-            onInbound
+            () =>
+              toMessageItem(
+                client,
+                event,
+                phone,
+                String(event.sequence),
+                onInbound
+              )
           ),
     subscribeLive: (cursor) =>
       withClose(client.messages.subscribeEvents(), cursor),
@@ -275,11 +327,24 @@ const pollStream = (
     label: streamLabel("polls", phone),
     recover,
     processLive: (event) =>
-      toPollItem(client, pollCache, event, phone, String(event.sequence)),
+      skipUnmappable(streamLabel("polls", phone), String(event.sequence), () =>
+        toPollItem(client, pollCache, event, phone, String(event.sequence))
+      ),
     processMissed: (event) =>
       event.type === "catchup.complete"
         ? Promise.resolve(toCatchUpCompleteItem(event))
-        : toPollItem(client, pollCache, event, phone, String(event.sequence)),
+        : skipUnmappable(
+            streamLabel("polls", phone),
+            String(event.sequence),
+            () =>
+              toPollItem(
+                client,
+                pollCache,
+                event,
+                phone,
+                String(event.sequence)
+              )
+          ),
     subscribeLive: (cursor) =>
       withClose(client.polls.subscribeEvents(), cursor),
   });
@@ -295,11 +360,17 @@ const groupStream = (
     label: streamLabel("groups", phone),
     recover,
     processLive: (event) =>
-      toGroupItem(client, event, phone, String(event.sequence)),
+      skipUnmappable(streamLabel("groups", phone), String(event.sequence), () =>
+        toGroupItem(client, event, phone, String(event.sequence))
+      ),
     processMissed: (event) =>
       event.type === "catchup.complete"
         ? Promise.resolve(toCatchUpCompleteItem(event))
-        : toGroupItem(client, event, phone, String(event.sequence)),
+        : skipUnmappable(
+            streamLabel("groups", phone),
+            String(event.sequence),
+            () => toGroupItem(client, event, phone, String(event.sequence))
+          ),
     subscribeLive: (cursor) =>
       withClose(client.groups.subscribeEvents(), cursor),
   });

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -118,17 +118,18 @@ const toMessageItem = async (
       return { cursor, id: event.message.guid, values: [] };
     }
 
+    const cache = getMessageCache(client);
+    const values = await toInboundMessages(client, cache, event, phone);
+
+    // After conversion succeeds — an event skipUnmappable discards must not
+    // trigger a contact-card share (and burn its 24h dedupe slot) for a
+    // message that was never delivered.
     const inboundChatGuid = event.message.chatGuids?.[0];
     if (inboundChatGuid) {
       onInbound?.(inboundChatGuid);
     }
 
-    const cache = getMessageCache(client);
-    return {
-      cursor,
-      id: event.message.guid,
-      values: await toInboundMessages(client, cache, event, phone),
-    };
+    return { cursor, id: event.message.guid, values };
   }
 
   if (event.type === "message.reactionAdded") {

--- a/packages/imessage/test/remote/stream.test.ts
+++ b/packages/imessage/test/remote/stream.test.ts
@@ -86,4 +86,143 @@ describe("remote iMessage streams", () => {
     expect(dedicated.subscribeToPolls).toHaveBeenCalledTimes(1);
     expect(dedicated.subscribeToGroups).toHaveBeenCalledTimes(1);
   });
+
+  it("skips an unmappable event instead of wedging the stream", async () => {
+    // A deterministic mapping throw must not loop catch-up on the poison
+    // event forever — the event after it must still be delivered.
+    const poison = { type: "message.received", sequence: 1 };
+    const valid = {
+      type: "message.received",
+      sequence: 2,
+      chatGuid: "s1",
+      isFromMe: false,
+      occurredAt: new Date(1_700_000_000_000),
+      message: {
+        guid: "msg-ok",
+        chatGuids: ["s1"],
+        content: { attachments: [], formatting: [], mentions: [], text: "hi" },
+        dateCreated: new Date(1_700_000_000_000),
+        isFromMe: false,
+        sender: { address: "+15550111" },
+      },
+    };
+
+    const eventStream = (events: unknown[]) => {
+      let index = 0;
+      const idle = idleEventStream();
+      return {
+        close: idle.close,
+        [Symbol.asyncIterator]() {
+          const idleIterator = idle[Symbol.asyncIterator]();
+          return {
+            next(): Promise<IteratorResult<unknown, undefined>> {
+              if (index < events.length) {
+                const value = events[index];
+                index += 1;
+                return Promise.resolve({ done: false, value });
+              }
+              return idleIterator.next();
+            },
+            return(): Promise<IteratorResult<unknown, undefined>> {
+              return idleIterator.return();
+            },
+          };
+        },
+      };
+    };
+
+    const entry: RemoteClient = {
+      phone: SHARED_PHONE,
+      client: {
+        messages: {
+          subscribeEvents: () => eventStream([poison, valid]),
+        },
+        polls: { subscribeEvents: idleEventStream },
+      } as unknown as AdvancedIMessage,
+    };
+
+    const stream = messages([entry]);
+    const iterator = stream[Symbol.asyncIterator]();
+    const first = await iterator.next();
+
+    expect(first.done).toBe(false);
+    expect(first.value?.id).toBe("msg-ok");
+    expect(first.value?.content).toMatchObject({ type: "text", text: "hi" });
+
+    await stream.close();
+    await settleSoon(iterator.next());
+  });
+
+  it("retries a transient mapping failure instead of skipping the message", async () => {
+    // Client errors marked retryable (network blips, gateway restarts) must
+    // keep the old retry-via-reconnect behavior — delivered late, not lost.
+    const validMessage = {
+      guid: "msg-transient",
+      chatGuids: ["s1"],
+      content: { attachments: [], formatting: [], mentions: [], text: "yo" },
+      dateCreated: new Date(1_700_000_000_000),
+      isFromMe: false,
+      sender: { address: "+15550111" },
+    };
+    let failuresLeft = 1;
+    const flakyEvent = {
+      type: "message.received",
+      sequence: 1,
+      chatGuid: "s1",
+      isFromMe: false,
+      get message() {
+        if (failuresLeft > 0) {
+          failuresLeft -= 1;
+          throw Object.assign(new Error("UNAVAILABLE: gateway restarting"), {
+            retryable: true,
+          });
+        }
+        return validMessage;
+      },
+    };
+
+    const idleAfter = (events: unknown[]) => {
+      let index = 0;
+      const idle = idleEventStream();
+      return {
+        close: idle.close,
+        [Symbol.asyncIterator]() {
+          const idleIterator = idle[Symbol.asyncIterator]();
+          return {
+            next(): Promise<IteratorResult<unknown, undefined>> {
+              if (index < events.length) {
+                const value = events[index];
+                index += 1;
+                return Promise.resolve({ done: false, value });
+              }
+              return idleIterator.next();
+            },
+            return(): Promise<IteratorResult<unknown, undefined>> {
+              return idleIterator.return();
+            },
+          };
+        },
+      };
+    };
+
+    const entry: RemoteClient = {
+      phone: SHARED_PHONE,
+      client: {
+        // Reconnect resubscribes; the same event replays and now maps.
+        messages: { subscribeEvents: () => idleAfter([flakyEvent]) },
+        polls: { subscribeEvents: idleEventStream },
+      } as unknown as AdvancedIMessage,
+    };
+
+    const stream = messages([entry]);
+    const iterator = stream[Symbol.asyncIterator]();
+    const first = await iterator.next();
+
+    expect(first.done).toBe(false);
+    expect(first.value?.id).toBe("msg-transient");
+    expect(failuresLeft).toBe(0);
+
+    await stream.close();
+    await settleSoon(iterator.next());
+  }, 15_000);
 });

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -622,6 +622,23 @@ export const send = async (
     await primary(clients).messages.markRead(parentWamid(content.target.id));
     return;
   }
+  if (content.type === "unsend") {
+    // The Cloud API can only retract reactions — resend the reaction with
+    // emoji: "" at the reacted message. Regular business messages cannot be
+    // deleted, so any other target stays unsupported.
+    const unsent = content.target.content;
+    if (unsent.type !== "reaction") {
+      throw UnsupportedError.content(content.type);
+    }
+    await primary(clients).messages.send({
+      to: spaceId,
+      reaction: {
+        messageId: parentWamid(unsent.target.id),
+        emoji: "",
+      },
+    });
+    return;
+  }
   const client = primary(clients);
   switch (content.type) {
     case "text":

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -28,6 +28,7 @@ import {
   asPollOption,
   asReaction,
   asText,
+  asUnsend,
   createLogger,
   errorAttrs,
   type ProviderMessageRecord,
@@ -321,12 +322,24 @@ const mapContent = (client: WhatsAppClient, msg: InboundMessage): Content => {
       return asCustom({ whatsapp_type: "location", ...content.location });
     case "reaction": {
       // Meta signals REMOVING a reaction as a reaction event whose emoji is
-      // the protobuf default "" which is not a valid `reaction` content (asReaction
-      // requires a non-empty emoji).
+      // the protobuf default "" — not valid `reaction` content (asReaction
+      // requires a non-empty emoji), and Meta doesn't say which emoji was
+      // removed (one reaction per user per message). Surface the portable
+      // `unsend` arm: the retracted "message" is the sender's reaction on
+      // the target, identified by the same synthetic `<id>:reaction:<user>`
+      // convention Slack uses for reaction messages.
       if (!content.reaction.emoji) {
-        return asCustom({
-          whatsapp_type: "reaction-removed",
-          messageId: content.reaction.messageId,
+        const reactedId = content.reaction.messageId;
+        const removedReaction = {
+          id: `${reactedId}:reaction:${msg.from}`,
+          content: asCustom({
+            whatsapp_type: "reaction-removed",
+            messageId: reactedId,
+            stub: true,
+          }),
+        };
+        return asUnsend({
+          target: removedReaction as Parameters<typeof asUnsend>[0]["target"],
         });
       }
       // WhatsApp reaction events carry only the target message id; synthesize

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -29,6 +29,7 @@ import {
   asReaction,
   asText,
   createLogger,
+  errorAttrs,
   type ProviderMessageRecord,
   tracedFetch,
 } from "@spectrum-ts/core/authoring";
@@ -319,6 +320,15 @@ const mapContent = (client: WhatsAppClient, msg: InboundMessage): Content => {
     case "location":
       return asCustom({ whatsapp_type: "location", ...content.location });
     case "reaction": {
+      // Meta signals REMOVING a reaction as a reaction event whose emoji is
+      // the protobuf default "" which is not a valid `reaction` content (asReaction
+      // requires a non-empty emoji).
+      if (!content.reaction.emoji) {
+        return asCustom({
+          whatsapp_type: "reaction-removed",
+          messageId: content.reaction.messageId,
+        });
+      }
       // WhatsApp reaction events carry only the target message id; synthesize
       // a minimal target Message shape. Core's wrapProviderMessage inflates
       // this into a full Message with react/reply methods at emit time.
@@ -547,7 +557,24 @@ const clientStream = (
     const pump = (async () => {
       try {
         for await (const event of eventStream) {
-          for (const m of toMessages(client, event.message)) {
+          // One unmappable event must not kill the live stream: a mapping
+          // throw here ends the merged stream for the whole project, and
+          // nothing downstream restarts it. Skip the event and keep pumping.
+          let mapped: WhatsAppMessage[];
+          try {
+            mapped = toMessages(client, event.message);
+          } catch (error) {
+            streamLog.warn(
+              "skipping unmappable whatsapp message event",
+              {
+                "spectrum.whatsapp.message_id": event.message.id,
+                ...errorAttrs(error),
+              },
+              error instanceof Error ? error : undefined
+            );
+            continue;
+          }
+          for (const m of mapped) {
             await emit(m);
           }
         }

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -322,12 +322,11 @@ const mapContent = (client: WhatsAppClient, msg: InboundMessage): Content => {
       return asCustom({ whatsapp_type: "location", ...content.location });
     case "reaction": {
       // Meta signals REMOVING a reaction as a reaction event whose emoji is
-      // the protobuf default "" — not valid `reaction` content (asReaction
+      // the protobuf default "" which is not a valid `reaction` content (asReaction
       // requires a non-empty emoji), and Meta doesn't say which emoji was
-      // removed (one reaction per user per message). Surface the portable
+      // removed (one reaction per user per message). Instead, we surface a
       // `unsend` arm: the retracted "message" is the sender's reaction on
-      // the target, identified by the same synthetic `<id>:reaction:<user>`
-      // convention Slack uses for reaction messages.
+      // the target, identified by the same synthetic `<id>:reaction:<user>`.
       if (!content.reaction.emoji) {
         const reactedId = content.reaction.messageId;
         const removedReaction = {

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -93,12 +93,10 @@ const cachePoll = (
   }
 };
 
-// Inbound reaction adds, keyed by (reacted message, reactor) — unique because
-// WhatsApp allows one reaction per user per message. A removal event carries
-// no emoji and no reaction wamid, so this cache is the only way to report
-// which emoji was taken out; best-effort by design (restart/eviction means a
-// removal can miss, falling back to a stub target).
-type CachedReaction = { id: string; emoji: string };
+interface CachedReaction {
+  emoji: string;
+  id: string;
+}
 const MAX_REACTION_CACHE_SIZE = 1000;
 const reactionCaches = new WeakMap<
   WhatsAppClient,
@@ -355,6 +353,53 @@ const toMessages = (
   ];
 };
 
+// Meta signals REMOVING a reaction as a reaction event whose emoji is the
+// protobuf default "" which is not a valid `reaction` content (asReaction
+// requires a non-empty emoji), and Meta doesn't say which emoji was removed
+// (one reaction per user per message).
+const mapReactionContent = (
+  client: WhatsAppClient,
+  msg: InboundMessage,
+  reaction: { messageId: string; emoji: string }
+): Content => {
+  const reactedId = reaction.messageId;
+  if (!reaction.emoji) {
+    const cached = takeCachedReaction(client, reactedId, msg.from);
+    const removedReaction = cached
+      ? {
+          id: cached.id,
+          content: asReaction({
+            emoji: cached.emoji,
+            target: reactionTargetStub(reactedId) as Parameters<
+              typeof asReaction
+            >[0]["target"],
+          }),
+        }
+      : {
+          id: `${reactedId}:reaction:${msg.from}`,
+          content: asCustom({
+            whatsapp_type: "reaction-removed",
+            messageId: reactedId,
+            stub: true,
+          }),
+        };
+    return asUnsend({
+      target: removedReaction as Parameters<typeof asUnsend>[0]["target"],
+    });
+  }
+  // Remember the add so a later removal can report which emoji left.
+  cacheReaction(client, reactedId, msg.from, {
+    id: msg.id,
+    emoji: reaction.emoji,
+  });
+  return asReaction({
+    emoji: reaction.emoji,
+    target: reactionTargetStub(reactedId) as Parameters<
+      typeof asReaction
+    >[0]["target"],
+  });
+};
+
 const mapContent = (client: WhatsAppClient, msg: InboundMessage): Content => {
   const { content } = msg;
   switch (content.type) {
@@ -378,51 +423,8 @@ const mapContent = (client: WhatsAppClient, msg: InboundMessage): Content => {
       return asCustom({ whatsapp_type: "sticker", ...content.sticker });
     case "location":
       return asCustom({ whatsapp_type: "location", ...content.location });
-    case "reaction": {
-      const reactedId = content.reaction.messageId;
-      // Meta signals REMOVING a reaction as a reaction event whose emoji is
-      // the protobuf default "" which is not a valid `reaction` content
-      // (asReaction requires a non-empty emoji), and Meta doesn't say which
-      // emoji was removed (one reaction per user per message). Instead, we
-      // surface a `unsend` arm whose target is the reaction being retracted:
-      // the cached original when the add was seen (real wamid + the emoji
-      // being taken out), else a synthetic `<id>:reaction:<user>` stub.
-      if (!content.reaction.emoji) {
-        const cached = takeCachedReaction(client, reactedId, msg.from);
-        const removedReaction = cached
-          ? {
-              id: cached.id,
-              content: asReaction({
-                emoji: cached.emoji,
-                target: reactionTargetStub(reactedId) as Parameters<
-                  typeof asReaction
-                >[0]["target"],
-              }),
-            }
-          : {
-              id: `${reactedId}:reaction:${msg.from}`,
-              content: asCustom({
-                whatsapp_type: "reaction-removed",
-                messageId: reactedId,
-                stub: true,
-              }),
-            };
-        return asUnsend({
-          target: removedReaction as Parameters<typeof asUnsend>[0]["target"],
-        });
-      }
-      // Remember the add so a later removal can report which emoji left.
-      cacheReaction(client, reactedId, msg.from, {
-        id: msg.id,
-        emoji: content.reaction.emoji,
-      });
-      return asReaction({
-        emoji: content.reaction.emoji,
-        target: reactionTargetStub(reactedId) as Parameters<
-          typeof asReaction
-        >[0]["target"],
-      });
-    }
+    case "reaction":
+      return mapReactionContent(client, msg, content.reaction);
     case "interactive": {
       const inter = content.interactive;
       if (inter.type === "button_reply" || inter.type === "list_reply") {

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -129,21 +129,13 @@ const cacheReaction = (
   }
 };
 
-const takeCachedReaction = (
+const getCachedReaction = (
   client: WhatsAppClient,
   reactedId: string,
   from: string
-): CachedReaction | undefined => {
-  const cache = reactionCaches.get(client);
-  const key = reactionCacheKey(reactedId, from);
-  const entry = cache?.get(key);
-  cache?.delete(key);
-  return entry;
-};
+): CachedReaction | undefined =>
+  reactionCaches.get(client)?.get(reactionCacheKey(reactedId, from));
 
-// WhatsApp reaction events carry only the target message id; synthesize a
-// minimal target Message shape. Core's wrapProviderMessage inflates this
-// into a full Message with react/reply methods at emit time.
 const reactionTargetStub = (reactedId: string) => ({
   id: reactedId,
   content: asCustom({ whatsapp_type: "reaction-target", stub: true }),
@@ -364,7 +356,7 @@ const mapReactionContent = (
 ): Content => {
   const reactedId = reaction.messageId;
   if (!reaction.emoji) {
-    const cached = takeCachedReaction(client, reactedId, msg.from);
+    const cached = getCachedReaction(client, reactedId, msg.from);
     const removedReaction = cached
       ? {
           id: cached.id,

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -93,6 +93,64 @@ const cachePoll = (
   }
 };
 
+// Inbound reaction adds, keyed by (reacted message, reactor) — unique because
+// WhatsApp allows one reaction per user per message. A removal event carries
+// no emoji and no reaction wamid, so this cache is the only way to report
+// which emoji was taken out; best-effort by design (restart/eviction means a
+// removal can miss, falling back to a stub target).
+type CachedReaction = { id: string; emoji: string };
+const MAX_REACTION_CACHE_SIZE = 1000;
+const reactionCaches = new WeakMap<
+  WhatsAppClient,
+  Map<string, CachedReaction>
+>();
+
+const reactionCacheKey = (reactedId: string, from: string): string =>
+  `${reactedId}:${from}`;
+
+const cacheReaction = (
+  client: WhatsAppClient,
+  reactedId: string,
+  from: string,
+  entry: CachedReaction
+): void => {
+  let cache = reactionCaches.get(client);
+  if (!cache) {
+    cache = new Map<string, CachedReaction>();
+    reactionCaches.set(client, cache);
+  }
+  const key = reactionCacheKey(reactedId, from);
+  // Delete-then-set keeps a re-reaction fresh in LRU order.
+  cache.delete(key);
+  cache.set(key, entry);
+  if (cache.size > MAX_REACTION_CACHE_SIZE) {
+    const first = cache.keys().next().value;
+    if (first !== undefined) {
+      cache.delete(first);
+    }
+  }
+};
+
+const takeCachedReaction = (
+  client: WhatsAppClient,
+  reactedId: string,
+  from: string
+): CachedReaction | undefined => {
+  const cache = reactionCaches.get(client);
+  const key = reactionCacheKey(reactedId, from);
+  const entry = cache?.get(key);
+  cache?.delete(key);
+  return entry;
+};
+
+// WhatsApp reaction events carry only the target message id; synthesize a
+// minimal target Message shape. Core's wrapProviderMessage inflates this
+// into a full Message with react/reply methods at emit time.
+const reactionTargetStub = (reactedId: string) => ({
+  id: reactedId,
+  content: asCustom({ whatsapp_type: "reaction-target", stub: true }),
+});
+
 const optionIndexFromId = (id: string): number | undefined => {
   if (!id.startsWith(OPTION_ID_PREFIX)) {
     return;
@@ -321,36 +379,48 @@ const mapContent = (client: WhatsAppClient, msg: InboundMessage): Content => {
     case "location":
       return asCustom({ whatsapp_type: "location", ...content.location });
     case "reaction": {
+      const reactedId = content.reaction.messageId;
       // Meta signals REMOVING a reaction as a reaction event whose emoji is
-      // the protobuf default "" which is not a valid `reaction` content (asReaction
-      // requires a non-empty emoji), and Meta doesn't say which emoji was
-      // removed (one reaction per user per message). Instead, we surface a
-      // `unsend` arm: the retracted "message" is the sender's reaction on
-      // the target, identified by the same synthetic `<id>:reaction:<user>`.
+      // the protobuf default "" which is not a valid `reaction` content
+      // (asReaction requires a non-empty emoji), and Meta doesn't say which
+      // emoji was removed (one reaction per user per message). Instead, we
+      // surface a `unsend` arm whose target is the reaction being retracted:
+      // the cached original when the add was seen (real wamid + the emoji
+      // being taken out), else a synthetic `<id>:reaction:<user>` stub.
       if (!content.reaction.emoji) {
-        const reactedId = content.reaction.messageId;
-        const removedReaction = {
-          id: `${reactedId}:reaction:${msg.from}`,
-          content: asCustom({
-            whatsapp_type: "reaction-removed",
-            messageId: reactedId,
-            stub: true,
-          }),
-        };
+        const cached = takeCachedReaction(client, reactedId, msg.from);
+        const removedReaction = cached
+          ? {
+              id: cached.id,
+              content: asReaction({
+                emoji: cached.emoji,
+                target: reactionTargetStub(reactedId) as Parameters<
+                  typeof asReaction
+                >[0]["target"],
+              }),
+            }
+          : {
+              id: `${reactedId}:reaction:${msg.from}`,
+              content: asCustom({
+                whatsapp_type: "reaction-removed",
+                messageId: reactedId,
+                stub: true,
+              }),
+            };
         return asUnsend({
           target: removedReaction as Parameters<typeof asUnsend>[0]["target"],
         });
       }
-      // WhatsApp reaction events carry only the target message id; synthesize
-      // a minimal target Message shape. Core's wrapProviderMessage inflates
-      // this into a full Message with react/reply methods at emit time.
-      const stubTarget = {
-        id: content.reaction.messageId,
-        content: asCustom({ whatsapp_type: "reaction-target", stub: true }),
-      };
+      // Remember the add so a later removal can report which emoji left.
+      cacheReaction(client, reactedId, msg.from, {
+        id: msg.id,
+        emoji: content.reaction.emoji,
+      });
       return asReaction({
         emoji: content.reaction.emoji,
-        target: stubTarget as Parameters<typeof asReaction>[0]["target"],
+        target: reactionTargetStub(reactedId) as Parameters<
+          typeof asReaction
+        >[0]["target"],
       });
     }
     case "interactive": {

--- a/packages/whatsapp-business/test/reaction-removal.test.ts
+++ b/packages/whatsapp-business/test/reaction-removal.test.ts
@@ -81,6 +81,29 @@ describe("whatsapp reaction removal", () => {
     });
   });
 
+  it("a duplicate removal webhook emits the same unsend target, not a stub", async () => {
+    // Meta delivery is at-least-once — a retried removal must not degrade
+    // to the synthetic stub shape, or consumers can't dedupe by target id.
+    const received = await receiveAll(
+      fakeClient([
+        reactionEvent("\u{1F44D}", "wamid.REACT1"),
+        reactionEvent("", "wamid.REMOVE1"),
+        reactionEvent("", "wamid.REMOVE1-RETRY"),
+      ])
+    );
+
+    expect(received).toHaveLength(3);
+    for (const removal of [received[1], received[2]]) {
+      expect(removal?.content).toMatchObject({
+        type: "unsend",
+        target: {
+          id: "wamid.REACT1",
+          content: { type: "reaction", emoji: "\u{1F44D}" },
+        },
+      });
+    }
+  });
+
   it("a re-reaction updates which emoji a later removal reports", async () => {
     const received = await receiveAll(
       fakeClient([

--- a/packages/whatsapp-business/test/reaction-removal.test.ts
+++ b/packages/whatsapp-business/test/reaction-removal.test.ts
@@ -23,8 +23,8 @@ const fakeClient = (inbounds: unknown[]): WhatsAppClient => {
   } as unknown as WhatsAppClient;
 };
 
-const reactionEvent = (emoji: string) => ({
-  id: "wamid.REACT1",
+const reactionEvent = (emoji: string, id = "wamid.REACT1") => ({
+  id,
   from: "15551234567",
   timestamp: new Date("2026-07-16T00:00:00.000Z"),
   content: {
@@ -62,7 +62,44 @@ describe("whatsapp reaction removal", () => {
     });
   });
 
-  it("surfaces an empty-emoji reaction (removal) as portable unsend content, not a throw", async () => {
+  it("surfaces a removal whose add was seen as unsend of the real reaction", async () => {
+    const received = await receiveAll(
+      fakeClient([
+        reactionEvent("\u{1F44D}", "wamid.REACT1"),
+        reactionEvent("", "wamid.REMOVE1"),
+      ])
+    );
+
+    expect(received).toHaveLength(2);
+    expect(received[1]?.content).toMatchObject({
+      type: "unsend",
+      target: {
+        // The cached original: its own wamid and the emoji being taken out.
+        id: "wamid.REACT1",
+        content: { type: "reaction", emoji: "\u{1F44D}" },
+      },
+    });
+  });
+
+  it("a re-reaction updates which emoji a later removal reports", async () => {
+    const received = await receiveAll(
+      fakeClient([
+        reactionEvent("\u{1F44D}", "wamid.REACT1"),
+        reactionEvent("\u{2764}\u{FE0F}", "wamid.REACT2"),
+        reactionEvent("", "wamid.REMOVE1"),
+      ])
+    );
+
+    expect(received[2]?.content).toMatchObject({
+      type: "unsend",
+      target: {
+        id: "wamid.REACT2",
+        content: { type: "reaction", emoji: "\u{2764}\u{FE0F}" },
+      },
+    });
+  });
+
+  it("surfaces a removal with no cached add as unsend of a stub, not a throw", async () => {
     const [received] = await receiveAll(fakeClient([reactionEvent("")]));
 
     expect(received?.content).toMatchObject({

--- a/packages/whatsapp-business/test/reaction-removal.test.ts
+++ b/packages/whatsapp-business/test/reaction-removal.test.ts
@@ -1,0 +1,98 @@
+import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
+import { describe, expect, it } from "vitest";
+import { messages } from "@/messages";
+import type { WhatsAppMessage } from "@/types";
+
+// Drives the real inbound path — messages() -> clientStream -> toMessages —
+// with a fake client whose event stream yields the given raw messages.
+// Meta represents removing a reaction as a reaction event whose emoji is the
+// protobuf default "" — before this fix that threw a ZodError inside the
+// stream pump and killed the project's entire messages stream (2026-07-16
+// production incident).
+const fakeClient = (inbounds: unknown[]): WhatsAppClient => {
+  const filtered = {
+    async *[Symbol.asyncIterator]() {
+      for (const inbound of inbounds) {
+        yield { type: "message", message: inbound };
+      }
+    },
+    close: async () => undefined,
+  };
+  return {
+    events: { subscribe: () => ({ filter: () => filtered }) },
+  } as unknown as WhatsAppClient;
+};
+
+const reactionEvent = (emoji: string) => ({
+  id: "wamid.REACT1",
+  from: "15551234567",
+  timestamp: new Date("2026-07-16T00:00:00.000Z"),
+  content: {
+    type: "reaction",
+    reaction: { messageId: "wamid.TARGET1", emoji },
+  },
+});
+
+const textEvent = (id: string, body: string) => ({
+  id,
+  from: "15551234567",
+  timestamp: new Date("2026-07-16T00:00:00.000Z"),
+  content: { type: "text", body },
+});
+
+const receiveAll = async (
+  client: WhatsAppClient
+): Promise<WhatsAppMessage[]> => {
+  const received: WhatsAppMessage[] = [];
+  for await (const m of messages([client])) {
+    received.push(m);
+  }
+  return received;
+};
+
+describe("whatsapp reaction removal", () => {
+  it("surfaces an emoji reaction as reaction content", async () => {
+    const [received] = await receiveAll(
+      fakeClient([reactionEvent("\u{1F44D}")])
+    );
+
+    expect(received?.content).toMatchObject({
+      type: "reaction",
+      emoji: "\u{1F44D}",
+    });
+  });
+
+  it("surfaces an empty-emoji reaction (removal) as a custom arm, not a throw", async () => {
+    const [received] = await receiveAll(fakeClient([reactionEvent("")]));
+
+    expect(received?.content).toMatchObject({
+      type: "custom",
+      raw: {
+        whatsapp_type: "reaction-removed",
+        messageId: "wamid.TARGET1",
+      },
+    });
+  });
+
+  it("keeps the stream alive when one event is unmappable", async () => {
+    // An event whose content shape crashes toMessages entirely (media with
+    // no payload) must be skipped — the messages after it still flow.
+    const poison = {
+      id: "wamid.POISON1",
+      from: "15551234567",
+      timestamp: new Date("2026-07-16T00:00:00.000Z"),
+      content: { type: "image" },
+    };
+
+    const received = await receiveAll(
+      fakeClient([poison, textEvent("wamid.OK1", "still alive")])
+    );
+
+    expect(received).toHaveLength(1);
+    expect(received[0]?.id).toBe("wamid.OK1");
+    expect(received[0]?.content).toMatchObject({
+      type: "text",
+      text: "still alive",
+    });
+  });
+});

--- a/packages/whatsapp-business/test/reaction-removal.test.ts
+++ b/packages/whatsapp-business/test/reaction-removal.test.ts
@@ -62,14 +62,24 @@ describe("whatsapp reaction removal", () => {
     });
   });
 
-  it("surfaces an empty-emoji reaction (removal) as a custom arm, not a throw", async () => {
+  it("surfaces an empty-emoji reaction (removal) as portable unsend content, not a throw", async () => {
     const [received] = await receiveAll(fakeClient([reactionEvent("")]));
 
     expect(received?.content).toMatchObject({
-      type: "custom",
-      raw: {
-        whatsapp_type: "reaction-removed",
-        messageId: "wamid.TARGET1",
+      type: "unsend",
+      target: {
+        // Synthetic reaction-message identity, mirroring Slack's
+        // `<id>:reaction:<user>` convention. parentWamid strips the suffix
+        // if a targeted action ever addresses it.
+        id: "wamid.TARGET1:reaction:15551234567",
+        content: {
+          type: "custom",
+          raw: {
+            whatsapp_type: "reaction-removed",
+            messageId: "wamid.TARGET1",
+            stub: true,
+          },
+        },
       },
     });
   });

--- a/packages/whatsapp-business/test/unsend-reaction.test.ts
+++ b/packages/whatsapp-business/test/unsend-reaction.test.ts
@@ -1,0 +1,64 @@
+import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
+import type { Content } from "@spectrum-ts/core";
+import { describe, expect, it, vi } from "vitest";
+import { send } from "@/messages";
+
+// Meta's Cloud API retracts a reaction by re-sending it with emoji: "" at the
+// reacted message. Regular business messages cannot be deleted, so unsend is
+// supported for reaction messages only.
+
+const UNSEND_UNSUPPORTED = /unsend/;
+
+const fakeSendClient = () => {
+  const sendMock = vi.fn(async () => ({ messageId: "wamid.NEW" }));
+  const client = {
+    messages: { send: sendMock },
+  } as unknown as WhatsAppClient;
+  return { client, sendMock };
+};
+
+const unsendOf = (targetContent: unknown): Content =>
+  ({
+    type: "unsend",
+    target: {
+      id: "wamid.SENT1",
+      direction: "outbound",
+      content: targetContent,
+    },
+  }) as unknown as Content;
+
+describe("whatsapp outbound unsend", () => {
+  it("retracts a reaction by sending an empty emoji at the reacted message", async () => {
+    const { client, sendMock } = fakeSendClient();
+
+    const result = await send(
+      [client],
+      "15551234567",
+      unsendOf({
+        type: "reaction",
+        emoji: "\u{1F44D}",
+        // Synthetic group-item suffix must be stripped for the Cloud API.
+        target: {
+          id: "wamid.TARGET1:0",
+          content: { type: "text", text: "hi" },
+        },
+      })
+    );
+
+    expect(result).toBeUndefined();
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock).toHaveBeenCalledWith({
+      to: "15551234567",
+      reaction: { messageId: "wamid.TARGET1", emoji: "" },
+    });
+  });
+
+  it("rejects unsend of a non-reaction message as unsupported", async () => {
+    const { client, sendMock } = fakeSendClient();
+
+    await expect(
+      send([client], "15551234567", unsendOf({ type: "text", text: "oops" }))
+    ).rejects.toThrow(UNSEND_UNSUPPORTED);
+    expect(sendMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## why

iMessage inbound runs through `resumableOrderedStream`, which retries *every* failure with cursor-based catch-up — by design, so transport blips heal themselves. But mapping throws go through the same loop: a **deterministic** per-event throw (schema/shape error, the class that took down WhatsApp inbound) means catch-up refetches the same poison event, mapping throws again, and the loop never advances the cursor. The stream doesn't die but instead it wedges forever, stalling every message behind the poison event, while the logs show only generic reconnect WARNs that look like a flaky transport.

## fix

`skipUnmappable` wraps all six mapping sites (`processLive`/`processMissed` across the messages, polls, and groups streams) and splits errors two ways:

- **Client errors flagged `retryable: true`** (network blips, gateway restarts) **rethrow** — preserving the existing retry-via-catch-up behavior. Mapping does RPC work (message/attachment rebuilds), so transient failures must cost latency, never messages. Retries are unbounded, matching the stream's existing transport-error philosophy.
- **Everything else** (deterministic throws, `retryable: false`, unflagged errors) is logged (`skipping unmappable imessage event`, WARN with error attrs + cursor) and converted to an **empty skip item** — the same `{cursor, id, values: []}` shape the existing `isFromMe` skips use, so the cursor advances past the event and the stream keeps flowing.

Default direction is deliberate: unknown errors *skip* rather than retry, because an unclassifiable deterministic throw is exactly the wedge this defends against.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786829367&installation_id=127326493&pr_number=197&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F197&signature=6e860e78a6f62c68e8feb351995b5502d6a7450d18f0c5988cb0b0bb1167681e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live inbound stream error handling and message semantics on two production channels; incorrect skip/retry classification could drop or duplicate events, though defaults favor skip over infinite retry.
> 
> **Overview**
> **iMessage** wraps message/poll/group live and catch-up mapping in `skipUnmappable`: errors with `retryable: true` still propagate for catch-up retry; other mapping failures log a warning and yield an empty skip item so the resume cursor advances. Contact-card sharing on inbound messages now runs only after mapping succeeds.
> 
> **WhatsApp** treats Meta’s empty-emoji reaction events as **`unsend`** of the cached reaction (or a synthetic stub when no prior add was seen), caches adds per user/message for removals and re-reactions, and skips unmappable inbound events in the live pump so later messages still emit. Outbound **`unsend`** is implemented for reaction targets only (Cloud API `emoji: ""`); other unsend types stay unsupported.
> 
> **Core** re-exports **`asUnsend`** from authoring for providers. New tests cover stream skip/retry behavior and WhatsApp reaction removal paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 892d0c7e6af856477bc7043ac1aaaad502b0cc4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for WhatsApp reaction removal, including inbound unsend events and outbound reaction retraction.
  * Added `asUnsend` to the provider authoring API.
* **Bug Fixes**
  * Improved reaction tracking for duplicate deliveries and emoji updates.
  * iMessage and WhatsApp streams now skip unmappable events while continuing to deliver later messages.
  * Transient mapping failures are retried automatically.
  * Unsupported non-reaction unsend requests now return a clear error.
* **Tests**
  * Added coverage for iMessage stream skip/retry behavior and WhatsApp reaction removal/unsend flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->