### PR TITLE
feat(core): accept Fusor JSON webhooks

### DIFF
--- a/docs/webhooks.mdx.vel
+++ b/docs/webhooks.mdx.vel
@@ -15,11 +15,11 @@ import { TypeTooltip } from "/snippets/type-tooltip.mdx";
 
 | | Native Spectrum webhook | Fusor webhook |
 |---|---|---|
-| Body | HMAC-signed, normalized JSON | Protobuf envelope (raw provider request) |
+| Body | HMAC-signed, normalized JSON | Versioned JSON envelope (original provider request included) |
 | Auth | HMAC over body, verified with `webhookSecret` | Platform's own signature via provider `verify()` |
 | Requires a Fusor provider | No | Yes |
 
-Detection is by payload shape (JSON vs protobuf), not headers. Your handler receives the same `(space, message)` pair either way.
+Fusor deliveries are selected by the CloudEvents header `ce-type: dev.spctrm.fusor.delivery`; every other request follows the native signed-webhook path. Your handler receives the same `(space, message)` pair either way.
 
 ## Configuring a webhook secret
 
@@ -78,6 +78,19 @@ The handler is invoked **fire-and-forget** — it runs after the HTTP response i
 <Warning>
 Pass the raw body bytes. The HMAC is computed over the exact bytes on the wire. If your framework parses the body to JSON and you re-stringify it, the bytes change and verification fails.
 </Warning>
+
+Fusor's schema-version `1` envelope is plain JSON. It exposes the original request's `method`, path (including query string), lower-case headers, a normalized `body` arm, and `rawBodyBase64`. The SDK validates the envelope and always passes the bytes decoded from `rawBodyBase64` to the provider's `verify()` function, so signatures are checked against the exact provider payload rather than reserialized JSON.
+
+`request.bodyEncoding` describes the JSON-friendly `request.body` value:
+
+| `bodyEncoding` | `request.body` |
+|---|---|
+| `json` | Any JSON value |
+| `form` | An object of strings, with repeated form keys represented as ordered string arrays |
+| `text` | A UTF-8 string |
+| `base64` | A base64 string, identical to `rawBodyBase64` |
+
+Low-code consumers can work directly with `request.body`. Signature-aware provider code should use the bytes decoded from `rawBodyBase64`; the SDK does this automatically before calling `verify()`.
 
 ## Framework adapters
 
@@ -205,7 +218,7 @@ First-party adapters mount the endpoint for you and handle raw-body parsing corr
 - **Signature verification.** Native webhooks are verified with `HMAC-SHA256` over `v0:<timestamp>:<rawBody>`, with a 5-minute replay window. Bad signature returns `401`, missing headers return `400`.
 - **Payload deserialization.** Native webhook JSON is deserialized into normal <TypeTooltip name="Message" type={`{{ message.signature }}`} /> and <TypeTooltip name="Space" type={`{{ space.signature }}`} /> objects, including reactions and grouped items.
 - **Attachment rehydration.** Native webhooks carry attachment metadata only. `read()` and `stream()` fetch the bytes lazily via the platform.
-- **Format detection.** Native vs Fusor is detected per request by payload shape — JSON for native, protobuf for Fusor.
+- **Format detection.** `ce-type: dev.spctrm.fusor.delivery` selects the Fusor v1 JSON path; all other requests use native HMAC verification.
 
 ## Delivery semantics
 

--- a/packages/core/src/fusor/core.ts
+++ b/packages/core/src/fusor/core.ts
@@ -38,6 +38,11 @@ export interface RegisteredFusorHandler<TPayload = unknown> {
   verify: FusorVerify<TPayload>;
 }
 
