### PR TITLE
fix: reject duplicate platform names and split local iMessage identity

### DIFF
--- a/docs/platform-narrowing.mdx.vel
+++ b/docs/platform-narrowing.mdx.vel
@@ -46,6 +46,13 @@ for await (const [space, message] of app.messages) {
 
 Narrowing a space from the wrong platform logs a structured warning at runtime. Always gate on `message.platform` (or a similar signal) first to avoid unexpected behavior.
 
+<Note>
+  Cloud iMessage reports `message.platform === "iMessage"`. The local macOS
+  package (`@spectrum-ts/imessage-local`) reports `"iMessage (local mode)"`.
+  Gate on the matching string for the provider you registered, or import
+  `IMESSAGE_PLATFORM` / `LOCAL_IMESSAGE_PLATFORM` from the provider packages.
+</Note>
+
 ## Narrowing a message
 
 Same idea for messages — useful when a provider declares a `message.schema` to attach extra properties:

--- a/docs/providers.mdx.vel
+++ b/docs/providers.mdx.vel
@@ -101,9 +101,11 @@ Call each provider's `config()` method and pass the results to `platforms`:
 
 <Note>
   `@spectrum-ts/imessage-local` is not part of the aggregate import. Install it
-  explicitly and import it from its scoped package. Do not register cloud and
-  local iMessage in the same `Spectrum()` instance: both represent the
-  `"iMessage"` platform.
+  explicitly and import it from its scoped package. Cloud registers as
+  `"iMessage"`; local registers as `"iMessage (local mode)"`. `Spectrum()`
+  rejects duplicate platform names, so the two ids can coexist in one instance.
+  Prefer separate composition modules so cloud deployments never pull in the
+  native SQLite stack.
 </Note>
 
 ## Writing your own

--- a/docs/providers/imessage.mdx.vel
+++ b/docs/providers/imessage.mdx.vel
@@ -3,20 +3,21 @@ title: "iMessage"
 description: "Choose and configure the cloud or local iMessage provider."
 ---
 
-Spectrum ships two iMessage packages. They expose the same provider name and
-the same `imessage.config()` registration pattern, but target different
-environments.
+Spectrum ships two iMessage packages. They share the `imessage.config()`
+registration pattern, but they register **distinct** platform ids so runtime
+routing never confuses cloud gRPC with the local Messages database.
 
-| Use case | Package | Included in `spectrum-ts`? | Runtime |
-|---|---|---|---|
-| Managed Spectrum Cloud lines | `@spectrum-ts/imessage` | Yes | Node.js or Bun |
-| This Mac's Messages database | `@spectrum-ts/imessage-local` | No | macOS with Bun or Node.js |
+| Use case | Package | Platform id (`message.platform`) | Included in `spectrum-ts`? | Runtime |
+|---|---|---|---|---|
+| Managed Spectrum Cloud lines | `@spectrum-ts/imessage` | `"iMessage"` | Yes | Node.js or Bun |
+| This Mac's Messages database | `@spectrum-ts/imessage-local` | `"iMessage (local mode)"` | No | macOS with Bun or Node.js |
 
-<Warning>
-  Choose one iMessage package per `Spectrum()` instance. Both packages register
-  the `"iMessage"` platform, so registering both would create an ambiguous
-  platform configuration.
-</Warning>
+<Note>
+  `Spectrum()` rejects duplicate platform names. Cloud and local iMessage can
+  coexist in one instance because their ids differ. Prefer separate composition
+  modules anyway so cloud deployments never pull in the native SQLite stack
+  (see [Keep deployment entrypoints separate](#keep-deployment-entrypoints-separate)).
+</Note>
 
 ## Cloud quick start
 

--- a/docs/providers/imessage/connection-and-routing.mdx.vel
+++ b/docs/providers/imessage/connection-and-routing.mdx.vel
@@ -43,7 +43,9 @@ choice is made by the import, not by a config flag.
   </Tab>
   <Tab title="Local: @spectrum-ts/imessage-local">
     Reads the macOS Messages SQLite database directly. It is an explicit,
-    macOS-only install and does not require project credentials.
+    macOS-only install and does not require project credentials. Inbound
+    messages report `message.platform === "iMessage (local mode)"` (cloud uses
+    `"iMessage"`).
 
     ```bash
     bun add spectrum-ts @spectrum-ts/imessage-local
@@ -105,7 +107,7 @@ When traffic to a dedicated line approaches its per-line capacity, Spectrum can 
 
 ## Space types
 
-iMessage spaces carry a `type` field, either `"dm"` or `"group"`, and a `phone` field indicating which phone number the conversation is routed through. Both are accessible through narrowing:
+iMessage spaces carry a `type` field, either `"dm"` or `"group"`, and a `phone` field indicating which phone number the conversation is routed through. Both are accessible through narrowing. The samples below gate on cloud `"iMessage"`; local inbound uses `"iMessage (local mode)"` instead.
 
 ```ts
 for await (const [space, message] of app.messages) {

--- a/packages/core/src/platform/unique-names.ts
+++ b/packages/core/src/platform/unique-names.ts
@@ -1,0 +1,35 @@
+import type { PlatformProviderConfig } from "./types";
+
+/**
+ * Fail closed when two providers share a `definePlatform` name.
+ *
+ * `Spectrum()` stores runtimes in a map keyed by `def.name`. Without this
+ * check, a later registration silently replaces an earlier one — the first
+ * client may still have been constructed, but routing, narrowing, and
+ * message subscription resolve against the overwritten entry.
+ *
+ * Call before any `createClient` work so a bad composition never leaves
+ * half-initialized providers behind.
+ */
+export const assertUniquePlatformNames = (
+  providers: readonly PlatformProviderConfig[]
+): void => {
+  const counts = new Map<string, number>();
+  for (const provider of providers) {
+    const name = provider.__definition.name;
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+
+  const duplicates = [...counts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([name, count]) => `"${name}" (${count}×)`);
+
+  if (duplicates.length === 0) {
+    return;
+  }
+
+  throw new Error(
+    `Spectrum received duplicate platform name(s): ${duplicates.join(", ")}. ` +
+      "Each definePlatform name must be unique within a single Spectrum() instance."
+  );
+};

--- a/packages/core/src/spectrum.ts
+++ b/packages/core/src/spectrum.ts
@@ -31,6 +31,7 @@ import type {
   PlatformRuntime,
   SpectrumLike,
 } from "./platform/types";
+import { assertUniquePlatformNames } from "./platform/unique-names";
 import type { Message } from "./types/message";
 import type { Space } from "./types/space";
 import type { AgentSender } from "./types/user";
@@ -322,6 +323,10 @@ export async function Spectrum<
   spectrumConfigSchema.parse({ ...options, projectId, projectSecret });
 
   const providers = resolveConfiguredProviders(options);
+  // Platform runtimes are keyed by definePlatform name. Reject duplicates
+  // before any network I/O or createClient work so a bad composition fails
+  // closed instead of silently overwriting an earlier registration.
+  assertUniquePlatformNames(providers);
   const { options: runtimeOptions, telemetry, webhookSecret } = options;
   const flattenGroups = runtimeOptions?.flattenGroups ?? false;
   // Honor an explicit log-level override before anything logs. Applies even

--- a/packages/core/src/utils/provider-packages.ts
+++ b/packages/core/src/utils/provider-packages.ts
@@ -12,6 +12,8 @@
 
 const OFFICIAL_PROVIDER_PACKAGES: Readonly<Record<string, string>> = {
   imessage: "@spectrum-ts/imessage",
+  // definePlatform("iMessage (local mode)") → normalizePlatformKey keeps parens
+  "imessage-(local-mode)": "@spectrum-ts/imessage-local",
   slack: "@spectrum-ts/slack",
   telegram: "@spectrum-ts/telegram",
   terminal: "@spectrum-ts/terminal",

--- a/packages/core/test/core/spectrum.unique-platforms.test.ts
+++ b/packages/core/test/core/spectrum.unique-platforms.test.ts
@@ -1,0 +1,73 @@
+import { stubCloud } from "@spectrum-ts/test-support/cloud";
+import { makeManagedProvider } from "@spectrum-ts/test-support/platform";
+import { describe, expect, it } from "vitest";
+import { assertUniquePlatformNames } from "@/platform/unique-names";
+import { Spectrum } from "@/spectrum";
+
+stubCloud();
+
+const DUPLICATE_IMESSAGE = /duplicate platform name.*"iMessage".*2×/;
+const DUPLICATE_DUP = /"dup" \(2×\)/;
+const DUPLICATE_OTHER = /"other" \(3×\)/;
+const DUPLICATE_SHARED = /duplicate platform name.*"shared"/;
+
+describe("assertUniquePlatformNames", () => {
+  it("accepts distinct platform names", () => {
+    expect(() =>
+      assertUniquePlatformNames([
+        makeManagedProvider("alpha").config({}),
+        makeManagedProvider("beta").config({}),
+      ])
+    ).not.toThrow();
+  });
+
+  it("rejects a duplicated definePlatform name", () => {
+    expect(() =>
+      assertUniquePlatformNames([
+        makeManagedProvider("iMessage").config({}),
+        makeManagedProvider("iMessage").config({}),
+      ])
+    ).toThrow(DUPLICATE_IMESSAGE);
+  });
+
+  it("lists every colliding name when several collide", () => {
+    const providers = [
+      makeManagedProvider("dup").config({}),
+      makeManagedProvider("ok").config({}),
+      makeManagedProvider("dup").config({}),
+      makeManagedProvider("other").config({}),
+      makeManagedProvider("other").config({}),
+      makeManagedProvider("other").config({}),
+    ];
+
+    expect(() => assertUniquePlatformNames(providers)).toThrow(DUPLICATE_DUP);
+    expect(() => assertUniquePlatformNames(providers)).toThrow(DUPLICATE_OTHER);
+  });
+});
+
+describe("Spectrum() unique platform names", () => {
+  it("fails closed when two providers share a definePlatform name", async () => {
+    await expect(
+      Spectrum({
+        providers: [
+          makeManagedProvider("shared").config({}),
+          makeManagedProvider("shared").config({}),
+        ],
+      })
+    ).rejects.toThrow(DUPLICATE_SHARED);
+  });
+
+  it("registers providers with distinct names side by side", async () => {
+    const app = await Spectrum({
+      platforms: [
+        makeManagedProvider("iMessage").config({}),
+        makeManagedProvider("iMessage (local mode)").config({}),
+      ],
+    });
+
+    expect(app.__providers).toHaveLength(2);
+    expect(app.__internal.platforms.has("iMessage")).toBe(true);
+    expect(app.__internal.platforms.has("iMessage (local mode)")).toBe(true);
+    await app.stop();
+  });
+});

--- a/packages/core/test/utils/env.test.ts
+++ b/packages/core/test/utils/env.test.ts
@@ -115,6 +115,12 @@ describe("normalizePlatformName", () => {
     expect(normalizePlatformName("iMessage")).toBe("IMESSAGE");
   });
 
+  it("normalizes the local iMessage platform id", () => {
+    expect(normalizePlatformName("iMessage (local mode)")).toBe(
+      "IMESSAGE_LOCAL_MODE"
+    );
+  });
+
   it("trims leading and trailing separators", () => {
     expect(normalizePlatformName(" Slack! ")).toBe("SLACK");
   });

--- a/packages/core/test/utils/provider-packages.test.ts
+++ b/packages/core/test/utils/provider-packages.test.ts
@@ -11,6 +11,9 @@ describe("normalizePlatformKey", () => {
   it("maps every spelling seen in the wild onto the manifest key", () => {
     // definePlatform labels
     expect(normalizePlatformKey("iMessage")).toBe("imessage");
+    expect(normalizePlatformKey("iMessage (local mode)")).toBe(
+      "imessage-(local-mode)"
+    );
     expect(normalizePlatformKey("Slack")).toBe("slack");
     expect(normalizePlatformKey("Terminal")).toBe("terminal");
     expect(normalizePlatformKey("WhatsApp Business")).toBe("whatsapp-business");
@@ -22,8 +25,11 @@ describe("normalizePlatformKey", () => {
 });
 
 describe("officialProviderPackage", () => {
-  it("resolves all five official providers from any spelling", () => {
+  it("resolves official providers from any spelling", () => {
     expect(officialProviderPackage("iMessage")).toBe("@spectrum-ts/imessage");
+    expect(officialProviderPackage("iMessage (local mode)")).toBe(
+      "@spectrum-ts/imessage-local"
+    );
     expect(officialProviderPackage("whatsapp_business")).toBe(
       "@spectrum-ts/whatsapp-business"
     );

--- a/packages/imessage-local/README.md
+++ b/packages/imessage-local/README.md
@@ -2,6 +2,9 @@
 
 Local macOS iMessage provider for spectrum-ts, powered by `@photon-ai/imessage-kit`.
 
+Registers as `"iMessage (local mode)"` (not cloud `"iMessage"`), so platform
+identity stays unambiguous when both packages are installed.
+
 ```sh
 bun add spectrum-ts @spectrum-ts/imessage-local
 ```
@@ -10,7 +13,7 @@ bun add spectrum-ts @spectrum-ts/imessage-local
 import { imessage } from "@spectrum-ts/imessage-local";
 import { Spectrum } from "spectrum-ts";
 
-const spectrum = Spectrum({
+const spectrum = await Spectrum({
   platforms: [imessage.config()],
 });
 ```

--- a/packages/imessage-local/src/index.ts
+++ b/packages/imessage-local/src/index.ts
@@ -40,6 +40,7 @@ import {
 } from "../../imessage/src/content/contact-card";
 import { isCustomizedMiniApp } from "../../imessage/src/content/customized-mini-app";
 import { messageEffects } from "../../imessage/src/content/effect";
+import { LOCAL_IMESSAGE_PLATFORM } from "../../imessage/src/shared/errors";
 import { chatTypeFromGuid, dmChatGuid } from "./ids";
 import {
   getMessage as localGetMessage,
@@ -54,7 +55,10 @@ import {
   userSchema,
 } from "./types";
 
-const LOCAL_PLATFORM = "iMessage (local mode)";
+/** Platform id registered by this package. Distinct from cloud `"iMessage"`. */
+export { LOCAL_IMESSAGE_PLATFORM } from "../../imessage/src/shared/errors";
+
+const LOCAL_PLATFORM = LOCAL_IMESSAGE_PLATFORM;
 
 const unsupportedAction = (action: string, detail?: string): never => {
   throw UnsupportedError.action(action, LOCAL_PLATFORM, detail);
@@ -150,7 +154,12 @@ const handleLocalOnlySend = async (
   return await localSend(client, spaceId, content);
 };
 
-export const imessage = definePlatform("iMessage", {
+/**
+ * Local Messages-database transport. Distinct from cloud `"iMessage"` so both
+ * packages can be composed in one Spectrum() instance without colliding on the
+ * platform-name map (and so `message.platform` identifies the transport).
+ */
+export const imessage = definePlatform(LOCAL_PLATFORM, {
   config: configSchema,
 
   static: {

--- a/packages/imessage-local/test/provider.test.ts
+++ b/packages/imessage-local/test/provider.test.ts
@@ -1,7 +1,11 @@
 import { IMessageSDK } from "@photon-ai/imessage-kit";
 import type { Content } from "@spectrum-ts/core";
 import { describe, expect, it, vi } from "vitest";
-import { imessage, nativeContactCard } from "@/index";
+import { imessage, LOCAL_IMESSAGE_PLATFORM, nativeContactCard } from "@/index";
+import {
+  imessage as cloudImessage,
+  IMESSAGE_PLATFORM,
+} from "../../imessage/src/index";
 
 const LOCAL_MODE_ERROR = /local mode/;
 const LOCAL_GROUP_ERROR = /local mode cannot create group chats/;
@@ -25,6 +29,17 @@ const appContent = (url: string): Content =>
   }) as Content;
 
 describe("@spectrum-ts/imessage-local", () => {
+  it("registers a platform name distinct from cloud iMessage", () => {
+    const cloud = cloudImessage.config({});
+    const local = imessage.config();
+
+    expect(LOCAL_IMESSAGE_PLATFORM).toBe("iMessage (local mode)");
+    expect(cloud.__name).toBe(IMESSAGE_PLATFORM);
+    expect(local.__name).toBe(LOCAL_IMESSAGE_PLATFORM);
+    expect(def.name).toBe(LOCAL_IMESSAGE_PLATFORM);
+    expect(cloud.__definition.name).not.toBe(local.__definition.name);
+  });
+
   it("constructs the provider with config()", () => {
     expect(imessage.config()).toMatchObject({
       __tag: "PlatformProviderConfig",

--- a/packages/imessage/README.md
+++ b/packages/imessage/README.md
@@ -35,7 +35,9 @@ See the [spectrum-ts documentation](https://photon.codes/spectrum) for the full 
 
 For direct access to the local macOS Messages database, install and import
 `@spectrum-ts/imessage-local` separately. The local provider is intentionally
-not included in the batteries-included `spectrum-ts` package.
+not included in the batteries-included `spectrum-ts` package. It registers as
+`"iMessage (local mode)"` so it does not collide with this package's
+`"iMessage"` platform id.
 
 ```sh
 bun add @spectrum-ts/imessage-local

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -90,7 +90,6 @@ import {
 } from "./remote/client";
 import { chatTypeFromGuid, dmChatGuid } from "./remote/ids";
 import { cacheMessage } from "./remote/inbound";
-import { IMESSAGE_PLATFORM } from "./shared/errors";
 import {
   configSchema,
   type IMessageClient,
@@ -459,7 +458,9 @@ const remoteForMessageTarget = (
   return clientForPhone(client, space.phone);
 };
 
-export const imessage = definePlatform(IMESSAGE_PLATFORM, {
+// Platform label must stay a string literal here: generate-manifest.ts only
+// resolves same-directory consts, and package.json#spectrum.label is "iMessage".
+export const imessage = definePlatform("iMessage", {
   config: configSchema,
 
   static: {

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -35,6 +35,7 @@ export {
   customizedMiniApp,
 } from "./content/customized-mini-app";
 export { effect, type IMessageMessageEffect } from "./content/effect";
+export { IMESSAGE_PLATFORM, LOCAL_IMESSAGE_PLATFORM } from "./shared/errors";
 
 import { createCloudClients, disposeCloudAuth } from "./auth";
 import { getMessageCache } from "./cache";
@@ -89,6 +90,7 @@ import {
 } from "./remote/client";
 import { chatTypeFromGuid, dmChatGuid } from "./remote/ids";
 import { cacheMessage } from "./remote/inbound";
+import { IMESSAGE_PLATFORM } from "./shared/errors";
 import {
   configSchema,
   type IMessageClient,
@@ -457,7 +459,7 @@ const remoteForMessageTarget = (
   return clientForPhone(client, space.phone);
 };
 
-export const imessage = definePlatform("iMessage", {
+export const imessage = definePlatform(IMESSAGE_PLATFORM, {
   config: configSchema,
 
   static: {


### PR DESCRIPTION
## Summary

Fixes [#202](https://github.com/photon-hq/spectrum-ts/issues/202).

`Spectrum()` stores provider runtimes in a map keyed by `definePlatform` name. `@spectrum-ts/imessage` and `@spectrum-ts/imessage-local` both registered as `"iMessage"`, so composing them silently replaced the first runtime. Routing, narrowing, and subscriptions could then hit the wrong transport (cloud gRPC vs local Messages DB) with no error.

This change does both parts of the preferred fix:

1. **Fail closed in core** for any duplicate platform name, before `createClient` or project fetch, so a bad composition never leaves half-initialized providers behind.
2. **Distinct local identity** so the official packages can coexist: local registers as `"iMessage (local mode)"` (the string already used for local unsupported-error copy). Cloud stays `"iMessage"`.

## Changes

- Add `assertUniquePlatformNames()` and call it from `Spectrum()` immediately after resolving `platforms` / `providers`.
- Point `@spectrum-ts/imessage-local` at `LOCAL_IMESSAGE_PLATFORM` from the shared iMessage errors module (single source of truth).
- Map install hints for `"iMessage (local mode)"` to `@spectrum-ts/imessage-local`.
- Update provider docs and READMEs for the two platform ids and narrowing gates.
- Cover uniqueness (including multi-collision counts), side-by-side registration under distinct names, and cloud vs local export name divergence.

## Behavior notes

- Duplicate names now throw: `Spectrum received duplicate platform name(s): "…" (N×). …`
- Local inbound `message.platform` is `"iMessage (local mode)"`. Apps that gate only on `"iMessage"` will skip local traffic when both providers are registered; gate on the matching id (or the exported constants).
- Cloud content helpers still tag `__platform: "iMessage"`. On local spaces, remote-only content continues to be rejected by the framework path; that is expected for cloud-only features.

## Test plan

- [x] `packages/core` Vitest (Bun): unique-platforms, provider-packages, env normalize
- [x] `packages/imessage-local` Vitest (Bun): full suite, including cloud/local name divergence
- [x] `tsc --noEmit` for core, imessage, imessage-local
- [ ] CI matrix (Node + Bun) on this PR
- [ ] Confirm docs preview for iMessage provider + platform-narrowing notes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud and local iMessage providers can coexist by using distinct platform identifiers.
  * Added exported constants to reliably identify cloud vs local iMessage platform ids.
  * Startup now fails fast when duplicate platform names are configured.
  * Provider diagnostics now recognize the local-mode iMessage package.
* **Documentation**
  * Updated iMessage, providers, and platform narrowing docs with exact `message.platform` guidance for cloud vs local.
  * Clarified space sample filtering and setup notes, plus updated local iMessage README examples for async initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->