### PR TITLE
fix(imessage): support native voice messages

### DIFF
--- a/packages/core/src/content/voice.ts
+++ b/packages/core/src/content/voice.ts
@@ -21,6 +21,7 @@ const audioMimeSchema = z
 
 export const voiceSchema = z.object({
   type: z.literal("voice"),
+  id: z.string().nonempty().optional(),
   name: z.string().nonempty().optional(),
   mimeType: audioMimeSchema,
   duration: z.number().nonnegative().optional(),
@@ -91,6 +92,7 @@ const resolveVoiceMimeType = (
 };
 
 export const asVoice = (input: {
+  id?: string;
   name?: string;
   mimeType: string;
   duration?: number;
@@ -111,6 +113,7 @@ export const asVoice = (input: {
 
   return voiceSchema.parse({
     type: "voice",
+    ...(input.id ? { id: input.id } : {}),
     name: input.name,
     mimeType: input.mimeType,
     duration: input.duration,

--- a/packages/core/src/webhook/deserialize.ts
+++ b/packages/core/src/webhook/deserialize.ts
@@ -13,6 +13,7 @@ import {
 } from "../content/membership";
 import { renameSchema } from "../content/rename";
 import type { Content } from "../content/types";
+import { asVoice } from "../content/voice";
 import type { ProviderMessageRecord } from "../platform/build";
 import { UnsupportedError } from "../utils/errors";
 import type {
@@ -144,6 +145,8 @@ const mapContent = (
       return deserializeGroup(raw, platform, spaceRef, ctx);
     case "attachment":
       return deserializeAttachment(raw, platform, spaceRef, ctx);
+    case "voice":
+      return deserializeVoice(raw, platform, spaceRef, ctx);
     case "addMember":
       return addMemberSchema.parse({
         type: "addMember",
@@ -229,6 +232,35 @@ const deserializeAttachment = (
     id,
     name: asString(raw.name) || DEFAULT_ATTACHMENT_NAME,
     mimeType: asString(raw.mimeType) || DEFAULT_MIME_TYPE,
+    size: typeof raw.size === "number" ? raw.size : undefined,
+    read: bytes ? bytes.read : unavailable,
+    stream: bytes?.stream,
+  });
+};
+
+const deserializeVoice = (
+  raw: Record<string, unknown>,
+  platform: string,
+  spaceRef: SpaceRef,
+  ctx: DeserializeContext
+): Content => {
+  const id = asString(raw.id);
+  const bytes = id
+    ? ctx.resolveAttachment?.(platform, spaceRef, id)
+    : undefined;
+  const unavailable = (): Promise<never> =>
+    Promise.reject(
+      UnsupportedError.action(
+        "getAttachment",
+        platform,
+        `voice attachment "${id}" arrived without bytes over the Spectrum webhook and "${platform}" exposes no getAttachment`
+      )
+    );
+  return asVoice({
+    ...(id ? { id } : {}),
+    name: asString(raw.name) || undefined,
+    mimeType: asString(raw.mimeType),
+    duration: typeof raw.duration === "number" ? raw.duration : undefined,
     size: typeof raw.size === "number" ? raw.size : undefined,
     read: bytes ? bytes.read : unavailable,
     stream: bytes?.stream,

--- a/packages/core/test/webhook/deserialize.test.ts
+++ b/packages/core/test/webhook/deserialize.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { Attachment } from "@/content/attachment";
 import type { Reaction } from "@/content/reaction";
 import type { Reply } from "@/content/reply";
+import type { Voice } from "@/content/voice";
 import {
   type DeserializeContext,
   deserializeSpectrumMessage,
@@ -228,6 +229,34 @@ describe("deserializeSpectrumMessage", () => {
     expect(content.name).toBe("doc.pdf");
     expect(content.mimeType).toBe("application/pdf");
     await expect(content.read()).rejects.toThrow(UNSUPPORTED_ATTACHMENT_ERROR);
+  });
+
+  it("reconstructs voice bytes and metadata via the attachment resolver", async () => {
+    const bytes = Buffer.from("caff-voice-bytes");
+    const ctx: DeserializeContext = {
+      resolveAttachment: (platform, _spaceRef, attachmentId) => {
+        expect(platform).toBe(PLATFORM);
+        expect(attachmentId).toBe("voice-att");
+        return { read: () => Promise.resolve(bytes) };
+      },
+    };
+    const { record } = deserialize(
+      {
+        type: "voice",
+        id: "voice-att",
+        name: "Audio Message.caf",
+        mimeType: "audio/x-caf",
+        size: 16,
+      },
+      ctx
+    );
+    const content = record.content as Voice;
+    expect(content.type).toBe("voice");
+    expect(content.id).toBe("voice-att");
+    expect(content.name).toBe("Audio Message.caf");
+    expect(content.mimeType).toBe("audio/x-caf");
+    expect(content.size).toBe(16);
+    expect(await content.read()).toEqual(bytes);
   });
 
   it("delivers an unknown content type as custom", () => {

--- a/packages/imessage-local/src/local/attachments.ts
+++ b/packages/imessage-local/src/local/attachments.ts
@@ -3,7 +3,11 @@ import { readFile } from "node:fs/promises";
 import { Readable } from "node:stream";
 import type { Message as LocalIMessage } from "@photon-ai/imessage-kit";
 import { type Content, fromVCard } from "@spectrum-ts/core";
-import { asAttachment, asContact } from "@spectrum-ts/core/authoring";
+import { asAttachment, asContact, asVoice } from "@spectrum-ts/core/authoring";
+import {
+  appleAudioMimeType,
+  normalizeAppleAttachmentMimeType,
+} from "../../../imessage/src/shared/audio";
 import { isVCardAttachment } from "../../../imessage/src/shared/vcard";
 
 export const DEFAULT_ATTACHMENT_NAME = "attachment";
@@ -26,7 +30,24 @@ const toAttachmentContent = (att: LocalAttachment): Content => {
   return asAttachment({
     id: att.id,
     name: att.fileName ?? DEFAULT_ATTACHMENT_NAME,
-    mimeType: att.mimeType,
+    mimeType: normalizeAppleAttachmentMimeType(att),
+    size: att.sizeBytes,
+    read: () => readLocalAttachment(att),
+    stream: localPath
+      ? async () =>
+          Readable.toWeb(
+            createReadStream(localPath)
+          ) as ReadableStream<Uint8Array>
+      : undefined,
+  });
+};
+
+const toVoiceContent = (att: LocalAttachment, mimeType: string): Content => {
+  const { localPath } = att;
+  return asVoice({
+    id: att.id,
+    name: att.fileName ?? undefined,
+    mimeType,
     size: att.sizeBytes,
     read: () => readLocalAttachment(att),
     stream: localPath
@@ -48,8 +69,14 @@ const toVCardContent = async (att: LocalAttachment): Promise<Content> => {
 };
 
 export const localAttachmentContent = async (
-  att: LocalAttachment
-): Promise<Content> =>
-  isVCardAttachment(att.mimeType, att.fileName)
-    ? await toVCardContent(att)
+  att: LocalAttachment,
+  isVoice = false
+): Promise<Content> => {
+  if (isVCardAttachment(att.mimeType, att.fileName)) {
+    return await toVCardContent(att);
+  }
+  const audioMimeType = isVoice ? appleAudioMimeType(att) : undefined;
+  return audioMimeType
+    ? toVoiceContent(att, audioMimeType)
     : toAttachmentContent(att);
+};

--- a/packages/imessage-local/src/local/inbound.ts
+++ b/packages/imessage-local/src/local/inbound.ts
@@ -10,6 +10,7 @@ import {
   asText,
   type ProviderMessageRecord,
 } from "@spectrum-ts/core/authoring";
+import { appleAudioMimeType } from "../../../imessage/src/shared/audio";
 import {
   ATTACHMENT_PLACEHOLDER,
   hasUsableTextPart,
@@ -31,6 +32,15 @@ const isPendingAttachmentJoin = (message: LocalIMessage): boolean =>
 
 const replyTargetId = (message: LocalIMessage): string | undefined =>
   message.threadRootMessageId ?? undefined;
+
+const voiceAttachmentId = (message: LocalIMessage): string | undefined => {
+  if (!message.isAudioMessage) {
+    return;
+  }
+  return message.attachments.find((attachment) =>
+    appleAudioMimeType(attachment)
+  )?.id;
+};
 
 const stubReplyTarget = (
   space: IMessageMessage["space"],
@@ -133,6 +143,7 @@ export const toMessages = async (
     timestamp: message.createdAt,
   };
   const targetId = replyTargetId(message);
+  const audioAttachmentId = voiceAttachmentId(message);
 
   if (message.attachments.length > 0) {
     if (!hasUsableTextPart(message.text)) {
@@ -140,7 +151,10 @@ export const toMessages = async (
         message.attachments.map(async (att) => ({
           ...base,
           id: `${message.id}:${att.id}`,
-          content: await localAttachmentContent(att),
+          content: await localAttachmentContent(
+            att,
+            att.id === audioAttachmentId
+          ),
         }))
       );
       return wrapReply(messages, targetId);
@@ -166,7 +180,10 @@ export const toMessages = async (
           : {
               ...base,
               id: `${message.id}:${part.attachment.id}`,
-              content: await localAttachmentContent(part.attachment),
+              content: await localAttachmentContent(
+                part.attachment,
+                part.attachment.id === audioAttachmentId
+              ),
               partIndex: i,
             }
       );

--- a/packages/imessage-local/test/local/inbound.test.ts
+++ b/packages/imessage-local/test/local/inbound.test.ts
@@ -10,7 +10,8 @@ const attachment = (
   id: string,
   fileName: string,
   mimeType: string,
-  sizeBytes = DEFAULT_ATTACHMENT_SIZE_BYTES
+  sizeBytes = DEFAULT_ATTACHMENT_SIZE_BYTES,
+  uti?: string
 ): LocalIMessage["attachments"][number] =>
   ({
     fileName,
@@ -22,7 +23,7 @@ const attachment = (
     sizeBytes,
     transferName: fileName,
     transferStatus: "finished",
-    uti: undefined,
+    uti,
   }) as unknown as LocalIMessage["attachments"][number];
 
 const localMessage = (overrides: Partial<LocalIMessage> = {}): LocalIMessage =>
@@ -126,6 +127,39 @@ describe("iMessage local toMessages", () => {
         partIndex: undefined,
       },
     ]);
+  });
+
+  it("maps native CAF audio messages to voice content", async () => {
+    const [message] = await toMessages(
+      localMessage({
+        attachments: [
+          attachment(
+            "voice-att",
+            "Audio Message.caf",
+            "application/octet-stream",
+            456,
+            "com.apple.coreaudio-format"
+          ),
+        ],
+        hasAttachments: true,
+        isAudioMessage: true,
+        isExpirable: true,
+        text: undefined,
+      })
+    );
+
+    expect(message?.content).toMatchObject({
+      id: "voice-att",
+      mimeType: "audio/x-caf",
+      name: "Audio Message.caf",
+      size: 456,
+      type: "voice",
+    });
+    if (message?.content.type !== "voice") {
+      throw new Error("expected voice content");
+    }
+    expect(message.content.read).toBeTypeOf("function");
+    expect(message.content.stream).toBeTypeOf("function");
   });
 
   it("wraps attachment replies without changing the local message id", async () => {

--- a/packages/imessage/src/remote/attachments.ts
+++ b/packages/imessage/src/remote/attachments.ts
@@ -4,6 +4,7 @@ import {
 } from "@photon-ai/advanced-imessage";
 import type { Attachment } from "@spectrum-ts/core";
 import { asAttachment } from "@spectrum-ts/core/authoring";
+import { normalizeAppleAttachmentMimeType } from "../shared/audio";
 
 /**
  * Stream the primary file bytes of an attachment as a `ReadableStream`.
@@ -102,7 +103,7 @@ export const getRemoteAttachment = async (
   return asAttachment({
     id: info.guid,
     name: info.fileName,
-    mimeType: info.mimeType,
+    mimeType: normalizeAppleAttachmentMimeType(info),
     size: info.totalBytes,
     read: () => downloadPrimaryAttachment(client, info.guid),
     stream: async () => downloadPrimaryAttachmentStream(client, info.guid),

--- a/packages/imessage/src/remote/inbound.ts
+++ b/packages/imessage/src/remote/inbound.ts
@@ -12,12 +12,17 @@ import {
   asCustom,
   asReply,
   asText,
+  asVoice,
   createLogger,
   errorAttrs,
   groupSchema,
   type ProviderMessageRecord,
 } from "@spectrum-ts/core/authoring";
 import { getMessageCache, type MessageCache } from "../cache";
+import {
+  appleAudioMimeType,
+  normalizeAppleAttachmentMimeType,
+} from "../shared/audio";
 import { type OrderedPart, toOrderedParts } from "../shared/inbound-parts";
 import { isVCardAttachment } from "../shared/vcard";
 import type { IMessageMessage } from "../types";
@@ -134,7 +139,21 @@ const toAttachmentContent = (
   asAttachment({
     id: info.guid,
     name: info.fileName,
-    mimeType: info.mimeType,
+    mimeType: normalizeAppleAttachmentMimeType(info),
+    size: info.totalBytes,
+    read: async () => await downloadPrimaryAttachment(client, info.guid),
+    stream: async () => downloadPrimaryAttachmentStream(client, info.guid),
+  });
+
+const toVoiceContent = (
+  client: AdvancedIMessage,
+  info: AppleAttachment,
+  mimeType: string
+): Content =>
+  asVoice({
+    id: info.guid,
+    name: info.fileName,
+    mimeType,
     size: info.totalBytes,
     read: async () => await downloadPrimaryAttachment(client, info.guid),
     stream: async () => downloadPrimaryAttachmentStream(client, info.guid),
@@ -159,11 +178,17 @@ const toVCardContent = async (
 
 const attachmentContent = async (
   client: AdvancedIMessage,
-  info: AppleAttachment
-): Promise<Content> =>
-  isVCardAttachment(info.mimeType, info.fileName)
-    ? await toVCardContent(client, info)
+  info: AppleAttachment,
+  isVoice: boolean
+): Promise<Content> => {
+  if (isVCardAttachment(info.mimeType, info.fileName)) {
+    return await toVCardContent(client, info);
+  }
+  const audioMimeType = isVoice ? appleAudioMimeType(info) : undefined;
+  return audioMimeType
+    ? toVoiceContent(client, info, audioMimeType)
     : toAttachmentContent(client, info);
+};
 
 const buildAttachmentMessage = async (
   client: AdvancedIMessage,
@@ -171,9 +196,10 @@ const buildAttachmentMessage = async (
   info: AppleAttachment,
   id: string,
   partIndex: number,
-  parentId?: string
+  parentId?: string,
+  isVoice = false
 ): Promise<IMessageMessage> => {
-  const content = await attachmentContent(client, info);
+  const content = await attachmentContent(client, info, isVoice);
   const msg: IMessageMessage = { ...base, id, content, partIndex };
   if (parentId !== undefined) {
     msg.parentId = parentId;
@@ -206,7 +232,8 @@ const buildOrderedPartMessage = async (
   part: OrderedPart<AppleAttachment>,
   id: string,
   partIndex: number,
-  parentId?: string
+  parentId?: string,
+  voiceAttachmentGuid?: string
 ): Promise<IMessageMessage> =>
   part.type === "text"
     ? buildTextMessage(base, part.text, id, partIndex, parentId)
@@ -216,7 +243,8 @@ const buildOrderedPartMessage = async (
         part.attachment,
         id,
         partIndex,
-        parentId
+        parentId,
+        part.attachment.guid === voiceAttachmentGuid
       );
 
 const buildUnwrappedContentMessage = async (
@@ -226,6 +254,9 @@ const buildUnwrappedContentMessage = async (
   messageGuidStr: string
 ): Promise<IMessageMessage> => {
   const attachments = messageAttachments(message);
+  const voiceAttachmentGuid = message.isAudioMessage
+    ? attachments.find((attachment) => appleAudioMimeType(attachment))?.guid
+    : undefined;
 
   if (attachments.length === 0) {
     const text = message.content.text;
@@ -251,7 +282,15 @@ const buildUnwrappedContentMessage = async (
     if (!part) {
       throw new Error("Unreachable: parts.length === 1 but no element");
     }
-    return buildOrderedPartMessage(client, base, part, messageGuidStr, 0);
+    return buildOrderedPartMessage(
+      client,
+      base,
+      part,
+      messageGuidStr,
+      0,
+      undefined,
+      voiceAttachmentGuid
+    );
   }
 
   const items: IMessageMessage[] = [];
@@ -267,7 +306,8 @@ const buildUnwrappedContentMessage = async (
         part,
         formatChildId(i, messageGuidStr),
         i,
-        messageGuidStr
+        messageGuidStr,
+        voiceAttachmentGuid
       )
     );
   }

--- a/packages/imessage/src/shared/audio.ts
+++ b/packages/imessage/src/shared/audio.ts
@@ -1,0 +1,29 @@
+const AUDIO_MIME_PATTERN = /^audio\//i;
+const CAF_MIME_TYPE = "audio/x-caf";
+const CAF_UTI = "com.apple.coreaudio-format";
+const GENERIC_BINARY_MIME_TYPE = "application/octet-stream";
+
+interface AppleAttachmentAudioMetadata {
+  readonly fileName?: string | null;
+  readonly mimeType: string;
+  readonly uti?: string | null;
+}
+
+const isCafAttachment = (attachment: AppleAttachmentAudioMetadata): boolean =>
+  attachment.uti?.toLowerCase() === CAF_UTI ||
+  attachment.fileName?.toLowerCase().endsWith(".caf") === true;
+
+export const normalizeAppleAttachmentMimeType = (
+  attachment: AppleAttachmentAudioMetadata
+): string =>
+  attachment.mimeType.toLowerCase() === GENERIC_BINARY_MIME_TYPE &&
+  isCafAttachment(attachment)
+    ? CAF_MIME_TYPE
+    : attachment.mimeType;
+
+export const appleAudioMimeType = (
+  attachment: AppleAttachmentAudioMetadata
+): string | undefined => {
+  const mimeType = normalizeAppleAttachmentMimeType(attachment);
+  return AUDIO_MIME_PATTERN.test(mimeType) ? mimeType : undefined;
+};

--- a/packages/imessage/test/remote/inbound.test.ts
+++ b/packages/imessage/test/remote/inbound.test.ts
@@ -64,12 +64,14 @@ const attachment = (
   guid: string,
   fileName: string,
   mimeType: string,
-  totalBytes = 123
+  totalBytes = 123,
+  uti = ""
 ) => ({
   guid,
   fileName,
   mimeType,
   totalBytes,
+  uti,
 });
 
 const summarizeGroupItem = (item: GroupItem) => {
@@ -396,6 +398,73 @@ describe("iMessage remote toInboundMessages content", () => {
     expect((message as { parentId?: string } | undefined)?.parentId).toBe(
       undefined
     );
+  });
+
+  it("maps native CAF audio messages to voice content", async () => {
+    const [message] = await toInboundMessages(
+      client,
+      new MessageCache(),
+      receivedEvent(
+        { address: "+15551234567" },
+        {
+          attachments: [
+            attachment(
+              "voice-att",
+              "Audio Message.caf",
+              "application/octet-stream",
+              456,
+              "com.apple.coreaudio-format"
+            ),
+          ],
+          text: undefined,
+        },
+        { isAudioMessage: true, isExpirable: true }
+      ),
+      "+15550000000"
+    );
+
+    expect(message?.content).toMatchObject({
+      id: "voice-att",
+      mimeType: "audio/x-caf",
+      name: "Audio Message.caf",
+      size: 456,
+      type: "voice",
+    });
+    if (message?.content.type !== "voice") {
+      throw new Error("expected voice content");
+    }
+    expect(message.content.read).toBeTypeOf("function");
+    expect(message.content.stream).toBeTypeOf("function");
+  });
+
+  it("normalizes ordinary CAF attachments without marking them as voice", async () => {
+    const [message] = await toInboundMessages(
+      client,
+      new MessageCache(),
+      receivedEvent(
+        { address: "+15551234567" },
+        {
+          attachments: [
+            attachment(
+              "audio-att",
+              "recording.caf",
+              "application/octet-stream",
+              456,
+              "com.apple.coreaudio-format"
+            ),
+          ],
+          text: undefined,
+        }
+      ),
+      "+15550000000"
+    );
+
+    expect(message?.content).toMatchObject({
+      id: "audio-att",
+      mimeType: "audio/x-caf",
+      name: "recording.caf",
+      type: "attachment",
+    });
   });
 
   it("keeps multiple attachments without usable text as an attachment-only group", async () => {


### PR DESCRIPTION
## Summary

* map native iMessage audio messages to Spectrum voice content
* normalize octet-stream CAF attachments to audio/x-caf without reclassifying ordinary CAF files
* preserve attachment IDs and restore lazy voice reads across Spectrum webhooks
* keep remote and local iMessage providers consistent

## Testing

* bun run check
* bun run test
* bun run typecheck
* built and smoke-imported core, imessage, and imessage-local

---

[![View with Codesmith](https://uploads.linear.app/52630eed-f1bb-4843-80e1-05c7afaccd70/87e49238-3b77-4d61-8c1f-e938add09032/e3d1a236-563f-48b4-a6e3-68b1289111ed?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzUyNjMwZWVkLWYxYmItNDg0My04MGUxLTA1YzdhZmFjY2Q3MC84N2U0OTIzOC0zYjc3LTRkNjEtOGMxZi1lOTM4YWRkMDkwMzIvZTNkMWEyMzYtNTYzZi00OGI0LWE2ZTMtNjhiMTI4OTExMWVkIiwiaWF0IjoxNzg0MzE4OTQ2LCJleHAiOjE4MTU4ODk1MDZ9.vqicJ-aSbfRS-mG7gH0k-caK2s3Bho-4VppoRwwx8eQ)](<https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/199>) Need help on this PR? Tag `/codesmith` with what you need.

Fix photon-hq/spectrum-ts#191<br>Fixes photon-hq/spectrum-ts#191

## Summary by CodeRabbit

* **New Features**
  * Added support for receiving and processing iMessage voice messages.
  * Voice messages now preserve audio metadata and provide playable content through reading or streaming.
  * Added support for deserializing voice content from Spectrum webhooks when audio attachments are available.
* **Bug Fixes**
  * Improved recognition and MIME type normalization for Apple CAF audio files.
  * Prevented regular audio attachments from being incorrectly classified as voice messages.