### PR TITLE
fix(core): reject duplicate platform names before initialization

### DIFF
--- a/docs/providers/imessage.mdx.vel
+++ b/docs/providers/imessage.mdx.vel
@@ -14,8 +14,8 @@ environments.
 
 <Warning>
   Choose one iMessage package per `Spectrum()` instance. Both packages register
-  the `"iMessage"` platform, so registering both would create an ambiguous
-  platform configuration.
+  the `"iMessage"` platform, so `Spectrum()` rejects an instance that registers
+  both.
 </Warning>
 
 ## Cloud quick start

--- a/packages/core/src/platform/unique-names.ts
+++ b/packages/core/src/platform/unique-names.ts
@@ -1,0 +1,17 @@
+import type { PlatformProviderConfig } from "./types";
+
+export const assertUniquePlatformNames = (
+  providers: readonly PlatformProviderConfig[]
+): void => {
+  const names = new Set<string>();
+
+  for (const provider of providers) {
+    const name = provider.__definition.name;
+    if (names.has(name)) {
+      throw new Error(
+        `Spectrum received multiple providers for platform "${name}". Register exactly one provider per platform.`
+      );
+    }
+    names.add(name);
+  }
+};

--- a/packages/core/src/spectrum.ts
+++ b/packages/core/src/spectrum.ts
@@ -31,6 +31,7 @@ import type {
   PlatformRuntime,
   SpectrumLike,
 } from "./platform/types";
+import { assertUniquePlatformNames } from "./platform/unique-names";
 import type { Message } from "./types/message";
 import type { Space } from "./types/space";
 import type { AgentSender } from "./types/user";
@@ -292,6 +293,7 @@ export async function Spectrum<
 ): Promise<SpectrumInstance<Providers>> {
   const { projectId, projectSecret } = resolveProjectCredentials(options);
   spectrumConfigSchema.parse({ ...options, projectId, projectSecret });
+  assertUniquePlatformNames(options.providers);
 
   const {
     options: runtimeOptions,

--- a/packages/core/test/core/spectrum.unique-platform-names.test.ts
+++ b/packages/core/test/core/spectrum.unique-platform-names.test.ts
@@ -1,0 +1,41 @@
+import { stubCloud } from "@spectrum-ts/test-support/cloud";
+import {
+  baseConfig,
+  makeManagedProvider,
+} from "@spectrum-ts/test-support/platform";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Spectrum } from "@/spectrum";
+
+const getProject = stubCloud();
+
+describe("Spectrum() platform name uniqueness", () => {
+  beforeEach(() => {
+    getProject.mockClear();
+  });
+
+  it("rejects duplicate platform names before initialization", async () => {
+    const first = makeManagedProvider("iMessage").config({});
+    const second = makeManagedProvider("iMessage").config({});
+    const firstCreateClient = vi.spyOn(
+      first.__definition.lifecycle,
+      "createClient"
+    );
+    const secondCreateClient = vi.spyOn(
+      second.__definition.lifecycle,
+      "createClient"
+    );
+
+    await expect(
+      Spectrum({
+        ...baseConfig,
+        providers: [first, second],
+      })
+    ).rejects.toThrow(
+      'Spectrum received multiple providers for platform "iMessage". Register exactly one provider per platform.'
+    );
+
+    expect(getProject).not.toHaveBeenCalled();
+    expect(firstCreateClient).not.toHaveBeenCalled();
+    expect(secondCreateClient).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

* Reject duplicate provider platform names during `Spectrum()` startup
* Run the uniqueness check before project lookup or provider client creation
* Add regression coverage confirming duplicate configurations have no initialization side effects
* Clarify that cloud and local iMessage providers cannot be registered together

## Why

Provider runtimes are stored in a `Map` keyed by the platform definition name. Registering two providers with the same name previously initialized both clients and silently replaced the first runtime with the second. The overwritten client was then excluded from routing and shutdown cleanup.

## Decision

Platform names remain exact and case-sensitive, matching the existing runtime map, message tags, and narrowing behavior.

Both iMessage packages retain the `"iMessage"` identity because they represent alternative implementations of the same platform. Renaming the local provider would change public routing and message identity semantics solely to support a configuration the documentation already discourages.

Duplicate names now fail before cloud requests, telemetry setup, or provider initialization with:

```text
Spectrum received multiple providers for platform "iMessage". Register exactly one provider per platform.
```

## Testing

* `bun run check`
* `bun run typecheck`
* `bun run test`
* `bun run build`
* `bun scripts/release/check-artifacts.ts`
* Focused regression test under Node and Bun

Fixes photon-hq/spectrum-ts#202

---

![View with Codesmith](https://camo.githubusercontent.com/6e22944985996f6a1201f1d35788e9dc855f2e6b7b781e7ed1c22d7fb14217e8/68747470733a2f2f70722d636f6d6d656e74732d6173736574732e626c61636b736d6974682e73682f636f6465736d6974682f766965772d776974682d636f6465736d6974682d6461726b2d76322e737667) ![Autofix with Codesmith](https://camo.githubusercontent.com/8e7d836069a9e09b18eb0f68d9afc9beb6c2b13211745830b36a5d88a500d653/68747470733a2f2f70722d636f6d6d656e74732d6173736574732e626c61636b736d6974682e73682f636f6465736d6974682f6175746f6669782d776974682d636f6465736d6974682d6461726b2e737667) Need help on this PR? Tag `/codesmith` with what you need. Autofix is disabled.

## Summary by CodeRabbit

* **Bug Fixes**
  * Spectrum now rejects configurations containing multiple providers for the same platform during startup.
  * Improved iMessage provider guidance explains the duplicate-platform restriction and resulting validation error.