### PR TITLE
refactor(auth): consolidate token renewal scheduling

### DIFF
--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -78,3 +78,8 @@ export {
   resumableOrderedStream,
 } from "./utils/resumable-stream";
 export { errorAttrs } from "./utils/telemetry";
+export {
+  createTokenRenewal,
+  type TokenRenewal,
+  type TokenRenewalOptions,
+} from "./utils/token-renewal";

--- a/packages/core/src/fusor/auth.ts
+++ b/packages/core/src/fusor/auth.ts
@@ -1,12 +1,5 @@
-import { createLogger } from "@photon-ai/otel";
 import { cloud } from "../utils/cloud";
-import { errorAttrs } from "../utils/telemetry";
-
-const log = createLogger("spectrum.fusor.auth");
-
-const RENEWAL_RATIO = 0.8;
-const EXPIRY_BUFFER_MS = 30_000;
-const RETRY_DELAY_MS = 30_000;
+import { createTokenRenewal } from "../utils/token-renewal";
 
 export interface FusorTokenProvider {
   dispose(): Promise<void>;
@@ -25,104 +18,24 @@ export function createFusorTokenProvider(
 ): Promise<FusorTokenProvider> {
   return (async () => {
     let tokenData = await cloud.issueFusorToken(projectId, projectSecret);
-    let tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
-    let disposed = false;
-    let renewalTimer: ReturnType<typeof setTimeout> | undefined;
-    let refreshFailures = 0;
-
-    const clearRenewalTimer = () => {
-      if (renewalTimer !== undefined) {
-        clearTimeout(renewalTimer);
-        renewalTimer = undefined;
-      }
-    };
-
-    const refresh = async (): Promise<void> => {
-      tokenData = await cloud.issueFusorToken(projectId, projectSecret);
-      tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
-    };
-
-    const onRefreshSuccess = () => {
-      if (refreshFailures > 0) {
-        log.info("fusor token refresh recovered", {
-          "spectrum.fusor.auth.attempt": refreshFailures,
-        });
-        refreshFailures = 0;
-      }
-    };
-
-    const onRefreshFailure = (error: unknown) => {
-      refreshFailures += 1;
-      log.warn(
-        "fusor token refresh failed; retrying",
-        {
-          "spectrum.fusor.auth.attempt": refreshFailures,
-          "spectrum.fusor.auth.retry_in_ms": RETRY_DELAY_MS,
-          ...errorAttrs(error),
-        },
-        error
-      );
-    };
-
-    const scheduleRetry = () => {
-      if (disposed) {
-        return;
-      }
-      clearRenewalTimer();
-      renewalTimer = setTimeout(async () => {
-        if (disposed) {
-          return;
-        }
-        try {
-          await refresh();
-          onRefreshSuccess();
-          scheduleRenewal();
-        } catch (retryErr) {
-          onRefreshFailure(retryErr);
-          scheduleRetry();
-        }
-      }, RETRY_DELAY_MS);
-      renewalTimer?.unref?.();
-    };
-
-    const scheduleRenewal = () => {
-      if (disposed) {
-        return;
-      }
-      clearRenewalTimer();
-      const ttlMs = tokenData.expiresIn * 1000;
-      const renewInMs = Math.max(ttlMs * RENEWAL_RATIO, 5000);
-
-      renewalTimer = setTimeout(async () => {
-        try {
-          await refresh();
-          onRefreshSuccess();
-          scheduleRenewal();
-        } catch (err) {
-          onRefreshFailure(err);
-          scheduleRetry();
-        }
-      }, renewInMs);
-      renewalTimer?.unref?.();
-    };
-
-    scheduleRenewal();
+    const renewal = createTokenRenewal({
+      expiresInSeconds: () => tokenData.expiresIn,
+      name: "fusor",
+      refresh: async () => {
+        tokenData = await cloud.issueFusorToken(projectId, projectSecret);
+      },
+    });
 
     return {
       async getToken(): Promise<string> {
-        if (Date.now() >= tokenExpiresAt - EXPIRY_BUFFER_MS) {
-          await refresh();
-          onRefreshSuccess();
-          scheduleRenewal();
-        }
+        await renewal.refreshIfNeeded();
         return tokenData.token;
       },
       invalidate(): void {
-        tokenExpiresAt = 0;
+        renewal.invalidate();
       },
       async dispose(): Promise<void> {
-        disposed = true;
-        clearRenewalTimer();
+        renewal.dispose();
       },
     };
   })();

--- a/packages/core/src/utils/token-renewal.ts
+++ b/packages/core/src/utils/token-renewal.ts
@@ -1,0 +1,121 @@
+import { createLogger } from "@photon-ai/otel";
+import { errorAttrs } from "./telemetry";
+
+const RENEWAL_RATIO = 0.8;
+const EXPIRY_BUFFER_MS = 30_000;
+const MIN_RENEWAL_DELAY_MS = 5000;
+const RETRY_DELAY_MS = 30_000;
+
+export interface TokenRenewal {
+  dispose(): void;
+  forceRefresh(): Promise<void>;
+  invalidate(): void;
+  refreshIfNeeded(): Promise<void>;
+}
+
+export interface TokenRenewalOptions {
+  expiresInSeconds(): number;
+  name: string;
+  refresh(): Promise<void>;
+}
+
+export const createTokenRenewal = (
+  options: TokenRenewalOptions
+): TokenRenewal => {
+  const telemetryPrefix = `spectrum.${options.name}.auth`;
+  const log = createLogger(telemetryPrefix);
+  let disposed = false;
+  let refreshFailures = 0;
+  let refreshInFlight: Promise<void> | undefined;
+  let renewalTimer: ReturnType<typeof setTimeout> | undefined;
+  let tokenExpiresAt = Date.now() + options.expiresInSeconds() * 1000;
+
+  const clearRenewalTimer = (): void => {
+    if (renewalTimer !== undefined) {
+      clearTimeout(renewalTimer);
+      renewalTimer = undefined;
+    }
+  };
+
+  const onRefreshSuccess = (): void => {
+    if (refreshFailures > 0) {
+      log.info(`${options.name} token refresh recovered`, {
+        [`${telemetryPrefix}.attempt`]: refreshFailures,
+      });
+      refreshFailures = 0;
+    }
+  };
+
+  const onRefreshFailure = (error: unknown): void => {
+    refreshFailures += 1;
+    log.warn(
+      `${options.name} token refresh failed; retrying`,
+      {
+        [`${telemetryPrefix}.attempt`]: refreshFailures,
+        [`${telemetryPrefix}.retry_in_ms`]: RETRY_DELAY_MS,
+        ...errorAttrs(error),
+      },
+      error
+    );
+  };
+
+  const refreshNow = async (): Promise<void> => {
+    await options.refresh();
+    tokenExpiresAt = Date.now() + options.expiresInSeconds() * 1000;
+    onRefreshSuccess();
+    scheduleRenewal();
+  };
+
+  const coalescedRefresh = (): Promise<void> => {
+    if (!refreshInFlight) {
+      refreshInFlight = refreshNow().finally(() => {
+        refreshInFlight = undefined;
+      });
+    }
+    return refreshInFlight;
+  };
+
+  const runScheduledRefresh = (): void => {
+    if (disposed) {
+      return;
+    }
+    coalescedRefresh().catch((error) => {
+      onRefreshFailure(error);
+      if (disposed) {
+        return;
+      }
+      renewalTimer = setTimeout(runScheduledRefresh, RETRY_DELAY_MS);
+      renewalTimer?.unref?.();
+    });
+  };
+
+  const scheduleRenewal = (): void => {
+    if (disposed) {
+      return;
+    }
+    clearRenewalTimer();
+    const ttlMs = options.expiresInSeconds() * 1000;
+    const renewInMs = Math.max(ttlMs * RENEWAL_RATIO, MIN_RENEWAL_DELAY_MS);
+    renewalTimer = setTimeout(runScheduledRefresh, renewInMs);
+    renewalTimer?.unref?.();
+  };
+
+  scheduleRenewal();
+
+  return {
+    dispose(): void {
+      disposed = true;
+      clearRenewalTimer();
+    },
+    forceRefresh: coalescedRefresh,
+    invalidate(): void {
+      tokenExpiresAt = 0;
+    },
+    async refreshIfNeeded(): Promise<void> {
+      if (Date.now() < tokenExpiresAt - EXPIRY_BUFFER_MS) {
+        return;
+      }
+      await coalescedRefresh();
+    },
+  };
+};

--- a/packages/core/test/utils/token-renewal.test.ts
+++ b/packages/core/test/utils/token-renewal.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTokenRenewal } from "@/utils/token-renewal";
+
+describe("createTokenRenewal", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renews at 80% of the TTL and reschedules from the refreshed TTL", async () => {
+    vi.useFakeTimers();
+    let expiresInSeconds = 10;
+    const refresh = vi.fn(async () => {
+      expiresInSeconds = 20;
+    });
+    const renewal = createTokenRenewal({
+      expiresInSeconds: () => expiresInSeconds,
+      name: "test",
+      refresh,
+    });
+
+    await vi.advanceTimersByTimeAsync(7999);
+    expect(refresh).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(15_999);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(2);
+    renewal.dispose();
+  });
+
+  it("uses a five-second minimum renewal delay", async () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn(() => Promise.resolve());
+    const renewal = createTokenRenewal({
+      expiresInSeconds: () => 1,
+      name: "test",
+      refresh,
+    });
+
+    await vi.advanceTimersByTimeAsync(4999);
+    expect(refresh).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    renewal.dispose();
+  });
+
+  it("refreshes inside the expiry buffer and coalesces concurrent callers", async () => {
+    vi.useFakeTimers();
+    let resolveRefresh: (() => void) | undefined;
+    const refresh = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+    const renewal = createTokenRenewal({
+      expiresInSeconds: () => 60,
+      name: "test",
+      refresh,
+    });
+
+    await vi.advanceTimersByTimeAsync(29_999);
+    await renewal.refreshIfNeeded();
+    expect(refresh).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    const first = renewal.refreshIfNeeded();
+    const second = renewal.refreshIfNeeded();
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    resolveRefresh?.();
+    await Promise.all([first, second]);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    renewal.dispose();
+  });
+
+  it("supports invalidation and unconditional refresh", async () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn(() => Promise.resolve());
+    const renewal = createTokenRenewal({
+      expiresInSeconds: () => 3600,
+      name: "test",
+      refresh,
+    });
+
+    renewal.invalidate();
+    await renewal.refreshIfNeeded();
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    await renewal.forceRefresh();
+    expect(refresh).toHaveBeenCalledTimes(2);
+    renewal.dispose();
+  });
+
+  it("coalesces a forced refresh with the scheduled renewal", async () => {
+    vi.useFakeTimers();
+    let resolveRefresh: (() => void) | undefined;
+    const refresh = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+    const renewal = createTokenRenewal({
+      expiresInSeconds: () => 10,
+      name: "test",
+      refresh,
+    });
+
+    await vi.advanceTimersByTimeAsync(7999);
+    const forced = renewal.forceRefresh();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    resolveRefresh?.();
+    await forced;
+    expect(refresh).toHaveBeenCalledTimes(1);
+    renewal.dispose();
+  });
+
+  it("retries a failed scheduled refresh after 30 seconds", async () => {
+    vi.useFakeTimers();
+    const refresh = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("refresh failed"))
+      .mockResolvedValue(undefined);
+    const renewal = createTokenRenewal({
+      expiresInSeconds: () => 10,
+      name: "test",
+      refresh,
+    });
+
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(29_999);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(2);
+    renewal.dispose();
+  });
+
+  it("allows an on-demand refresh to be retried after rejection", async () => {
+    vi.useFakeTimers();
+    const refresh = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error("refresh failed"))
+      .mockResolvedValue(undefined);
+    const renewal = createTokenRenewal({
+      expiresInSeconds: () => 60,
+      name: "test",
+      refresh,
+    });
+
+    renewal.invalidate();
+    await expect(renewal.refreshIfNeeded()).rejects.toThrow("refresh failed");
+    await renewal.refreshIfNeeded();
+    expect(refresh).toHaveBeenCalledTimes(2);
+    renewal.dispose();
+  });
+
+  it("cancels a pending renewal timer", async () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn(() => Promise.resolve());
+    const renewal = createTokenRenewal({
+      expiresInSeconds: () => 10,
+      name: "test",
+      refresh,
+    });
+
+    renewal.dispose();
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("does not rearm after an in-flight refresh settles", async () => {
+    vi.useFakeTimers();
+    let resolveRefresh: (() => void) | undefined;
+    const refresh = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+    const renewal = createTokenRenewal({
+      expiresInSeconds: () => 10,
+      name: "test",
+      refresh,
+    });
+
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    renewal.dispose();
+    resolveRefresh?.();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -4,14 +4,9 @@ import {
   type DedicatedTokenData,
   type SharedTokenData,
 } from "@spectrum-ts/core";
-import { createLogger, errorAttrs } from "@spectrum-ts/core/authoring";
+import { createTokenRenewal } from "@spectrum-ts/core/authoring";
 import { type RemoteClient, SHARED_PHONE } from "./types";
 
-const log = createLogger("spectrum.imessage.auth");
-
-const RENEWAL_RATIO = 0.8;
-const EXPIRY_BUFFER_MS = 30_000;
-const RETRY_DELAY_MS = 30_000;
 // Floor between forced re-mints so a stream reconnect storm can't hammer the
 // cloud token endpoint — well below any token TTL, just enough to coalesce the
 // message + poll streams asking at nearly the same instant.
@@ -37,11 +32,6 @@ export async function createCloudClients(
   projectSecret: string
 ): Promise<RemoteClient[]> {
   let tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
-  let tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
-  let disposed = false;
-  let renewalTimer: ReturnType<typeof setTimeout> | undefined;
-  let refreshFailures = 0;
-  let refreshInFlight: Promise<void> | undefined;
   let lastRefreshAt = Date.now();
 
   // The instanceId stays paired with each entry in this closure so renewal
@@ -55,90 +45,17 @@ export async function createCloudClients(
     }
   };
 
-  const onRefreshSuccess = () => {
-    if (refreshFailures > 0) {
-      log.info("imessage token refresh recovered", {
-        "spectrum.imessage.auth.attempt": refreshFailures,
-      });
-      refreshFailures = 0;
-    }
-  };
-
-  const onRefreshFailure = (error: unknown) => {
-    refreshFailures += 1;
-    log.warn(
-      "imessage token refresh failed; retrying",
-      {
-        "spectrum.imessage.auth.attempt": refreshFailures,
-        "spectrum.imessage.auth.retry_in_ms": RETRY_DELAY_MS,
-        ...errorAttrs(error),
-      },
-      error
-    );
-  };
-
-  const refreshNow = async (): Promise<void> => {
-    tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
-    tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
-    lastRefreshAt = Date.now();
-    if (tokenData.type === "dedicated") {
-      syncPhones(tokenData);
-    }
-    onRefreshSuccess();
-    scheduleRenewal();
-  };
-
-  // Coalesce concurrent re-mints: the message + poll streams and the renewal
-  // timer can all ask at once, but only one issueImessageTokens call should run.
-  const coalescedRefresh = (): Promise<void> => {
-    if (!refreshInFlight) {
-      refreshInFlight = refreshNow().finally(() => {
-        refreshInFlight = undefined;
-      });
-    }
-    return refreshInFlight;
-  };
-
-  const scheduleRenewal = () => {
-    if (disposed) {
-      return;
-    }
-    // Clear any prior timer first — refreshNow()/forceRefresh() can re-arm the
-    // schedule, and leaving the old timer running would leak overlapping renewals.
-    if (renewalTimer !== undefined) {
-      clearTimeout(renewalTimer);
-      renewalTimer = undefined;
-    }
-    const ttlMs = tokenData.expiresIn * 1000;
-    const renewInMs = Math.max(ttlMs * RENEWAL_RATIO, 5000);
-
-    const runScheduledRefresh = () => {
-      coalescedRefresh().catch((error) => {
-        onRefreshFailure(error);
-        if (disposed) {
-          return;
-        }
-        // Retry the refresh itself after RETRY_DELAY_MS. Re-running
-        // scheduleRenewal would instead wait another full renewal window (80%
-        // of TTL), leaving the token stale/expired during an outage. On
-        // success, refreshNow() re-arms the next renewal.
-        renewalTimer = setTimeout(runScheduledRefresh, RETRY_DELAY_MS);
-        renewalTimer?.unref?.();
-      });
-    };
-
-    renewalTimer = setTimeout(runScheduledRefresh, renewInMs);
-    renewalTimer?.unref?.();
-  };
-
-  scheduleRenewal();
-
-  const refreshIfNeeded = async (): Promise<void> => {
-    if (Date.now() < tokenExpiresAt - EXPIRY_BUFFER_MS) {
-      return;
-    }
-    await coalescedRefresh();
-  };
+  const renewal = createTokenRenewal({
+    expiresInSeconds: () => tokenData.expiresIn,
+    name: "imessage",
+    refresh: async () => {
+      tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
+      lastRefreshAt = Date.now();
+      if (tokenData.type === "dedicated") {
+        syncPhones(tokenData);
+      }
+    },
+  });
 
   // Re-mint unconditionally — wired to the stream recover hook so a token the
   // server rejects after a restart (UNAUTHENTICATED / "Invalid credentials",
@@ -148,17 +65,10 @@ export async function createCloudClients(
     if (Date.now() - lastRefreshAt < FORCE_REFRESH_MIN_INTERVAL_MS) {
       return;
     }
-    await coalescedRefresh();
+    await renewal.forceRefresh();
   };
 
-  const dispose = () => {
-    disposed = true;
-    if (renewalTimer !== undefined) {
-      clearTimeout(renewalTimer);
-      renewalTimer = undefined;
-    }
-  };
-  const cloudAuth: CloudAuth = { dispose, forceRefresh };
+  const cloudAuth: CloudAuth = { dispose: renewal.dispose, forceRefresh };
 
   if (tokenData.type === "shared") {
     const address =
@@ -177,7 +87,7 @@ export async function createCloudClients(
           retry: true,
           tls: true,
           token: async () => {
-            await refreshIfNeeded();
+            await renewal.refreshIfNeeded();
             return (tokenData as SharedTokenData).token;
           },
         }),
@@ -199,7 +109,7 @@ export async function createCloudClients(
         retry: true,
         tls: true,
         token: async () => {
-          await refreshIfNeeded();
+          await renewal.refreshIfNeeded();
           const data = tokenData as DedicatedTokenData;
           return data.auth[instanceId] ?? token;
         },

--- a/packages/imessage/test/auth.test.ts
+++ b/packages/imessage/test/auth.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FakeDedicatedTokenData {
+  auth: Record<string, string>;
+  expiresIn: number;
+  numbers: Record<string, string | null>;
+  type: "dedicated";
+}
+
+interface FakeClientOptions {
+  token: () => Promise<string>;
+}
+
+const initialTokenData: FakeDedicatedTokenData = {
+  auth: { "instance-1": "token-1" },
+  expiresIn: 3600,
+  numbers: { "instance-1": "+15550000001" },
+  type: "dedicated",
+};
+
+const issueImessageTokens = vi.fn(() => Promise.resolve(initialTokenData));
+const clientOptions: FakeClientOptions[] = [];
+const createClient = vi.fn((options: FakeClientOptions) => {
+  clientOptions.push(options);
+  return {};
+});
+
+vi.doMock("@spectrum-ts/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@spectrum-ts/core")>();
+  return {
+    ...actual,
+    cloud: { ...actual.cloud, issueImessageTokens },
+  };
+});
+
+vi.doMock("@photon-ai/advanced-imessage", () => ({ createClient }));
+
+const { createCloudClients, disposeCloudAuth, getCloudRecover } = await import(
+  "@/auth"
+);
+
+describe("imessage cloud auth", () => {
+  beforeEach(() => {
+    issueImessageTokens.mockReset();
+    issueImessageTokens.mockResolvedValue(initialTokenData);
+    createClient.mockClear();
+    clientOptions.length = 0;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("coalesces forced recovery and updates dedicated clients in place", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    let resolveRefresh:
+      | ((
+          value: FakeDedicatedTokenData | PromiseLike<FakeDedicatedTokenData>
+        ) => void)
+      | undefined;
+    issueImessageTokens.mockResolvedValueOnce(initialTokenData);
+    issueImessageTokens.mockImplementationOnce(
+      () =>
+        new Promise<FakeDedicatedTokenData>((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+
+    const clients = await createCloudClients("project-1", "secret-1");
+    const recover = getCloudRecover(clients);
+    if (!recover) {
+      throw new Error("expected cloud recovery hook");
+    }
+
+    await vi.advanceTimersByTimeAsync(5000);
+    const first = recover();
+    const second = recover();
+    expect(issueImessageTokens).toHaveBeenCalledTimes(2);
+
+    resolveRefresh?.({
+      auth: { "instance-1": "token-2" },
+      expiresIn: 3600,
+      numbers: { "instance-1": "+15550000002" },
+      type: "dedicated",
+    });
+    await Promise.all([first, second]);
+
+    expect(issueImessageTokens).toHaveBeenCalledTimes(2);
+    expect(clients[0]?.phone).toBe("+15550000002");
+    expect(await clientOptions[0]?.token()).toBe("token-2");
+
+    await disposeCloudAuth(clients);
+    expect(getCloudRecover(clients)).toBeUndefined();
+  });
+});

--- a/packages/slack/src/auth.ts
+++ b/packages/slack/src/auth.ts
@@ -5,13 +5,7 @@ import {
   type TokenProvider,
 } from "@photon-ai/slack";
 import { cloud, type SlackTokenData } from "@spectrum-ts/core";
-import { createLogger, errorAttrs } from "@spectrum-ts/core/authoring";
-
-const log = createLogger("spectrum.slack.auth");
-
-const RENEWAL_RATIO = 0.8;
-const EXPIRY_BUFFER_MS = 30_000;
-const RETRY_DELAY_MS = 30_000;
+import { createTokenRenewal } from "@spectrum-ts/core/authoring";
 
 interface CloudAuth {
   dispose: () => Promise<void>;
@@ -44,101 +38,17 @@ export async function createCloudClients(
   endpoint: string | undefined
 ): Promise<SlackClient> {
   let tokenData = await cloud.issueSlackTokens(projectId, projectSecret);
-  let tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
-  let disposed = false;
-  let renewalTimer: ReturnType<typeof setTimeout> | undefined;
-  let refreshFailures = 0;
-
-  const clearRenewalTimer = () => {
-    if (renewalTimer !== undefined) {
-      clearTimeout(renewalTimer);
-      renewalTimer = undefined;
-    }
-  };
-
-  const refreshTokens = async (): Promise<void> => {
-    tokenData = await cloud.issueSlackTokens(projectId, projectSecret);
-    tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
-  };
-
-  const onRefreshSuccess = () => {
-    if (refreshFailures > 0) {
-      log.info("slack token refresh recovered", {
-        "spectrum.slack.auth.attempt": refreshFailures,
-      });
-      refreshFailures = 0;
-    }
-  };
-
-  const onRefreshFailure = (error: unknown) => {
-    refreshFailures += 1;
-    log.warn(
-      "slack token refresh failed; retrying",
-      {
-        "spectrum.slack.auth.attempt": refreshFailures,
-        "spectrum.slack.auth.retry_in_ms": RETRY_DELAY_MS,
-        ...errorAttrs(error),
-      },
-      error
-    );
-  };
-
-  const scheduleRetry = () => {
-    if (disposed) {
-      return;
-    }
-    clearRenewalTimer();
-    renewalTimer = setTimeout(async () => {
-      if (disposed) {
-        return;
-      }
-      try {
-        await refreshTokens();
-        onRefreshSuccess();
-        scheduleRenewal();
-      } catch (retryErr) {
-        onRefreshFailure(retryErr);
-        scheduleRetry();
-      }
-    }, RETRY_DELAY_MS);
-    renewalTimer?.unref?.();
-  };
-
-  const scheduleRenewal = () => {
-    if (disposed) {
-      return;
-    }
-    clearRenewalTimer();
-    const ttlMs = tokenData.expiresIn * 1000;
-    const renewInMs = Math.max(ttlMs * RENEWAL_RATIO, 5000);
-
-    renewalTimer = setTimeout(async () => {
-      try {
-        await refreshTokens();
-        onRefreshSuccess();
-        scheduleRenewal();
-      } catch (err) {
-        onRefreshFailure(err);
-        scheduleRetry();
-      }
-    }, renewInMs);
-    renewalTimer?.unref?.();
-  };
-
-  const refreshIfNeeded = async (): Promise<void> => {
-    if (Date.now() < tokenExpiresAt - EXPIRY_BUFFER_MS) {
-      return;
-    }
-    await refreshTokens();
-    onRefreshSuccess();
-    scheduleRenewal();
-  };
-
-  scheduleRenewal();
+  const renewal = createTokenRenewal({
+    expiresInSeconds: () => tokenData.expiresIn,
+    name: "slack",
+    refresh: async () => {
+      tokenData = await cloud.issueSlackTokens(projectId, projectSecret);
+    },
+  });
 
   const tokenProvider: TokenProvider = {
     async getAccessToken(teamId: string): Promise<string> {
-      await refreshIfNeeded();
+      await renewal.refreshIfNeeded();
       const token = tokenData.auth[teamId];
       if (!token) {
         throw new Error(
@@ -151,10 +61,10 @@ export async function createCloudClients(
       // Force the next `getAccessToken` to refetch by pulling expiry forward.
       // slack-ts's auth middleware calls this on UNAUTHENTICATED — clearing
       // the deadline is enough; the next call awaits refresh before stamping.
-      tokenExpiresAt = 0;
+      renewal.invalidate();
     },
     async listTeams() {
-      await refreshIfNeeded();
+      await renewal.refreshIfNeeded();
       const entries: [string, TeamMetadata][] = Object.entries(
         tokenData.teams
       ).map(([teamId, meta]) => [teamId, toTeamMetadata(meta)]);
@@ -169,8 +79,7 @@ export async function createCloudClients(
 
   cloudAuthState.set(client, {
     dispose: async () => {
-      disposed = true;
-      clearRenewalTimer();
+      renewal.dispose();
     },
   });
 

--- a/packages/slack/test/auth.test.ts
+++ b/packages/slack/test/auth.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FakeTeamMetadata {
+  appId: string;
+  botUserId: string;
+  grantedScopes: string[];
+  teamName: string;
+}
+
+interface FakeTokenData {
+  auth: Record<string, string>;
+  expiresIn: number;
+  teams: Record<string, FakeTeamMetadata>;
+}
+
+interface FakeTokenProvider {
+  getAccessToken(teamId: string): Promise<string>;
+  invalidate(teamId: string): void;
+  listTeams(): Promise<Map<string, FakeTeamMetadata>>;
+}
+
+const initialTokenData: FakeTokenData = {
+  auth: { "team-1": "token-1" },
+  expiresIn: 3600,
+  teams: {
+    "team-1": {
+      appId: "app-1",
+      botUserId: "bot-1",
+      grantedScopes: ["chat:write"],
+      teamName: "First team",
+    },
+  },
+};
+
+const issueSlackTokens = vi.fn(() => Promise.resolve(initialTokenData));
+let tokenProvider: FakeTokenProvider | undefined;
+
+const createClient = vi.fn((options: { tokenProvider: FakeTokenProvider }) => {
+  tokenProvider = options.tokenProvider;
+  return {};
+});
+
+vi.doMock("@spectrum-ts/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@spectrum-ts/core")>();
+  return {
+    ...actual,
+    cloud: { ...actual.cloud, issueSlackTokens },
+  };
+});
+
+vi.doMock("@photon-ai/slack", () => ({ createClient }));
+
+const { createCloudClients, disposeCloudAuth } = await import("@/auth");
+
+describe("slack cloud auth", () => {
+  beforeEach(() => {
+    issueSlackTokens.mockReset();
+    issueSlackTokens.mockResolvedValue(initialTokenData);
+    createClient.mockClear();
+    tokenProvider = undefined;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("coalesces invalidated token and team metadata refreshes", async () => {
+    vi.useFakeTimers();
+    let resolveRefresh:
+      | ((value: FakeTokenData | PromiseLike<FakeTokenData>) => void)
+      | undefined;
+    issueSlackTokens.mockResolvedValueOnce(initialTokenData);
+    issueSlackTokens.mockImplementationOnce(
+      () =>
+        new Promise<FakeTokenData>((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+
+    const client = await createCloudClients("project-1", "secret-1", undefined);
+    const provider = tokenProvider;
+    if (!provider) {
+      throw new Error("expected Slack token provider");
+    }
+
+    provider.invalidate("team-1");
+    const accessToken = provider.getAccessToken("team-1");
+    const teams = provider.listTeams();
+    expect(issueSlackTokens).toHaveBeenCalledTimes(2);
+
+    resolveRefresh?.({
+      auth: { "team-1": "token-2" },
+      expiresIn: 3600,
+      teams: {
+        "team-1": {
+          appId: "app-2",
+          botUserId: "bot-2",
+          grantedScopes: ["chat:write", "reactions:write"],
+          teamName: "Updated team",
+        },
+      },
+    });
+
+    expect(await accessToken).toBe("token-2");
+    expect((await teams).get("team-1")?.teamName).toBe("Updated team");
+    expect(issueSlackTokens).toHaveBeenCalledTimes(2);
+    await disposeCloudAuth(client);
+  });
+});

--- a/packages/whatsapp-business/src/auth.ts
+++ b/packages/whatsapp-business/src/auth.ts
@@ -6,14 +6,14 @@ import {
   type WhatsAppEvent,
 } from "@photon-ai/whatsapp-business";
 import { cloud, stream } from "@spectrum-ts/core";
-import { createLogger, errorAttrs } from "@spectrum-ts/core/authoring";
+import {
+  createLogger,
+  createTokenRenewal,
+  errorAttrs,
+} from "@spectrum-ts/core/authoring";
 
-const log = createLogger("spectrum.whatsapp.auth");
 const streamLog = createLogger("spectrum.whatsapp.stream");
 
-const RENEWAL_RATIO = 0.8;
-const EXPIRY_BUFFER_MS = 30_000;
-const RETRY_DELAY_MS = 30_000;
 const RESUBSCRIBE_BACKOFF_MS = 500;
 
 const ignoreCleanupError = () => undefined;
@@ -45,11 +45,6 @@ export async function createCloudClients(
     projectId,
     projectSecret
   );
-  let tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
-  let disposed = false;
-  let renewalTimer: ReturnType<typeof setTimeout> | undefined;
-  let refreshFailures = 0;
-  let refreshInFlight: Promise<void> | undefined;
 
   const lines = new Map<string, LineState>();
 
@@ -68,7 +63,6 @@ export async function createCloudClients(
       projectId,
       projectSecret
     );
-    tokenExpiresAt = Date.now() + tokenData.expiresIn * 1000;
 
     for (const [phoneNumberId, state] of lines) {
       if (!tokenData.auth[phoneNumberId]) {
@@ -83,81 +77,11 @@ export async function createCloudClients(
     }
   };
 
-  const onRefreshSuccess = () => {
-    if (refreshFailures > 0) {
-      log.info("whatsapp token refresh recovered", {
-        "spectrum.whatsapp.auth.attempt": refreshFailures,
-      });
-      refreshFailures = 0;
-    }
-  };
-
-  const onRefreshFailure = (error: unknown) => {
-    refreshFailures += 1;
-    log.warn(
-      "whatsapp token refresh failed; retrying",
-      {
-        "spectrum.whatsapp.auth.attempt": refreshFailures,
-        "spectrum.whatsapp.auth.retry_in_ms": RETRY_DELAY_MS,
-        ...errorAttrs(error),
-      },
-      error
-    );
-  };
-
-  const clearRenewalTimer = () => {
-    if (renewalTimer !== undefined) {
-      clearTimeout(renewalTimer);
-      renewalTimer = undefined;
-    }
-  };
-
-  const refreshNow = async (): Promise<void> => {
-    await refreshTokens();
-    onRefreshSuccess();
-    scheduleRenewal();
-  };
-
-  const coalescedRefresh = (): Promise<void> => {
-    if (!refreshInFlight) {
-      refreshInFlight = refreshNow().finally(() => {
-        refreshInFlight = undefined;
-      });
-    }
-    return refreshInFlight;
-  };
-
-  const scheduleRenewal = () => {
-    if (disposed) {
-      return;
-    }
-    clearRenewalTimer();
-    const ttlMs = tokenData.expiresIn * 1000;
-    const renewInMs = Math.max(ttlMs * RENEWAL_RATIO, 5000);
-
-    const runScheduledRefresh = () => {
-      coalescedRefresh().catch((err) => {
-        onRefreshFailure(err);
-        if (disposed) {
-          return;
-        }
-        renewalTimer = setTimeout(runScheduledRefresh, RETRY_DELAY_MS);
-        renewalTimer?.unref?.();
-      });
-    };
-
-    renewalTimer = setTimeout(runScheduledRefresh, renewInMs);
-    renewalTimer?.unref?.();
-  };
-
-  const refreshIfNeeded = async (): Promise<void> => {
-    if (Date.now() < tokenExpiresAt - EXPIRY_BUFFER_MS) {
-      return;
-    }
-    await coalescedRefresh();
-  };
-
-  scheduleRenewal();
+  const renewal = createTokenRenewal({
+    expiresInSeconds: () => tokenData.expiresIn,
+    name: "whatsapp",
+    refresh: refreshTokens,
+  });
 
   const clients: WhatsAppClient[] = Object.keys(tokenData.auth).map(
     (phoneNumberId) => {
@@ -166,14 +90,13 @@ export async function createCloudClients(
         subscriptions: new Set(),
       };
       lines.set(phoneNumberId, state);
-      return buildClientProxy(state, refreshIfNeeded);
+      return buildClientProxy(state, renewal.refreshIfNeeded);
     }
   );
 
   cloudAuthState.set(clients, {
     dispose: async () => {
-      disposed = true;
-      clearRenewalTimer();
+      renewal.dispose();
       for (const state of lines.values()) {
         for (const sub of state.subscriptions) {
           sub.close();


### PR DESCRIPTION
## Summary

* extract the duplicated token-renewal scheduler into a shared `createTokenRenewal` helper in core
* migrate Fusor, iMessage, Slack, and WhatsApp Business to small provider-specific adapters
* coalesce concurrent refresh requests while preserving separate renewal state and timers for every provider instance
* preserve provider-specific behavior, including iMessage forced-recovery throttling and WhatsApp line resubscription
* centralize renewal timing, retry handling, telemetry, invalidation, and disposal behavior

## Testing

* added focused coverage for renewal scheduling, expiry buffering, invalidation, refresh coalescing, retry timing, and disposal
* added adapter coverage for iMessage forced recovery and Slack invalidation
* verified the full repository with:
  * `bun run check`
  * `bun run typecheck`
  * `bun run test`
  * `bun run build`

Closes photon-hq/spectrum-ts#206

---

![View with Codesmith](https://camo.githubusercontent.com/6e22944985996f6a1201f1d35788e9dc855f2e6b7b781e7ed1c22d7fb14217e8/68747470733a2f2f70722d636f6d6d656e74732d6173736574732e626c61636b736d6974682e73682f636f6465736d6974682f766965772d776974682d636f6465736d6974682d6461726b2d76322e737667) ![Autofix with Codesmith](https://camo.githubusercontent.com/8e7d836069a9e09b18eb0f68d9afc9beb6c2b13211745830b36a5d88a500d653/68747470733a2f2f70722d636f6d6d656e74732d6173736574732e626c61636b736d6974682e73682f636f6465736d6974682f6175746f6669782d776974682d636f6465736d6974682d6461726b2e737667) Need help on this PR? Tag `/codesmith` with what you need. Autofix is disabled.

## Summary by CodeRabbit

* **Improvements**
  * Added consistent automatic access-token renewal across Fusor, iMessage, Slack, and WhatsApp Business integrations.
  * Tokens now refresh proactively before expiration, retry after temporary failures, and avoid duplicate refresh requests.
  * Improved recovery when credentials are invalidated or expire during active client sessions.
  * Authentication cleanup now reliably stops renewal activity when clients are disposed.
* **Tests**
  * Added coverage for scheduled renewal, retries, forced refreshes, invalidation, concurrent requests, and cleanup behavior.