### PR TITLE
Enforce canonical platform IDs across providers and documentation

### DIFF
--- a/docs/custom-platforms.mdx.vel
+++ b/docs/custom-platforms.mdx.vel
@@ -7,14 +7,20 @@ import { TypeTooltip } from "/snippets/type-tooltip.mdx";
 
 {% set spaceType = symbol("ts:spectrum-ts#Space") %}
 {% set messageType = symbol("ts:spectrum-ts#Message") %}
-`definePlatform` is the entry point for building your own provider. It takes a name and a definition object, and returns a callable that:
+`definePlatform` is the entry point for building your own provider. It takes a platform ID and a definition object, and returns a callable that:
 
 - exposes a `.config()` method for registering the provider on `Spectrum()`
 - accepts the app, a <TypeTooltip name="Space" type={`{{ spaceType.signature }}`} />, or a <TypeTooltip name="Message" type={`{{ messageType.signature }}`} /> for [narrowing](/spectrum-ts/platform-narrowing)
 - carries any `static` properties you declare (like iMessage's effect constants)
 
 {% set pd = symbol("ts:spectrum-ts#PlatformDef") %}
-The core definition shape is <TypeTooltip name="PlatformDef" type={`{{ pd.signature }}`} />. You pass `name` as the first argument to `definePlatform`. The optional `static` object is an additional `definePlatform` input whose properties are copied onto the returned provider.
+The core definition shape is <TypeTooltip name="PlatformDef" type={`{{ pd.signature }}`} />. You pass the platform ID as the first argument to `definePlatform`. The optional `static` object is an additional `definePlatform` input whose properties are copied onto the returned provider.
+
+## Platform IDs
+
+Platform IDs are stable, developer-facing identifiers. Spectrum exposes the ID on `message.platform` and `__platform`, and uses it for provider registration, webhook routing, telemetry, and environment-variable prefixes.
+
+An ID must start with a lowercase letter and contain only lowercase letters, numbers, and single underscores between segments. In other words, it must match `/^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/`. Examples include `discord`, `whatsapp_business`, and `my_platform`. `definePlatform` rejects invalid IDs instead of silently normalizing them, so names containing uppercase letters, spaces, or hyphens must be corrected by the platform author.
 
 ## Shape
 
@@ -22,7 +28,7 @@ The core definition shape is <TypeTooltip name="PlatformDef" type={`{{ pd.signat
 import { definePlatform } from "spectrum-ts";
 import z from "zod";
 
-export const myPlatform = definePlatform("my-platform", {
+export const myPlatform = definePlatform("my_platform", {
   // Validate provider config
   config: z.object({
     apiKey: z.string(),
@@ -195,7 +201,7 @@ Two tiers share the `actions` slot:
 - **Platform-specific actions** — free-form keys for platform ergonomics (e.g. iMessage's `getAttachment`). Only present when declared.
 
 ```ts
-export const myPlatform = definePlatform("my-platform", {
+export const myPlatform = definePlatform("my_platform", {
   // ...
   actions: {
     getMessage: async ({ client }, space, messageId) => {
@@ -224,14 +230,14 @@ When your platform receives inbound messages through webhooks (rather than a per
 import { definePlatform, fusor } from "spectrum-ts";
 import z from "zod";
 
-export const myWebhookPlatform = definePlatform("my-webhook-platform", {
+export const myWebhookPlatform = definePlatform("my_webhook_platform", {
   config: z.object({
     webhookSecret: z.string(),
   }),
 
   lifecycle: {
     createClient: async ({ config }) =>
-      fusor("my-webhook-platform", (req) => {
+      fusor("my_webhook_platform", (req) => {
         verifySignature(req.rawBody, req.headers, config.webhookSecret);
         return JSON.parse(new TextDecoder().decode(req.rawBody));
       }),

--- a/docs/getting-started.mdx.vel
+++ b/docs/getting-started.mdx.vel
@@ -52,10 +52,10 @@ bun add spectrum-ts @spectrum-ts/imessage-local
 
 ```ts
 import { Spectrum } from "spectrum-ts";
-import { imessage } from "@spectrum-ts/imessage-local";
+import { localIMessage } from "@spectrum-ts/imessage-local";
 
 const app = await Spectrum({
-  providers: [imessage.config()],
+  providers: [localIMessage.config()],
 });
 ```
 

--- a/docs/platform-narrowing.mdx.vel
+++ b/docs/platform-narrowing.mdx.vel
@@ -10,7 +10,10 @@ import { TypeTooltip } from "/snippets/type-tooltip.mdx";
 {% set space = symbol("ts:spectrum-ts#Space") %}
 {% set message = symbol("ts:spectrum-ts#Message") %}
 
-Every platform provider exports a callable — `imessage`, `terminal`, `whatsappBusiness`, `telegram` — that **narrows** generic Spectrum types into platform-specific ones. The same function handles three different inputs.
+Every platform provider exports a callable — `imessage`, `localIMessage`,
+`slack`, `terminal`, `whatsappBusiness`, `telegram` — that **narrows** generic
+Spectrum types into platform-specific ones. The same function handles three
+different inputs.
 
 ## Narrowing the app
 
@@ -35,7 +38,7 @@ Pass an existing space to access platform-specific fields:
 
 ```ts
 for await (const [space, message] of app.messages) {
-  if (message.platform !== "iMessage") continue;
+  if (message.platform !== "imessage") continue;
 
   const imessageSpace = imessage(space);
   if (imessageSpace.type === "group") {
@@ -46,13 +49,17 @@ for await (const [space, message] of app.messages) {
 
 Narrowing a space from the wrong platform logs a structured warning at runtime. Always gate on `message.platform` (or a similar signal) first to avoid unexpected behavior.
 
+The local macOS provider is a separate platform. Gate on
+`message.platform === "local_imessage"` and narrow with `localIMessage(...)`;
+the cloud provider continues to use `"imessage"` and `imessage(...)`.
+
 ## Narrowing a message
 
 Same idea for messages — useful when a provider declares a `message.schema` to attach extra properties:
 
 ```ts
 for await (const [space, message] of app.messages) {
-  if (message.platform !== "iMessage") continue;
+  if (message.platform !== "imessage") continue;
   const imessageMessage = imessage(message);
   // imessageMessage carries any iMessage-specific fields
 }

--- a/docs/providers.mdx.vel
+++ b/docs/providers.mdx.vel
@@ -96,9 +96,9 @@ Call each provider's `config()` method and pass the results to `providers`:
 
 <Note>
   `@spectrum-ts/imessage-local` is not part of the aggregate import. Install it
-  explicitly and import it from its scoped package. Do not register cloud and
-  local iMessage in the same `Spectrum()` instance: both represent the
-  `"iMessage"` platform.
+  explicitly and import `localIMessage` from its scoped package. Cloud iMessage
+  uses the `"imessage"` platform ID; local iMessage uses `"local_imessage"`, so
+  a macOS application can register both when it needs both transports.
 </Note>
 
 ## Writing your own

--- a/docs/providers/imessage.mdx.vel
+++ b/docs/providers/imessage.mdx.vel
@@ -3,20 +3,20 @@ title: "iMessage"
 description: "Choose and configure the cloud or local iMessage provider."
 ---
 
-Spectrum ships two iMessage packages. They expose the same provider name and
-the same `imessage.config()` registration pattern, but target different
-environments.
+Spectrum ships two independent iMessage platforms. The cloud package exports
+`imessage` with the `"imessage"` platform ID. The local package exports
+`localIMessage` with the `"local_imessage"` platform ID.
 
 | Use case | Package | Included in `spectrum-ts`? | Runtime |
 |---|---|---|---|
 | Managed Spectrum Cloud lines | `@spectrum-ts/imessage` | Yes | Node.js or Bun |
 | This Mac's Messages database | `@spectrum-ts/imessage-local` | No | macOS with Bun or Node.js |
 
-<Warning>
-  Choose one iMessage package per `Spectrum()` instance. Both packages register
-  the `"iMessage"` platform, so `Spectrum()` rejects an instance that registers
-  both.
-</Warning>
+<Note>
+  Because their platform IDs are different, a macOS application can register
+  both providers in one `Spectrum()` instance. Use `message.platform` to
+  distinguish `"imessage"` cloud messages from `"local_imessage"` messages.
+</Note>
 
 ## Cloud quick start
 
@@ -93,10 +93,10 @@ bun add spectrum-ts @spectrum-ts/imessage-local
 
 ```ts
 import { Spectrum } from "spectrum-ts";
-import { imessage } from "@spectrum-ts/imessage-local";
+import { localIMessage } from "@spectrum-ts/imessage-local";
 
 const app = await Spectrum({
-  providers: [imessage.config()],
+  providers: [localIMessage.config()],
 });
 ```
 
@@ -146,9 +146,9 @@ export const providers = [imessage.config()];
 
 ```ts
 // mac-app.ts
-import { imessage } from "@spectrum-ts/imessage-local";
+import { localIMessage } from "@spectrum-ts/imessage-local";
 
-export const providers = [imessage.config()];
+export const providers = [localIMessage.config()];
 ```
 
 Avoid a shared module that statically imports both packages and chooses one at
@@ -173,10 +173,10 @@ with the explicit local package:
 ```ts
 // After
 import { Spectrum } from "spectrum-ts";
-import { imessage } from "@spectrum-ts/imessage-local";
+import { localIMessage } from "@spectrum-ts/imessage-local";
 
 const app = await Spectrum({
-  providers: [imessage.config()],
+  providers: [localIMessage.config()],
 });
 ```
 

--- a/docs/providers/imessage/connection-and-routing.mdx.vel
+++ b/docs/providers/imessage/connection-and-routing.mdx.vel
@@ -7,8 +7,9 @@ description: "Configure cloud or local iMessage packages, lines, spaces, and per
 import { TypeTooltip } from "/snippets/type-tooltip.mdx";
 
 Use this page to choose an iMessage package and understand how Spectrum routes
-iMessage conversations. Cloud and local iMessage are separate packages; the
-choice is made by the import, not by a config flag.
+iMessage conversations. Cloud and local iMessage are separate platforms; each
+is selected by its provider import, not by a config flag. A macOS application
+can register both when it needs both transports.
 
 ## Provider packages
 
@@ -51,12 +52,15 @@ choice is made by the import, not by a config flag.
 
     ```ts
     import { Spectrum } from "spectrum-ts";
-    import { imessage } from "@spectrum-ts/imessage-local";
+    import { localIMessage } from "@spectrum-ts/imessage-local";
 
     const app = await Spectrum({
-      providers: [imessage.config()],
+      providers: [localIMessage.config()],
     });
     ```
+
+    Local messages use `"local_imessage"` in `message.platform`. Narrow local
+    spaces and messages with the same `localIMessage` export.
 
     <Note>
       Local iMessage supports receiving and sending text, attachments, and
@@ -109,7 +113,7 @@ iMessage spaces carry a `type` field, either `"dm"` or `"group"`, and a `phone` 
 
 ```ts
 for await (const [space, message] of app.messages) {
-  if (message.platform !== "iMessage") continue;
+  if (message.platform !== "imessage") continue;
   const im = imessage(space);
   console.log(im.phone); // the phone number handling this conversation
   if (im.type === "group") {
@@ -138,7 +142,7 @@ These fields are also available on `message.sender` after narrowing:
 
 ```ts
 for await (const [space, message] of app.messages) {
-  if (message.platform !== "iMessage") continue;
+  if (message.platform !== "imessage") continue;
   const imMsg = imessage(message);
   console.log(imMsg.sender?.service);
 }

--- a/docs/providers/slack/conversations-and-events.mdx.vel
+++ b/docs/providers/slack/conversations-and-events.mdx.vel
@@ -24,7 +24,7 @@ Slack spaces carry a `teamId` field indicating which workspace the conversation 
 
 ```ts
 for await (const [space, message] of app.messages) {
-  if (message.platform !== "Slack") continue;
+  if (message.platform !== "slack") continue;
   const slackSpace = slack(space);
   console.log(slackSpace.teamId);
 }

--- a/docs/troubleshooting/imessage.mdx.vel
+++ b/docs/troubleshooting/imessage.mdx.vel
@@ -19,10 +19,10 @@ bun add @spectrum-ts/imessage-local
 
 ```ts
 import { Spectrum } from "spectrum-ts";
-import { imessage } from "@spectrum-ts/imessage-local";
+import { localIMessage } from "@spectrum-ts/imessage-local";
 
 const app = await Spectrum({
-  providers: [imessage.config()],
+  providers: [localIMessage.config()],
 });
 ```
 

--- a/packages/core/src/platform/define.ts
+++ b/packages/core/src/platform/define.ts
@@ -35,6 +35,17 @@ import type {
 
 const platformLog = createLogger("spectrum.platform");
 
+const PLATFORM_ID_PATTERN = /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/;
+
+const assertValidPlatformId = (platformId: string): void => {
+  if (PLATFORM_ID_PATTERN.test(platformId)) {
+    return;
+  }
+  throw new Error(
+    `Invalid platform id "${platformId}". Platform ids must use lowercase snake_case (for example, "my_platform").`
+  );
+};
+
 type NoInferValue<T> = [T][T extends unknown ? 0 : never];
 
 type RawActionFactory = (
@@ -361,7 +372,7 @@ export function definePlatform<
   >,
   _Actions extends Record<string, InstanceActionFn> = Record<never, never>,
 >(
-  name: _Name,
+  platformId: _Name,
   def: {
     lifecycle: {
       createClient: (
@@ -434,7 +445,7 @@ export function definePlatform<
     never
   >,
 >(
-  name: _Name,
+  platformId: _Name,
   def: Omit<
     PlatformDef<
       _Name,
@@ -501,14 +512,19 @@ export function definePlatform<
 // `AnyPlatformDef` and the overload return types restore precision at the call
 // site. The runtime is identical for both modes: fusor's `messages`/`events`
 // are read off `__definition` by FusorCore, never invoked here.
-export function definePlatform(name: string, rawDef: unknown): unknown {
+export function definePlatform(platformId: string, rawDef: unknown): unknown {
+  assertValidPlatformId(platformId);
   const def = rawDef as AnyPlatformDef & {
     static?: Record<string, unknown>;
   };
   type Def = AnyPlatformDef;
 
   // Every string-leaf config field falls back to `SPECTRUM_<PLATFORM>_<KEY>`
-  const fullDef = { ...def, name, config: envAwareConfig(name, def.config) };
+  const fullDef = {
+    ...def,
+    name: platformId,
+    config: envAwareConfig(platformId, def.config),
+  };
 
   const platformCache = new WeakMap<SpectrumLike, PlatformInstance<Def>>();
 
@@ -518,9 +534,9 @@ export function definePlatform(name: string, rawDef: unknown): unknown {
       return cached;
     }
 
-    const runtime = spectrum.__internal.platforms.get(name);
+    const runtime = spectrum.__internal.platforms.get(platformId);
     if (!runtime) {
-      throw new Error(`Platform "${name}" is not registered`);
+      throw new Error(`Platform "${platformId}" is not registered`);
     }
 
     const instance = createPlatformInstance<Def, unknown, z.ZodType<object>>(
@@ -532,9 +548,9 @@ export function definePlatform(name: string, rawDef: unknown): unknown {
   };
 
   const narrowSpace = (input: Space) => {
-    if (input.__platform !== name) {
+    if (input.__platform !== platformId) {
       platformLog.warn("space platform mismatch; narrowing skipped", {
-        "spectrum.platform.expected": name,
+        "spectrum.platform.expected": platformId,
         "spectrum.platform.actual": input.__platform,
       });
     }
@@ -542,9 +558,9 @@ export function definePlatform(name: string, rawDef: unknown): unknown {
   };
 
   const narrowMessage = (input: Message) => {
-    if (input.platform !== name) {
+    if (input.platform !== platformId) {
       platformLog.warn("message platform mismatch; narrowing skipped", {
-        "spectrum.platform.expected": name,
+        "spectrum.platform.expected": platformId,
         "spectrum.platform.actual": input.platform,
       });
     }
@@ -569,7 +585,7 @@ export function definePlatform(name: string, rawDef: unknown): unknown {
     return {
       __tag: "PlatformProviderConfig" as const,
       __def: undefined as unknown as Def,
-      __name: name,
+      __name: platformId,
       config: resolvedConfig,
       __definition: fullDef as AnyPlatformDef,
     } satisfies PlatformProviderConfig<Def> as PlatformProviderConfig<Def>;
@@ -580,10 +596,10 @@ export function definePlatform(name: string, rawDef: unknown): unknown {
       return false;
     }
     if ("__platform" in input) {
-      return (input as { __platform?: unknown }).__platform === name;
+      return (input as { __platform?: unknown }).__platform === platformId;
     }
     if ("platform" in input) {
-      return (input as { platform?: unknown }).platform === name;
+      return (input as { platform?: unknown }).platform === platformId;
     }
     return false;
   }) as Platform<Def>["is"];

--- a/packages/core/src/platform/types.ts
+++ b/packages/core/src/platform/types.ts
@@ -603,7 +603,7 @@ interface ToCustomEventVariant<EventName extends string> extends Fn {
 }
 
 // ---------------------------------------------------------------------------
-// HasProvider — check if a platform name exists in providers tuple
+// HasProvider — check if a platform id exists in providers tuple
 // ---------------------------------------------------------------------------
 
 export type HasProvider<

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -48,8 +48,8 @@ export const fromEnv = <T extends z.ZodType>(envKey: string, schema: T) =>
  * Normalize a platform id into the env-var prefix segment: upper-case, with any
  * run of non-alphanumeric characters collapsed to a single `_`. This is a
  * whole-name transform, NOT camelCase splitting, so it reproduces the prefixes
- * the adapters used by hand — `"telegram"` → `TELEGRAM`,
- * `"WhatsApp Business"` → `WHATSAPP_BUSINESS`, `"Slack"` → `SLACK`.
+ * canonical platform ids use lowercase snake_case, so `"telegram"` becomes
+ * `TELEGRAM` and `"whatsapp_business"` becomes `WHATSAPP_BUSINESS`.
  */
 const NON_ALPHANUMERIC_RUN = /[^A-Z0-9]+/;
 

--- a/packages/core/src/utils/provider-packages.ts
+++ b/packages/core/src/utils/provider-packages.ts
@@ -5,23 +5,25 @@
 // only place a user who forgot one gets told what's missing.
 //
 // Keep keys in sync with the provider packages' `package.json#spectrum.key`
-// (generate-manifest.ts validates those against each provider's source).
-// Lookup is tolerant of the three spellings that occur in the wild: the
-// `definePlatform` label ("iMessage", "WhatsApp Business"), the fusor routing
-// key ("telegram"), and the cloud platform key ("whatsapp_business").
+// (generate-manifest.ts validates those against each provider's source). Local
+// iMessage is the explicit-install exception and is intentionally not in the
+// batteries-included provider manifest.
+// Lookup remains tolerant of legacy display-name and kebab-case spellings, but
+// canonical platform ids use lowercase snake_case everywhere.
 
 const OFFICIAL_PROVIDER_PACKAGES: Readonly<Record<string, string>> = {
   imessage: "@spectrum-ts/imessage",
+  local_imessage: "@spectrum-ts/imessage-local",
   slack: "@spectrum-ts/slack",
   telegram: "@spectrum-ts/telegram",
   terminal: "@spectrum-ts/terminal",
-  "whatsapp-business": "@spectrum-ts/whatsapp-business",
+  whatsapp_business: "@spectrum-ts/whatsapp-business",
 };
 
-const SEPARATORS = /[\s_]+/g;
+const LEGACY_SEPARATORS = /[\s-]+/g;
 
 export const normalizePlatformKey = (platform: string): string =>
-  platform.trim().toLowerCase().replace(SEPARATORS, "-");
+  platform.trim().toLowerCase().replace(LEGACY_SEPARATORS, "_");
 
 export const officialProviderPackage = (platform: string): string | undefined =>
   OFFICIAL_PROVIDER_PACKAGES[normalizePlatformKey(platform)];

--- a/packages/core/test/core/platform-wise-reads.test.ts
+++ b/packages/core/test/core/platform-wise-reads.test.ts
@@ -14,13 +14,13 @@ const ICON_BYTES = "png-bytes";
 const ICON_MIME = "image/png";
 
 const MEMBERS_UNSUPPORTED =
-  /reads-members-bare does not support action "getMembers"/;
+  /reads_members_bare does not support action "getMembers"/;
 const AVATAR_UNSUPPORTED =
-  /reads-avatar-bare does not support action "getAvatar"/;
+  /reads_avatar_bare does not support action "getAvatar"/;
 const INSTANCE_MEMBERS_UNSUPPORTED =
-  /reads-instance-bare does not support action "getMembers"/;
+  /reads_instance_bare does not support action "getMembers"/;
 const INSTANCE_AVATAR_UNSUPPORTED =
-  /reads-instance-bare does not support action "getAvatar"/;
+  /reads_instance_bare does not support action "getAvatar"/;
 
 // Shared def slots for a minimal provider. The message queue is closed
 // immediately — every test gets its space from `space.create`, not the
@@ -68,7 +68,7 @@ const makeBareProvider = (name: string) => definePlatform(name, baseSlots());
 
 describe("space.getMembers()", () => {
   it("returns provider records tagged with __platform, extras preserved", async () => {
-    const provider = makeReadProvider("reads-members");
+    const provider = makeReadProvider("reads_members");
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -79,8 +79,8 @@ describe("space.getMembers()", () => {
 
       expect(members.map((m) => m.id)).toEqual(["u1", "u2"]);
       expect(members.map((m) => m.__platform)).toEqual([
-        "reads-members",
-        "reads-members",
+        "reads_members",
+        "reads_members",
       ]);
       expect((members[0] as { role?: string }).role).toBe("admin");
     } finally {
@@ -89,7 +89,7 @@ describe("space.getMembers()", () => {
   });
 
   it("throws UnsupportedError when the provider has no implementation", async () => {
-    const provider = makeBareProvider("reads-members-bare");
+    const provider = makeBareProvider("reads_members_bare");
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -106,7 +106,7 @@ describe("space.getMembers()", () => {
 
 describe("space.getAvatar()", () => {
   it("passes the provider's { data, mimeType } through untouched", async () => {
-    const provider = makeReadProvider("reads-avatar");
+    const provider = makeReadProvider("reads_avatar");
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -124,7 +124,7 @@ describe("space.getAvatar()", () => {
   });
 
   it("resolves undefined when the provider reports no avatar", async () => {
-    const provider = makeReadProvider("reads-avatar-none", { avatar: "none" });
+    const provider = makeReadProvider("reads_avatar_none", { avatar: "none" });
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -138,7 +138,7 @@ describe("space.getAvatar()", () => {
   });
 
   it("throws UnsupportedError when the provider has no implementation", async () => {
-    const provider = makeBareProvider("reads-avatar-bare");
+    const provider = makeBareProvider("reads_avatar_bare");
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -154,7 +154,7 @@ describe("space.getAvatar()", () => {
 
 describe("platform instance read methods", () => {
   it("im.getMembers/getAvatar resolve the provider records raw", async () => {
-    const provider = makeReadProvider("reads-instance");
+    const provider = makeReadProvider("reads_instance");
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -179,7 +179,7 @@ describe("platform instance read methods", () => {
     // The instance default throws synchronously (define.ts wires a plain
     // `() => { throw ... }`) — same contract as `im.getMessage` — so these
     // asserts use `toThrow`, not `rejects`.
-    const provider = makeBareProvider("reads-instance-bare");
+    const provider = makeBareProvider("reads_instance_bare");
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],

--- a/packages/core/test/core/receive-membership.test.ts
+++ b/packages/core/test/core/receive-membership.test.ts
@@ -46,7 +46,7 @@ const firstMessage = async (app: Awaited<ReturnType<typeof Spectrum>>) => {
 
 describe("inbound membership events", () => {
   it("delivers a sender-less membership event with content intact", async () => {
-    const provider = makeInboundProvider("membership-inbound", [
+    const provider = makeInboundProvider("membership_inbound", [
       {
         id: "evt-1",
         content: { type: "addMember", members: ["+15550100"] },
@@ -74,7 +74,7 @@ describe("inbound membership events", () => {
   });
 
   it("tags an inbound membership sender with the platform", async () => {
-    const provider = makeInboundProvider("membership-inbound-sender", [
+    const provider = makeInboundProvider("membership_inbound_sender", [
       {
         id: "evt-2",
         content: { type: "removeMember", members: ["+15550100"] },
@@ -92,7 +92,7 @@ describe("inbound membership events", () => {
       expect(message.content.type).toBe("removeMember");
       expect(message.sender).toEqual({
         id: "+15550111",
-        __platform: "membership-inbound-sender",
+        __platform: "membership_inbound_sender",
       });
     } finally {
       await app.stop();
@@ -100,7 +100,7 @@ describe("inbound membership events", () => {
   });
 
   it("delivers leaveSpace with the leaver as sender", async () => {
-    const provider = makeInboundProvider("membership-inbound-leave", [
+    const provider = makeInboundProvider("membership_inbound_leave", [
       {
         id: "evt-3",
         content: { type: "leaveSpace" },

--- a/packages/core/test/core/send-markdown-fallback.test.ts
+++ b/packages/core/test/core/send-markdown-fallback.test.ts
@@ -95,8 +95,8 @@ const noMarkdownSend = (platform: string) => {
 
 describe("markdown plain-text fallback", () => {
   it("re-sends the markdown as readable plain text", async () => {
-    const { seen, sendImpl } = noMarkdownSend("md-fallback-text");
-    const provider = makeProvider("md-fallback-text", sendImpl);
+    const { seen, sendImpl } = noMarkdownSend("md_fallback_text");
+    const provider = makeProvider("md_fallback_text", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -121,8 +121,8 @@ describe("markdown plain-text fallback", () => {
   });
 
   it("preserves the reply wrapper (and its target) in the fallback send", async () => {
-    const { seen, sendImpl } = noMarkdownSend("md-fallback-reply");
-    const provider = makeProvider("md-fallback-reply", sendImpl);
+    const { seen, sendImpl } = noMarkdownSend("md_fallback_reply");
+    const provider = makeProvider("md_fallback_reply", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -145,8 +145,8 @@ describe("markdown plain-text fallback", () => {
   });
 
   it("preserves the edit wrapper in the fallback send", async () => {
-    const { seen, sendImpl } = noMarkdownSend("md-fallback-edit");
-    const provider = makeProvider("md-fallback-edit", sendImpl);
+    const { seen, sendImpl } = noMarkdownSend("md_fallback_edit");
+    const provider = makeProvider("md_fallback_edit", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -172,8 +172,8 @@ describe("markdown plain-text fallback", () => {
   });
 
   it("downgrades markdown group items in place, leaving the rest untouched", async () => {
-    const { seen, sendImpl } = noMarkdownSend("md-fallback-group");
-    const provider = makeProvider("md-fallback-group", sendImpl);
+    const { seen, sendImpl } = noMarkdownSend("md_fallback_group");
+    const provider = makeProvider("md_fallback_group", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -205,10 +205,10 @@ describe("markdown plain-text fallback", () => {
     const sendImpl: SendImpl = (content) => {
       seen.push(content);
       return Promise.reject(
-        UnsupportedError.content(content.type, "md-fallback-none")
+        UnsupportedError.content(content.type, "md_fallback_none")
       );
     };
-    const provider = makeProvider("md-fallback-none", sendImpl);
+    const provider = makeProvider("md_fallback_none", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -225,8 +225,8 @@ describe("markdown plain-text fallback", () => {
   });
 
   it("warn-and-skips when the markdown renders to empty plain text", async () => {
-    const { seen, sendImpl } = noMarkdownSend("md-fallback-empty");
-    const provider = makeProvider("md-fallback-empty", sendImpl);
+    const { seen, sendImpl } = noMarkdownSend("md_fallback_empty");
+    const provider = makeProvider("md_fallback_empty", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -248,10 +248,10 @@ describe("markdown plain-text fallback", () => {
     const sendImpl: SendImpl = (content) => {
       seen.push(content);
       return Promise.reject(
-        UnsupportedError.content(content.type, "md-fallback-other")
+        UnsupportedError.content(content.type, "md_fallback_other")
       );
     };
-    const provider = makeProvider("md-fallback-other", sendImpl);
+    const provider = makeProvider("md_fallback_other", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -278,7 +278,7 @@ describe("markdown plain-text fallback", () => {
         timestamp: SENT_TIMESTAMP,
       });
     };
-    const provider = makeProvider("md-native", sendImpl);
+    const provider = makeProvider("md_native", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],

--- a/packages/core/test/core/send-membership.test.ts
+++ b/packages/core/test/core/send-membership.test.ts
@@ -75,7 +75,7 @@ const recordingSend = () => {
 describe("membership sends are fire-and-forget", () => {
   it("space.add() dispatches addMember content with normalized members", async () => {
     const { seen, sendImpl } = recordingSend();
-    const provider = makeMembershipProvider("membership-add", sendImpl);
+    const provider = makeMembershipProvider("membership_add", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -94,7 +94,7 @@ describe("membership sends are fire-and-forget", () => {
 
   it("space.add() batches an array into one dispatch", async () => {
     const { seen, sendImpl } = recordingSend();
-    const provider = makeMembershipProvider("membership-add-batch", sendImpl);
+    const provider = makeMembershipProvider("membership_add_batch", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -117,7 +117,7 @@ describe("membership sends are fire-and-forget", () => {
 
   it("space.remove() dispatches removeMember content", async () => {
     const { seen, sendImpl } = recordingSend();
-    const provider = makeMembershipProvider("membership-remove", sendImpl);
+    const provider = makeMembershipProvider("membership_remove", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -136,7 +136,7 @@ describe("membership sends are fire-and-forget", () => {
 
   it("space.leave() dispatches leaveSpace content", async () => {
     const { seen, sendImpl } = recordingSend();
-    const provider = makeMembershipProvider("membership-leave", sendImpl);
+    const provider = makeMembershipProvider("membership_leave", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -153,7 +153,7 @@ describe("membership sends are fire-and-forget", () => {
 
   it("space.send(addMember(...)) resolves undefined", async () => {
     const { sendImpl } = recordingSend();
-    const provider = makeMembershipProvider("membership-canonical", sendImpl);
+    const provider = makeMembershipProvider("membership_canonical", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -168,11 +168,11 @@ describe("membership sends are fire-and-forget", () => {
 
   it("resolves silently when the platform does not support membership", async () => {
     const provider = makeMembershipProvider(
-      "membership-unsupported",
+      "membership_unsupported",
       (content) => {
         if (MEMBERSHIP_TYPES.has(content.type)) {
           return Promise.reject(
-            UnsupportedError.content(content.type, "membership-unsupported")
+            UnsupportedError.content(content.type, "membership_unsupported")
           );
         }
         return Promise.resolve({

--- a/packages/core/test/core/send-reaction.test.ts
+++ b/packages/core/test/core/send-reaction.test.ts
@@ -58,7 +58,7 @@ const firstMessage = async (app: Awaited<ReturnType<typeof Spectrum>>) => {
 
 describe("reaction sends return a Message", () => {
   it("message.react resolves to the reaction Message with the built target", async () => {
-    const provider = makeReactionProvider("react-ok", (content) =>
+    const provider = makeReactionProvider("react_ok", (content) =>
       Promise.resolve({
         id: "r1",
         content,
@@ -88,7 +88,7 @@ describe("reaction sends return a Message", () => {
   });
 
   it("space.send(reaction(...)) resolves to the same shape", async () => {
-    const provider = makeReactionProvider("react-canonical", (content) =>
+    const provider = makeReactionProvider("react_canonical", (content) =>
       Promise.resolve({
         id: "r2",
         content,
@@ -117,8 +117,8 @@ describe("reaction sends return a Message", () => {
   });
 
   it("resolves undefined when the platform does not support reactions", async () => {
-    const provider = makeReactionProvider("react-unsupported", () =>
-      Promise.reject(UnsupportedError.content("reaction", "react-unsupported"))
+    const provider = makeReactionProvider("react_unsupported", () =>
+      Promise.reject(UnsupportedError.content("reaction", "react_unsupported"))
     );
     const app = await Spectrum({
       ...baseConfig,
@@ -142,7 +142,7 @@ describe("reaction sends return a Message", () => {
   });
 
   it("rejects when a provider returns no record for a reaction", async () => {
-    const provider = makeReactionProvider("react-void", () =>
+    const provider = makeReactionProvider("react_void", () =>
       Promise.resolve(undefined)
     );
     const app = await Spectrum({
@@ -191,7 +191,7 @@ describe("inbound reaction target direction", () => {
   };
 
   it("honors a provider-supplied outbound direction on a raw reaction target", async () => {
-    const provider = makeInboundReactionProvider("react-target-outbound", {
+    const provider = makeInboundReactionProvider("react_target_outbound", {
       id: "bot-message",
       content: { type: "text", text: "from the bot" },
       direction: "outbound",
@@ -217,7 +217,7 @@ describe("inbound reaction target direction", () => {
   });
 
   it("keeps the legacy inbound fallback when a raw reaction target has no direction", async () => {
-    const provider = makeInboundReactionProvider("react-target-fallback", {
+    const provider = makeInboundReactionProvider("react_target_fallback", {
       id: "unknown-message",
       content: { type: "text", text: "unknown owner" },
       space: { id: "s1" },
@@ -274,7 +274,7 @@ describe("inbound reply target wrapping", () => {
   };
 
   it("wraps a raw reply target into a Message", async () => {
-    const provider = makeInboundReplyProvider("reply-target-wrap", {
+    const provider = makeInboundReplyProvider("reply_target_wrap", {
       id: "question-1",
       content: { type: "text", text: "question" },
       space: { id: "s1" },
@@ -300,7 +300,7 @@ describe("inbound reply target wrapping", () => {
 
   it("wraps raw group items inside a reply", async () => {
     const provider = makeInboundReplyProvider(
-      "reply-inner-group-wrap",
+      "reply_inner_group_wrap",
       {
         id: "question-1",
         content: { type: "text", text: "question" },
@@ -336,7 +336,7 @@ describe("inbound reply target wrapping", () => {
       }
       const [item] = message.content.content.items;
       expect(item?.id).toBe("reply-part-1");
-      expect(item?.platform).toBe("reply-inner-group-wrap");
+      expect(item?.platform).toBe("reply_inner_group_wrap");
       expect(typeof item?.reply).toBe("function");
     } finally {
       await app.stop();

--- a/packages/core/test/core/send-read.test.ts
+++ b/packages/core/test/core/send-read.test.ts
@@ -74,7 +74,7 @@ const recordingSend = () => {
 describe("read sends are fire-and-forget", () => {
   it("message.read() dispatches read content targeting the message", async () => {
     const { seen, sendImpl } = recordingSend();
-    const provider = makeReadProvider("read-ok", sendImpl);
+    const provider = makeReadProvider("read_ok", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -94,7 +94,7 @@ describe("read sends are fire-and-forget", () => {
 
   it("space.send(read(message)) resolves undefined", async () => {
     const { sendImpl } = recordingSend();
-    const provider = makeReadProvider("read-canonical", sendImpl);
+    const provider = makeReadProvider("read_canonical", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -109,7 +109,7 @@ describe("read sends are fire-and-forget", () => {
 
   it("space.read(message) delegates to the same dispatch", async () => {
     const { seen, sendImpl } = recordingSend();
-    const provider = makeReadProvider("read-space-sugar", sendImpl);
+    const provider = makeReadProvider("read_space_sugar", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -127,10 +127,10 @@ describe("read sends are fire-and-forget", () => {
   });
 
   it("resolves silently when the platform does not support read", async () => {
-    const provider = makeReadProvider("read-unsupported", (content) => {
+    const provider = makeReadProvider("read_unsupported", (content) => {
       if (content.type === "read") {
         return Promise.reject(
-          UnsupportedError.content("read", "read-unsupported")
+          UnsupportedError.content("read", "read_unsupported")
         );
       }
       return Promise.resolve({
@@ -155,7 +155,7 @@ describe("read sends are fire-and-forget", () => {
 
   it("rejects marking an outbound message as read", async () => {
     const { sendImpl } = recordingSend();
-    const provider = makeReadProvider("read-outbound", sendImpl);
+    const provider = makeReadProvider("read_outbound", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],

--- a/packages/core/test/core/send-stream-text-fallback.test.ts
+++ b/packages/core/test/core/send-stream-text-fallback.test.ts
@@ -88,8 +88,8 @@ const noStreamingSend = (platform: string) => {
 
 describe("streamText plain-text fallback", () => {
   it("waits for the stream to finish and re-sends the full text", async () => {
-    const { seen, sendImpl } = noStreamingSend("stream-fallback-text");
-    const provider = makeProvider("stream-fallback-text", sendImpl);
+    const { seen, sendImpl } = noStreamingSend("stream_fallback_text");
+    const provider = makeProvider("stream_fallback_text", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -108,8 +108,8 @@ describe("streamText plain-text fallback", () => {
   });
 
   it("preserves the reply wrapper (and its target) in the fallback send", async () => {
-    const { seen, sendImpl } = noStreamingSend("stream-fallback-reply");
-    const provider = makeProvider("stream-fallback-reply", sendImpl);
+    const { seen, sendImpl } = noStreamingSend("stream_fallback_reply");
+    const provider = makeProvider("stream_fallback_reply", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -132,8 +132,8 @@ describe("streamText plain-text fallback", () => {
   });
 
   it("preserves the edit wrapper in the fallback send", async () => {
-    const { seen, sendImpl } = noStreamingSend("stream-fallback-edit");
-    const provider = makeProvider("stream-fallback-edit", sendImpl);
+    const { seen, sendImpl } = noStreamingSend("stream_fallback_edit");
+    const provider = makeProvider("stream_fallback_edit", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -159,8 +159,8 @@ describe("streamText plain-text fallback", () => {
   });
 
   it("skips the fallback when the stream produces no text", async () => {
-    const { seen, sendImpl } = noStreamingSend("stream-fallback-empty");
-    const provider = makeProvider("stream-fallback-empty", sendImpl);
+    const { seen, sendImpl } = noStreamingSend("stream_fallback_empty");
+    const provider = makeProvider("stream_fallback_empty", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -190,7 +190,7 @@ describe("streamText plain-text fallback", () => {
         }
         throw UnsupportedError.content(
           "streamText",
-          "stream-consumed",
+          "stream_consumed",
           `stream produced no text (got "${drained}")`
         );
       }
@@ -201,7 +201,7 @@ describe("streamText plain-text fallback", () => {
         timestamp: SENT_TIMESTAMP,
       };
     };
-    const provider = makeProvider("stream-consumed", sendImpl);
+    const provider = makeProvider("stream_consumed", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -224,10 +224,10 @@ describe("streamText plain-text fallback", () => {
     const sendImpl: SendImpl = (content) => {
       seen.push(content);
       return Promise.reject(
-        UnsupportedError.content(content.type, "stream-fallback-none")
+        UnsupportedError.content(content.type, "stream_fallback_none")
       );
     };
-    const provider = makeProvider("stream-fallback-none", sendImpl);
+    const provider = makeProvider("stream_fallback_none", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -244,8 +244,8 @@ describe("streamText plain-text fallback", () => {
   });
 
   it("propagates stream errors instead of swallowing them", async () => {
-    const { sendImpl } = noStreamingSend("stream-fallback-error");
-    const provider = makeProvider("stream-fallback-error", sendImpl);
+    const { sendImpl } = noStreamingSend("stream_fallback_error");
+    const provider = makeProvider("stream_fallback_error", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -265,8 +265,8 @@ describe("streamText plain-text fallback", () => {
   it("re-sends a drained markdown-formatted stream as markdown content", async () => {
     // `noStreamingSend` accepts everything except streams — so the drained
     // markdown lands natively, without a second downgrade.
-    const { seen, sendImpl } = noStreamingSend("stream-md-supported");
-    const provider = makeProvider("stream-md-supported", sendImpl);
+    const { seen, sendImpl } = noStreamingSend("stream_md_supported");
+    const provider = makeProvider("stream_md_supported", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -293,7 +293,7 @@ describe("streamText plain-text fallback", () => {
           : content;
       if (inner.type === "streamText" || inner.type === "markdown") {
         return Promise.reject(
-          UnsupportedError.content(inner.type, "stream-md-chain")
+          UnsupportedError.content(inner.type, "stream_md_chain")
         );
       }
       return Promise.resolve({
@@ -303,7 +303,7 @@ describe("streamText plain-text fallback", () => {
         timestamp: SENT_TIMESTAMP,
       });
     };
-    const provider = makeProvider("stream-md-chain", sendImpl);
+    const provider = makeProvider("stream_md_chain", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -339,7 +339,7 @@ describe("streamText plain-text fallback", () => {
       const inner = content.type === "reply" ? content.content : content;
       if (inner.type === "streamText" || inner.type === "markdown") {
         return Promise.reject(
-          UnsupportedError.content(inner.type, "stream-md-reply")
+          UnsupportedError.content(inner.type, "stream_md_reply")
         );
       }
       return Promise.resolve({
@@ -349,7 +349,7 @@ describe("streamText plain-text fallback", () => {
         timestamp: SENT_TIMESTAMP,
       });
     };
-    const provider = makeProvider("stream-md-reply", sendImpl);
+    const provider = makeProvider("stream_md_reply", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -395,7 +395,7 @@ describe("streamText plain-text fallback", () => {
         timestamp: SENT_TIMESTAMP,
       };
     };
-    const provider = makeProvider("stream-native", sendImpl);
+    const provider = makeProvider("stream_native", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],

--- a/packages/core/test/core/send-unsend.test.ts
+++ b/packages/core/test/core/send-unsend.test.ts
@@ -75,7 +75,7 @@ const recordingSend = () => {
 describe("unsend sends are fire-and-forget", () => {
   it("message.unsend() dispatches unsend content targeting the message", async () => {
     const { seen, sendImpl } = recordingSend();
-    const provider = makeUnsendProvider("unsend-ok", sendImpl);
+    const provider = makeUnsendProvider("unsend_ok", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -97,7 +97,7 @@ describe("unsend sends are fire-and-forget", () => {
 
   it("space.send(unsend(message)) resolves undefined", async () => {
     const { sendImpl } = recordingSend();
-    const provider = makeUnsendProvider("unsend-canonical", sendImpl);
+    const provider = makeUnsendProvider("unsend_canonical", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -113,7 +113,7 @@ describe("unsend sends are fire-and-forget", () => {
 
   it("space.unsend(message) delegates to the same dispatch", async () => {
     const { seen, sendImpl } = recordingSend();
-    const provider = makeUnsendProvider("unsend-space-sugar", sendImpl);
+    const provider = makeUnsendProvider("unsend_space_sugar", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -133,7 +133,7 @@ describe("unsend sends are fire-and-forget", () => {
 
   it("unsends a reaction via the handle returned by react()", async () => {
     const { seen, sendImpl } = recordingSend();
-    const provider = makeUnsendProvider("unsend-reaction", sendImpl);
+    const provider = makeUnsendProvider("unsend_reaction", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -154,10 +154,10 @@ describe("unsend sends are fire-and-forget", () => {
   });
 
   it("resolves silently when the platform does not support unsend", async () => {
-    const provider = makeUnsendProvider("unsend-unsupported", (content) => {
+    const provider = makeUnsendProvider("unsend_unsupported", (content) => {
       if (content.type === "unsend") {
         return Promise.reject(
-          UnsupportedError.content("unsend", "unsend-unsupported")
+          UnsupportedError.content("unsend", "unsend_unsupported")
         );
       }
       return Promise.resolve({
@@ -183,7 +183,7 @@ describe("unsend sends are fire-and-forget", () => {
 
   it("rejects unsending an inbound message", async () => {
     const { sendImpl } = recordingSend();
-    const provider = makeUnsendProvider("unsend-inbound", sendImpl);
+    const provider = makeUnsendProvider("unsend_inbound", sendImpl);
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],

--- a/packages/core/test/core/space.test.ts
+++ b/packages/core/test/core/space.test.ts
@@ -10,11 +10,11 @@ import { Spectrum } from "@/spectrum";
 stubCloud();
 
 const NEEDS_HOOK_ERROR =
-  /space-get-needs-hook.*cannot construct a space from an id alone[\s\S]*space\.get/;
+  /space_get_needs_hook.*cannot construct a space from an id alone[\s\S]*space\.get/;
 
 describe("space.create", () => {
   it("resolves a single string user through user.resolve and builds a full space", async () => {
-    const provider = makeManagedProvider("space-create-single");
+    const provider = makeManagedProvider("space_create_single");
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -23,7 +23,7 @@ describe("space.create", () => {
       const instance = provider(app);
       const space = await instance.space.create("u42");
       expect(space.id).toBe("u42");
-      expect(space.__platform).toBe("space-create-single");
+      expect(space.__platform).toBe("space_create_single");
       expect(typeof space.send).toBe("function");
     } finally {
       await app.stop();
@@ -31,7 +31,7 @@ describe("space.create", () => {
   });
 
   it("accepts mixed string/PlatformUser arrays and resolves every entry", async () => {
-    const provider = makeSchemaProvider("space-create-mixed");
+    const provider = makeSchemaProvider("space_create_mixed");
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -50,7 +50,7 @@ describe("space.create", () => {
   });
 
   it("validates params against the provider params schema", async () => {
-    const provider = makeSchemaProvider("space-create-params");
+    const provider = makeSchemaProvider("space_create_params");
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -65,7 +65,7 @@ describe("space.create", () => {
   });
 
   it("validates the created space against the space schema", async () => {
-    const provider = makeSchemaProvider("space-create-schema");
+    const provider = makeSchemaProvider("space_create_schema");
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -83,7 +83,7 @@ describe("space.create", () => {
 
 describe("space.get", () => {
   it("defaults to { id } when the provider has no get hook and no schema", async () => {
-    const provider = makeManagedProvider("space-get-default");
+    const provider = makeManagedProvider("space_get_default");
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -92,7 +92,7 @@ describe("space.get", () => {
       const instance = provider(app);
       const space = await instance.space.get("s9");
       expect(space.id).toBe("s9");
-      expect(space.__platform).toBe("space-get-default");
+      expect(space.__platform).toBe("space_get_default");
       expect(typeof space.send).toBe("function");
     } finally {
       await app.stop();
@@ -100,7 +100,7 @@ describe("space.get", () => {
   });
 
   it("hydrates platform fields through the provider get hook", async () => {
-    const provider = makeSchemaProvider("space-get-hook", { withGet: true });
+    const provider = makeSchemaProvider("space_get_hook", { withGet: true });
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],
@@ -116,7 +116,7 @@ describe("space.get", () => {
   });
 
   it("fails loudly when the schema needs fields the default { id } cannot supply", async () => {
-    const provider = makeSchemaProvider("space-get-needs-hook");
+    const provider = makeSchemaProvider("space_get_needs_hook");
     const app = await Spectrum({
       ...baseConfig,
       providers: [provider.config({})],

--- a/packages/core/test/core/spectrum.shutdown.test.ts
+++ b/packages/core/test/core/spectrum.shutdown.test.ts
@@ -24,7 +24,7 @@ describe("Spectrum.stop() shutdown", () => {
     const app = await Spectrum({
       ...baseConfig,
       providers: [
-        makeManagedProvider("managed-a", { withDestroy: true }).config({}),
+        makeManagedProvider("managed_a", { withDestroy: true }).config({}),
       ],
     });
     const messagesIterator = app.messages[Symbol.asyncIterator]();
@@ -39,7 +39,7 @@ describe("Spectrum.stop() shutdown", () => {
   it("managed-stream provider with no destroyClient: resolves promptly (stream self-closes)", async () => {
     const app = await Spectrum({
       ...baseConfig,
-      providers: [makeManagedProvider("managed-nodestroy").config({})],
+      providers: [makeManagedProvider("managed_nodestroy").config({})],
     });
     const messagesIterator = app.messages[Symbol.asyncIterator]();
     await messagesIterator.next();
@@ -53,8 +53,8 @@ describe("Spectrum.stop() shutdown", () => {
     const app = await Spectrum({
       ...baseConfig,
       providers: [
-        makeManagedProvider("managed-1", { withDestroy: true }).config({}),
-        makeManagedProvider("managed-2").config({}),
+        makeManagedProvider("managed_1", { withDestroy: true }).config({}),
+        makeManagedProvider("managed_2").config({}),
       ],
     });
     const messagesIterator = app.messages[Symbol.asyncIterator]();
@@ -69,7 +69,7 @@ describe("Spectrum.stop() shutdown", () => {
     const app = await Spectrum({
       ...baseConfig,
       providers: [
-        makeManagedProvider("managed-nosub", { withDestroy: true }).config({}),
+        makeManagedProvider("managed_nosub", { withDestroy: true }).config({}),
       ],
     });
     expect(await withinMs(app.stop(), PROMPT_SHUTDOWN_TIMEOUT_MS)).toBe(

--- a/packages/core/test/core/spectrum.unique-platform-names.test.ts
+++ b/packages/core/test/core/spectrum.unique-platform-names.test.ts
@@ -4,6 +4,7 @@ import {
   makeManagedProvider,
 } from "@spectrum-ts/test-support/platform";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { assertUniquePlatformNames } from "@/platform/unique-names";
 import { Spectrum } from "@/spectrum";
 
 const getProject = stubCloud();
@@ -14,8 +15,8 @@ describe("Spectrum() platform name uniqueness", () => {
   });
 
   it("rejects duplicate platform names before initialization", async () => {
-    const first = makeManagedProvider("iMessage").config({});
-    const second = makeManagedProvider("iMessage").config({});
+    const first = makeManagedProvider("imessage").config({});
+    const second = makeManagedProvider("imessage").config({});
     const firstCreateClient = vi.spyOn(
       first.__definition.lifecycle,
       "createClient"
@@ -31,11 +32,32 @@ describe("Spectrum() platform name uniqueness", () => {
         providers: [first, second],
       })
     ).rejects.toThrow(
-      'Spectrum received multiple providers for platform "iMessage". Register exactly one provider per platform.'
+      'Spectrum received multiple providers for platform "imessage". Register exactly one provider per platform.'
     );
 
     expect(getProject).not.toHaveBeenCalled();
     expect(firstCreateClient).not.toHaveBeenCalled();
     expect(secondCreateClient).not.toHaveBeenCalled();
+  });
+
+  it("accepts cloud and local iMessage as separate platforms", () => {
+    const cloud = makeManagedProvider("imessage").config({});
+    const local = makeManagedProvider("local_imessage").config({});
+
+    expect(() => assertUniquePlatformNames([cloud, local])).not.toThrow();
+  });
+
+  it.each([
+    "iMessage",
+    "WhatsApp Business",
+    "whatsapp-business",
+    "_telegram",
+    "telegram_",
+    "telegram__bot",
+    "",
+  ])("rejects invalid platform id %j", (platformId) => {
+    expect(() => makeManagedProvider(platformId)).toThrow(
+      `Invalid platform id "${platformId}". Platform ids must use lowercase snake_case (for example, "my_platform").`
+    );
   });
 });

--- a/packages/core/test/platform/define.test.ts
+++ b/packages/core/test/platform/define.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import z from "zod";
+import { definePlatform } from "@/index";
+
+const minimalDefinition = {
+  config: z.object({}),
+  lifecycle: {
+    createClient: () => Promise.resolve({}),
+  },
+  user: {
+    resolve: () => Promise.resolve({ id: "user" }),
+  },
+  space: {
+    create: () => Promise.resolve({ id: "space" }),
+  },
+  async *messages() {},
+  send: () => Promise.resolve(undefined),
+};
+
+describe("definePlatform platform ids", () => {
+  it.each([
+    "imessage",
+    "local_imessage",
+    "platform2",
+  ])("accepts valid lowercase snake_case id %j", (platformId) => {
+    expect(() => definePlatform(platformId, minimalDefinition)).not.toThrow();
+  });
+
+  it.each([
+    ["uppercase", "iMessage"],
+    ["hyphenated", "local-imessage"],
+    ["leading underscore", "_imessage"],
+    ["trailing underscore", "imessage_"],
+    ["consecutive underscores", "local__imessage"],
+  ])("rejects %s id %j", (_case, platformId) => {
+    expect(() => definePlatform(platformId, minimalDefinition)).toThrowError(
+      `Invalid platform id "${platformId}". Platform ids must use lowercase snake_case (for example, "my_platform").`
+    );
+  });
+});

--- a/packages/core/test/utils/provider-packages.test.ts
+++ b/packages/core/test/utils/provider-packages.test.ts
@@ -8,22 +8,28 @@ import {
 const INSTALL_COMMAND = /bun add|npm install/;
 
 describe("normalizePlatformKey", () => {
-  it("maps every spelling seen in the wild onto the manifest key", () => {
-    // definePlatform labels
+  it("maps canonical and legacy spellings onto the platform id", () => {
+    // legacy definePlatform labels
     expect(normalizePlatformKey("iMessage")).toBe("imessage");
+    expect(normalizePlatformKey("Local iMessage")).toBe("local_imessage");
     expect(normalizePlatformKey("Slack")).toBe("slack");
     expect(normalizePlatformKey("Terminal")).toBe("terminal");
-    expect(normalizePlatformKey("WhatsApp Business")).toBe("whatsapp-business");
+    expect(normalizePlatformKey("WhatsApp Business")).toBe("whatsapp_business");
     // fusor routing key
     expect(normalizePlatformKey("telegram")).toBe("telegram");
     // cloud platform key
-    expect(normalizePlatformKey("whatsapp_business")).toBe("whatsapp-business");
+    expect(normalizePlatformKey("whatsapp_business")).toBe("whatsapp_business");
+    // legacy manifest key
+    expect(normalizePlatformKey("whatsapp-business")).toBe("whatsapp_business");
   });
 });
 
 describe("officialProviderPackage", () => {
-  it("resolves all five official providers from any spelling", () => {
+  it("resolves all six official providers from any spelling", () => {
     expect(officialProviderPackage("iMessage")).toBe("@spectrum-ts/imessage");
+    expect(officialProviderPackage("local_imessage")).toBe(
+      "@spectrum-ts/imessage-local"
+    );
     expect(officialProviderPackage("whatsapp_business")).toBe(
       "@spectrum-ts/whatsapp-business"
     );

--- a/packages/imessage-local/README.md
+++ b/packages/imessage-local/README.md
@@ -7,11 +7,11 @@ bun add spectrum-ts @spectrum-ts/imessage-local
 ```
 
 ```ts
-import { imessage } from "@spectrum-ts/imessage-local";
+import { localIMessage } from "@spectrum-ts/imessage-local";
 import { Spectrum } from "spectrum-ts";
 
 const spectrum = Spectrum({
-  providers: [imessage.config()],
+  providers: [localIMessage.config()],
 });
 ```
 

--- a/packages/imessage-local/src/index.ts
+++ b/packages/imessage-local/src/index.ts
@@ -54,10 +54,11 @@ import {
   userSchema,
 } from "./types";
 
-const LOCAL_PLATFORM = "iMessage (local mode)";
+const PLATFORM_ID = "local_imessage";
 
 const unsupportedAction = (action: string, detail?: string): never => {
-  throw UnsupportedError.action(action, LOCAL_PLATFORM, detail);
+  const localDetail = detail ? `local mode: ${detail}` : "local mode";
+  throw UnsupportedError.action(action, PLATFORM_ID, localDetail);
 };
 
 const handleLocalOnlySend = async (
@@ -150,7 +151,7 @@ const handleLocalOnlySend = async (
   return await localSend(client, spaceId, content);
 };
 
-export const imessage = definePlatform("iMessage", {
+export const localIMessage = definePlatform(PLATFORM_ID, {
   config: configSchema,
 
   static: {

--- a/packages/imessage-local/test/provider.test.ts
+++ b/packages/imessage-local/test/provider.test.ts
@@ -1,12 +1,12 @@
 import { IMessageSDK } from "@photon-ai/imessage-kit";
 import type { Content } from "@spectrum-ts/core";
 import { describe, expect, it, vi } from "vitest";
-import { imessage, nativeContactCard } from "@/index";
+import { effect, localIMessage, nativeContactCard } from "@/index";
 
 const LOCAL_MODE_ERROR = /local mode/;
 const LOCAL_GROUP_ERROR = /local mode cannot create group chats/;
 
-const def = imessage.config().__definition;
+const def = localIMessage.config().__definition;
 const localClient = (send = vi.fn((_: unknown) => Promise.resolve())) =>
   Object.assign(Object.create(IMessageSDK.prototype), { send }) as IMessageSDK;
 
@@ -26,8 +26,10 @@ const appContent = (url: string): Content =>
 
 describe("@spectrum-ts/imessage-local", () => {
   it("constructs the provider with config()", () => {
-    expect(imessage.config()).toMatchObject({
+    expect(localIMessage.config()).toMatchObject({
+      __name: "local_imessage",
       __tag: "PlatformProviderConfig",
+      __definition: { name: "local_imessage" },
     });
   });
 
@@ -106,5 +108,21 @@ describe("@spectrum-ts/imessage-local", () => {
         space: { id: "any;-;+15550123", type: "dm", phone: "" },
       })
     ).rejects.toThrow(LOCAL_MODE_ERROR);
+  });
+
+  it("tags unsupported local content with the local platform id", async () => {
+    await expect(
+      def.send({
+        ...ctx,
+        content: await effect(
+          "hello",
+          localIMessage.effect.message.slam
+        ).build(),
+        space: { id: "any;-;+15550123", type: "dm", phone: "" },
+      })
+    ).rejects.toMatchObject({
+      platform: "local_imessage",
+      detail: expect.stringContaining("local mode"),
+    });
   });
 });

--- a/packages/imessage/package.json
+++ b/packages/imessage/package.json
@@ -35,7 +35,7 @@
   "spectrum": {
     "key": "imessage",
     "import": "imessage",
-    "label": "iMessage"
+    "label": "imessage"
   },
   "scripts": {
     "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js",

--- a/packages/imessage/src/content/background.ts
+++ b/packages/imessage/src/content/background.ts
@@ -11,7 +11,7 @@ import z from "zod";
  * provider — never enters the universal `Content` discriminated union. The
  * framework recognizes it via two generic content-level contracts:
  *
- * 1. `__platform: "iMessage"` — `findUnsupportedPlatformContent` in
+ * 1. `__platform: "imessage"` — `findUnsupportedPlatformContent` in
  *    `platform/build.ts` reads this tag and warns-and-skips when a different
  *    platform receives it.
  * 2. `__fireAndForget: true` — `dispatchSend`'s fire-and-forget check
@@ -23,7 +23,7 @@ import z from "zod";
  */
 export const backgroundSchema = z.object({
   type: z.literal("background"),
-  __platform: z.literal("iMessage"),
+  __platform: z.literal("imessage"),
   __fireAndForget: z.literal(true),
   action: photoActionSchema,
 });
@@ -76,7 +76,7 @@ export function background(
     build: async () =>
       backgroundSchema.parse({
         type: "background",
-        __platform: "iMessage",
+        __platform: "imessage",
         __fireAndForget: true,
         action,
       }) as unknown as Content,

--- a/packages/imessage/src/content/contact-card.ts
+++ b/packages/imessage/src/content/contact-card.ts
@@ -15,7 +15,7 @@ import z from "zod";
  * enters the universal `Content` discriminated union. The framework recognizes
  * it via two generic content-level contracts:
  *
- * 1. `__platform: "iMessage"` — `findUnsupportedPlatformContent` in
+ * 1. `__platform: "imessage"` — `findUnsupportedPlatformContent` in
  *    `platform/build.ts` reads this tag and warns-and-skips when a different
  *    platform receives it.
  * 2. `__fireAndForget: true` — `dispatchSend`'s fire-and-forget check treats
@@ -27,7 +27,7 @@ import z from "zod";
  */
 export const contactCardSchema = z.object({
   type: z.literal("contactCard"),
-  __platform: z.literal("iMessage"),
+  __platform: z.literal("imessage"),
   __fireAndForget: z.literal(true),
 });
 
@@ -59,7 +59,7 @@ export function nativeContactCard(): ContentBuilder {
     build: async () =>
       contactCardSchema.parse({
         type: "contactCard",
-        __platform: "iMessage",
+        __platform: "imessage",
         __fireAndForget: true,
       }) as unknown as Content,
   };

--- a/packages/imessage/src/content/customized-mini-app.ts
+++ b/packages/imessage/src/content/customized-mini-app.ts
@@ -16,7 +16,7 @@ const layoutSchema = appLayoutSchema;
  * provider — never enters the universal `Content` discriminated union. The
  * framework recognizes it via the generic content-level platform contract:
  *
- * - `__platform: "iMessage"` — `findUnsupportedPlatformContent` reads this tag
+ * - `__platform: "imessage"` — `findUnsupportedPlatformContent` reads this tag
  *   and warns-and-skips when a different platform receives it.
  *
  * Unlike `background` / `read`, this content is **not** `__fireAndForget`: it
@@ -26,7 +26,7 @@ const layoutSchema = appLayoutSchema;
  */
 export const customizedMiniAppSchema = z.object({
   type: z.literal("customized-mini-app"),
-  __platform: z.literal("iMessage"),
+  __platform: z.literal("imessage"),
   // Display name of the owning app, shown by Messages fallback UI.
   appName: z.string().nonempty(),
   // Apple App Store numeric id of the owning app. Positive when set; omit to
@@ -60,7 +60,7 @@ export const asCustomizedMiniApp = (
 ): CustomizedMiniApp =>
   customizedMiniAppSchema.parse({
     type: "customized-mini-app",
-    __platform: "iMessage",
+    __platform: "imessage",
     ...input,
   });
 

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -53,6 +53,7 @@ import {
   isCustomizedMiniApp,
 } from "./content/customized-mini-app";
 import { messageEffects } from "./content/effect";
+import { IMESSAGE_PLATFORM } from "./platform";
 import {
   addParticipants as remoteAddParticipants,
   editMessage as remoteEditMessage,
@@ -148,7 +149,7 @@ const handleEdit = async (
     if (!miniAppCardSession) {
       throw UnsupportedError.content(
         "edit",
-        "iMessage",
+        IMESSAGE_PLATFORM,
         "mini app card edits require a miniAppCardSession from the original send"
       );
     }
@@ -172,7 +173,7 @@ const handleEdit = async (
     if (!miniAppCardSession) {
       throw UnsupportedError.content(
         "edit",
-        "iMessage",
+        IMESSAGE_PLATFORM,
         "customized mini app card edits require a miniAppCardSession from the original send"
       );
     }
@@ -195,7 +196,7 @@ const handleEdit = async (
     // UnsupportedError so dispatchSend warn-and-skips uniformly.
     throw UnsupportedError.content(
       "edit",
-      "iMessage",
+      IMESSAGE_PLATFORM,
       `only text content can be edited (got "${content.content.type}")`
     );
   }
@@ -212,7 +213,7 @@ const handleUnsend = async (
     // The SDK has no poll delete; mirrors the reply/react poll guards.
     throw UnsupportedError.action(
       "unsend",
-      "iMessage",
+      IMESSAGE_PLATFORM,
       "iMessage polls cannot be unsent"
     );
   }
@@ -330,7 +331,7 @@ const handleRename = async (
   if (space.type !== "group") {
     throw UnsupportedError.action(
       "rename",
-      "iMessage",
+      IMESSAGE_PLATFORM,
       "only group chats can be renamed (this space is a DM)"
     );
   }
@@ -346,7 +347,7 @@ const handleAvatar = async (
   if (space.type !== "group") {
     throw UnsupportedError.action(
       "avatar",
-      "iMessage",
+      IMESSAGE_PLATFORM,
       "only group chats have avatars (this space is a DM)"
     );
   }
@@ -366,7 +367,7 @@ const remoteGroupClient = (
   detail: string
 ): AdvancedIMessage => {
   if (space.type !== "group") {
-    throw UnsupportedError.action(action, "iMessage", detail);
+    throw UnsupportedError.action(action, IMESSAGE_PLATFORM, detail);
   }
   return clientForPhone(client, space.phone);
 };
@@ -450,14 +451,14 @@ const remoteForMessageTarget = (
   if (isPollContent(target.content)) {
     throw UnsupportedError.action(
       action,
-      "iMessage",
+      IMESSAGE_PLATFORM,
       `iMessage polls do not support ${pollNoun}`
     );
   }
   return clientForPhone(client, space.phone);
 };
 
-export const imessage = definePlatform("iMessage", {
+export const imessage = definePlatform(IMESSAGE_PLATFORM, {
   config: configSchema,
 
   static: {
@@ -493,7 +494,7 @@ export const imessage = definePlatform("iMessage", {
 
       if (!(projectId && projectSecret)) {
         throw new Error(
-          "Cloud iMessage requires projectId and projectSecret. Pass credentials to Spectrum() or provide explicit clients with imessage.config({ clients: [...] }). For local Messages access, install @spectrum-ts/imessage-local and use its imessage.config()."
+          "Cloud iMessage requires projectId and projectSecret. Pass credentials to Spectrum() or provide explicit clients with imessage.config({ clients: [...] }). For local Messages access, install @spectrum-ts/imessage-local and use localIMessage.config()."
         );
       }
 
@@ -780,7 +781,7 @@ export const imessage = definePlatform("iMessage", {
       return withSpan(
         "spectrum.imessage.getAttachment",
         {
-          "spectrum.provider": "iMessage",
+          "spectrum.provider": IMESSAGE_PLATFORM,
           "spectrum.imessage.attachment.guid": guid,
           "spectrum.imessage.phone": routedPhone,
         },

--- a/packages/imessage/src/platform.ts
+++ b/packages/imessage/src/platform.ts
@@ -1,0 +1,1 @@
+export const IMESSAGE_PLATFORM = "imessage";

--- a/packages/imessage/src/shared/errors.ts
+++ b/packages/imessage/src/shared/errors.ts
@@ -1,7 +1,7 @@
 import { UnsupportedError } from "@spectrum-ts/core";
+import { IMESSAGE_PLATFORM } from "../platform";
 
-export const IMESSAGE_PLATFORM = "iMessage";
-export const LOCAL_IMESSAGE_PLATFORM = "iMessage (local mode)";
+const LOCAL_IMESSAGE_PLATFORM = "local_imessage";
 
 export const unsupportedRemoteContent = (
   type: string,
@@ -13,4 +13,8 @@ export const unsupportedLocalContent = (
   type: string,
   detail?: string
 ): UnsupportedError =>
-  UnsupportedError.content(type, LOCAL_IMESSAGE_PLATFORM, detail);
+  UnsupportedError.content(
+    type,
+    LOCAL_IMESSAGE_PLATFORM,
+    detail ? `local mode: ${detail}` : "local mode"
+  );

--- a/packages/imessage/test/contact-card.test.ts
+++ b/packages/imessage/test/contact-card.test.ts
@@ -8,7 +8,7 @@ import { type RemoteClient, SHARED_PHONE } from "@/types";
 
 const SIGNAL = {
   type: "contactCard",
-  __platform: "iMessage",
+  __platform: "imessage",
   __fireAndForget: true,
 } as const;
 

--- a/packages/imessage/test/read-actions.test.ts
+++ b/packages/imessage/test/read-actions.test.ts
@@ -153,7 +153,7 @@ describe("iMessage actions.getMembers", () => {
       id: GROUP_GUID,
       type: "group",
       phone: SELF_PHONE,
-      __platform: "iMessage",
+      __platform: "imessage",
     } as const;
 
     const members = await callGetMembers(client, space);
@@ -174,7 +174,7 @@ describe("iMessage actions.getMembers", () => {
       id: GROUP_GUID,
       type: "group",
       phone: SHARED_PHONE,
-      __platform: "iMessage",
+      __platform: "imessage",
     } as const;
 
     const members = await callGetMembers(client, space);
@@ -188,7 +188,7 @@ describe("iMessage actions.getMembers", () => {
       id: DM_GUID,
       type: "dm",
       phone: SELF_PHONE,
-      __platform: "iMessage",
+      __platform: "imessage",
     } as const;
 
     await expect(callGetMembers(client, space)).rejects.toThrow(
@@ -207,7 +207,7 @@ describe("iMessage actions.getMembers", () => {
       id: GROUP_GUID,
       type: "group",
       phone: "+15550200",
-      __platform: "iMessage",
+      __platform: "imessage",
     } as const;
 
     await callGetMembers(
@@ -233,7 +233,7 @@ describe("iMessage actions.getAvatar", () => {
       id: GROUP_GUID,
       type: "group",
       phone: SELF_PHONE,
-      __platform: "iMessage",
+      __platform: "imessage",
     } as const;
 
     const icon = await callGetAvatar(client, space);
@@ -254,7 +254,7 @@ describe("iMessage actions.getAvatar", () => {
       id: GROUP_GUID,
       type: "group",
       phone: SELF_PHONE,
-      __platform: "iMessage",
+      __platform: "imessage",
     } as const;
 
     expect(await callGetAvatar(client, space)).toBeUndefined();
@@ -279,7 +279,7 @@ describe("iMessage actions.getAvatar", () => {
       id: GROUP_GUID,
       type: "group",
       phone: SELF_PHONE,
-      __platform: "iMessage",
+      __platform: "imessage",
     } as const;
 
     await expect(callGetAvatar(client, space)).rejects.toThrow(NotFoundError);
@@ -291,7 +291,7 @@ describe("iMessage actions.getAvatar", () => {
       id: DM_GUID,
       type: "dm",
       phone: SELF_PHONE,
-      __platform: "iMessage",
+      __platform: "imessage",
     } as const;
 
     await expect(callGetAvatar(client, space)).rejects.toThrow(
@@ -310,7 +310,7 @@ describe("iMessage actions.getDisplayName", () => {
       id: GROUP_GUID,
       type: "group",
       phone: SELF_PHONE,
-      __platform: "iMessage",
+      __platform: "imessage",
     } as const;
 
     expect(await callGetDisplayName(client, space)).toBe("Team Chat");
@@ -327,7 +327,7 @@ describe("iMessage actions.getDisplayName", () => {
       id: GROUP_GUID,
       type: "group",
       phone: SELF_PHONE,
-      __platform: "iMessage",
+      __platform: "imessage",
     } as const;
 
     expect(await callGetDisplayName(client, space)).toBeUndefined();
@@ -342,7 +342,7 @@ describe("iMessage actions.getDisplayName", () => {
       id: DM_GUID,
       type: "dm",
       phone: SELF_PHONE,
-      __platform: "iMessage",
+      __platform: "imessage",
     } as const;
 
     await expect(callGetDisplayName(client, space)).rejects.toThrow(

--- a/packages/imessage/test/remote/app.test.ts
+++ b/packages/imessage/test/remote/app.test.ts
@@ -59,7 +59,7 @@ describe("toSpectrumMiniApp", () => {
     const card = toSpectrumMiniApp("https://x.example/1", { caption: "C" });
     expect(card).toMatchObject({
       type: "customized-mini-app",
-      __platform: "iMessage",
+      __platform: "imessage",
       ...SPECTRUM_MINI_APP,
       url: "https://x.example/1",
       layout: { caption: "C" },

--- a/packages/imessage/test/remote/reactions.test.ts
+++ b/packages/imessage/test/remote/reactions.test.ts
@@ -210,7 +210,7 @@ describe("iMessage remote toReactionMessages", () => {
       client: [{ client: remote, phone: "+15551234567" }],
       content: await text(fromArray(["hello"])).build(),
       space: {
-        __platform: "iMessage",
+        __platform: "imessage",
         id: "s1",
         phone: "+15551234567",
         type: "dm",

--- a/packages/slack/package.json
+++ b/packages/slack/package.json
@@ -35,7 +35,7 @@
   "spectrum": {
     "key": "slack",
     "import": "slack",
-    "label": "Slack"
+    "label": "slack"
   },
   "scripts": {
     "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js",

--- a/packages/slack/src/index.ts
+++ b/packages/slack/src/index.ts
@@ -12,7 +12,9 @@ import {
   userSchema,
 } from "./types";
 
-export const slack = definePlatform("Slack", {
+const PLATFORM_ID = "slack";
+
+export const slack = definePlatform(PLATFORM_ID, {
   config: configSchema,
 
   lifecycle: {
@@ -71,7 +73,7 @@ export const slack = definePlatform("Slack", {
       if (input.users.length > 1) {
         throw UnsupportedError.action(
           "space.create",
-          "Slack",
+          PLATFORM_ID,
           "group DMs require an explicit channel id (Slack's conversations.open is not exposed); use space.get(channelId, { teamId })"
         );
       }

--- a/packages/slack/test/config.test.ts
+++ b/packages/slack/test/config.test.ts
@@ -2,9 +2,9 @@ import { envAwareConfig } from "@spectrum-ts/core/authoring";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { isCloudConfig, configSchema as rawConfigSchema } from "@/types";
 
-// `definePlatform("Slack", ...)` applies the env fallback from the platform id;
+// `definePlatform("slack", ...)` applies the env fallback from the platform id;
 // mirror that here so the test exercises the same `SPECTRUM_SLACK_*` resolution.
-const configSchema = envAwareConfig("Slack", rawConfigSchema);
+const configSchema = envAwareConfig("slack", rawConfigSchema);
 
 const ENDPOINT = "SPECTRUM_SLACK_ENDPOINT";
 

--- a/packages/spectrum-ts/scripts/generate-manifest.ts
+++ b/packages/spectrum-ts/scripts/generate-manifest.ts
@@ -7,8 +7,8 @@
  *
  * Each entry derives from the provider package's own `package.json#spectrum`
  * field (`{ key, import, label }`), validated against the provider's source:
- * `src/index.ts` must contain `export const <import> = definePlatform(<label>)`
- * (label as string literal or resolved through a shared const). That keeps the
+ * `src/index.ts` must contain `export const <import> = definePlatform(<platformId>)`
+ * (the id may be a string literal or resolved through a shared const). That keeps the
  * hand-written metadata from drifting out of sync with the code.
  *
  * The manifest `path` is the provider's npm package name — what a consumer
@@ -40,10 +40,10 @@ const OUT_PATH = join(PKG_ROOT, "dist", "manifest.json");
 const DEFINE_PLATFORM_RE =
   /^export\s+const\s+(\w+)\s*=\s*definePlatform\(\s*(?:"([^"]+)"|(\w+))/m;
 
-// Fusor providers pass their platform name as a shared const — the single
-// source of truth for the routing key — rather than a string literal. When
-// the label isn't inline, resolve the const from the provider's own sources.
-async function resolvePlatformLabel(
+// Providers may pass their platform id as a shared const — the single source
+// of truth for routing and runtime tagging — rather than a string literal. When
+// the id isn't inline, resolve the const from the provider's own sources.
+async function resolvePlatformId(
   srcDir: string,
   constName: string
 ): Promise<string> {
@@ -78,21 +78,21 @@ async function validateAgainstSource(
   const match = source.match(DEFINE_PLATFORM_RE);
   if (!match) {
     throw new Error(
-      `${pkgName}: ${sourcePath} does not match the expected \`export const <name> = definePlatform(<label>, ...)\` pattern. If you intentionally renamed the call, update generate-manifest.ts.`
+      `${pkgName}: ${sourcePath} does not match the expected \`export const <name> = definePlatform(<platformId>, ...)\` pattern. If you intentionally renamed the call, update generate-manifest.ts.`
     );
   }
-  const [, importName, literalLabel, labelConst] = match;
+  const [, importName, literalId, idConst] = match;
   if (importName !== spectrum.import) {
     throw new Error(
       `${pkgName}: package.json#spectrum.import is "${spectrum.import}" but src/index.ts exports \`${importName}\`.`
     );
   }
-  const label =
-    literalLabel ??
-    (labelConst ? await resolvePlatformLabel(srcDir, labelConst) : undefined);
-  if (label !== spectrum.label) {
+  const platformId =
+    literalId ??
+    (idConst ? await resolvePlatformId(srcDir, idConst) : undefined);
+  if (platformId !== spectrum.label) {
     throw new Error(
-      `${pkgName}: package.json#spectrum.label is "${spectrum.label}" but definePlatform uses "${label}".`
+      `${pkgName}: package.json#spectrum.label is "${spectrum.label}" but definePlatform uses "${platformId}".`
     );
   }
 }

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -35,7 +35,7 @@
   "spectrum": {
     "key": "terminal",
     "import": "terminal",
-    "label": "Terminal"
+    "label": "terminal"
   },
   "scripts": {
     "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js",

--- a/packages/terminal/src/index.ts
+++ b/packages/terminal/src/index.ts
@@ -46,6 +46,7 @@ const SPAWN_CONNECT_TIMEOUT_MS = 10_000;
 // protocol handshake gets stuck, we'd rather fail fast than hang
 // createClient indefinitely.
 const INITIALIZE_TIMEOUT_MS = 10_000;
+const PLATFORM_ID = "terminal";
 
 const commandSchema = z.object({
   name: z.string().regex(/^\/[A-Za-z0-9_-]+$/, "command must start with /"),
@@ -465,7 +466,7 @@ async function spectrumToProtocol(
   // crashes the whole process.
   throw UnsupportedError.content(
     (content as { type: string }).type,
-    "Terminal"
+    PLATFORM_ID
   );
 }
 
@@ -561,7 +562,7 @@ interface TerminalInboundMessage {
   timestamp: Date;
 }
 
-export const terminal = definePlatform("Terminal", {
+export const terminal = definePlatform(PLATFORM_ID, {
   config: z.object({
     commands: z.array(commandSchema).optional(),
   }),

--- a/packages/whatsapp-business/package.json
+++ b/packages/whatsapp-business/package.json
@@ -33,9 +33,9 @@
     }
   },
   "spectrum": {
-    "key": "whatsapp-business",
+    "key": "whatsapp_business",
     "import": "whatsappBusiness",
-    "label": "WhatsApp Business"
+    "label": "whatsapp_business"
   },
   "scripts": {
     "build": "tsdown && node ../../scripts/smoke-import.mjs dist/index.js",

--- a/packages/whatsapp-business/src/content/template.ts
+++ b/packages/whatsapp-business/src/content/template.ts
@@ -5,7 +5,7 @@ import z from "zod";
  * WhatsApp-only template message content. Lives entirely under the WhatsApp
  * Business provider — never enters the universal `Content` discriminated
  * union. The framework recognizes it via the generic content-level platform
- * contract: `__platform: "WhatsApp Business"` lets
+ * contract: `__platform: "whatsapp_business"` lets
  * `findUnsupportedPlatformContent` warn-and-skip when a different platform
  * receives it.
  *
@@ -18,7 +18,7 @@ import z from "zod";
  */
 export const whatsappTemplateSchema = z.object({
   type: z.literal("whatsapp-template"),
-  __platform: z.literal("WhatsApp Business"),
+  __platform: z.literal("whatsapp_business"),
   // Name of an approved template in the WhatsApp Business account.
   name: z.string().min(1),
   // Template language/locale code as approved, e.g. "en_US".
@@ -42,7 +42,7 @@ export const asWhatsAppTemplate = (
 ): WhatsAppTemplate =>
   whatsappTemplateSchema.parse({
     type: "whatsapp-template",
-    __platform: "WhatsApp Business",
+    __platform: "whatsapp_business",
     ...input,
   });
 

--- a/packages/whatsapp-business/src/index.ts
+++ b/packages/whatsapp-business/src/index.ts
@@ -20,7 +20,9 @@ export {
 } from "./content/template";
 export { WhatsAppPartialSendError } from "./errors/partial-send";
 
-export const whatsappBusiness = definePlatform("WhatsApp Business", {
+const PLATFORM_ID = "whatsapp_business";
+
+export const whatsappBusiness = definePlatform(PLATFORM_ID, {
   config: configSchema,
 
   lifecycle: {
@@ -73,7 +75,7 @@ export const whatsappBusiness = definePlatform("WhatsApp Business", {
       if (input.users.length > 1) {
         throw UnsupportedError.action(
           "space.create",
-          "WhatsApp Business",
+          PLATFORM_ID,
           "only 1:1 conversations are supported"
         );
       }

--- a/packages/whatsapp-business/test/config.test.ts
+++ b/packages/whatsapp-business/test/config.test.ts
@@ -2,10 +2,10 @@ import { envAwareConfig } from "@spectrum-ts/core/authoring";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { isCloudConfig, configSchema as rawConfigSchema } from "@/types";
 
-// `definePlatform("WhatsApp Business", ...)` applies the env fallback from the
+// `definePlatform("whatsapp_business", ...)` applies the env fallback from the
 // platform id; mirror that here so the test exercises the same
 // `SPECTRUM_WHATSAPP_BUSINESS_*` resolution.
-const configSchema = envAwareConfig("WhatsApp Business", rawConfigSchema);
+const configSchema = envAwareConfig("whatsapp_business", rawConfigSchema);
 
 const ACCESS_TOKEN = "SPECTRUM_WHATSAPP_BUSINESS_ACCESS_TOKEN";
 const PHONE_NUMBER_ID = "SPECTRUM_WHATSAPP_BUSINESS_PHONE_NUMBER_ID";

--- a/packages/whatsapp-business/test/template.test.ts
+++ b/packages/whatsapp-business/test/template.test.ts
@@ -27,7 +27,7 @@ describe("whatsapp template content", () => {
     expect(isWhatsAppTemplate(built)).toBe(true);
     expect(built).toMatchObject({
       type: "whatsapp-template",
-      __platform: "WhatsApp Business",
+      __platform: "whatsapp_business",
     });
   });
 


### PR DESCRIPTION
## Summary
- Enforce lowercase snake_case platform IDs at runtime
- Update provider lookup, environment prefixes, and tests to use canonical IDs
- Document distinct cloud and local iMessage platform IDs and exports

## Breaking change
- Runtime platform IDs and `message.platform` values now use lowercase snake_case. Update literal comparisons and any persisted platform tags when upgrading.

## Testing
- Updated affected platform tests and documentation examples

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787089726&installation_id=127326493&pr_number=209&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F209&signature=a9e1fc3d47b1b83ef0c84304140103551dbdbbd85c823e78bbee6ef6d0ace75d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `definePlatform` now requires a lowercase `snake_case` platform ID and rejects invalid IDs (no normalization).
  * Distinct platform IDs for cloud vs local iMessage are supported together in the same macOS app.
* **Documentation**
  * Updated setup, provider registration, platform narrowing/routing, troubleshooting, and examples to use the corrected platform IDs and identifiers (including `imessage` vs `local_imessage`, `slack`, and `whatsapp_business`).
* **Bug Fixes**
  * Standardized message/content and error classification tags to the new lowercase platform IDs.
  * Fixed platform string guards to compare using the correct lowercase values.  
* **Tests**
  * Updated test fixtures and expectations to match the underscore-based platform identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->