### PR TITLE
fix(fanout-websocket): harden recovery and backpressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,62 @@ The fastest way to ship is with **Spectrum Cloud** — hosted infrastructure for
 
 Spectrum also runs fully standalone — you can connect to a local iMessage database with the separate [`@spectrum-ts/imessage-local`](https://npmjs.com/package/@spectrum-ts/imessage-local) package, bring your own gRPC endpoints, or build your own platform provider. See the [docs](https://docs.photon.codes) for self-hosted setups.
 
+### Production Fusor stream resume
+
+When `app.messages` consumes a Fusor-backed provider (for example Telegram),
+inbound events arrive over a long-lived WebSocket. This path requires a runtime
+with a global standards-compatible `WebSocket`: use Bun or Node 22 or newer.
+On an older Node release, install a compatible implementation and assign it to
+`globalThis.WebSocket` before initializing Spectrum. Spectrum keeps a
+process-local cursor by default, which survives reconnects but not a process
+restart. Production services can supply a durable cursor store:
+
+```typescript
+import { Spectrum, type FusorCursorStore } from "spectrum-ts";
+import { telegram } from "spectrum-ts/providers/telegram";
+
+const fusorCursorStore: FusorCursorStore = {
+  async load(projectId) {
+    return database.cursors.get(projectId);
+  },
+  async save(projectId, seq) {
+    // Commit durably and monotonically before this promise resolves.
+    await database.cursors.advance(projectId, seq);
+  },
+};
+
+const app = await Spectrum({
+  projectId: process.env.PROJECT_ID,
+  projectSecret: process.env.PROJECT_SECRET,
+  platforms: [telegram.config({ botToken: process.env.TELEGRAM_BOT_TOKEN! })],
+  options: { fusorCursorStore },
+});
+```
+
+Namespace stored cursors by Fusor deployment or stream identity in addition to
+project ID; never reuse a production cursor in staging. Spectrum checkpoints
+only after the provider pipeline has accepted the event and any synchronous
+reply has been queued. Delivery remains at-least-once, so application side
+effects should still be idempotent.
+
+Spectrum also bounds the WebSocket event backlog to 64 admitted events and
+8 MiB of UTF-8 event-frame data by default (the currently executing handler is
+included). If either limit is exceeded, Spectrum closes the session, discards
+unstarted queued work, and reconnects from the last durable cursor; the
+overflowing event is never checkpointed. Tune the bounds with
+`options.fusorMaxPendingEvents` and `options.fusorMaxPendingBytes` when provider
+latency and payload sizes justify it.
+
+Shutdown aborts the `signal` passed to each Fusor provider's `messages`
+context. Providers should pass that signal to cancellable I/O. Spectrum waits
+at most `options.fusorShutdownTimeoutMs` (2 seconds by default) for a handler
+that ignores cancellation, then lets shutdown finish without replying to or
+checkpointing that event.
+
+Initial token issuance and connection failures use the same referenced retry
+loop, so a stream-only Node worker remains alive during reconnect backoff until
+`app.stop()` cancels it.
+
 ## Documentation
 
 Visit **[docs.photon.codes](https://docs.photon.codes)** to view the full documentation.

--- a/docs/getting-started.mdx.vel
+++ b/docs/getting-started.mdx.vel
@@ -146,6 +146,92 @@ Custom events emitted by providers are exposed as flat async iterables on the sa
 
 `app.webhook()` handles both native Spectrum webhooks and Fusor webhooks through the same method. See [Webhooks](/spectrum-ts/webhooks) for setup and framework adapters.
 
+## Reliable Fusor stream resume
+
+When `app.messages` consumes a Fusor-backed provider such as Telegram, inbound
+events arrive over a long-lived WebSocket. This requires a global
+standards-compatible `WebSocket`: use Bun or Node 22 or newer. On an older Node
+release, install a compatible implementation and assign it to
+`globalThis.WebSocket` before initializing Spectrum. Spectrum sends the last
+safe stream sequence when it reconnects, and Fusor resumes at the following
+sequence. The default cursor store is in-memory: it protects reconnects in the
+current process, but a process restart starts a new live tail until a positive
+cursor exists.
+
+Pass a durable store through `options.fusorCursorStore` in production:
+
+```ts
+import { Spectrum, type FusorCursorStore } from "spectrum-ts";
+import { telegram } from "spectrum-ts/providers/telegram";
+
+const fusorCursorStore: FusorCursorStore = {
+  async load(projectId) {
+    return database.cursors.get(projectId);
+  },
+  async save(projectId, seq) {
+    await database.cursors.advance(projectId, seq);
+  },
+};
+
+const app = await Spectrum({
+  projectId: process.env.PROJECT_ID!,
+  projectSecret: process.env.PROJECT_SECRET!,
+  platforms: [telegram.config({ botToken: process.env.TELEGRAM_BOT_TOKEN! })],
+  options: { fusorCursorStore },
+});
+```
+
+The store contract is deliberately small:
+
+- `load(projectId)` returns the last committed stream sequence, or `undefined`
+  for a live tail.
+- `save(projectId, seq)` must commit durably and monotonically before resolving.
+- The store or its key namespace must also be scoped to the Fusor deployment
+  or stream identity. Never share a cursor between staging and production.
+
+Spectrum processes event frames in order and checkpoints only after the
+provider pipeline has accepted an event and any synchronous provider reply has
+been queued. A failed checkpoint closes the socket and reconnects from the old
+cursor; a bounded process-local event-ID cache suppresses duplicate provider
+delivery while that checkpoint is retried. Across process restarts, delivery is
+still at-least-once, so make application side effects idempotent.
+
+Reconnects use equal-jitter exponential backoff (capped at 30 seconds), do not
+reset the attempt counter until a connection has remained ready for one minute,
+and honor typed server retry hints up to five minutes. This avoids reconnect
+storms during rollouts, capacity shedding, and NATS interruptions. Initial
+token issuance failures enter the same retry loop, and its timer remains
+referenced so a stream-only Node process cannot exit cleanly during backoff;
+`app.stop()` cancels the timer immediately.
+
+The client admits at most 64 event frames and 8 MiB of UTF-8 event-frame data
+by default, counting the handler currently executing. When either backlog
+limit is exceeded, it closes the session, drops work that has not started, and
+reconnects from the last durable cursor. The overflowing event is not delivered
+or checkpointed. You can tune the limits for known provider latency and payload
+profiles:
+
+```ts
+const app = await Spectrum({
+  projectId: process.env.PROJECT_ID!,
+  projectSecret: process.env.PROJECT_SECRET!,
+  platforms: [imessage.config()],
+  options: {
+    fusorCursorStore,
+    fusorMaxPendingEvents: 64,
+    fusorMaxPendingBytes: 8 * 1024 * 1024,
+    fusorShutdownTimeoutMs: 2_000,
+  },
+});
+```
+
+Fusor provider `messages` handlers receive an `AbortSignal` as `signal` in
+their context. Pass it to cancellable database and HTTP operations. On shutdown
+or backlog shedding, Spectrum aborts that signal and waits up to the configured
+shutdown timeout (2 seconds by default); if a handler ignores cancellation,
+shutdown still completes and the unfinished event is neither replied to nor
+checkpointed.
+
 ## Multi-platform in three lines
 
 Combine providers to receive and send across platforms simultaneously:

--- a/packages/core/src/fusor/core.ts
+++ b/packages/core/src/fusor/core.ts
@@ -7,10 +7,19 @@ import type { ProviderMessageRecord } from "../platform/types";
 import { officialProviderInstallHint } from "../utils/provider-packages";
 import { errorAttrs } from "../utils/telemetry";
 import { createFusorTokenProvider, type FusorTokenProvider } from "./auth";
+import {
+  type FusorCursorStore,
+  MemoryFusorCursorStore,
+  normalizeFusorCursor,
+} from "./cursor";
 import { FUSOR_MESSAGES_CHANNEL, isFusorEvent } from "./event";
 import { type ParsedHttpRequest, parseHttpRequest } from "./parse";
 import type { FusorMessagesReturn, FusorReply, FusorVerify } from "./types";
 import {
+  DEFAULT_FUSOR_MAX_PENDING_BYTES,
+  DEFAULT_FUSOR_MAX_PENDING_EVENTS,
+  DEFAULT_FUSOR_SHUTDOWN_TIMEOUT_MS,
+  FusorWsError,
   type FusorWsSession,
   isWsAuthError,
   runFusorWsSession,
@@ -20,8 +29,12 @@ const DEFAULT_FUSOR_WS_URL =
   "wss://fusor-ws.spectrum.photon.codes/v1/subscribe";
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30_000;
+const RETRY_AFTER_MAX_MS = 300_000;
+const STABLE_SESSION_MS = 60_000;
+const EVENT_DEDUPE_CAPACITY = 10_000;
 
 const log = createLogger("spectrum.fusor");
+const NEVER_ABORTED_SIGNAL = new AbortController().signal;
 
 const errorText = (error: unknown): string =>
   error instanceof Error ? error.message : String(error);
@@ -30,6 +43,7 @@ export interface RegisteredFusorHandler<TPayload = unknown> {
   messages: (ctx: {
     payload: TPayload;
     respond: (reply: FusorReply) => void;
+    signal: AbortSignal;
   }) => FusorMessagesReturn | Promise<FusorMessagesReturn>;
   // Route a `fusorEvent(channel, data)` to its custom event channel. Wired by
   // the Spectrum bootstrap to the per-(platform, channel) queue.
@@ -128,11 +142,15 @@ function routeHandlerResult(
 function runHandlerOnce<TPayload>(
   handler: RegisteredFusorHandler<TPayload>,
   parsedRequest: ParsedHttpRequest,
-  deliver: (record: ProviderMessageRecord) => void = handler.pushMessage
+  deliver: (record: ProviderMessageRecord) => void = handler.pushMessage,
+  signal: AbortSignal = NEVER_ABORTED_SIGNAL
 ): Promise<HandlerOutcome> {
   return (async () => {
     try {
       const payload = await handler.verify(parsedRequest);
+      if (signal.aborted) {
+        return { ok: false, errorReason: "event processing aborted" };
+      }
       let reply: FusorReply | undefined;
       let respondCalled = false;
       let returned = false;
@@ -147,9 +165,12 @@ function runHandlerOnce<TPayload>(
         respondCalled = true;
         reply = next;
       };
-      const result = await handler.messages({ payload, respond });
+      const result = await handler.messages({ payload, respond, signal });
       returned = true;
 
+      if (signal.aborted) {
+        return { ok: false, errorReason: "event processing aborted" };
+      }
       routeHandlerResult(result, handler as RegisteredFusorHandler, deliver);
       return { ok: true, reply };
     } catch (error) {
@@ -159,12 +180,20 @@ function runHandlerOnce<TPayload>(
 }
 
 export interface FusorCoreOptions {
+  /** Cursor persistence used by the streaming transport. */
+  cursorStore?: FusorCursorStore;
+  /** Maximum UTF-8 wire bytes held by admitted WebSocket event frames. */
+  maxPendingBytes?: number;
+  /** Maximum admitted WebSocket events, including the in-flight event. */
+  maxPendingEvents?: number;
   // Optional: only the streaming transport (start) needs cloud credentials to
   // mint a token. The webhook path (processEvent) routes registered handlers
   // without them, so a webhook-only Spectrum can construct a core with
   // neither set.
   projectId?: string;
   projectSecret?: string;
+  /** Maximum time shutdown waits for an uncooperative event handler. */
+  shutdownTimeoutMs?: number;
   /**
    * fusor-fanout-websocket endpoint (`wss://…/v1/subscribe`) — the
    * streaming transport. Defaults to the `SPECTRUM_FUSOR_WS_URL` env
@@ -176,6 +205,11 @@ export interface FusorCoreOptions {
 export class FusorCore {
   private readonly options: FusorCoreOptions;
   private readonly websocketEndpoint: string;
+  private readonly cursorStore: FusorCursorStore;
+  private readonly maxPendingEvents: number;
+  private readonly maxPendingBytes: number;
+  private readonly shutdownTimeoutMs: number;
+  private readonly processedEventIds = new Map<string, undefined>();
   private readonly handlers = new Map<string, RegisteredFusorHandler[]>();
   private tokenProvider?: FusorTokenProvider;
   private wsSession?: FusorWsSession;
@@ -194,6 +228,13 @@ export class FusorCore {
       options.websocketEndpoint ??
       process.env.SPECTRUM_FUSOR_WS_URL ??
       DEFAULT_FUSOR_WS_URL;
+    this.cursorStore = options.cursorStore ?? new MemoryFusorCursorStore();
+    this.maxPendingEvents =
+      options.maxPendingEvents ?? DEFAULT_FUSOR_MAX_PENDING_EVENTS;
+    this.maxPendingBytes =
+      options.maxPendingBytes ?? DEFAULT_FUSOR_MAX_PENDING_BYTES;
+    this.shutdownTimeoutMs =
+      options.shutdownTimeoutMs ?? DEFAULT_FUSOR_SHUTDOWN_TIMEOUT_MS;
     this.stoppedPromise = new Promise<void>((resolve) => {
       this.stopResolve = resolve;
     });
@@ -221,41 +262,46 @@ export class FusorCore {
       return;
     }
     this.started = true;
-    this.tokenProvider = await createFusorTokenProvider(
-      this.options.projectId,
-      this.options.projectSecret
-    );
     this.connectionLoop = this.runConnectionLoop().catch((error) => {
       log.error("fusor connection loop crashed", errorAttrs(error), error);
     });
   }
 
-  // Streaming transport: the fusor.v1.json WebSocket plane. A session that
-  // runs to a clean end reconnects immediately; an errored session backs
-  // off exponentially (reset on the next clean run).
+  // Streaming transport: every reconnect uses equal-jitter exponential
+  // backoff. The failure counter resets only after a minute of stable ready
+  // time, so accept-then-close loops cannot pin retries at one second.
   private async runConnectionLoop(): Promise<void> {
     let attempt = 0;
     while (!this.stopped) {
-      const wsRan = await this.tryWebsocketOnce();
+      const outcome = await this.tryWebsocketOnce();
       if (this.stopped) {
         return;
       }
-      if (wsRan) {
+      if (outcome.stable) {
         attempt = 0;
-        continue;
       }
-
       attempt += 1;
-      await this.backoffSleep(this.backoffMs(attempt));
+      const retryAfterMs = Math.min(
+        outcome.retryAfterMs ?? 0,
+        RETRY_AFTER_MAX_MS
+      );
+      await this.backoffSleep(Math.max(this.backoffMs(attempt), retryAfterMs));
     }
   }
 
-  // True when the stream ran to a clean end; false when it errored (the
-  // loop then backs off before reconnecting).
-  private async tryWebsocketOnce(): Promise<boolean> {
+  private async tryWebsocketOnce(): Promise<{
+    retryAfterMs?: number;
+    stable: boolean;
+  }> {
+    let readyAt: number | undefined;
     try {
-      await this.runWebsocketOnce();
-      return true;
+      await this.runWebsocketOnce(() => {
+        readyAt ??= Date.now();
+      });
+      return {
+        stable:
+          readyAt !== undefined && Date.now() - readyAt >= STABLE_SESSION_MS,
+      };
     } catch (error) {
       // Drop a stale token on auth failure so the next attempt mints a
       // fresh one instead of replaying the rejected token.
@@ -269,43 +315,96 @@ export class FusorCore {
           error
         );
       }
-      return false;
+      return {
+        stable:
+          readyAt !== undefined && Date.now() - readyAt >= STABLE_SESSION_MS,
+        retryAfterMs:
+          error instanceof FusorWsError ? error.retryAfterMs : undefined,
+      };
     }
   }
 
   private backoffMs(attempt: number): number {
-    return Math.min(RECONNECT_BASE_MS * 2 ** (attempt - 1), RECONNECT_MAX_MS);
+    const cap = Math.min(
+      RECONNECT_BASE_MS * 2 ** (attempt - 1),
+      RECONNECT_MAX_MS
+    );
+    return Math.round(cap / 2 + Math.random() * (cap / 2));
   }
 
   // Cancelable sleep: close() clears the timer and resolves it so
-  // shutdown doesn't wait out the (up to 30s) backoff.
+  // shutdown doesn't wait out the (up to 30s) backoff. Keep the timer
+  // referenced: a stream-only Node worker may have no other active handle,
+  // and must stay alive long enough to reconnect.
   private async backoffSleep(backoff: number): Promise<void> {
     await new Promise<void>((resolve) => {
       this.reconnectResolve = resolve;
       const timer = setTimeout(resolve, backoff);
-      timer.unref?.();
       this.reconnectTimer = timer;
     });
     this.reconnectTimer = undefined;
     this.reconnectResolve = undefined;
   }
 
-  private async runWebsocketOnce(): Promise<void> {
+  private async runWebsocketOnce(onReady: () => void): Promise<void> {
+    const projectId = this.options.projectId;
+    const projectSecret = this.options.projectSecret;
+    if (!(projectId && projectSecret)) {
+      throw new Error("fusor: project credentials not initialized");
+    }
     if (!this.tokenProvider) {
-      throw new Error("fusor: token not initialized");
+      const tokenProvider = await createFusorTokenProvider(
+        projectId,
+        projectSecret
+      );
+      if (this.stopped) {
+        await tokenProvider.dispose();
+        return;
+      }
+      this.tokenProvider = tokenProvider;
     }
     const token = await this.tokenProvider.getToken();
+    if (this.stopped) {
+      return;
+    }
+    const startSeq = normalizeFusorCursor(
+      await this.cursorStore.load(projectId)
+    );
+    if (this.stopped) {
+      return;
+    }
     const session = runFusorWsSession({
       url: this.websocketEndpoint,
       token,
-      onEvent: async (event, sendReply) => {
-        if (this.stopped) {
+      startSeq,
+      maxPendingBytes: this.maxPendingBytes,
+      maxPendingEvents: this.maxPendingEvents,
+      shutdownTimeoutMs: this.shutdownTimeoutMs,
+      onReady,
+      onEvent: async (event, seq, sendReply, signal) => {
+        if (this.stopped || signal.aborted) {
           return;
         }
-        const reply = await this.processEvent(event);
+        if (this.processedEventIds.has(event.eventId)) {
+          if (signal.aborted) {
+            return;
+          }
+          await this.cursorStore.save(projectId, seq);
+          return;
+        }
+        const reply = await this.processEvent(event, undefined, signal);
+        if (this.stopped || signal.aborted) {
+          return;
+        }
         // The server answers unexpected replies with typed notices —
         // only reply when asked (sendReply is set iff replyExpected).
         sendReply?.(reply);
+        // Remember successful processing before the durable checkpoint. If
+        // the store fails, the reconnect deliberately asks for this event
+        // again; the process-local id cache then retries the checkpoint
+        // without duplicating provider delivery.
+        this.rememberProcessedEvent(event.eventId);
+        await this.cursorStore.save(projectId, seq);
       },
     });
     this.wsSession = session;
@@ -313,6 +412,18 @@ export class FusorCore {
       await session.done;
     } finally {
       this.wsSession = undefined;
+    }
+  }
+
+  private rememberProcessedEvent(eventId: string): void {
+    this.processedEventIds.delete(eventId);
+    this.processedEventIds.set(eventId, undefined);
+    if (this.processedEventIds.size <= EVENT_DEDUPE_CAPACITY) {
+      return;
+    }
+    const oldest = this.processedEventIds.keys().next().value;
+    if (oldest !== undefined) {
+      this.processedEventIds.delete(oldest);
     }
   }
 
@@ -326,7 +437,8 @@ export class FusorCore {
   // request instead.
   async processEvent(
     event: RawInboundEvent,
-    deliver?: (record: ProviderMessageRecord) => void
+    deliver?: (record: ProviderMessageRecord) => void,
+    signal: AbortSignal = NEVER_ABORTED_SIGNAL
   ): Promise<InboundReply> {
     const handlers = this.handlers.get(event.platform) ?? [];
     if (handlers.length === 0) {
@@ -372,7 +484,9 @@ export class FusorCore {
     }
 
     const outcomes = await Promise.all(
-      handlers.map((handler) => runHandlerOnce(handler, parsedRequest, deliver))
+      handlers.map((handler) =>
+        runHandlerOnce(handler, parsedRequest, deliver, signal)
+      )
     );
 
     const combined = combineReplies(outcomes);

--- a/packages/core/src/fusor/cursor.ts
+++ b/packages/core/src/fusor/cursor.ts
@@ -1,0 +1,48 @@
+const isCursor = (value: number): boolean =>
+  Number.isSafeInteger(value) && value >= 0;
+
+/**
+ * Stores the latest safely accepted Fusor stream sequence for a project.
+ *
+ * A production implementation must durably and monotonically commit `save`
+ * before its promise resolves. Use a store instance/key namespace scoped to
+ * the Fusor deployment (or stream identity) as well as the project; cursors
+ * must never be shared across environments or streams.
+ */
+export interface FusorCursorStore {
+  /** Return the last committed sequence, or `undefined` for a live tail. */
+  load(projectId: string): Promise<number | undefined>;
+
+  /** Atomically advance the committed sequence without moving it backwards. */
+  save(projectId: string, seq: number): Promise<void>;
+}
+
+/** Default process-local cursor storage used when no durable store is set. */
+export class MemoryFusorCursorStore implements FusorCursorStore {
+  private readonly cursors = new Map<string, number>();
+
+  async load(projectId: string): Promise<number | undefined> {
+    return this.cursors.get(projectId);
+  }
+
+  async save(projectId: string, seq: number): Promise<void> {
+    if (!isCursor(seq)) {
+      throw new Error(`fusor: invalid cursor ${seq}`);
+    }
+    const current = this.cursors.get(projectId);
+    if (current === undefined || seq > current) {
+      this.cursors.set(projectId, seq);
+    }
+  }
+}
+
+/** Validate values loaded from user-supplied stores before putting them on wire. */
+export function normalizeFusorCursor(value: number | undefined): number {
+  if (value === undefined) {
+    return 0;
+  }
+  if (!isCursor(value)) {
+    throw new Error(`fusor: cursor store returned invalid cursor ${value}`);
+  }
+  return value;
+}

--- a/packages/core/src/fusor/index.ts
+++ b/packages/core/src/fusor/index.ts
@@ -1,5 +1,9 @@
 import { FUSOR_BRAND, type FusorClient, type FusorVerify } from "./types";
 
+export {
+  type FusorCursorStore,
+  MemoryFusorCursorStore,
+} from "./cursor";
 export { type FusorEvent, fusorEvent, isFusorEvent } from "./event";
 export type {
   FusorClient,

--- a/packages/core/src/fusor/types.ts
+++ b/packages/core/src/fusor/types.ts
@@ -35,6 +35,8 @@ export interface FusorMessagesCtx<TPayload, TConfig = unknown> {
    */
   projectConfig: ProjectData | undefined;
   respond: FusorRespond;
+  /** Aborted when the Fusor session closes or sheds an overloaded backlog. */
+  signal: AbortSignal;
   /** Per-platform in-memory key/value store, shared with the rest of the platform. */
   store: Store;
 }

--- a/packages/core/src/fusor/websocket.ts
+++ b/packages/core/src/fusor/websocket.ts
@@ -29,16 +29,26 @@ export const FUSOR_WS_SUBPROTOCOL = "fusor.v1.json";
 // bounds how long we wait for the server to acknowledge the init.
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 const STALENESS_GRACE_MS = 5000;
+export const DEFAULT_FUSOR_MAX_PENDING_EVENTS = 64;
+export const DEFAULT_FUSOR_MAX_PENDING_BYTES = 8 * 1024 * 1024;
+export const DEFAULT_FUSOR_SHUTDOWN_TIMEOUT_MS = 2000;
 
 export class FusorWsError extends Error {
   readonly closeCode?: number;
   readonly errorCode?: string;
+  readonly retryAfterMs?: number;
 
-  constructor(message: string, closeCode?: number, errorCode?: string) {
+  constructor(
+    message: string,
+    closeCode?: number,
+    errorCode?: string,
+    retryAfterMs?: number
+  ) {
     super(message);
     this.name = "FusorWsError";
     this.closeCode = closeCode;
     this.errorCode = errorCode;
+    this.retryAfterMs = retryAfterMs;
   }
 }
 
@@ -74,6 +84,13 @@ function encodeBase64(bytes: Uint8Array): string {
   return btoa(parts.join(""));
 }
 
+function utf8ByteLength(value: string): number {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.byteLength(value, "utf8");
+  }
+  return new TextEncoder().encode(value).byteLength;
+}
+
 interface WsEventFrame {
   event: {
     eventId: string;
@@ -103,6 +120,10 @@ function toRawInboundEvent(frame: WsEventFrame): RawInboundEvent {
 }
 
 export interface FusorWsSessionOptions {
+  /** Maximum UTF-8 wire bytes held by admitted event frames. */
+  maxPendingBytes?: number;
+  /** Maximum admitted events, including the event currently being handled. */
+  maxPendingEvents?: number;
   /**
    * Called for every event frame, in arrival order. `sendReply` is set
    * only when the server flagged `replyExpected` — replying to anything
@@ -111,8 +132,14 @@ export interface FusorWsSessionOptions {
    */
   onEvent: (
     event: RawInboundEvent,
-    sendReply: ((reply: InboundReply) => void) | undefined
+    seq: number,
+    sendReply: ((reply: InboundReply) => void) | undefined,
+    signal: AbortSignal
   ) => Promise<void>;
+  onReady?: () => void;
+  /** Maximum time close waits for an in-flight event handler to return. */
+  shutdownTimeoutMs?: number;
+  startSeq: number;
   token: string;
   url: string;
 }
@@ -138,20 +165,47 @@ export function runFusorWsSession(
   // error above can fire.
   const wsOpen = WebSocketCtor.OPEN;
 
+  const maxPendingEvents =
+    options.maxPendingEvents ?? DEFAULT_FUSOR_MAX_PENDING_EVENTS;
+  const maxPendingBytes =
+    options.maxPendingBytes ?? DEFAULT_FUSOR_MAX_PENDING_BYTES;
+  const shutdownTimeoutMs =
+    options.shutdownTimeoutMs ?? DEFAULT_FUSOR_SHUTDOWN_TIMEOUT_MS;
+  for (const [name, value] of [
+    ["maxPendingEvents", maxPendingEvents],
+    ["maxPendingBytes", maxPendingBytes],
+    ["shutdownTimeoutMs", shutdownTimeoutMs],
+  ] as const) {
+    if (!(Number.isSafeInteger(value) && value > 0)) {
+      throw new FusorWsError(`fusor ws: ${name} must be a positive integer`);
+    }
+  }
+
   const ws = new WebSocketCtor(options.url, [FUSOR_WS_SUBPROTOCOL]);
 
   let settled = false;
+  let finishStarted = false;
   let closedByUs = false;
   // Last fatal `error` frame — the close event that follows carries only
   // a code, so this is what makes the rejection actionable.
-  let pendingError: { code: string; message: string; reason?: string } | null =
-    null;
+  let pendingError: {
+    code: string;
+    message: string;
+    reason?: string;
+    retryAfterMs?: number;
+  } | null = null;
   let stalenessBudgetMs =
     2 * DEFAULT_HEARTBEAT_INTERVAL_MS + STALENESS_GRACE_MS;
   let watchdog: ReturnType<typeof setTimeout> | undefined;
-  // Events are processed strictly in arrival order even though the
-  // handler is async (same discipline as the server side).
-  let tail: Promise<void> = Promise.resolve();
+  const processingAbort = new AbortController();
+  interface PendingEvent {
+    byteLength: number;
+    frame: WsEventFrame;
+  }
+  const pendingEvents: PendingEvent[] = [];
+  let pendingEventCount = 0;
+  let pendingEventBytes = 0;
+  let worker: Promise<void> | undefined;
 
   let resolveDone!: () => void;
   let rejectDone!: (error: Error) => void;
@@ -175,8 +229,56 @@ export function runFusorWsSession(
     }
   };
 
+  const finish = (error?: Error): void => {
+    if (finishStarted) {
+      return;
+    }
+    finishStarted = true;
+    processingAbort.abort();
+    if (watchdog) {
+      clearTimeout(watchdog);
+      watchdog = undefined;
+    }
+    // Queued frames have not entered application code and must be replayed
+    // from the durable cursor on the next session. Release them immediately;
+    // only the single in-flight handler can remain after this point.
+    for (const pending of pendingEvents.splice(0)) {
+      pendingEventCount -= 1;
+      pendingEventBytes -= pending.byteLength;
+    }
+    const activeWorker = worker;
+    if (!activeWorker) {
+      settle(error);
+      return;
+    }
+    const shutdownTimer = setTimeout(() => {
+      log.warn("fusor ws: event handler exceeded shutdown deadline", {
+        "spectrum.fusor.ws.shutdown_timeout_ms": shutdownTimeoutMs,
+      });
+      settle(error);
+    }, shutdownTimeoutMs);
+    // Keep this referenced. On an overload failure the socket may already be
+    // the process's last other handle, and the deadline must fire so the core
+    // can enter its reconnect loop. Intentional shutdown is bounded by the
+    // same short deadline.
+    activeWorker.then(
+      () => {
+        clearTimeout(shutdownTimer);
+        settle(error);
+      },
+      (workerError: unknown) => {
+        clearTimeout(shutdownTimer);
+        settle(
+          workerError instanceof Error
+            ? workerError
+            : new FusorWsError(String(workerError))
+        );
+      }
+    );
+  };
+
   const armWatchdog = (): void => {
-    if (settled) {
+    if (settled || finishStarted) {
       return;
     }
     if (watchdog) {
@@ -186,7 +288,7 @@ export function runFusorWsSession(
       log.warn("fusor ws: no frame within staleness budget; closing", {
         "spectrum.fusor.ws.staleness_budget_ms": stalenessBudgetMs,
       });
-      settle(new FusorWsError("websocket heartbeat timeout"));
+      finish(new FusorWsError("websocket heartbeat timeout"));
       try {
         ws.close();
       } catch {
@@ -200,7 +302,9 @@ export function runFusorWsSession(
     (eventId: string): ((reply: InboundReply) => void) =>
     (reply) => {
       if (ws.readyState !== wsOpen) {
-        return;
+        throw new FusorWsError(
+          `fusor ws: cannot queue reply for ${eventId}; socket is not open`
+        );
       }
       ws.send(
         JSON.stringify({
@@ -225,33 +329,111 @@ export function runFusorWsSession(
       "spectrum.fusor.ws.heartbeat_interval_ms":
         typeof interval === "number" ? interval : 0,
     });
+    options.onReady?.();
   };
 
-  const handleEventFrame = (frame: Record<string, unknown>): void => {
-    const eventFrame = frame as unknown as WsEventFrame;
-    let event: RawInboundEvent;
+  const processPendingEvent = async (
+    pending: PendingEvent
+  ): Promise<boolean> => {
+    const eventFrame = pending.frame;
     try {
-      event = toRawInboundEvent(eventFrame);
+      if (!Number.isSafeInteger(eventFrame.seq) || eventFrame.seq <= 0) {
+        throw new FusorWsError("fusor ws: invalid event sequence");
+      }
+      const event = toRawInboundEvent(eventFrame);
+      const sendReply = eventFrame.replyExpected
+        ? sendReplyFor(event.eventId)
+        : undefined;
+      await options.onEvent(
+        event,
+        eventFrame.seq,
+        sendReply,
+        processingAbort.signal
+      );
+      return true;
     } catch (error) {
+      const failure =
+        error instanceof Error ? error : new FusorWsError(String(error));
       log.warn(
-        "fusor ws: undecodable event frame; skipping",
-        errorAttrs(error),
+        "fusor ws: event handler failed",
+        {
+          "spectrum.fusor.ws.event_id": eventFrame.event?.eventId ?? "",
+          ...errorAttrs(error),
+        },
         error
       );
+      try {
+        ws.close(1011, "event handler failed");
+      } catch {
+        // Already closing.
+      }
+      finish(failure);
+      return false;
+    } finally {
+      pendingEventCount -= 1;
+      pendingEventBytes -= pending.byteLength;
+    }
+  };
+
+  const processPendingEvents = async (): Promise<void> => {
+    while (!processingAbort.signal.aborted) {
+      const pending = pendingEvents.shift();
+      if (!(pending && (await processPendingEvent(pending)))) {
+        return;
+      }
+    }
+  };
+
+  const startEventWorker = (): void => {
+    if (worker || finishStarted) {
       return;
     }
-    const sendReply = eventFrame.replyExpected
-      ? sendReplyFor(event.eventId)
-      : undefined;
-    tail = tail
-      .then(() => options.onEvent(event, sendReply))
-      .catch((error) => {
-        log.warn(
-          "fusor ws: event handler failed",
-          { "spectrum.fusor.ws.event_id": event.eventId, ...errorAttrs(error) },
-          error
-        );
+    worker = processPendingEvents().finally(() => {
+      worker = undefined;
+      if (pendingEvents.length > 0 && !finishStarted) {
+        startEventWorker();
+      }
+    });
+    worker.catch(() => undefined);
+  };
+
+  const handleEventFrame = (
+    frame: Record<string, unknown>,
+    byteLength: number
+  ): void => {
+    if (finishStarted) {
+      return;
+    }
+    const nextEventCount = pendingEventCount + 1;
+    const nextEventBytes = pendingEventBytes + byteLength;
+    if (nextEventCount > maxPendingEvents || nextEventBytes > maxPendingBytes) {
+      const failure = new FusorWsError(
+        "fusor ws: pending event backlog exceeded its admission limit",
+        1013,
+        "event_backlog_overflow"
+      );
+      log.warn("fusor ws: pending event backlog overflow; reconnecting", {
+        "spectrum.fusor.ws.pending_events": pendingEventCount,
+        "spectrum.fusor.ws.pending_bytes": pendingEventBytes,
+        "spectrum.fusor.ws.incoming_event_bytes": byteLength,
+        "spectrum.fusor.ws.max_pending_events": maxPendingEvents,
+        "spectrum.fusor.ws.max_pending_bytes": maxPendingBytes,
       });
+      finish(failure);
+      try {
+        ws.close(1013, "event backlog overflow");
+      } catch {
+        // Already closing.
+      }
+      return;
+    }
+    pendingEventCount = nextEventCount;
+    pendingEventBytes = nextEventBytes;
+    pendingEvents.push({
+      byteLength,
+      frame: frame as unknown as WsEventFrame,
+    });
+    startEventWorker();
   };
 
   const handleErrorFrame = (frame: Record<string, unknown>): void => {
@@ -259,8 +441,14 @@ export function runFusorWsSession(
     const message =
       typeof frame.message === "string" ? frame.message : "server error";
     const reason = typeof frame.reason === "string" ? frame.reason : undefined;
+    const retryAfterMs =
+      typeof frame.retryAfterMs === "number" &&
+      Number.isSafeInteger(frame.retryAfterMs) &&
+      frame.retryAfterMs >= 0
+        ? frame.retryAfterMs
+        : undefined;
     if (frame.fatal === true) {
-      pendingError = { code, message, reason };
+      pendingError = { code, message, reason, retryAfterMs };
     } else {
       // Typed non-fatal notice (reply_unknown_event, frame_invalid, …)
       // — the stream keeps running; surface it for debugging.
@@ -289,7 +477,7 @@ export function runFusorWsSession(
         handleReadyFrame(frame);
         return;
       case "event":
-        handleEventFrame(frame);
+        handleEventFrame(frame, utf8ByteLength(raw));
         return;
       case "error":
         handleErrorFrame(frame);
@@ -304,7 +492,11 @@ export function runFusorWsSession(
   ws.onopen = () => {
     armWatchdog();
     ws.send(
-      JSON.stringify({ type: "init", startSeq: 0, token: options.token })
+      JSON.stringify({
+        type: "init",
+        startSeq: options.startSeq,
+        token: options.token,
+      })
     );
   };
 
@@ -320,17 +512,18 @@ export function runFusorWsSession(
 
   ws.onclose = (closeEvent: CloseEvent) => {
     if (closedByUs) {
-      settle();
+      finish();
       return;
     }
     const detail = pendingError
       ? `${pendingError.code}${pendingError.reason ? `:${pendingError.reason}` : ""} — ${pendingError.message}`
       : closeEvent.reason || "connection closed";
-    settle(
+    finish(
       new FusorWsError(
         `fusor websocket closed (${closeEvent.code}): ${detail}`,
         closeEvent.code,
-        pendingError?.code ?? (closeEvent.reason || undefined)
+        pendingError?.code ?? (closeEvent.reason || undefined),
+        pendingError?.retryAfterMs
       )
     );
   };
@@ -342,15 +535,12 @@ export function runFusorWsSession(
     done,
     close() {
       closedByUs = true;
+      finish();
       try {
         ws.close(1000);
       } catch {
         // Already closed.
       }
-      // Some runtimes skip the close event for never-opened sockets;
-      // don't let done hang on shutdown.
-      const failsafe = setTimeout(() => settle(), 2000);
-      failsafe.unref?.();
     },
   };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -73,6 +73,7 @@ export { type Voice, voice } from "./content/voice";
 export { Emoji, type EmojiKey } from "./emoji";
 export type {
   FusorClient,
+  FusorCursorStore,
   FusorEvent,
   FusorMessages,
   FusorMessagesCtx,
@@ -102,7 +103,11 @@ export type {
   SchemaMessage,
   SpaceNamespace,
 } from "./platform/types";
-export { Spectrum, type SpectrumInstance } from "./spectrum";
+export {
+  Spectrum,
+  type SpectrumInstance,
+  type SpectrumOptions,
+} from "./spectrum";
 export type { Message } from "./types/message";
 export type { Space } from "./types/space";
 export type { AgentSender, User } from "./types/user";

--- a/packages/core/src/spectrum.ts
+++ b/packages/core/src/spectrum.ts
@@ -11,6 +11,7 @@ import z from "zod";
 import { SPECTRUM_BUILD_ENV, SPECTRUM_SDK_VERSION } from "./build-env";
 import type { ContentInput } from "./content/types";
 import { FusorCore, type RegisteredFusorHandler } from "./fusor/core";
+import type { FusorCursorStore } from "./fusor/cursor";
 import { isFusorClient } from "./fusor/index";
 import type {
   FusorClient,
@@ -151,6 +152,41 @@ export interface SpectrumOptions {
   flattenGroups?: boolean;
 
   /**
+   * Persists the last Fusor stream sequence accepted by the provider pipeline.
+   * Supply a durable, monotonic implementation in production so reconnects
+   * and process restarts resume after the last checkpoint. The default is
+   * process-local memory and does not survive a restart.
+   */
+  fusorCursorStore?: FusorCursorStore;
+
+  /**
+   * Maximum UTF-8 wire bytes retained by admitted Fusor WebSocket event
+   * frames. Exceeding the limit closes the session and replays from the last
+   * durable cursor.
+   *
+   * @default 8388608 (8 MiB)
+   */
+  fusorMaxPendingBytes?: number;
+
+  /**
+   * Maximum Fusor WebSocket events admitted at once, including the event
+   * currently executing in the provider pipeline. Exceeding the limit closes
+   * the session and replays from the last durable cursor.
+   *
+   * @default 64
+   */
+  fusorMaxPendingEvents?: number;
+
+  /**
+   * Maximum time `stop()` waits for an in-flight Fusor provider handler that
+   * does not observe cancellation. Work that finishes after the deadline is
+   * not replied to or checkpointed.
+   *
+   * @default 2000
+   */
+  fusorShutdownTimeoutMs?: number;
+
+  /**
    * Minimum severity emitted by the SDK's structured logger (to both the
    * console and, when telemetry is on, OTLP). Applies process-wide. The
    * `LOG_LEVEL` environment variable still takes precedence.
@@ -167,6 +203,10 @@ export interface SpectrumOptions {
 const spectrumOptionsSchema = z
   .object({
     flattenGroups: z.boolean().optional(),
+    fusorCursorStore: z.custom<FusorCursorStore>().optional(),
+    fusorMaxPendingBytes: z.number().int().positive().optional(),
+    fusorMaxPendingEvents: z.number().int().positive().optional(),
+    fusorShutdownTimeoutMs: z.number().int().positive().optional(),
     logLevel: z.enum(["debug", "info", "warn", "error", "silent"]).optional(),
   })
   .optional();
@@ -619,7 +659,14 @@ export async function Spectrum<
   }
 
   if (fusorPlatforms.length > 0) {
-    fusorCore = new FusorCore({ projectId, projectSecret });
+    fusorCore = new FusorCore({
+      projectId,
+      projectSecret,
+      cursorStore: runtimeOptions?.fusorCursorStore,
+      maxPendingBytes: runtimeOptions?.fusorMaxPendingBytes,
+      maxPendingEvents: runtimeOptions?.fusorMaxPendingEvents,
+      shutdownTimeoutMs: runtimeOptions?.fusorShutdownTimeoutMs,
+    });
     for (const { name, client } of fusorPlatforms) {
       const queue = createAsyncQueue<ProviderMessageRecord>();
       fusorMessageSources.set(name, queue);

--- a/packages/core/test/core/fusor/websocket.test.ts
+++ b/packages/core/test/core/fusor/websocket.test.ts
@@ -4,19 +4,25 @@
 import { once } from "node:events";
 import type { AddressInfo } from "node:net";
 import { setTimeout as sleep } from "node:timers/promises";
+import { stubCloud } from "@spectrum-ts/test-support/cloud";
+import { makeSlack } from "@spectrum-ts/test-support/fusor";
+import { baseConfig } from "@spectrum-ts/test-support/platform";
 import { NO_MESSAGE_WAIT_MS } from "@spectrum-ts/test-support/timing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import { FusorCore, type RegisteredFusorHandler } from "@/fusor/core";
+import type { FusorCursorStore } from "@/fusor/cursor";
 import type { FusorMessagesReturn } from "@/fusor/types";
+import { Spectrum } from "@/spectrum";
 import { cloud } from "@/utils/cloud";
+
+stubCloud();
 
 const PLATFORM = "tg";
 // waitFor polling: generous ceiling, tight poll.
 const WAIT_TIMEOUT_MS = 5000;
 const WAIT_POLL_MS = 10;
-// close() must return promptly: above the 2s never-opened-socket
-// failsafe, far below the 30s max reconnect backoff.
+// close() must return promptly, far below the 30s max reconnect backoff.
 const CLOSE_PROMPTLY_MS = 3000;
 
 const httpBytes = (json: string): string =>
@@ -36,6 +42,7 @@ interface WsServerScript {
 
 async function makeFusorWsServer(script: WsServerScript) {
   const inits: Frame[] = [];
+  const initTimes: number[] = [];
   const replies: Frame[] = [];
   let connections = 0;
   const wss = new WebSocketServer({
@@ -49,6 +56,7 @@ async function makeFusorWsServer(script: WsServerScript) {
       const frame = JSON.parse(String(raw)) as Frame;
       if (frame.type === "init") {
         inits.push(frame);
+        initTimes.push(Date.now());
         for (const out of script.onInit(frame, connection)) {
           ws.send(JSON.stringify(out));
         }
@@ -68,8 +76,19 @@ async function makeFusorWsServer(script: WsServerScript) {
   return {
     url: `ws://localhost:${port}/v1/subscribe`,
     inits,
+    initTimes,
     replies,
     connectionCount: () => connections,
+    send: (...frames: Frame[]) => {
+      for (const client of wss.clients) {
+        if (client.readyState !== 1) {
+          continue;
+        }
+        for (const frame of frames) {
+          client.send(JSON.stringify(frame));
+        }
+      }
+    },
     // Fire-and-forget, matching the old Bun.serve stop(true): under Bun's ws
     // shim the close callback never fires once clients were terminated
     // server-side, so awaiting it would deadlock the afterEach cleanup.
@@ -103,7 +122,8 @@ const eventFrame = (
   eventId: string,
   json: string,
   replyExpected: boolean,
-  seq = 1
+  seq = 1,
+  platform = PLATFORM
 ): Frame => ({
   type: "event",
   seq,
@@ -111,11 +131,19 @@ const eventFrame = (
   event: {
     eventId,
     projectId: "proj",
-    platform: PLATFORM,
+    platform,
     receivedAt: "2026-06-11T00:00:00.000Z",
     prevSubjectSeq: 0,
     rawRequest: b64(httpBytes(json)),
   },
+});
+
+const emptyReply = (eventId: string) => ({
+  eventId,
+  errorReason: "",
+  status: 200,
+  headers: {},
+  body: new Uint8Array(0),
 });
 
 async function waitFor(
@@ -188,6 +216,448 @@ describe("fusor websocket streaming", () => {
     );
   });
 
+  it("loads a durable cursor and checkpoints after provider processing", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: () => [
+        { type: "ready", projectId: "proj", heartbeatIntervalMs: 30_000 },
+        eventFrame("evt-42", '{"text":"durable"}', false, 42),
+      ],
+    });
+    cleanups.push(server.stop);
+
+    const order: string[] = [];
+    const cursorStore: FusorCursorStore = {
+      load: async (projectId) => {
+        order.push(`load:${projectId}`);
+        return 41;
+      },
+      save: async (projectId, seq) => {
+        order.push(`save:${projectId}:${seq}`);
+      },
+    };
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+      cursorStore,
+    });
+    cleanups.push(() => core.close());
+    core.register(PLATFORM, {
+      ...makeHandler({ payloads: [] }),
+      messages: () => {
+        order.push("handle");
+        return [];
+      },
+    });
+    await core.start();
+
+    await waitFor(() => order.includes("save:proj:42"));
+    expect(server.inits[0]?.startSeq).toBe(41);
+    expect(order).toEqual(["load:proj", "handle", "save:proj:42"]);
+  });
+
+  it("replays an event when provider processing fails before checkpointing", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    cleanups.push(() => tokenSpy.mockRestore());
+    cleanups.push(() => randomSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: () => [
+        { type: "ready", projectId: "proj", heartbeatIntervalMs: 30_000 },
+        eventFrame("evt-replay", '{"text":"retry"}', false, 11),
+      ],
+    });
+    cleanups.push(server.stop);
+
+    const saved: number[] = [];
+    const cursorStore: FusorCursorStore = {
+      load: () => Promise.resolve(10),
+      save: (_projectId, seq) => {
+        saved.push(seq);
+        return Promise.resolve();
+      },
+    };
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+      cursorStore,
+    });
+    cleanups.push(() => core.close());
+    const processSpy = vi
+      .spyOn(core, "processEvent")
+      .mockRejectedValueOnce(new Error("provider unavailable"))
+      .mockResolvedValue({
+        eventId: "evt-replay",
+        errorReason: "",
+        status: 200,
+        headers: {},
+        body: new Uint8Array(0),
+      });
+    cleanups.push(() => processSpy.mockRestore());
+    await core.start();
+
+    await waitFor(() => saved.length === 1);
+    expect(processSpy).toHaveBeenCalledTimes(2);
+    expect(saved).toEqual([11]);
+    expect(server.inits.slice(0, 2).map((init) => init.startSeq)).toEqual([
+      10, 10,
+    ]);
+  });
+
+  it("retries a failed checkpoint without duplicating provider delivery", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    cleanups.push(() => tokenSpy.mockRestore());
+    cleanups.push(() => randomSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: () => [
+        { type: "ready", projectId: "proj", heartbeatIntervalMs: 30_000 },
+        eventFrame("evt-checkpoint", '{"text":"once"}', false, 11),
+      ],
+    });
+    cleanups.push(server.stop);
+
+    let saveAttempts = 0;
+    const cursorStore: FusorCursorStore = {
+      load: () => Promise.resolve(10),
+      save: () => {
+        saveAttempts += 1;
+        return saveAttempts === 1
+          ? Promise.reject(new Error("checkpoint unavailable"))
+          : Promise.resolve();
+      },
+    };
+    const capture = { payloads: [] as unknown[] };
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+      cursorStore,
+    });
+    cleanups.push(() => core.close());
+    core.register(PLATFORM, makeHandler(capture));
+    await core.start();
+
+    await waitFor(() => saveAttempts === 2);
+    expect(capture.payloads).toEqual([{ text: "once" }]);
+    expect(server.inits.slice(0, 2).map((init) => init.startSeq)).toEqual([
+      10, 10,
+    ]);
+  });
+
+  it("closes an overflowing event backlog and replays from the durable cursor", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    cleanups.push(() => tokenSpy.mockRestore());
+    cleanups.push(() => randomSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: (_init, connection) =>
+        connection === 1
+          ? [
+              {
+                type: "ready",
+                projectId: "proj",
+                heartbeatIntervalMs: 30_000,
+              },
+              eventFrame("evt-blocked", '{"text":"blocked"}', false, 11),
+              eventFrame("evt-overflow", '{"text":"overflow"}', false, 12),
+            ]
+          : [
+              {
+                type: "ready",
+                projectId: "proj",
+                heartbeatIntervalMs: 30_000,
+              },
+            ],
+    });
+    cleanups.push(server.stop);
+
+    const saved: number[] = [];
+    const cursorStore: FusorCursorStore = {
+      load: () => Promise.resolve(10),
+      save: (_projectId, seq) => {
+        saved.push(seq);
+        return Promise.resolve();
+      },
+    };
+    let releaseHandler!: () => void;
+    const blockedHandler = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+      cursorStore,
+      maxPendingEvents: 1,
+      shutdownTimeoutMs: 25,
+    });
+    cleanups.push(() => core.close());
+    const processSpy = vi
+      .spyOn(core, "processEvent")
+      .mockImplementation(async (event) => {
+        await blockedHandler;
+        return emptyReply(event.eventId);
+      });
+    cleanups.push(() => processSpy.mockRestore());
+    await core.start();
+
+    await waitFor(() => server.inits.length === 2);
+    expect(processSpy).toHaveBeenCalledTimes(1);
+    expect(saved).toEqual([]);
+    expect(server.inits.slice(0, 2).map((init) => init.startSeq)).toEqual([
+      10, 10,
+    ]);
+
+    releaseHandler();
+    await sleep(50);
+    expect(saved).toEqual([]);
+  });
+
+  it("enforces the pending-byte limit before provider delivery", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    cleanups.push(() => tokenSpy.mockRestore());
+    cleanups.push(() => randomSpy.mockRestore());
+
+    const oversized = eventFrame(
+      "evt-oversized-字",
+      '{"text":"too large"}',
+      false,
+      11
+    );
+    const frameBytes = Buffer.byteLength(JSON.stringify(oversized), "utf8");
+    const server = await makeFusorWsServer({
+      onInit: (_init, connection) =>
+        connection === 1
+          ? [
+              {
+                type: "ready",
+                projectId: "proj",
+                heartbeatIntervalMs: 30_000,
+              },
+              oversized,
+            ]
+          : [
+              {
+                type: "ready",
+                projectId: "proj",
+                heartbeatIntervalMs: 30_000,
+              },
+            ],
+    });
+    cleanups.push(server.stop);
+
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+      maxPendingBytes: frameBytes - 1,
+      shutdownTimeoutMs: 25,
+    });
+    cleanups.push(() => core.close());
+    const processSpy = vi.spyOn(core, "processEvent");
+    cleanups.push(() => processSpy.mockRestore());
+    await core.start();
+
+    await waitFor(() => server.inits.length === 2);
+    expect(processSpy).not.toHaveBeenCalled();
+    expect(server.inits.slice(0, 2).map((init) => init.startSeq)).toEqual([
+      0, 0,
+    ]);
+  });
+
+  it("releases pending-byte accounting after each durable event", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const first = eventFrame("evt-byte-1", '{"text":"first"}', false, 1);
+    const second = eventFrame("evt-byte-2-字", '{"text":"second"}', false, 2);
+    const maxPendingBytes = Math.max(
+      Buffer.byteLength(JSON.stringify(first), "utf8"),
+      Buffer.byteLength(JSON.stringify(second), "utf8")
+    );
+    const server = await makeFusorWsServer({
+      onInit: () => [
+        { type: "ready", projectId: "proj", heartbeatIntervalMs: 30_000 },
+        first,
+      ],
+    });
+    cleanups.push(server.stop);
+
+    const saved: number[] = [];
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+      maxPendingBytes,
+      cursorStore: {
+        load: () => Promise.resolve(0),
+        save: (_projectId, seq) => {
+          saved.push(seq);
+          return Promise.resolve();
+        },
+      },
+    });
+    cleanups.push(() => core.close());
+    const processSpy = vi
+      .spyOn(core, "processEvent")
+      .mockImplementation((event) =>
+        Promise.resolve(emptyReply(event.eventId))
+      );
+    cleanups.push(() => processSpy.mockRestore());
+    await core.start();
+
+    await waitFor(() => saved.includes(1));
+    await sleep(WAIT_POLL_MS);
+    server.send(second);
+    await waitFor(() => saved.includes(2));
+
+    expect(saved).toEqual([1, 2]);
+    expect(processSpy).toHaveBeenCalledTimes(2);
+    expect(server.connectionCount()).toBe(1);
+  });
+
+  it("honors drain retry hints and keeps backing off unstable sessions", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    cleanups.push(() => tokenSpy.mockRestore());
+    cleanups.push(() => randomSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: (_init, connection) => {
+        if (connection === 1) {
+          return [
+            {
+              type: "error",
+              code: "server_draining",
+              message: "rollout",
+              fatal: true,
+              retryAfterMs: 1100,
+            },
+          ];
+        }
+        return [
+          { type: "ready", projectId: "proj", heartbeatIntervalMs: 30_000 },
+        ];
+      },
+      closeAfterInit: (connection) => {
+        if (connection === 1) {
+          return { code: 1001, reason: "server_draining" };
+        }
+        if (connection === 2) {
+          return { code: 1012, reason: "restart" };
+        }
+      },
+    });
+    cleanups.push(server.stop);
+
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+    });
+    cleanups.push(() => core.close());
+    await core.start();
+
+    await waitFor(() => server.inits.length === 3, 7000);
+    const firstDelay = (server.initTimes[1] ?? 0) - (server.initTimes[0] ?? 0);
+    const secondDelay = (server.initTimes[2] ?? 0) - (server.initTimes[1] ?? 0);
+    expect(firstDelay).toBeGreaterThanOrEqual(1000);
+    // Equal jitter with Math.random() = 0 is half the exponential cap:
+    // attempt two waits 1000ms. A ready-then-close loop must not reset it.
+    expect(secondDelay).toBeGreaterThanOrEqual(900);
+  });
+
+  it("wires a public Spectrum cursor store into the Fusor stream", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: () => [
+        { type: "ready", projectId: "proj", heartbeatIntervalMs: 30_000 },
+        eventFrame(
+          "evt-public-store",
+          '{"type":"message","text":"public"}',
+          false,
+          8,
+          "slack"
+        ),
+      ],
+    });
+    cleanups.push(server.stop);
+
+    const previousEndpoint = process.env.SPECTRUM_FUSOR_WS_URL;
+    process.env.SPECTRUM_FUSOR_WS_URL = server.url;
+    cleanups.push(() => {
+      if (previousEndpoint === undefined) {
+        delete process.env.SPECTRUM_FUSOR_WS_URL;
+      } else {
+        process.env.SPECTRUM_FUSOR_WS_URL = previousEndpoint;
+      }
+    });
+
+    const saved: number[] = [];
+    const cursorStore: FusorCursorStore = {
+      load: () => Promise.resolve(7),
+      save: (_projectId, seq) => {
+        saved.push(seq);
+        return Promise.resolve();
+      },
+    };
+    const app = await Spectrum({
+      ...baseConfig,
+      platforms: [makeSlack().config({})],
+      options: { fusorCursorStore: cursorStore },
+    });
+    cleanups.push(() => app.stop());
+    const iterator = app.messages[Symbol.asyncIterator]();
+    cleanups.push(async () => {
+      await iterator.return?.();
+    });
+
+    const result = await iterator.next();
+    expect(result.done).toBe(false);
+    expect(result.value?.[1].content).toEqual({
+      type: "text",
+      text: "public",
+    });
+    await waitFor(() => saved.length === 1);
+    expect(server.inits[0]?.startSeq).toBe(7);
+    expect(saved).toEqual([8]);
+  });
+
   it("invalidates the token on a 4401 close and reconnects with a fresh one", async () => {
     let minted = 0;
     const tokenSpy = vi
@@ -235,6 +705,66 @@ describe("fusor websocket streaming", () => {
     expect(server.inits[1]?.token).toBe("t2");
   });
 
+  it("recovers when the initial token mint fails transiently", async () => {
+    const tokenSpy = vi
+      .spyOn(cloud, "issueFusorToken")
+      .mockRejectedValueOnce(new Error("token service unavailable"))
+      .mockResolvedValue({ token: "recovered", expiresIn: 900 });
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    cleanups.push(() => tokenSpy.mockRestore());
+    cleanups.push(() => randomSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: () => [
+        { type: "ready", projectId: "proj", heartbeatIntervalMs: 30_000 },
+      ],
+    });
+    cleanups.push(server.stop);
+
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+    });
+    cleanups.push(() => core.close());
+    await core.start();
+
+    await waitFor(() => server.inits.length === 1);
+    expect(tokenSpy).toHaveBeenCalledTimes(2);
+    expect(server.inits[0]?.token).toBe("recovered");
+  });
+
+  it("keeps reconnect backoff referenced until close cancels it", async () => {
+    const tokenSpy = vi
+      .spyOn(cloud, "issueFusorToken")
+      .mockRejectedValue(new Error("token service unavailable"));
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(1);
+    cleanups.push(() => tokenSpy.mockRestore());
+    cleanups.push(() => randomSpy.mockRestore());
+
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+    });
+    await core.start();
+
+    interface CoreWithReconnectTimer {
+      reconnectTimer?: ReturnType<typeof setTimeout>;
+    }
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    await waitFor(() => {
+      reconnectTimer = (core as unknown as CoreWithReconnectTimer)
+        .reconnectTimer;
+      return reconnectTimer !== undefined;
+    });
+    expect(reconnectTimer?.hasRef()).toBe(true);
+
+    await core.close();
+    expect(
+      (core as unknown as CoreWithReconnectTimer).reconnectTimer
+    ).toBeUndefined();
+  });
+
   it("close() tears down an active websocket session promptly", async () => {
     const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
       token: "t1",
@@ -261,5 +791,62 @@ describe("fusor websocket streaming", () => {
     const start = Date.now();
     await core.close();
     expect(Date.now() - start).toBeLessThan(CLOSE_PROMPTLY_MS);
+  });
+
+  it("close() bounds an uncooperative handler and never checkpoints it later", async () => {
+    const tokenSpy = vi.spyOn(cloud, "issueFusorToken").mockResolvedValue({
+      token: "t1",
+      expiresIn: 900,
+    });
+    cleanups.push(() => tokenSpy.mockRestore());
+
+    const server = await makeFusorWsServer({
+      onInit: () => [
+        { type: "ready", projectId: "proj", heartbeatIntervalMs: 30_000 },
+        eventFrame("evt-hung", '{"text":"hung"}', true, 1),
+      ],
+    });
+    cleanups.push(server.stop);
+
+    const saved: number[] = [];
+    let releaseHandler!: () => void;
+    const hungHandler = new Promise<void>((resolve) => {
+      releaseHandler = resolve;
+    });
+    const core = new FusorCore({
+      projectId: "proj",
+      projectSecret: "secret",
+      websocketEndpoint: server.url,
+      shutdownTimeoutMs: 50,
+      cursorStore: {
+        load: () => Promise.resolve(0),
+        save: (_projectId, seq) => {
+          saved.push(seq);
+          return Promise.resolve();
+        },
+      },
+    });
+    const processSpy = vi
+      .spyOn(core, "processEvent")
+      .mockImplementation(async (event) => {
+        await hungHandler;
+        return emptyReply(event.eventId);
+      });
+    cleanups.push(() => processSpy.mockRestore());
+    await core.start();
+    await waitFor(() => processSpy.mock.calls.length === 1);
+
+    const closeOutcome = await Promise.race([
+      core.close().then(() => "closed" as const),
+      sleep(1000).then(() => "timed-out" as const),
+    ]);
+    expect(closeOutcome).toBe("closed");
+    expect(saved).toEqual([]);
+    expect(server.replies).toEqual([]);
+
+    releaseHandler();
+    await sleep(50);
+    expect(saved).toEqual([]);
+    expect(server.replies).toEqual([]);
   });
 });


### PR DESCRIPTION
## What

Hardens the Fusor WebSocket client for production workloads:

- Adds durable, monotonic cursor storage through `FusorCursorStore`.
- Replays from the last committed sequence after handler, reply, checkpoint, or connection failure.
- Bounds admitted work to 64 events and 8 MiB by default, with public tuning options.
- Aborts and drops unstarted work on overload, then reconnects without checkpointing the overflowing event.
- Adds a 2-second bounded shutdown and exposes an `AbortSignal` to Fusor handlers.
- Uses equal-jitter reconnect backoff, honors server retry hints, refreshes rejected tokens, and retries initial token-mint failures.
- Keeps retry timers referenced so stream-only Node workers cannot exit during backoff.
- Documents runtime requirements, durable cursors, overload behavior, and shutdown semantics.

Linear: [ENG-1992](https://linear.app/photonhq/issue/ENG-1992/make-fanout-websocket-production-ready-for-10k-connections)

## Why / root cause

Event dispatch previously appended every frame to an unbounded async tail. A slow or hung provider could retain unlimited events and bytes, exhaust memory, and prevent shutdown. Resume state was process-local, unstable sessions could reconnect too aggressively, and an initial token failure or unreferenced backoff timer could leave the stream permanently stopped or let a Node worker exit.

## Impact

- Memory retained by the SDK backlog is explicitly bounded.
- Overflow and failures retain at-least-once delivery by resuming from the durable cursor.
- Completed provider delivery is not duplicated when only cursor persistence needs retrying.
- Shutdown completes even when a handler ignores cancellation; late work cannot reply or checkpoint.
- The default cursor remains process-local for compatibility. Production consumers must supply durable storage to survive restarts.

## Checks

- Node focused WebSocket suite: 14/14
- Bun focused WebSocket suite: 14/14
- Full Node core suite: 273/273
- Full Bun core suite: 273/273
- Monorepo typecheck: 13/13 tasks
- Ultracite: 308 files clean
- `git diff --check`

## Dependencies / merge gates

- Base: `main`
- Reviewed commit: `7184d28376e640dff9677b5fc2e54b2f13b7c093`
- Publish only after the ENG-1992 Fusor server release supports the matching cursor, sequence, reply, and retry-hint contract.
- Production adopters must configure a deployment-scoped durable cursor store before relying on restart-safe resume.
- Roll out after the related infrastructure and GitOps capacity changes are ready.
- JavaScript cannot forcibly terminate a handler that ignores `AbortSignal`; the SDK detaches it after the deadline and suppresses reply/checkpoint activity.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786933865&installation_id=127326493&pr_number=200&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F200&signature=416ec8a588dd9953b0345e12c8d3d0674cbed29208bf6bb8018f4ca4a439cec4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->