+export interface FusorEventMetadata {
+  eventId: string;
+  platform: string;
+}
+
 function toReplyBytes(body: string | Uint8Array | undefined): Uint8Array {
   if (body === undefined) {
     return new Uint8Array(0);
@@ -160,7 +165,7 @@ function runHandlerOnce<TPayload>(
 
 export interface FusorCoreOptions {
   // Optional: only the streaming transport (start) needs cloud credentials to
-  // mint a token. The webhook path (processEvent) routes registered handlers
+  // mint a token. The webhook path (processRequest) routes registered handlers
   // without them, so a webhook-only Spectrum can construct a core with
   // neither set.
   projectId?: string;
@@ -316,40 +321,53 @@ export class FusorCore {
     }
   }
 
-  // Transport-independent event processing: route by platform, parse the wire
-  // request, run every registered handler (verify → messages), and combine the
-  // results into a single InboundReply. Returns the reply instead of writing it
-  // anywhere, so both the streaming session (sendReply) and the synchronous
-  // webhook path can drive it. `deliver` controls where produced records go:
-  // the streaming path defaults to each handler's pushMessage (the per-platform
-  // queue feeding spectrum.messages); the webhook path collects them for the
-  // request instead.
+  private noHandlerReply(event: FusorEventMetadata): InboundReply {
+    // Reply shape stays wire-compatible; only the local log gets the install
+    // hint (since v5 the official providers are separate packages, so "no
+    // handler" is usually a missing install, not a routing bug).
+    const hint = officialProviderInstallHint(event.platform);
+    log.warn(
+      hint
+        ? `fusor: no handler for platform — ${hint}`
+        : "fusor: no handler for platform",
+      {
+        "spectrum.fusor.platform": event.platform,
+        "spectrum.fusor.event_id": event.eventId,
+      }
+    );
+    return {
+      eventId: event.eventId,
+      errorReason: `no handler for platform ${event.platform}`,
+      status: 0,
+      headers: {},
+      body: new Uint8Array(0),
+    };
+  }
+
+  private async processParsedRequest(
+    event: FusorEventMetadata,
+    parsedRequest: ParsedHttpRequest,
+    handlers: RegisteredFusorHandler[],
+    deliver?: (record: ProviderMessageRecord) => void
+  ): Promise<InboundReply> {
+    const outcomes = await Promise.all(
+      handlers.map((handler) => runHandlerOnce(handler, parsedRequest, deliver))
+    );
+
+    const combined = combineReplies(outcomes);
+    combined.eventId = event.eventId;
+    return combined;
+  }
+
+  // WebSocket events still carry protobuf/raw HTTP. Parse that transport shape,
+  // then hand the resulting request to the shared provider pipeline.
   async processEvent(
     event: RawInboundEvent,
     deliver?: (record: ProviderMessageRecord) => void
   ): Promise<InboundReply> {
     const handlers = this.handlers.get(event.platform) ?? [];
     if (handlers.length === 0) {
-      // Reply shape stays wire-compatible; only the local log gets the
-      // install hint (since v5 the official providers are separate packages,
-      // so "no handler" is usually a missing install, not a routing bug).
-      const hint = officialProviderInstallHint(event.platform);
-      log.warn(
-        hint
-          ? `fusor: no handler for platform — ${hint}`
-          : "fusor: no handler for platform",
-        {
-          "spectrum.fusor.platform": event.platform,
-          "spectrum.fusor.event_id": event.eventId,
-        }
-      );
-      return {
-        eventId: event.eventId,
-        errorReason: `no handler for platform ${event.platform}`,
-        status: 0,
-        headers: {},
-        body: new Uint8Array(0),
-      };
+      return this.noHandlerReply(event);
     }
 
     let parsedRequest: ParsedHttpRequest;
@@ -371,13 +389,22 @@ export class FusorCore {
       };
     }
 
-    const outcomes = await Promise.all(
-      handlers.map((handler) => runHandlerOnce(handler, parsedRequest, deliver))
-    );
+    return this.processParsedRequest(event, parsedRequest, handlers, deliver);
+  }
 
-    const combined = combineReplies(outcomes);
-    combined.eventId = event.eventId;
-    return combined;
+  // HTTP JSON deliveries already provide method/path/headers plus the exact
+  // original body bytes, so they enter after raw HTTP parsing. Keeping this
+  // seam shared means WebSocket protobuf behavior remains unchanged.
+  async processRequest(
+    event: FusorEventMetadata,
+    parsedRequest: ParsedHttpRequest,
+    deliver?: (record: ProviderMessageRecord) => void
+  ): Promise<InboundReply> {
+    const handlers = this.handlers.get(event.platform) ?? [];
+    if (handlers.length === 0) {
+      return this.noHandlerReply(event);
+    }
+    return this.processParsedRequest(event, parsedRequest, handlers, deliver);
   }
 
   async close(): Promise<void> {

--- a/packages/core/src/fusor/parse.ts
+++ b/packages/core/src/fusor/parse.ts
@@ -23,9 +23,9 @@ function findHeaderEnd(bytes: Uint8Array): number {
 }
 
 /**
- * Parses an HTTP/1.1 wire-format request out of `raw_request` from
- * `RawInboundEvent`. Headers are lowercased. Multiple header values with the
- * same name are joined with ", " (RFC 7230 §3.2.2).
+ * Parses the HTTP/1.1 wire-format request carried by the WebSocket protobuf
+ * transport. HTTP JSON deliveries already contain these parsed fields. Headers
+ * are lowercased; repeated values are joined with ", " (RFC 7230 §3.2.2).
  */
 export function parseHttpRequest(bytes: Uint8Array): ParsedHttpRequest {
   const headerEnd = findHeaderEnd(bytes);

--- a/packages/core/src/fusor/parse.ts
+++ b/packages/core/src/fusor/parse.ts
@@ -8,6 +8,17 @@ export interface ParsedHttpRequest {
 const CR = 0x0d;
 const LF = 0x0a;
 
+export function mergeHeaderValue(
+  headers: Record<string, string>,
+  name: string,
+  value: string
+): void {
+  const lowerName = name.toLowerCase();
+  headers[lowerName] = Object.hasOwn(headers, lowerName)
+    ? `${headers[lowerName]}, ${value}`
+    : value;
+}
+
 function findHeaderEnd(bytes: Uint8Array): number {
   for (let i = 0; i + 3 < bytes.length; i++) {
     if (
@@ -61,13 +72,12 @@ export function parseHttpRequest(bytes: Uint8Array): ParsedHttpRequest {
     if (colon < 0) {
       continue;
     }
-    const key = line.slice(0, colon).trim().toLowerCase();
+    const key = line.slice(0, colon).trim();
     const value = line.slice(colon + 1).trim();
     if (!key) {
       continue;
     }
-    const existing = headers[key];
-    headers[key] = existing ? `${existing}, ${value}` : value;
+    mergeHeaderValue(headers, key, value);
   }
 
   return { method, path, headers, rawBody };

--- a/packages/core/src/fusor/types.ts
+++ b/packages/core/src/fusor/types.ts
@@ -87,11 +87,13 @@ export type WebhookHandler = (
  * JSON/text body — native Spectrum HMAC verification is over those bytes, and
  * Fusor validates its versioned JSON envelope from them.
  *
- * `headers` are required for routing and verification. Fusor deliveries carry
- * `ce-type: dev.spctrm.fusor.delivery`; every other request is treated as a
- * native Spectrum webhook, whose `X-Spectrum-Signature` /
- * `X-Spectrum-Timestamp` are verified against `Spectrum({ webhookSecret })`.
- * The natural `{ headers: req.headers, body: req.body }` shape works for both.
+ * `headers` is optional on this raw-input type; omitted headers are treated as
+ * an empty record. Routing and verification still depend on them: Fusor
+ * deliveries carry `ce-type: dev.spctrm.fusor.delivery`; every other request is
+ * treated as a native Spectrum webhook, whose `X-Spectrum-Signature` /
+ * `X-Spectrum-Timestamp` are verified against `Spectrum({ webhookSecret })` and
+ * rejected when missing. The natural `{ headers: req.headers, body: req.body }`
+ * shape works for both.
  */
 export interface WebhookRawRequest {
   body: Uint8Array | ArrayBuffer;

--- a/packages/core/src/fusor/types.ts
+++ b/packages/core/src/fusor/types.ts
@@ -84,15 +84,14 @@ export type WebhookHandler = (
 /**
  * Raw webhook input for HTTP servers without Web `Request`/`Response` (Express,
  * raw Node). `body` MUST be the exact bytes POSTed — never a re-encoded
- * JSON/text body — so both the protobuf decode (fusor) and the HMAC
- * verification (native Spectrum webhook) work.
+ * JSON/text body — native Spectrum HMAC verification is over those bytes, and
+ * Fusor validates its versioned JSON envelope from them.
  *
- * `headers` ARE read for **native Spectrum webhooks**: `X-Spectrum-Signature` /
- * `X-Spectrum-Timestamp` carry the HMAC verified against
- * `Spectrum({ webhookSecret })`, and the signature header also selects the
- * native path. For **fusor** envelopes they are ignored (authenticity is the
- * per-platform `verify()` reading the inner reconstructed request). The natural
- * `{ headers: req.headers, body: req.body }` shape works for both.
+ * `headers` are required for routing and verification. Fusor deliveries carry
+ * `ce-type: dev.spctrm.fusor.delivery`; every other request is treated as a
+ * native Spectrum webhook, whose `X-Spectrum-Signature` /
+ * `X-Spectrum-Timestamp` are verified against `Spectrum({ webhookSecret })`.
+ * The natural `{ headers: req.headers, body: req.body }` shape works for both.
  */
 export interface WebhookRawRequest {
   body: Uint8Array | ArrayBuffer;

--- a/packages/core/src/fusor/webhook.ts
+++ b/packages/core/src/fusor/webhook.ts
@@ -1,5 +1,5 @@
 import z from "zod";
-import type { ParsedHttpRequest } from "./parse";
+import { mergeHeaderValue, type ParsedHttpRequest } from "./parse";
 
 export const FUSOR_DELIVERY_CE_TYPE = "dev.spctrm.fusor.delivery";
 
@@ -91,10 +91,7 @@ const normalizeHeaders = (
     string
   >;
   for (const [name, value] of Object.entries(input)) {
-    const lowerName = name.toLowerCase();
-    headers[lowerName] = Object.hasOwn(headers, lowerName)
-      ? `${headers[lowerName]}, ${value}`
-      : value;
+    mergeHeaderValue(headers, name, value);
   }
   return headers;
 };

--- a/packages/core/src/fusor/webhook.ts
+++ b/packages/core/src/fusor/webhook.ts
@@ -1,0 +1,126 @@
+import z from "zod";
+import type { ParsedHttpRequest } from "./parse";
+
+export const FUSOR_DELIVERY_CE_TYPE = "dev.spctrm.fusor.delivery";
+
+const CANONICAL_BASE64 =
+  /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+const canonicalBase64Schema = z.string().refine((value) => {
+  if (!CANONICAL_BASE64.test(value)) {
+    return false;
+  }
+  try {
+    const binary = atob(value);
+    return btoa(binary) === value;
+  } catch {
+    return false;
+  }
+}, "expected canonical padded base64");
+
+const requestFields = {
+  method: z.string().min(1),
+  path: z.string().min(1),
+  headers: z.record(z.string(), z.string()),
+  rawBodyBase64: canonicalBase64Schema,
+};
+
+const fusorWebhookRequestSchema = z.discriminatedUnion("bodyEncoding", [
+  z.looseObject({
+    ...requestFields,
+    bodyEncoding: z.literal("json"),
+    body: z.json(),
+  }),
+  z.looseObject({
+    ...requestFields,
+    bodyEncoding: z.literal("form"),
+    body: z.record(z.string(), z.union([z.string(), z.array(z.string())])),
+  }),
+  z.looseObject({
+    ...requestFields,
+    bodyEncoding: z.literal("text"),
+    body: z.string(),
+  }),
+  z.looseObject({
+    ...requestFields,
+    bodyEncoding: z.literal("base64"),
+    body: canonicalBase64Schema,
+  }),
+]);
+
+const fusorWebhookEnvelopeSchema = z
+  .looseObject({
+    schemaVersion: z.literal(1),
+    eventId: z.string().min(1),
+    projectId: z.string().min(1),
+    platform: z.string().min(1),
+    receivedAt: z.iso.datetime({ offset: true }).optional(),
+    sourceId: z.string().min(1).optional(),
+    prevSubjectSeq: z.number().int().nonnegative().safe(),
+    request: fusorWebhookRequestSchema,
+  })
+  .superRefine((envelope, context) => {
+    if (
+      envelope.request.bodyEncoding === "base64" &&
+      envelope.request.body !== envelope.request.rawBodyBase64
+    ) {
+      context.addIssue({
+        code: "custom",
+        path: ["request", "body"],
+        message: "base64 body must equal rawBodyBase64",
+      });
+    }
+  });
+
+export interface FusorWebhookEvent {
+  eventId: string;
+  platform: string;
+  request: ParsedHttpRequest;
+}
+
+const decodeCanonicalBase64 = (value: string): Uint8Array => {
+  const binary = atob(value);
+  return Uint8Array.from(binary, (character) => character.charCodeAt(0));
+};
+
+const normalizeHeaders = (
+  input: Record<string, string>
+): Record<string, string> => {
+  const headers: Record<string, string> = Object.create(null) as Record<
+    string,
+    string
+  >;
+  for (const [name, value] of Object.entries(input)) {
+    const lowerName = name.toLowerCase();
+    headers[lowerName] = Object.hasOwn(headers, lowerName)
+      ? `${headers[lowerName]}, ${value}`
+      : value;
+  }
+  return headers;
+};
+
+/**
+ * Parses the versioned JSON envelope delivered by Fusor over HTTP. The
+ * normalized `body` arm is validation/debugging data; provider verification
+ * always receives the exact original bytes from `rawBodyBase64`.
+ */
+export const decodeFusorWebhookEvent = (
+  bodyBytes: Uint8Array
+): FusorWebhookEvent | null => {
+  try {
+    const json = new TextDecoder("utf-8", { fatal: true }).decode(bodyBytes);
+    const envelope = fusorWebhookEnvelopeSchema.parse(JSON.parse(json));
+    return {
+      eventId: envelope.eventId,
+      platform: envelope.platform,
+      request: {
+        method: envelope.request.method,
+        path: envelope.request.path,
+        headers: normalizeHeaders(envelope.request.headers),
+        rawBody: decodeCanonicalBase64(envelope.request.rawBodyBase64),
+      },
+    };
+  } catch {
+    return null;
+  }
+};

--- a/packages/core/src/spectrum.ts
+++ b/packages/core/src/spectrum.ts
@@ -1316,7 +1316,7 @@ export async function Spectrum<
       return buildWebhookResult(asWeb, {
         status: 400,
         headers: {},
-        body: new Uint8Array(0),
+        body: encodeText("malformed Fusor envelope"),
       });
     }
 

--- a/packages/core/src/spectrum.ts
+++ b/packages/core/src/spectrum.ts
@@ -6,7 +6,6 @@ import {
   setupOtel,
   withSpan,
 } from "@photon-ai/otel";
-import { RawInboundEvent } from "@photon-ai/proto/photon/fusor/v1/inbound";
 import z from "zod";
 import { SPECTRUM_BUILD_ENV, SPECTRUM_SDK_VERSION } from "./build-env";
 import type { ContentInput } from "./content/types";
@@ -19,6 +18,11 @@ import type {
   WebhookRawRequest,
   WebhookRawResult,
 } from "./fusor/types";
+import {
+  decodeFusorWebhookEvent,
+  FUSOR_DELIVERY_CE_TYPE,
+  type FusorWebhookEvent,
+} from "./fusor/webhook";
 import {
   buildSpace,
   type ProviderMessageRecord,
@@ -102,14 +106,16 @@ export type SpectrumInstance<
      *   against `Spectrum({ webhookSecret })` (a bad signature → 401), the slim
      *   payload is deserialized into `[space, message]`, and a `200` is returned.
      *   Works without any fusor provider configured.
-     * - **Fusor webhook** (the body is a protobuf envelope): a protobuf wrapping a
-     *   raw provider request is decoded and routed to the matching provider's
+     * - **Fusor webhook** (the body is a versioned JSON envelope): Fusor's
+     *   normalized request metadata plus exact original body bytes are validated
+     *   and routed to the matching provider's
      *   verify + message pipeline; the HTTP response is that platform's
      *   `respond()` reply (including protocol echoes like Slack
      *   `url_verification`), computed synchronously and returned immediately.
      *
-     * Detection is by payload shape, not headers — Spectrum signs both kinds with
-     * `X-Spectrum-Signature`, so the header can't discriminate.
+     * Fusor deliveries are selected by
+     * `ce-type: dev.spctrm.fusor.delivery`; every other request follows the
+     * native signed-webhook path.
      *
      * `handler` is invoked once per resolved message **fire-and-forget** — it is
      * dispatched after the response is computed and is NOT awaited, so its
@@ -1000,8 +1006,8 @@ export async function Spectrum<
     return result;
   };
 
-  // Read the RAW request bytes without re-encoding — both the protobuf decode
-  // (fusor) and the HMAC verification (native) need the exact bytes received.
+  // Read the RAW request bytes without re-encoding — both the Fusor envelope
+  // parser and the native HMAC verification need the exact bytes received.
   // `asWeb` records whether to reply with a Web `Response` or the raw result
   // shape; `headers` (keys lowercased) carry the native webhook's signature.
   const readWebhookInput = async (
@@ -1063,20 +1069,17 @@ export async function Spectrum<
     }
   };
 
-  // Decode the protobuf envelope; null = undecodable (poison → 400).
+  // Decode the versioned Fusor JSON envelope; null = malformed (poison → 400).
   const decodeWebhookEvent = (
     bodyBytes: Uint8Array
-  ): RawInboundEvent | null => {
-    try {
-      return RawInboundEvent.decode(bodyBytes);
-    } catch (error) {
-      lifecycleLog.warn(
-        "spectrum.webhook: undecodable RawInboundEvent body",
-        errorAttrs(error),
-        error
-      );
-      return null;
+  ): FusorWebhookEvent | null => {
+    const event = decodeFusorWebhookEvent(bodyBytes);
+    if (!event) {
+      lifecycleLog.warn("spectrum.webhook: malformed Fusor JSON envelope", {
+        "spectrum.webhook.reason": "invalid-fusor-envelope",
+      });
     }
+    return event;
   };
 
   // Run the shared fusor pipeline for a decoded event and map it to an HTTP
@@ -1084,11 +1087,11 @@ export async function Spectrum<
   // do not feed spectrum.messages).
   const processWebhookEvent = async (
     core: FusorCore,
-    event: RawInboundEvent,
+    event: FusorWebhookEvent,
     handler: WebhookHandler
   ): Promise<WebhookRawResult> => {
     const collected: ProviderMessageRecord[] = [];
-    const reply = await core.processEvent(event, (record) => {
+    const reply = await core.processRequest(event, event.request, (record) => {
       collected.push(record);
     });
 
@@ -1140,21 +1143,6 @@ export async function Spectrum<
   };
 
   // --- Native Spectrum webhook (signed, normalized JSON) -------------------
-
-  // Distinguish a native Spectrum webhook from a fusor one by the PAYLOAD, not a
-  // header: Spectrum signs both kinds with `x-spectrum-signature`, so the header
-  // can't tell them apart. A native body is a JSON object (`{…`); a fusor body is
-  // a binary protobuf `RawInboundEvent`, which never starts with `{`.
-  const looksLikeNativePayload = (bodyBytes: Uint8Array): boolean => {
-    for (const byte of bodyBytes) {
-      // Skip leading ASCII whitespace (space, tab, LF, CR).
-      if (byte === 0x20 || byte === 0x09 || byte === 0x0a || byte === 0x0d) {
-        continue;
-      }
-      return byte === 0x7b; // "{"
-    }
-    return false;
-  };
 
   const webhookText = (status: number, text: string): WebhookRawResult => ({
     status,
@@ -1311,21 +1299,16 @@ export async function Spectrum<
   ): Promise<Response | WebhookRawResult> => {
     const { asWeb, bodyBytes, headers } = await readWebhookInput(request);
 
-    // Route by payload shape: a native webhook is JSON, a fusor one is protobuf.
-    // Both may carry an `x-spectrum-signature` header, so it can't discriminate.
-    if (looksLikeNativePayload(bodyBytes)) {
+    // Fusor JSON and native Spectrum payloads are both JSON. CloudEvents type is
+    // therefore the stable discriminator; native verification still happens on
+    // raw bytes before parsing.
+    if (headers["ce-type"] !== FUSOR_DELIVERY_CE_TYPE) {
       const spectrumResult = await handleSpectrumWebhook(
         bodyBytes,
         headers,
         handler
       );
       return buildWebhookResult(asWeb, spectrumResult);
-    }
-
-    if (!fusorCore) {
-      throw new Error(
-        "spectrum.webhook() received a non-Spectrum (fusor) request but no fusor provider is configured"
-      );
     }
 
     const event = decodeWebhookEvent(bodyBytes);
@@ -1335,6 +1318,12 @@ export async function Spectrum<
         headers: {},
         body: new Uint8Array(0),
       });
+    }
+
+    if (!fusorCore) {
+      throw new Error(
+        "spectrum.webhook() received a non-Spectrum (fusor) request but no fusor provider is configured"
+      );
     }
 
     const result = await processWebhookEvent(fusorCore, event, handler);

--- a/packages/core/src/webhook/types.ts
+++ b/packages/core/src/webhook/types.ts
@@ -4,10 +4,10 @@ import z from "zod";
  * Wire schemas for the **native Spectrum webhook**
  * (https://photon.codes/docs/webhooks).
  *
- * Unlike the fusor webhook — which relays a raw provider request inside a
- * protobuf envelope — the native webhook delivers Spectrum's own message model
- * already normalized to slim JSON (methods and byte payloads stripped), signed
- * with an HMAC. These schemas validate the fields the deserializer depends on
+ * Unlike the Fusor webhook — which carries a versioned JSON envelope with the
+ * original provider request bytes — the native webhook delivers Spectrum's own
+ * message model already normalized to slim JSON (methods and byte payloads
+ * stripped), signed with an HMAC. These schemas validate the fields the deserializer depends on
  * while **preserving** unknown/extra fields (`z.looseObject`), so additive
  * changes — new platform-specific space fields, future content arms — never
  * break an older SDK. Content is discriminated by hand in `deserialize.ts`

--- a/packages/core/test/core/fusor/parse.test.ts
+++ b/packages/core/test/core/fusor/parse.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { parseHttpRequest } from "@/fusor/parse";
+
+describe("parseHttpRequest", () => {
+  it("lowercases and joins duplicate headers without dropping empty values", () => {
+    const request = new TextEncoder().encode(
+      "POST /hooks HTTP/1.1\r\nX-Probe:\r\nx-PROBE: second\r\n\r\nbody"
+    );
+
+    const parsed = parseHttpRequest(request);
+
+    expect(parsed.headers["x-probe"]).toBe(", second");
+    expect(new TextDecoder().decode(parsed.rawBody)).toBe("body");
+  });
+});

--- a/packages/core/test/core/fusor/webhook.test.ts
+++ b/packages/core/test/core/fusor/webhook.test.ts
@@ -200,6 +200,9 @@ describe("spectrum.webhook", () => {
     );
 
     expect(result.status).toBe(400);
+    expect(new TextDecoder().decode(result.body)).toBe(
+      "malformed Fusor envelope"
+    );
     await spectrum.stop();
   });
 

--- a/packages/core/test/core/fusor/webhook.test.ts
+++ b/packages/core/test/core/fusor/webhook.test.ts
@@ -3,6 +3,9 @@ import {
   CTX_PROBE_PLATFORM,
   type CtxProbeCapture,
   encodeEvent,
+  encodeFusorEnvelope,
+  encodeLegacyEvent,
+  FUSOR_WEBHOOK_HEADERS,
   makeCtxProbe,
   makePresence,
   makeSlack,
@@ -16,6 +19,7 @@ import {
 } from "@spectrum-ts/test-support/timing";
 import { describe, expect, it, vi } from "vitest";
 import { FusorCore } from "@/fusor/core";
+import type { FusorVerifyRequest } from "@/fusor/types";
 import { Spectrum } from "@/spectrum";
 import type { Message } from "@/types/message";
 
@@ -34,7 +38,7 @@ describe("spectrum.webhook", () => {
 
     const result = await spectrum.webhook(
       {
-        headers: { "content-type": "application/x-protobuf" },
+        headers: FUSOR_WEBHOOK_HEADERS,
         body: encodeEvent(
           "slack",
           JSON.stringify({ type: "message", text: "hello" })
@@ -72,7 +76,7 @@ describe("spectrum.webhook", () => {
 
     const result = await spectrum.webhook(
       {
-        headers: {},
+        headers: FUSOR_WEBHOOK_HEADERS,
         body: encodeEvent(
           CTX_PROBE_PLATFORM,
           JSON.stringify({ text: "hello ctx" })
@@ -108,7 +112,7 @@ describe("spectrum.webhook", () => {
 
     const result = await spectrum.webhook(
       {
-        headers: {},
+        headers: FUSOR_WEBHOOK_HEADERS,
         body: encodeEvent("slack", JSON.stringify({ type: "typing" })),
       },
       (_space, message) => {
@@ -134,7 +138,7 @@ describe("spectrum.webhook", () => {
 
     const request = new Request("https://app.example.com/webhooks/fusor", {
       method: "POST",
-      headers: { "content-type": "application/x-protobuf" },
+      headers: FUSOR_WEBHOOK_HEADERS,
       body: encodeEvent(
         "slack",
         JSON.stringify({ type: "url_verification", challenge: "abc123" })
@@ -165,11 +169,15 @@ describe("spectrum.webhook", () => {
     );
 
     const rawResult = await spectrum.webhook(
-      { headers: {}, body },
+      { headers: FUSOR_WEBHOOK_HEADERS, body },
       () => undefined
     );
     const webResult = await spectrum.webhook(
-      new Request("https://app.example.com/h", { method: "POST", body }),
+      new Request("https://app.example.com/h", {
+        method: "POST",
+        headers: FUSOR_WEBHOOK_HEADERS,
+        body,
+      }),
       () => undefined
     );
 
@@ -187,11 +195,221 @@ describe("spectrum.webhook", () => {
     });
 
     const result = await spectrum.webhook(
-      { headers: {}, body: new Uint8Array([0xff]) },
+      { headers: FUSOR_WEBHOOK_HEADERS, body: new Uint8Array([0xff]) },
       () => undefined
     );
 
     expect(result.status).toBe(400);
+    await spectrum.stop();
+  });
+
+  it("passes exact body bytes and normalized request metadata to verify()", async () => {
+    const capture: { request?: FusorVerifyRequest } = {};
+    const spectrum = await Spectrum({
+      ...baseConfig,
+      providers: [makeSlack({ captureRequest: capture }).config({})],
+    });
+    const rawBody = new TextEncoder().encode(
+      '{ "type": "message", "text": "byte exact" }\n'
+    );
+    const body = encodeFusorEnvelope({
+      platform: "slack",
+      method: "PATCH",
+      path: "/hooks/slack?token=a%2Bb",
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        "X-Probe": "first",
+        "x-probe": "second",
+      },
+      bodyEncoding: "json",
+      body: { type: "message", text: "byte exact" },
+      rawBody,
+    });
+
+    const result = await spectrum.webhook(
+      { headers: FUSOR_WEBHOOK_HEADERS, body },
+      () => undefined
+    );
+
+    expect(result.status).toBe(200);
+    expect(capture.request?.method).toBe("PATCH");
+    expect(capture.request?.path).toBe("/hooks/slack?token=a%2Bb");
+    expect(capture.request?.headers["content-type"]).toBe(
+      "application/json; charset=utf-8"
+    );
+    expect(capture.request?.headers["x-probe"]).toBe("first, second");
+    expect(capture.request?.rawBody).toEqual(rawBody);
+
+    await spectrum.stop();
+  });
+
+  it("preserves exact form, text, binary, and empty bodies", async () => {
+    const capture: { request?: FusorVerifyRequest } = {};
+    const spectrum = await Spectrum({
+      ...baseConfig,
+      providers: [
+        makeSlack({ acceptRawBody: true, captureRequest: capture }).config({}),
+      ],
+    });
+    const binary = new Uint8Array([0, 255, 128, 1]);
+    const binaryBase64 = btoa(
+      Array.from(binary, (byte) => String.fromCharCode(byte)).join("")
+    );
+    const cases = [
+      {
+        bodyEncoding: "form" as const,
+        body: { name: "测试", tag: ["a", "b"] },
+        rawBody: new TextEncoder().encode(
+          "name=%E6%B5%8B%E8%AF%95&tag=a&tag=b"
+        ),
+      },
+      {
+        bodyEncoding: "text" as const,
+        body: "héllo 世界",
+        rawBody: new TextEncoder().encode("héllo 世界"),
+      },
+      {
+        bodyEncoding: "base64" as const,
+        body: binaryBase64,
+        rawBody: binary,
+      },
+      {
+        bodyEncoding: "text" as const,
+        body: "",
+        rawBody: new Uint8Array(0),
+      },
+    ];
+
+    for (const testCase of cases) {
+      const result = await spectrum.webhook(
+        {
+          headers: FUSOR_WEBHOOK_HEADERS,
+          body: encodeFusorEnvelope({
+            platform: "slack",
+            ...testCase,
+          }),
+        },
+        () => undefined
+      );
+      expect(result.status).toBe(200);
+      expect(capture.request?.rawBody).toEqual(testCase.rawBody);
+    }
+
+    await spectrum.stop();
+  });
+
+  it("accepts additive v1 fields", async () => {
+    const spectrum = await Spectrum({
+      ...baseConfig,
+      providers: [makeSlack().config({})],
+    });
+    const encoded = encodeEvent(
+      "slack",
+      JSON.stringify({ type: "message", text: "future" })
+    );
+    const envelope = JSON.parse(new TextDecoder().decode(encoded)) as {
+      request: Record<string, unknown>;
+      [key: string]: unknown;
+    };
+    envelope.futureTopLevel = { enabled: true };
+    envelope.request.futureRequestField = 42;
+
+    const result = await spectrum.webhook(
+      {
+        headers: FUSOR_WEBHOOK_HEADERS,
+        body: new TextEncoder().encode(JSON.stringify(envelope)),
+      },
+      () => undefined
+    );
+
+    expect(result.status).toBe(200);
+    await spectrum.stop();
+  });
+
+  it("rejects legacy protobuf envelopes", async () => {
+    const spectrum = await Spectrum({
+      ...baseConfig,
+      providers: [makeSlack().config({})],
+    });
+
+    const result = await spectrum.webhook(
+      {
+        headers: FUSOR_WEBHOOK_HEADERS,
+        body: encodeLegacyEvent("slack", '{"type":"message"}'),
+      },
+      () => undefined
+    );
+
+    expect(result.status).toBe(400);
+    await spectrum.stop();
+  });
+
+  it("rejects invalid versions, encodings, body arms, and base64", async () => {
+    const spectrum = await Spectrum({
+      ...baseConfig,
+      providers: [makeSlack().config({})],
+    });
+    const valid = JSON.parse(
+      new TextDecoder().decode(encodeEvent("slack", '{"type":"message"}'))
+    ) as {
+      eventId: string;
+      platform: string;
+      prevSubjectSeq: number;
+      projectId: string;
+      receivedAt: string;
+      schemaVersion: number;
+      request: {
+        body: unknown;
+        bodyEncoding: string;
+        method: string;
+        rawBodyBase64: string;
+      };
+    };
+    const invalidEnvelopes = [
+      { ...structuredClone(valid), schemaVersion: 2 },
+      { ...structuredClone(valid), eventId: "" },
+      { ...structuredClone(valid), projectId: "" },
+      { ...structuredClone(valid), platform: "" },
+      { ...structuredClone(valid), prevSubjectSeq: -1 },
+      { ...structuredClone(valid), receivedAt: "not-a-timestamp" },
+      {
+        ...structuredClone(valid),
+        request: { ...valid.request, method: "" },
+      },
+      {
+        ...structuredClone(valid),
+        request: { ...valid.request, bodyEncoding: "yaml" },
+      },
+      {
+        ...structuredClone(valid),
+        request: { ...valid.request, bodyEncoding: "text", body: {} },
+      },
+      {
+        ...structuredClone(valid),
+        request: { ...valid.request, rawBodyBase64: "AB==" },
+      },
+      {
+        ...structuredClone(valid),
+        request: {
+          ...valid.request,
+          bodyEncoding: "base64",
+          body: "AA==",
+          rawBodyBase64: "AQ==",
+        },
+      },
+    ];
+
+    for (const envelope of invalidEnvelopes) {
+      const result = await spectrum.webhook(
+        {
+          headers: FUSOR_WEBHOOK_HEADERS,
+          body: new TextEncoder().encode(JSON.stringify(envelope)),
+        },
+        () => undefined
+      );
+      expect(result.status).toBe(400);
+    }
+
     await spectrum.stop();
   });
 
@@ -202,7 +420,10 @@ describe("spectrum.webhook", () => {
     });
 
     const result = await spectrum.webhook(
-      { headers: {}, body: encodeEvent("discord", "{}") },
+      {
+        headers: FUSOR_WEBHOOK_HEADERS,
+        body: encodeEvent("discord", "{}"),
+      },
       () => undefined
     );
 
@@ -218,7 +439,7 @@ describe("spectrum.webhook", () => {
 
     const result = await spectrum.webhook(
       {
-        headers: {},
+        headers: FUSOR_WEBHOOK_HEADERS,
         body: encodeEvent(
           "slack",
           JSON.stringify({ type: "message", text: "x" })
@@ -242,7 +463,7 @@ describe("spectrum.webhook", () => {
 
     const result = await spectrum.webhook(
       {
-        headers: {},
+        headers: FUSOR_WEBHOOK_HEADERS,
         body: encodeEvent(
           "slack",
           JSON.stringify({ type: "message", text: "x" })
@@ -273,7 +494,7 @@ describe("spectrum.webhook", () => {
     const { promise: finished, resolve: done } = Promise.withResolvers<void>();
     await spectrum.webhook(
       {
-        headers: {},
+        headers: FUSOR_WEBHOOK_HEADERS,
         body: encodeEvent(
           "slack",
           JSON.stringify({ type: "group", texts: ["a", "b"] })
@@ -307,7 +528,7 @@ describe("spectrum.webhook", () => {
     const { promise: finished, resolve: done } = Promise.withResolvers<void>();
     await spectrum.webhook(
       {
-        headers: {},
+        headers: FUSOR_WEBHOOK_HEADERS,
         body: encodeEvent(
           "slack",
           JSON.stringify({ type: "group", texts: ["a", "b"] })
@@ -336,7 +557,13 @@ describe("spectrum.webhook", () => {
     const spectrum = await Spectrum({ providers: [] });
 
     await expect(
-      spectrum.webhook({ headers: {}, body: new Uint8Array() }, () => undefined)
+      spectrum.webhook(
+        {
+          headers: FUSOR_WEBHOOK_HEADERS,
+          body: encodeEvent("slack", '{"type":"message"}'),
+        },
+        () => undefined
+      )
     ).rejects.toThrow(NO_FUSOR_PROVIDER_ERROR);
 
     await spectrum.stop();
@@ -354,7 +581,7 @@ describe("spectrum.webhook", () => {
 
       await spectrum.webhook(
         {
-          headers: {},
+          headers: FUSOR_WEBHOOK_HEADERS,
           body: encodeEvent(
             "slack",
             JSON.stringify({ type: "message", text: "x" })
@@ -393,7 +620,7 @@ describe("spectrum.webhook", () => {
 
       await spectrum.webhook(
         {
-          headers: {},
+          headers: FUSOR_WEBHOOK_HEADERS,
           body: encodeEvent(
             "slack",
             JSON.stringify({ type: "message", text: "x" })
@@ -435,7 +662,7 @@ describe("fusor events", () => {
     let handlerCalls = 0;
     const result = await spectrum.webhook(
       {
-        headers: {},
+        headers: FUSOR_WEBHOOK_HEADERS,
         body: encodeEvent(
           PRESENCE_PLATFORM,
           JSON.stringify({ type: "presence", user: "alice" })
@@ -471,7 +698,7 @@ describe("fusor events", () => {
 
     const result = await spectrum.webhook(
       {
-        headers: {},
+        headers: FUSOR_WEBHOOK_HEADERS,
         body: encodeEvent(
           PRESENCE_PLATFORM,
           JSON.stringify({ type: "via-messages", text: "hi" })
@@ -499,7 +726,7 @@ describe("fusor events", () => {
     let handlerCalls = 0;
     const result = await spectrum.webhook(
       {
-        headers: {},
+        headers: FUSOR_WEBHOOK_HEADERS,
         body: encodeEvent(
           PRESENCE_PLATFORM,
           JSON.stringify({ type: "undeclared" })

--- a/packages/core/test/webhook/spectrum.test.ts
+++ b/packages/core/test/webhook/spectrum.test.ts
@@ -1,5 +1,9 @@
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
-import { encodeEvent, makeSlack } from "@spectrum-ts/test-support/fusor";
+import {
+  encodeEvent,
+  FUSOR_WEBHOOK_HEADERS,
+  makeSlack,
+} from "@spectrum-ts/test-support/fusor";
 import {
   baseConfig,
   makeManagedProvider,
@@ -192,7 +196,7 @@ describe("spectrum.webhook (native Spectrum webhook)", () => {
 });
 
 describe("spectrum.webhook (dispatch / fusor coexistence)", () => {
-  it("routes a protobuf body (no signature header) to the fusor path", async () => {
+  it("routes a Fusor JSON envelope by CloudEvents type", async () => {
     const spectrum = await Spectrum({
       ...baseConfig,
       providers: [makeSlack().config({})],
@@ -203,7 +207,7 @@ describe("spectrum.webhook (dispatch / fusor coexistence)", () => {
 
     const result = await spectrum.webhook(
       {
-        headers: { "content-type": "application/x-protobuf" },
+        headers: FUSOR_WEBHOOK_HEADERS,
         body: encodeEvent(
           "slack",
           JSON.stringify({ type: "message", text: "hello" })
@@ -222,9 +226,7 @@ describe("spectrum.webhook (dispatch / fusor coexistence)", () => {
     await spectrum.stop();
   });
 
-  it("routes a SIGNED protobuf body to the fusor path (header doesn't force native)", async () => {
-    // Spectrum signs fusor deliveries too, so an `x-spectrum-signature` header on
-    // a protobuf body must NOT be misrouted into the native JSON parser.
+  it("routes a signed Fusor JSON envelope by CloudEvents type", async () => {
     const spectrum = await Spectrum({
       ...baseConfig,
       providers: [makeSlack().config({})],
@@ -236,13 +238,13 @@ describe("spectrum.webhook (dispatch / fusor coexistence)", () => {
     const result = await spectrum.webhook(
       {
         headers: {
-          "content-type": "application/x-protobuf",
+          ...FUSOR_WEBHOOK_HEADERS,
           "x-spectrum-signature": "v0=deadbeef",
           "x-spectrum-timestamp": String(Math.floor(Date.now() / 1000)),
         },
         body: encodeEvent(
           "slack",
-          JSON.stringify({ type: "message", text: "signed-protobuf" })
+          JSON.stringify({ type: "message", text: "signed-fusor" })
         ),
       },
       (_space, message) => {
@@ -255,7 +257,7 @@ describe("spectrum.webhook (dispatch / fusor coexistence)", () => {
     expect(result.status).toBe(200);
     expect(received[0]?.content).toEqual({
       type: "text",
-      text: "signed-protobuf",
+      text: "signed-fusor",
     });
 
     await spectrum.stop();
@@ -268,7 +270,7 @@ describe("spectrum.webhook (dispatch / fusor coexistence)", () => {
         await expect(
           spectrum.webhook(
             {
-              headers: { "content-type": "application/x-protobuf" },
+              headers: FUSOR_WEBHOOK_HEADERS,
               body: encodeEvent("slack", JSON.stringify({ type: "message" })),
             },
             () => {

--- a/packages/elysia/test/elysia.test.ts
+++ b/packages/elysia/test/elysia.test.ts
@@ -1,6 +1,11 @@
 import { type Message, Spectrum } from "@spectrum-ts/core";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
+  encodeEvent,
+  FUSOR_WEBHOOK_HEADERS,
+  makeSlack,
+} from "@spectrum-ts/test-support/fusor";
+import {
   baseConfig,
   makeManagedProvider,
 } from "@spectrum-ts/test-support/platform";
@@ -94,6 +99,44 @@ describe("spectrum (elysia plugin)", () => {
 
       expect(response.status).toBe(401);
       expect(called).toBe(false);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("delivers a Fusor application/json envelope", async () => {
+    const app = await makeApp({ providers: [makeSlack().config({})] });
+    try {
+      const { promise: finished, resolve: done } =
+        Promise.withResolvers<void>();
+      const received: Message[] = [];
+      const elysia = new Elysia().use(
+        spectrum({
+          app,
+          onMessage: (_space, message) => {
+            received.push(message);
+            done();
+          },
+        })
+      );
+
+      const response = await elysia.handle(
+        new Request(DEFAULT_URL, {
+          method: "POST",
+          headers: FUSOR_WEBHOOK_HEADERS,
+          body: encodeEvent(
+            "slack",
+            JSON.stringify({ type: "message", text: "from fusor" })
+          ),
+        })
+      );
+      await finished;
+
+      expect(response.status).toBe(200);
+      expect(received[0]?.content).toEqual({
+        type: "text",
+        text: "from fusor",
+      });
     } finally {
       await app.stop();
     }

--- a/packages/express/src/index.ts
+++ b/packages/express/src/index.ts
@@ -7,7 +7,7 @@
 // mounts `express.raw({ type: "*/*" })` on its own route — Spectrum verifies the
 // native webhook's HMAC over the EXACT wire bytes
 // (`HMAC-SHA256(secret, "v0:<ts>:<rawBody>")`), so a parsed-and-re-encoded body
-// would break verification (and the fusor protobuf body would fail to decode).
+// would break native HMAC verification (and may corrupt the Fusor JSON bytes).
 //
 // ⚠️ Ordering hazard (the Express analog of Elysia's parse lifecycle): a global
 // `express.json()` mounted BEFORE this router consumes the request stream first,

--- a/packages/express/test/express.test.ts
+++ b/packages/express/test/express.test.ts
@@ -2,6 +2,11 @@ import type { AddressInfo } from "node:net";
 import { type Message, Spectrum } from "@spectrum-ts/core";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
+  encodeEvent,
+  FUSOR_WEBHOOK_HEADERS,
+  makeSlack,
+} from "@spectrum-ts/test-support/fusor";
+import {
   baseConfig,
   makeManagedProvider,
 } from "@spectrum-ts/test-support/platform";
@@ -108,6 +113,43 @@ describe("spectrum (express plugin)", () => {
 
       expect(response.status).toBe(401);
       expect(called).toBe(false);
+    } finally {
+      await close();
+      await app.stop();
+    }
+  });
+
+  it("delivers a Fusor application/json envelope", async () => {
+    const app = await makeApp({ providers: [makeSlack().config({})] });
+    const received: Message[] = [];
+    const { promise: finished, resolve: done } = Promise.withResolvers<void>();
+    const server = express().use(
+      spectrum({
+        app,
+        onMessage: (_space, message) => {
+          received.push(message);
+          done();
+        },
+      })
+    );
+    const { url, close } = await listen(server);
+
+    try {
+      const response = await fetch(`${url}/spectrum/webhook`, {
+        method: "POST",
+        headers: FUSOR_WEBHOOK_HEADERS,
+        body: encodeEvent(
+          "slack",
+          JSON.stringify({ type: "message", text: "from fusor" })
+        ),
+      });
+      await finished;
+
+      expect(response.status).toBe(200);
+      expect(received[0]?.content).toEqual({
+        type: "text",
+        text: "from fusor",
+      });
     } finally {
       await close();
       await app.stop();

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -5,7 +5,7 @@
 // the raw request body payload bytes as a `Buffer`. Spectrum verifies the
 // native webhook's HMAC over the EXACT wire bytes
 // (`HMAC-SHA256(secret, "v0:<ts>:<rawBody>")`), so a parsed-and-re-encoded body
-// would break verification (and the fusor protobuf body would fail to decode).
+// would break native HMAC verification (and may corrupt the Fusor JSON bytes).
 //
 // ⚠️ Encapsulation: registering the content type parser inside this plugin's
 // scope ensures it only applies to this route, preventing interference with
@@ -86,7 +86,7 @@ export async function spectrum(
   fastify.removeAllContentTypeParsers();
 
   // Custom parser to capture the exact raw body bytes as a Buffer. Using "*"
-  // captures all content types (application/json, application/x-protobuf, etc.)
+  // captures all content types (application/json, text/plain, etc.)
   // under the scope of this plugin only.
   fastify.addContentTypeParser("*", (_request, payload, done) => {
     const chunks: Uint8Array[] = [];

--- a/packages/fastify/test/fastify.test.ts
+++ b/packages/fastify/test/fastify.test.ts
@@ -1,6 +1,11 @@
 import { type Message, Spectrum } from "@spectrum-ts/core";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
+  encodeEvent,
+  FUSOR_WEBHOOK_HEADERS,
+  makeSlack,
+} from "@spectrum-ts/test-support/fusor";
+import {
   baseConfig,
   makeManagedProvider,
 } from "@spectrum-ts/test-support/platform";
@@ -103,6 +108,42 @@ describe("spectrum (fastify plugin)", () => {
 
       expect(response.status).toBe(401);
       expect(called).toBe(false);
+    } finally {
+      await close();
+      await app.stop();
+    }
+  });
+
+  it("delivers a Fusor application/json envelope", async () => {
+    const app = await makeApp({ providers: [makeSlack().config({})] });
+    const received: Message[] = [];
+    const { promise: finished, resolve: done } = Promise.withResolvers<void>();
+    const server = Fastify();
+    await server.register(spectrum, {
+      app,
+      onMessage: (_space, message) => {
+        received.push(message);
+        done();
+      },
+    });
+    const { url, close } = await listen(server);
+
+    try {
+      const response = await fetch(`${url}/spectrum/webhook`, {
+        method: "POST",
+        headers: FUSOR_WEBHOOK_HEADERS,
+        body: encodeEvent(
+          "slack",
+          JSON.stringify({ type: "message", text: "from fusor" })
+        ),
+      });
+      await finished;
+
+      expect(response.status).toBe(200);
+      expect(received[0]?.content).toEqual({
+        type: "text",
+        text: "from fusor",
+      });
     } finally {
       await close();
       await app.stop();

--- a/packages/hono/test/hono.test.ts
+++ b/packages/hono/test/hono.test.ts
@@ -1,6 +1,11 @@
 import { type Message, Spectrum } from "@spectrum-ts/core";
 import { stubCloud } from "@spectrum-ts/test-support/cloud";
 import {
+  encodeEvent,
+  FUSOR_WEBHOOK_HEADERS,
+  makeSlack,
+} from "@spectrum-ts/test-support/fusor";
+import {
   baseConfig,
   makeManagedProvider,
 } from "@spectrum-ts/test-support/platform";
@@ -96,6 +101,45 @@ describe("spectrum (hono plugin)", () => {
 
       expect(response.status).toBe(401);
       expect(called).toBe(false);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("delivers a Fusor application/json envelope", async () => {
+    const app = await makeApp({ providers: [makeSlack().config({})] });
+    try {
+      const { promise: finished, resolve: done } =
+        Promise.withResolvers<void>();
+      const received: Message[] = [];
+      const hono = new Hono().route(
+        "/",
+        spectrum({
+          app,
+          onMessage: (_space, message) => {
+            received.push(message);
+            done();
+          },
+        })
+      );
+
+      const response = await hono.request(
+        new Request(DEFAULT_URL, {
+          method: "POST",
+          headers: FUSOR_WEBHOOK_HEADERS,
+          body: encodeEvent(
+            "slack",
+            JSON.stringify({ type: "message", text: "from fusor" })
+          ),
+        })
+      );
+      await finished;
+
+      expect(response.status).toBe(200);
+      expect(received[0]?.content).toEqual({
+        type: "text",
+        text: "from fusor",
+      });
     } finally {
       await app.stop();
     }

--- a/packages/test-support/src/fusor.ts
+++ b/packages/test-support/src/fusor.ts
@@ -1,5 +1,10 @@
 import { RawInboundEvent } from "@photon-ai/proto/photon/fusor/v1/inbound";
-import type { Content, FusorMessages, ProjectData } from "@spectrum-ts/core";
+import type {
+  Content,
+  FusorMessages,
+  FusorVerifyRequest,
+  ProjectData,
+} from "@spectrum-ts/core";
 import { definePlatform, fusor, fusorEvent } from "@spectrum-ts/core";
 import z from "zod";
 
@@ -11,6 +16,15 @@ export type SlackPayload =
   | { kind: "verify"; challenge: string }
   | { kind: "group"; texts: string[] }
   | { kind: "typing" };
+
+const captureVerifyRequest = (
+  capture: { request?: FusorVerifyRequest } | undefined,
+  request: FusorVerifyRequest
+): void => {
+  if (capture) {
+    capture.request = request;
+  }
+};
 
 // A typed `FusorMessages` reference (not an inline arrow). Overload resolution
 // keys on this: a typed reference is non-context-sensitive, so it's checked in
@@ -53,15 +67,25 @@ const slackMessages: FusorMessages<SlackPayload> = ({ payload, respond }) => {
   };
 };
 
-export const makeSlack = (opts: { verifyThrows?: boolean } = {}) =>
+export const makeSlack = (
+  opts: {
+    acceptRawBody?: boolean;
+    captureRequest?: { request?: FusorVerifyRequest };
+    verifyThrows?: boolean;
+  } = {}
+) =>
   definePlatform("slack", {
     config: z.object({}),
     lifecycle: {
       createClient: () =>
         Promise.resolve(
           fusor<SlackPayload>("slack", (req) => {
+            captureVerifyRequest(opts.captureRequest, req);
             if (opts.verifyThrows) {
               throw new Error("bad platform signature");
+            }
+            if (opts.acceptRawBody) {
+              return { kind: "typing" };
             }
             const body = JSON.parse(new TextDecoder().decode(req.rawBody)) as {
               type: string;
@@ -91,9 +115,74 @@ export const makeSlack = (opts: { verifyThrows?: boolean } = {}) =>
     send: () => Promise.resolve(undefined),
   });
 
-// Build the protobuf POST body fusor would deliver: a RawInboundEvent whose
-// rawRequest is the platform's original HTTP/1.1 wire bytes.
+export const FUSOR_WEBHOOK_HEADERS = {
+  "ce-type": "dev.spctrm.fusor.delivery",
+  "content-type": "application/json",
+} as const;
+
+const encodeBase64 = (bytes: Uint8Array): string => {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+};
+
+export interface TestFusorWebhookEnvelope {
+  body: unknown;
+  bodyEncoding: "base64" | "form" | "json" | "text";
+  eventId?: string;
+  headers?: Record<string, string>;
+  method?: string;
+  path?: string;
+  platform: string;
+  rawBody: Uint8Array;
+}
+
+export const encodeFusorEnvelope = (
+  input: TestFusorWebhookEnvelope
+): Uint8Array => {
+  const rawBodyBase64 = encodeBase64(input.rawBody);
+  return new TextEncoder().encode(
+    JSON.stringify({
+      schemaVersion: 1,
+      eventId: input.eventId ?? "evt-1",
+      projectId: "proj",
+      platform: input.platform,
+      receivedAt: "2026-07-19T00:00:00.000Z",
+      sourceId: "source-1",
+      prevSubjectSeq: 0,
+      request: {
+        method: input.method ?? "POST",
+        path: input.path ?? `/${input.platform}`,
+        headers: input.headers ?? { "content-type": "application/json" },
+        bodyEncoding: input.bodyEncoding,
+        body: input.body,
+        rawBodyBase64,
+      },
+    })
+  );
+};
+
+// Build the versioned JSON POST body Fusor delivers. `rawBodyBase64` preserves
+// the provider's exact request body bytes independently from normalized JSON.
 export const encodeEvent = (
+  platform: string,
+  httpBody: string,
+  eventId = "evt-1"
+): Uint8Array => {
+  const rawBody = new TextEncoder().encode(httpBody);
+  return encodeFusorEnvelope({
+    platform,
+    eventId,
+    bodyEncoding: "json",
+    body: JSON.parse(httpBody),
+    rawBody,
+  });
+};
+
+// A pre-v1 protobuf envelope, used to assert the HTTP hard cut rejects it.
+export const encodeLegacyEvent = (
   platform: string,
   httpBody: string,
   eventId = "evt-1"


### PR DESCRIPTION
## Summary

- recognize Fusor HTTP deliveries by `ce-type: dev.spctrm.fusor.delivery`
- validate the additive `schemaVersion: 1` JSON envelope and reject legacy protobuf or invalid payloads with 400
- pass exact decoded `rawBodyBase64` bytes plus method, path, and lowercase headers into the existing Fusor provider pipeline
- keep native Spectrum HMAC verification and WebSocket protobuf handling unchanged
- add Node/Bun core coverage plus Hono, Express, Fastify, and Elysia JSON delivery tests
- document all four body encodings and low-code/signature-aware consumption

## Why

Fusor customer webhook fanout is moving from protobuf to plain JSON so low-code platforms such as n8n can consume it. The SDK must accept the new public contract without reconstructing provider request bytes.

## Impact

This is a hard cut: legacy Fusor protobuf webhook bodies now return 400. Publish this SDK change before deploying the coordinated `photon-hq/fusor` branch `codex/fanout-webhook-json`. Native Spectrum webhooks and Fusor WebSocket events are unchanged. Package versions remain at 11.2.0 in source because the lockstep release workflow owns versioning.

## Validation

- `bun run check`
- `bun run typecheck` — 13 tasks
- `bun run test` — 32/32 Node+Bun tasks
- `bun run build` — 12/12 tasks
- all four framework adapter JSON-delivery tests
- cross-repository binary round-trip audit against the Fusor producer
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787037917&installation_id=127326493&pr_number=205&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F205&signature=6b1a384330c7d85b8286fdd4fa4c16120ab92e030c03e550da75a5aec029c9f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for versioned Fusor webhook envelopes (schema v1) with JSON, form, text, and base64-encoded binary body handling.
  * Fusor requests are now routed by CloudEvents `ce-type`.
  * Provider verification uses the exact original POST bytes plus normalized method/path/headers.

* **Bug Fixes**
  * Malformed/invalid Fusor envelopes are rejected with client-error responses.
  * Improved preservation of empty and canonical base64 bodies, and more reliable repeated-header handling.

* **Documentation**
  * Updated webhook delivery/verification guidance, including how request bodies map to `bodyEncoding`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->