### PR TITLE
feat(imessage): handle dedicated Fusor supplemental events

### DIFF
--- a/packages/imessage/README.md
+++ b/packages/imessage/README.md
@@ -26,6 +26,12 @@ service can continue delivering customer webhooks by consuming that stream;
 raw Fusor envelopes are not accepted through the public `spectrum.webhook()`
 handler. The SDK no longer opens direct gRPC inbound streams.
 
+Dedicated Fusor delivery includes received messages, added reactions, poll
+changes, and group changes. Chat-only changes remain deliberate no-ops because
+they do not map to a public Spectrum message. Supplemental events keep the
+same public IDs as the former direct stream and carry the stable dedicated
+phone on their spaces.
+
 All outbound sends and unary, attachment, and file operations use Advanced
 iMessage HTTP clients. Spectrum Cloud returns each dedicated instance's token
 and assigned E.164 phone; the SDK sends the instance id to the existing HTTP

--- a/packages/imessage/src/remote/fusor.ts
+++ b/packages/imessage/src/remote/fusor.ts
@@ -1,6 +1,8 @@
 import {
   decodeCatchUpEvent,
+  type GroupEvent,
   type MessageEvent,
+  type PollEvent,
 } from "@photon-ai/advanced-imessage/http";
 import {
   FusorTerminalError,
@@ -8,17 +10,36 @@ import {
   type HybridFusorMessages,
 } from "@spectrum-ts/core";
 import type z from "zod";
-import { getMessageCache } from "../cache";
+import { getMessageCache, getPollCache } from "../cache";
 import type { IMessageClient, RemoteClient } from "../types";
 import { type configSchema, SHARED_PHONE } from "../types";
 import { inspectCatchUpSequence } from "./catchup-sequence";
 import { clientEntryForPhone, isSharedMode } from "./client";
 import { getContactShareTracker } from "./contact-share";
+import { groupEventActor, toGroupEventMessages } from "./group-events";
 import { type ReceivedEvent, toInboundMessages } from "./inbound";
+import { cachePollEvent, toPollDeltaMessages } from "./polls";
+import { toReactionMessages } from "./reactions";
 
-const EVENT_PATH = "/imessage/events/messageChanged";
 const PROTOBUF_CONTENT_TYPE = "application/x-protobuf";
 type LegacyTransformVersion = "1" | "2" | "3";
+type ReactionAddedEvent = Extract<
+  MessageEvent,
+  { type: "message.reactionAdded" }
+>;
+type DedicatedImessageEvent =
+  | GroupEvent
+  | PollEvent
+  | ReactionAddedEvent
+  | ReceivedEvent;
+
+const DEDICATED_EVENT_TYPES = {
+  groupChanged: "group.changed",
+  messageChanged: "message.received",
+  pollChanged: "poll.changed",
+  reactionAdded: "message.reactionAdded",
+} as const;
+type DedicatedImessageEventType = keyof typeof DEDICATED_EVENT_TYPES;
 
 const LEGACY_TRANSFORM_VERSIONS = new Set<LegacyTransformVersion>([
   "1",
@@ -125,7 +146,8 @@ interface LegacyImessageFusorPayload {
 }
 
 interface DedicatedImessageFusorPayload {
-  event: ReceivedEvent;
+  event: DedicatedImessageEvent;
+  eventType: DedicatedImessageEventType;
   kind: "dedicated";
   lineId: string;
   phone: string;
@@ -148,15 +170,25 @@ const destinationPhone = (
     : destinationCallerId;
 };
 
-const decodeReceivedEvent = (
+const receivedChatGuid = (event: ReceivedEvent): string | undefined =>
+  event.chatGuid || event.message.chatGuids?.[0];
+
+const decodeEvent = (
   rawBody: Uint8Array,
   sourceSequence: string
-): ReceivedEvent => {
+): ReturnType<typeof decodeCatchUpEvent> => {
   const inspection = inspectCatchUpSequence(rawBody);
   if (inspection.sequenceDecimal !== sourceSequence) {
     throw new Error("Invalid iMessage Fusor event: sequence mismatch");
   }
-  const decoded = decodeCatchUpEvent(inspection.decoderBody);
+  return decodeCatchUpEvent(inspection.decoderBody);
+};
+
+const decodeReceivedEvent = (
+  rawBody: Uint8Array,
+  sourceSequence: string
+): ReceivedEvent => {
+  const decoded = decodeEvent(rawBody, sourceSequence);
   if (decoded?.type !== "message.received") {
     throw new Error("Invalid iMessage Fusor event payload");
   }
@@ -173,7 +205,7 @@ const isLegacyTransformVersion = (
   LEGACY_TRANSFORM_VERSIONS.has(value as LegacyTransformVersion);
 
 const assertBaseRequest = (request: FusorVerifyRequest): void => {
-  if (request.method !== "POST" || request.path !== EVENT_PATH) {
+  if (request.method !== "POST") {
     throw new Error("Invalid iMessage Fusor event route");
   }
   const contentType = header(request, "content-type")
@@ -183,15 +215,30 @@ const assertBaseRequest = (request: FusorVerifyRequest): void => {
   if (contentType !== PROTOBUF_CONTENT_TYPE) {
     throw new Error("Invalid iMessage Fusor event content type");
   }
-  if (header(request, "x-fusor-imessage-event-type") !== "messageChanged") {
+};
+
+const assertEventContract = (
+  request: FusorVerifyRequest,
+  eventType: string
+): void => {
+  if (
+    request.path !== `/imessage/events/${eventType}` ||
+    header(request, "x-fusor-imessage-event-type") !== eventType
+  ) {
     throw new Error("Invalid iMessage Fusor event type");
   }
 };
+
+const isDedicatedEventType = (
+  value: string
+): value is DedicatedImessageEventType =>
+  Object.hasOwn(DEDICATED_EVENT_TYPES, value);
 
 const parseLegacyPayload = (
   request: FusorVerifyRequest,
   transformVersion: LegacyTransformVersion
 ): LegacyImessageFusorPayload => {
+  assertEventContract(request, "messageChanged");
   const sourceSequence = requireHeader(request, "x-fusor-imessage-log-id");
   if (!POSITIVE_INTEGER_RE.test(sourceSequence)) {
     throw new Error("Invalid iMessage Fusor source log id");
@@ -218,6 +265,11 @@ const parseDedicatedPayload = (
       "Invalid dedicated iMessage Fusor event: physical instance id is forbidden"
     );
   }
+  const eventType = requireHeader(request, "x-fusor-imessage-event-type");
+  if (!isDedicatedEventType(eventType)) {
+    throw new Error("Invalid dedicated iMessage Fusor event type");
+  }
+  assertEventContract(request, eventType);
   const lineId = requireHeader(request, "x-fusor-imessage-line-id");
   if (!UUID_RE.test(lineId)) {
     throw new Error("Invalid dedicated iMessage Fusor line id");
@@ -233,15 +285,29 @@ const parseDedicatedPayload = (
   if (!POSITIVE_INTEGER_RE.test(sourceSequence)) {
     throw new Error("Invalid dedicated iMessage Fusor source sequence");
   }
-  const event = decodeReceivedEvent(request.rawBody, sourceSequence);
-  const destination = destinationPhone(event.message.destinationCallerId);
-  if (destination !== undefined && destination !== phone) {
+  const event = decodeEvent(request.rawBody, sourceSequence);
+  if (event?.type !== DEDICATED_EVENT_TYPES[eventType]) {
+    throw new Error("Invalid dedicated iMessage Fusor event payload");
+  }
+  if (event.type === "message.received") {
+    if (event.isFromMe || event.message.isFromMe) {
+      throw new Error("Invalid iMessage Fusor event: outbound message");
+    }
+    const destination = destinationPhone(event.message.destinationCallerId);
+    if (destination !== undefined && destination !== phone) {
+      throw new Error(
+        `Invalid dedicated iMessage Fusor destination ${destination}`
+      );
+    }
+  }
+  if (event.type !== "message.received" && !event.chatGuid) {
     throw new Error(
-      `Invalid dedicated iMessage Fusor destination ${destination}`
+      "Invalid dedicated iMessage Fusor event: missing chat guid"
     );
   }
   return {
     event,
+    eventType,
     kind: "dedicated",
     lineId,
     phone,
@@ -303,6 +369,13 @@ const selectClient = (
   }
 };
 
+const isEventFromCurrentAccount = (
+  event: Pick<DedicatedImessageEvent, "actor" | "isFromMe">,
+  phone: string
+): boolean =>
+  event.isFromMe ||
+  (event.actor?.address !== undefined && event.actor.address === phone);
+
 export const handleImessageFusorMessages: HybridFusorMessages<
   ImessageFusorPayload,
   IMessageClient,
@@ -310,14 +383,68 @@ export const handleImessageFusorMessages: HybridFusorMessages<
 > = async ({ client, payload, projectConfig }) => {
   const selected = selectClient(client, payload);
   const phone = payload.kind === "dedicated" ? payload.phone : SHARED_PHONE;
-  const messages = await toInboundMessages(
-    selected.client,
-    getMessageCache(selected.client),
-    payload.event,
-    phone
-  );
-  if (projectConfig?.profile?.imessageSynced === true) {
-    getContactShareTracker(selected.client).maybeShare(payload.event.chatGuid);
+  if (payload.event.type === "message.received") {
+    const messages = await toInboundMessages(
+      selected.client,
+      getMessageCache(selected.client),
+      payload.event,
+      phone
+    );
+    if (projectConfig?.profile?.imessageSynced === true) {
+      const chatGuid = receivedChatGuid(payload.event);
+      if (chatGuid) {
+        getContactShareTracker(selected.client).maybeShare(chatGuid);
+      }
+    }
+    return messages;
   }
-  return messages;
+
+  if (payload.kind !== "dedicated") {
+    throw new FusorTerminalError(
+      "Legacy iMessage delivery cannot contain supplemental events"
+    );
+  }
+
+  if (payload.event.type === "message.reactionAdded") {
+    if (isEventFromCurrentAccount(payload.event, phone)) {
+      return [];
+    }
+    return await toReactionMessages(
+      selected.client,
+      getMessageCache(selected.client),
+      payload.event,
+      phone,
+      payload.sourceSequence
+    );
+  }
+
+  if (payload.event.type === "poll.changed") {
+    const pollCache = getPollCache(selected.client);
+    cachePollEvent(pollCache, payload.event);
+    if (isEventFromCurrentAccount(payload.event, phone)) {
+      return [];
+    }
+    return await toPollDeltaMessages(
+      selected.client,
+      pollCache,
+      payload.event,
+      phone
+    );
+  }
+
+  const actor = groupEventActor(payload.event);
+  if (
+    isEventFromCurrentAccount(
+      { actor, isFromMe: payload.event.isFromMe },
+      phone
+    )
+  ) {
+    return [];
+  }
+  return await toGroupEventMessages(
+    selected.client,
+    payload.event,
+    phone,
+    payload.sourceSequence
+  );
 };

--- a/packages/imessage/src/remote/group-events.ts
+++ b/packages/imessage/src/remote/group-events.ts
@@ -25,8 +25,10 @@ const log = createLogger("spectrum.imessage.group");
  * (the dedup key across live/catch-up) and the surfaced message. `sequence`
  * is monotonic per line, so the id is unique across all change kinds.
  */
-export const groupEventMessageId = (event: GroupEvent): string =>
-  `${event.chatGuid}:group:${event.sequence}`;
+export const groupEventMessageId = (
+  event: GroupEvent,
+  sourceSequence = String(event.sequence)
+): string => `${event.chatGuid}:group:${sourceSequence}`;
 
 /**
  * The acting party of a group change. For `participantLeft` that is the
@@ -136,7 +138,8 @@ const toGroupChangeContent = async (
 export const toGroupEventMessages = async (
   client: AdvancedIMessage,
   event: GroupEvent,
-  phone: string
+  phone: string,
+  sourceSequence = String(event.sequence)
 ): Promise<IMessageMessage[]> => {
   const content = await toGroupChangeContent(client, event);
   if (!content) {
@@ -146,7 +149,7 @@ export const toGroupEventMessages = async (
     {
       // No `direction`: the stream path defaults provider records to inbound
       // (the agent's own echoes are suppressed before conversion).
-      id: groupEventMessageId(event),
+      id: groupEventMessageId(event, sourceSequence),
       content,
       sender: toOptionalSenderRef(groupEventActor(event)),
       space: {

--- a/packages/imessage/src/remote/reactions.ts
+++ b/packages/imessage/src/remote/reactions.ts
@@ -88,7 +88,8 @@ export const toReactionMessages = async (
   client: AdvancedIMessage,
   cache: MessageCache,
   event: ReactionAddedEvent,
-  phone: string
+  phone: string,
+  sourceSequence = String(event.sequence)
 ): Promise<IMessageMessage[]> => {
   const emoji = reactionEmoji(event.reaction);
   if (!emoji) {
@@ -123,7 +124,7 @@ export const toReactionMessages = async (
         phone,
       },
       timestamp: event.occurredAt,
-      id: `${event.messageGuid}:reaction:${event.sequence}${partSuffix}`,
+      id: `${event.messageGuid}:reaction:${sourceSequence}${partSuffix}`,
       content: asProviderReaction(emoji, resolved),
     },
   ];

--- a/packages/imessage/test/remote/fusor.test.ts
+++ b/packages/imessage/test/remote/fusor.test.ts
@@ -63,6 +63,39 @@ const NATIVE_FRAME = replaceAscii(
   "spc-msg-message-guid",
   NATIVE_MESSAGE_GUID
 );
+const REACTION_FRAME = Uint8Array.from(
+  Buffer.from(
+    "CCtSWQoXaU1lc3NhZ2U7LTsrMTU1NTEyMzQ1NjcSCwiA4s+qBhDAqdM6GhQKDCsxNTU1NzY1NDMyMRABGgJVU3IbChNuYXRpdmUtbWVzc2FnZS1ndWlkEAIaAggB",
+    "base64"
+  )
+);
+const POLL_FRAME = Uint8Array.from(
+  Buffer.from(
+    "CCxiYgoXaU1lc3NhZ2U7KztuYXRpdmUtZ3JvdXASEG5hdGl2ZS1wb2xsLWd1aWQaCwiA4s+qBhDAqdM6IhQKDCsxNTU1NzY1NDMyMRABGgJVU2ISChBuYXRpdmUtb3B0aW9uLWlk",
+    "base64"
+  )
+);
+const GROUP_FRAME = Uint8Array.from(
+  Buffer.from(
+    "CC1aVAoXaU1lc3NhZ2U7KztuYXRpdmUtZ3JvdXASCwiA4s+qBhDAqdM6GhQKDCsxNTU1NzY1NDMyMRABGgJVU1oWChQKDCsxNTU1MDAwOTk5ORABGgJVUw==",
+    "base64"
+  )
+);
+
+type DedicatedEventType =
+  | "groupChanged"
+  | "messageChanged"
+  | "pollChanged"
+  | "reactionAdded";
+
+const DEDICATED_FIXTURES: Readonly<
+  Record<DedicatedEventType, { body: Uint8Array; sequence: string }>
+> = {
+  groupChanged: { body: GROUP_FRAME, sequence: "45" },
+  messageChanged: { body: NATIVE_FRAME, sequence: "42" },
+  pollChanged: { body: POLL_FRAME, sequence: "44" },
+  reactionAdded: { body: REACTION_FRAME, sequence: "43" },
+};
 
 const encodeVarint = (value: bigint): Uint8Array => {
   const bytes: number[] = [];
@@ -76,8 +109,8 @@ const encodeVarint = (value: bigint): Uint8Array => {
 };
 
 const withSequence = (body: Uint8Array, sequence: bigint): Uint8Array => {
-  if (body[0] !== 8 || body[1] !== 42) {
-    throw new Error("fixture no longer starts with sequence field 1 = 42");
+  if (body[0] !== 8 || (body[1] ?? 128) >= 128) {
+    throw new Error("fixture no longer starts with a one-byte field 1");
   }
   const encoded = encodeVarint(sequence);
   const result = new Uint8Array(body.byteLength - 1 + encoded.byteLength);
@@ -111,22 +144,26 @@ const legacyRequest = (
 };
 
 const dedicatedRequest = (
-  overrides: Partial<FusorVerifyRequest> = {}
-): FusorVerifyRequest => ({
-  method: "POST",
-  path: "/imessage/events/messageChanged",
-  headers: {
-    "content-type": "application/x-protobuf",
-    "x-fusor-imessage-event-type": "messageChanged",
-    "x-fusor-imessage-line-id": LINE_ID,
-    "x-fusor-imessage-phone": LINE_PHONE,
-    "x-fusor-imessage-source-sequence": "42",
-    "x-fusor-imessage-transform-version": "4",
-    "x-fusor-source": "fusor-fanin-imessage",
-  },
-  rawBody: NATIVE_FRAME,
-  ...overrides,
-});
+  overrides: Partial<FusorVerifyRequest> = {},
+  eventType: DedicatedEventType = "messageChanged"
+): FusorVerifyRequest => {
+  const fixture = DEDICATED_FIXTURES[eventType];
+  return {
+    method: "POST",
+    path: `/imessage/events/${eventType}`,
+    headers: {
+      "content-type": "application/x-protobuf",
+      "x-fusor-imessage-event-type": eventType,
+      "x-fusor-imessage-line-id": LINE_ID,
+      "x-fusor-imessage-phone": LINE_PHONE,
+      "x-fusor-imessage-source-sequence": fixture.sequence,
+      "x-fusor-imessage-transform-version": "4",
+      "x-fusor-source": "fusor-fanin-imessage",
+    },
+    rawBody: fixture.body,
+    ...overrides,
+  };
+};
 
 const decodedFixture = (body: Uint8Array = NATIVE_FRAME): ReceivedEvent => {
   const event = decodeCatchUpEvent(body);
@@ -136,14 +173,34 @@ const decodedFixture = (body: Uint8Array = NATIVE_FRAME): ReceivedEvent => {
   return event;
 };
 
-const decodeOnceAs = (event: ReceivedEvent): void => {
+const decodeOnceAs = (
+  event: NonNullable<ReturnType<typeof decodeCatchUpEvent>>
+): void => {
   vi.mocked(decodeCatchUpEvent).mockReturnValueOnce(event);
+};
+
+type DedicatedReceivedPayload = Extract<
+  ReturnType<typeof verifyImessageFusorRequest>,
+  { kind: "dedicated" }
+> & { event: ReceivedEvent };
+
+const dedicatedReceivedPayload = (): DedicatedReceivedPayload => {
+  const payload = verifyImessageFusorRequest(dedicatedRequest());
+  if (
+    payload.kind !== "dedicated" ||
+    payload.event.type !== "message.received"
+  ) {
+    throw new Error("expected a dedicated message.received payload");
+  }
+  return payload as DedicatedReceivedPayload;
 };
 
 interface ClientSpies {
   client: AdvancedIMessage;
   downloadStream: ReturnType<typeof vi.fn>;
+  getGroupIcon: ReturnType<typeof vi.fn>;
   getMessage: ReturnType<typeof vi.fn>;
+  getPoll: ReturnType<typeof vi.fn>;
   shareContactInfo: ReturnType<typeof vi.fn>;
 }
 
@@ -162,16 +219,26 @@ const remoteClient = (overrides: Partial<ClientSpies> = {}): ClientSpies => {
   const getMessage =
     overrides.getMessage ??
     vi.fn(() => Promise.reject(new Error("message lookup not expected")));
+  const getPoll =
+    overrides.getPoll ??
+    vi.fn(() => Promise.reject(new Error("poll lookup not expected")));
+  const getGroupIcon =
+    overrides.getGroupIcon ??
+    vi.fn(() => Promise.reject(new Error("group icon lookup not expected")));
   const shareContactInfo =
     overrides.shareContactInfo ?? vi.fn(() => Promise.resolve());
   return {
     client: {
       attachments: { downloadStream },
       chats: { shareContactInfo },
+      groups: { getIcon: getGroupIcon },
       messages: { get: getMessage },
+      polls: { get: getPoll },
     } as unknown as AdvancedIMessage,
     downloadStream,
+    getGroupIcon,
     getMessage,
+    getPoll,
     shareContactInfo,
   };
 };
@@ -338,6 +405,50 @@ describe("iMessage Fusor request verification", () => {
       },
       type: "message.received",
     });
+  });
+
+  it.each([
+    ["reactionAdded", "message.reactionAdded", "43"],
+    ["pollChanged", "poll.changed", "44"],
+    ["groupChanged", "group.changed", "45"],
+  ] as const)("decodes a golden dedicated %s frame only through its exact v4 contract", (eventType, decodedType, sourceSequence) => {
+    const payload = verifyImessageFusorRequest(dedicatedRequest({}, eventType));
+
+    expect(payload).toMatchObject({
+      event: { type: decodedType },
+      eventType,
+      kind: "dedicated",
+      lineId: LINE_ID,
+      phone: LINE_PHONE,
+      sourceSequence,
+      transformVersion: "4",
+    });
+  });
+
+  it("rejects a v4 event whose exact path/header kind disagrees with the protobuf", () => {
+    const input = dedicatedRequest({}, "reactionAdded");
+    expect(() =>
+      verifyImessageFusorRequest({
+        ...input,
+        rawBody: withSequence(POLL_FRAME, 43n),
+      })
+    ).toThrow("event payload");
+  });
+
+  it("rejects chat-only and unknown v4 event kinds", () => {
+    for (const eventType of ["chatChanged", "reactionRemoved"]) {
+      const input = dedicatedRequest();
+      expect(() =>
+        verifyImessageFusorRequest({
+          ...input,
+          headers: {
+            ...input.headers,
+            "x-fusor-imessage-event-type": eventType,
+          },
+          path: `/imessage/events/${eventType}`,
+        })
+      ).toThrow("event type");
+    }
   });
 
   it("keeps an exact signed-int64 sequence above Number.MAX_SAFE_INTEGER", () => {
@@ -596,6 +707,271 @@ describe("iMessage Fusor delivery routing", () => {
     });
   });
 
+  it("maps a native reaction through only the selected phone and preserves its public id", async () => {
+    const base = decodedFixture();
+    const getMessage = vi.fn(() =>
+      Promise.resolve({
+        ...base.message,
+        content: { ...base.message.content, text: "reaction target" },
+        guid: "native-message-guid",
+      })
+    );
+    const selected = remoteClient({ getMessage });
+    const other = remoteClient();
+    const payload = verifyImessageFusorRequest(
+      dedicatedRequest({}, "reactionAdded")
+    );
+    const records = await handle(
+      [
+        {
+          client: other.client,
+          phone: OTHER_PHONE,
+        },
+        { client: selected.client, phone: LINE_PHONE },
+      ],
+      payload,
+      true
+    );
+    const record = Array.isArray(records) ? records[0] : records;
+
+    expect(record).toMatchObject({
+      id: "native-message-guid:reaction:43:2",
+      space: {
+        id: "iMessage;-;+15551234567",
+        phone: LINE_PHONE,
+      },
+    });
+    if (record?.content.type !== "reaction") {
+      throw new Error("expected reaction content");
+    }
+    expect(record.content.target).toMatchObject({
+      id: "native-message-guid",
+      space: { phone: LINE_PHONE },
+    });
+    expect(record.space).not.toHaveProperty("lineId");
+    expect(record.content.target.space).not.toHaveProperty("lineId");
+    expect(selected.getMessage).toHaveBeenCalledWith("native-message-guid");
+    expect(other.getMessage).not.toHaveBeenCalled();
+    expect(selected.shareContactInfo).not.toHaveBeenCalled();
+  });
+
+  it("maps a native poll vote through only the selected phone", async () => {
+    const getPoll = vi.fn(() =>
+      Promise.resolve({
+        chatGuid: "iMessage;+;native-group",
+        options: [
+          {
+            optionIdentifier: "native-option-id",
+            text: "Ship it",
+          },
+          {
+            optionIdentifier: "native-option-id-2",
+            text: "Wait",
+          },
+        ],
+        pollMessageGuid: "native-poll-guid",
+        title: "Release?",
+        votes: [],
+      })
+    );
+    const selected = remoteClient({ getPoll });
+    const other = remoteClient();
+    const payload = verifyImessageFusorRequest(
+      dedicatedRequest({}, "pollChanged")
+    );
+    const records = await handle(
+      [
+        {
+          client: other.client,
+          phone: OTHER_PHONE,
+        },
+        { client: selected.client, phone: LINE_PHONE },
+      ],
+      payload
+    );
+    const record = Array.isArray(records) ? records[0] : records;
+
+    expect(record).toMatchObject({
+      id: "native-poll-guid:+15557654321:native-option-id:selected:1700000000123",
+      content: { selected: true, type: "poll_option" },
+      space: {
+        id: "iMessage;+;native-group",
+        phone: LINE_PHONE,
+      },
+    });
+    expect(record?.space).not.toHaveProperty("lineId");
+    expect(selected.getPoll).toHaveBeenCalledWith("native-poll-guid");
+    expect(other.getPoll).not.toHaveBeenCalled();
+  });
+
+  it("caches self-authored poll metadata before suppressing its echo", async () => {
+    const selected = remoteClient();
+    const vote = verifyImessageFusorRequest(
+      dedicatedRequest({}, "pollChanged")
+    );
+    if (vote.kind !== "dedicated" || vote.event.type !== "poll.changed") {
+      throw new Error("expected a dedicated poll change");
+    }
+    const created = {
+      ...vote,
+      event: {
+        ...vote.event,
+        actor: { address: LINE_PHONE, service: "iMessage" as const },
+        delta: {
+          options: [
+            { optionIdentifier: "native-option-id", text: "Ship it" },
+            { optionIdentifier: "native-option-id-2", text: "Wait" },
+          ],
+          title: "Release?",
+          type: "created" as const,
+        },
+        isFromMe: true,
+      },
+    };
+    const clients = [{ client: selected.client, phone: LINE_PHONE }];
+
+    await expect(handle(clients, created)).resolves.toEqual([]);
+    const records = await handle(clients, vote);
+
+    expect(Array.isArray(records) ? records[0]?.content.type : undefined).toBe(
+      "poll_option"
+    );
+    expect(selected.getPoll).not.toHaveBeenCalled();
+  });
+
+  it("maps a native group change with the pre-migration synthetic id", async () => {
+    const selected = remoteClient();
+    const payload = verifyImessageFusorRequest(
+      dedicatedRequest({}, "groupChanged")
+    );
+    const records = await handle(
+      [{ client: selected.client, phone: LINE_PHONE }],
+      payload
+    );
+
+    expect(Array.isArray(records) ? records[0] : records).toMatchObject({
+      id: "iMessage;+;native-group:group:45",
+      content: { members: ["+15550009999"], type: "addMember" },
+      space: {
+        id: "iMessage;+;native-group",
+        phone: LINE_PHONE,
+      },
+    });
+    expect(
+      Array.isArray(records) ? records[0]?.space : records?.space
+    ).not.toHaveProperty("lineId");
+  });
+
+  it("uses the exact source sequence in supplemental ids above Number.MAX_SAFE_INTEGER", async () => {
+    const groupInput = dedicatedRequest({}, "groupChanged");
+    const groupPayload = verifyImessageFusorRequest({
+      ...groupInput,
+      headers: {
+        ...groupInput.headers,
+        "x-fusor-imessage-source-sequence": SIGNED_INT64_MAX.toString(),
+      },
+      rawBody: withSequence(GROUP_FRAME, SIGNED_INT64_MAX),
+    });
+    const groupClient = remoteClient();
+    const groupRecords = await handle(
+      [{ client: groupClient.client, phone: LINE_PHONE }],
+      groupPayload
+    );
+
+    expect(
+      Array.isArray(groupRecords) ? groupRecords[0]?.id : groupRecords?.id
+    ).toBe(`iMessage;+;native-group:group:${SIGNED_INT64_MAX}`);
+
+    const base = decodedFixture();
+    const reactionClient = remoteClient({
+      getMessage: vi.fn(() =>
+        Promise.resolve({
+          ...base.message,
+          content: { ...base.message.content, text: "reaction target" },
+          guid: "native-message-guid",
+        })
+      ),
+    });
+    const reactionInput = dedicatedRequest({}, "reactionAdded");
+    const reactionPayload = verifyImessageFusorRequest({
+      ...reactionInput,
+      headers: {
+        ...reactionInput.headers,
+        "x-fusor-imessage-source-sequence": SIGNED_INT64_MAX.toString(),
+      },
+      rawBody: withSequence(REACTION_FRAME, SIGNED_INT64_MAX),
+    });
+    const reactionRecords = await handle(
+      [{ client: reactionClient.client, phone: LINE_PHONE }],
+      reactionPayload
+    );
+
+    expect(
+      Array.isArray(reactionRecords)
+        ? reactionRecords[0]?.id
+        : reactionRecords?.id
+    ).toBe(`native-message-guid:reaction:${SIGNED_INT64_MAX}:2`);
+  });
+
+  it("suppresses supplemental self echoes with the same dedicated-line rules as the old stream", async () => {
+    const selected = remoteClient();
+
+    const reaction = verifyImessageFusorRequest(
+      dedicatedRequest({}, "reactionAdded")
+    );
+    if (
+      reaction.kind !== "dedicated" ||
+      reaction.event.type !== "message.reactionAdded"
+    ) {
+      throw new Error("expected a dedicated reaction");
+    }
+    await expect(
+      handle([{ client: selected.client, phone: LINE_PHONE }], {
+        ...reaction,
+        event: { ...reaction.event, isFromMe: true },
+      })
+    ).resolves.toEqual([]);
+
+    const poll = verifyImessageFusorRequest(
+      dedicatedRequest({}, "pollChanged")
+    );
+    if (poll.kind !== "dedicated" || poll.event.type !== "poll.changed") {
+      throw new Error("expected a dedicated poll change");
+    }
+    await expect(
+      handle([{ client: selected.client, phone: LINE_PHONE }], {
+        ...poll,
+        event: {
+          ...poll.event,
+          actor: { address: LINE_PHONE, service: "iMessage" },
+        },
+      })
+    ).resolves.toEqual([]);
+
+    const group = verifyImessageFusorRequest(
+      dedicatedRequest({}, "groupChanged")
+    );
+    if (group.kind !== "dedicated" || group.event.type !== "group.changed") {
+      throw new Error("expected a dedicated group change");
+    }
+    await expect(
+      handle([{ client: selected.client, phone: LINE_PHONE }], {
+        ...group,
+        event: {
+          ...group.event,
+          actor: undefined,
+          change: {
+            participant: { address: LINE_PHONE, service: "iMessage" },
+            type: "participantLeft",
+          },
+        },
+      })
+    ).resolves.toEqual([]);
+
+    expect(selected.getMessage).not.toHaveBeenCalled();
+    expect(selected.getPoll).not.toHaveBeenCalled();
+  });
+
   it("terminal-fails a missing dedicated phone route", async () => {
     const other = remoteClient();
     const payload = verifyImessageFusorRequest(dedicatedRequest());
@@ -623,7 +999,7 @@ describe("iMessage Fusor delivery routing", () => {
 
   it("puts the dedicated phone on every returned multipart space", async () => {
     const selected = remoteClient();
-    const decoded = verifyImessageFusorRequest(dedicatedRequest());
+    const decoded = dedicatedReceivedPayload();
     const payload = {
       ...decoded,
       event: {
@@ -669,7 +1045,7 @@ describe("iMessage Fusor delivery routing", () => {
   it("reads a native attachment through only the selected HTTP client", async () => {
     const selected = remoteClient();
     const other = remoteClient();
-    const decoded = verifyImessageFusorRequest(dedicatedRequest());
+    const decoded = dedicatedReceivedPayload();
     const payload = {
       ...decoded,
       event: {
@@ -729,7 +1105,7 @@ describe("iMessage Fusor delivery routing", () => {
     );
     const selected = remoteClient({ getMessage: selectedGet });
     const other = remoteClient();
-    const decoded = verifyImessageFusorRequest(dedicatedRequest());
+    const decoded = dedicatedReceivedPayload();
     const payload = {
       ...decoded,
       event: {
@@ -758,9 +1134,35 @@ describe("iMessage Fusor delivery routing", () => {
     expect(other.getMessage).not.toHaveBeenCalled();
   });
 
+  it("accepts a received frame whose chat guid is carried only by the message", async () => {
+    const fallbackChatGuid = "iMessage;-;+15557654321";
+    const base = decodedFixture();
+    decodeOnceAs({
+      ...base,
+      chatGuid: "",
+      message: {
+        ...base.message,
+        chatGuids: [fallbackChatGuid],
+      },
+    });
+    const payload = verifyImessageFusorRequest(dedicatedRequest());
+    const selected = remoteClient();
+
+    const records = await handle(
+      [{ client: selected.client, phone: LINE_PHONE }],
+      payload,
+      true
+    );
+
+    expect(Array.isArray(records) ? records[0]?.space.id : undefined).toBe(
+      fallbackChatGuid
+    );
+    expect(selected.shareContactInfo).toHaveBeenCalledWith(fallbackChatGuid);
+  });
+
   it("shares a synced chat only after inbound conversion succeeds", async () => {
     const successful = remoteClient();
-    const payload = verifyImessageFusorRequest(dedicatedRequest());
+    const payload = dedicatedReceivedPayload();
     await handle(
       [
         {

--- a/packages/imessage/test/remote/fusor.test.ts
+++ b/packages/imessage/test/remote/fusor.test.ts
@@ -36,6 +36,16 @@ const LINE_PHONE = "+15550001111";
 const OTHER_PHONE = "+15550002222";
 const NATIVE_MESSAGE_GUID = "native-guid-00000001";
 const SIGNED_INT64_MAX = 9_223_372_036_854_775_807n;
+const MESSAGE_SOURCE_SEQUENCE = "42";
+const REACTION_SOURCE_SEQUENCE = "43";
+const POLL_SOURCE_SEQUENCE = "44";
+const GROUP_SOURCE_SEQUENCE = "45";
+const REACTION_TARGET_PART_INDEX = 2;
+const POLL_EVENT_TIMESTAMP_MS = 1_700_000_000_123;
+const PROTOBUF_VARINT_BASE = 128n;
+const PROTOBUF_VARINT_CONTINUATION_FLAG = 0x80;
+const CATCH_UP_SEQUENCE_FIELD_TAG = 8;
+const SINGLE_BYTE_SEQUENCE_PREFIX_LENGTH = 2;
 
 const replaceAscii = (
   body: Uint8Array,
@@ -91,32 +101,41 @@ type DedicatedEventType =
 const DEDICATED_FIXTURES: Readonly<
   Record<DedicatedEventType, { body: Uint8Array; sequence: string }>
 > = {
-  groupChanged: { body: GROUP_FRAME, sequence: "45" },
-  messageChanged: { body: NATIVE_FRAME, sequence: "42" },
-  pollChanged: { body: POLL_FRAME, sequence: "44" },
-  reactionAdded: { body: REACTION_FRAME, sequence: "43" },
+  groupChanged: { body: GROUP_FRAME, sequence: GROUP_SOURCE_SEQUENCE },
+  messageChanged: { body: NATIVE_FRAME, sequence: MESSAGE_SOURCE_SEQUENCE },
+  pollChanged: { body: POLL_FRAME, sequence: POLL_SOURCE_SEQUENCE },
+  reactionAdded: { body: REACTION_FRAME, sequence: REACTION_SOURCE_SEQUENCE },
 };
 
 const encodeVarint = (value: bigint): Uint8Array => {
   const bytes: number[] = [];
   let remaining = value;
   do {
-    const payload = Number(remaining % 128n);
-    remaining /= 128n;
-    bytes.push(remaining === 0n ? payload : payload + 128);
+    const payload = Number(remaining % PROTOBUF_VARINT_BASE);
+    remaining /= PROTOBUF_VARINT_BASE;
+    bytes.push(
+      remaining === 0n ? payload : payload + PROTOBUF_VARINT_CONTINUATION_FLAG
+    );
   } while (remaining !== 0n);
   return Uint8Array.from(bytes);
 };
 
 const withSequence = (body: Uint8Array, sequence: bigint): Uint8Array => {
-  if (body[0] !== 8 || (body[1] ?? 128) >= 128) {
+  if (
+    body[0] !== CATCH_UP_SEQUENCE_FIELD_TAG ||
+    (body[1] ?? PROTOBUF_VARINT_CONTINUATION_FLAG) >=
+      PROTOBUF_VARINT_CONTINUATION_FLAG
+  ) {
     throw new Error("fixture no longer starts with a one-byte field 1");
   }
   const encoded = encodeVarint(sequence);
   const result = new Uint8Array(body.byteLength - 1 + encoded.byteLength);
-  result[0] = 8;
+  result[0] = CATCH_UP_SEQUENCE_FIELD_TAG;
   result.set(encoded, 1);
-  result.set(body.subarray(2), 1 + encoded.byteLength);
+  result.set(
+    body.subarray(SINGLE_BYTE_SEQUENCE_PREFIX_LENGTH),
+    1 + encoded.byteLength
+  );
   return result;
 };
 
@@ -127,7 +146,7 @@ const legacyRequest = (
   const headers: Record<string, string> = {
     "content-type": "application/x-protobuf",
     "x-fusor-imessage-event-type": "messageChanged",
-    "x-fusor-imessage-log-id": "42",
+    "x-fusor-imessage-log-id": MESSAGE_SOURCE_SEQUENCE,
     "x-fusor-imessage-transform-version": version,
     "x-fusor-source": "spectrum-imessage",
   };
@@ -278,7 +297,7 @@ describe("iMessage Fusor request verification", () => {
 
     expect(payload).toMatchObject({
       kind: "legacy",
-      sourceSequence: "42",
+      sourceSequence: MESSAGE_SOURCE_SEQUENCE,
       transformVersion: version,
     });
     if (payload.kind !== "legacy") {
@@ -294,7 +313,7 @@ describe("iMessage Fusor request verification", () => {
         guid: "spc-msg-message-guid",
         isFromMe: false,
       },
-      sequence: 42,
+      sequence: Number(MESSAGE_SOURCE_SEQUENCE),
       type: "message.received",
     });
   });
@@ -395,7 +414,7 @@ describe("iMessage Fusor request verification", () => {
       kind: "dedicated",
       lineId: LINE_ID,
       phone: LINE_PHONE,
-      sourceSequence: "42",
+      sourceSequence: MESSAGE_SOURCE_SEQUENCE,
       transformVersion: "4",
     });
     expect(payload.event).toMatchObject({
@@ -408,9 +427,9 @@ describe("iMessage Fusor request verification", () => {
   });
 
   it.each([
-    ["reactionAdded", "message.reactionAdded", "43"],
-    ["pollChanged", "poll.changed", "44"],
-    ["groupChanged", "group.changed", "45"],
+    ["reactionAdded", "message.reactionAdded", REACTION_SOURCE_SEQUENCE],
+    ["pollChanged", "poll.changed", POLL_SOURCE_SEQUENCE],
+    ["groupChanged", "group.changed", GROUP_SOURCE_SEQUENCE],
   ] as const)("decodes a golden dedicated %s frame only through its exact v4 contract", (eventType, decodedType, sourceSequence) => {
     const payload = verifyImessageFusorRequest(dedicatedRequest({}, eventType));
 
@@ -430,7 +449,7 @@ describe("iMessage Fusor request verification", () => {
     expect(() =>
       verifyImessageFusorRequest({
         ...input,
-        rawBody: withSequence(POLL_FRAME, 43n),
+        rawBody: withSequence(POLL_FRAME, BigInt(REACTION_SOURCE_SEQUENCE)),
       })
     ).toThrow("event payload");
   });
@@ -474,7 +493,7 @@ describe("iMessage Fusor request verification", () => {
         ...dedicatedRequest(),
         headers: {
           ...dedicatedRequest().headers,
-          "x-fusor-imessage-source-sequence": "43",
+          "x-fusor-imessage-source-sequence": REACTION_SOURCE_SEQUENCE,
         },
       })
     ).toThrow("sequence mismatch");
@@ -735,7 +754,7 @@ describe("iMessage Fusor delivery routing", () => {
     const record = Array.isArray(records) ? records[0] : records;
 
     expect(record).toMatchObject({
-      id: "native-message-guid:reaction:43:2",
+      id: `native-message-guid:reaction:${REACTION_SOURCE_SEQUENCE}:${REACTION_TARGET_PART_INDEX}`,
       space: {
         id: "iMessage;-;+15551234567",
         phone: LINE_PHONE,
@@ -792,7 +811,7 @@ describe("iMessage Fusor delivery routing", () => {
     const record = Array.isArray(records) ? records[0] : records;
 
     expect(record).toMatchObject({
-      id: "native-poll-guid:+15557654321:native-option-id:selected:1700000000123",
+      id: `native-poll-guid:+15557654321:native-option-id:selected:${POLL_EVENT_TIMESTAMP_MS}`,
       content: { selected: true, type: "poll_option" },
       space: {
         id: "iMessage;+;native-group",
@@ -850,7 +869,7 @@ describe("iMessage Fusor delivery routing", () => {
     );
 
     expect(Array.isArray(records) ? records[0] : records).toMatchObject({
-      id: "iMessage;+;native-group:group:45",
+      id: `iMessage;+;native-group:group:${GROUP_SOURCE_SEQUENCE}`,
       content: { members: ["+15550009999"], type: "addMember" },
       space: {
         id: "iMessage;+;native-group",
@@ -910,7 +929,9 @@ describe("iMessage Fusor delivery routing", () => {
       Array.isArray(reactionRecords)
         ? reactionRecords[0]?.id
         : reactionRecords?.id
-    ).toBe(`native-message-guid:reaction:${SIGNED_INT64_MAX}:2`);
+    ).toBe(
+      `native-message-guid:reaction:${SIGNED_INT64_MAX}:${REACTION_TARGET_PART_INDEX}`
+    );
   });
 
   it("suppresses supplemental self echoes with the same dedicated-line rules as the old stream", async () => {


### PR DESCRIPTION
## Summary

- decode and verify dedicated transform-v4 `messageChanged`, `reactionAdded`, `pollChanged`, and `groupChanged` envelopes
- dispatch supplemental events through existing Spectrum helpers while preserving legacy shared transform v1-v3 behavior and WebSocket-only Fusor inbound transport
- select the dedicated HTTP client by exact E.164 phone; keep `lineId` only as verified inbound transport provenance
- retain self-event suppression, poll-cache ordering, opaque native GUIDs, and exact decimal source-sequence IDs above JavaScript's safe integer range
- do not expose `lineId` on emitted spaces or reconstructed reaction targets

Linear: [ENG-2051](https://linear.app/photonhq/issue/ENG-2051/complete-dedicated-imessage-supplemental-event-parity)

## Stack

- stacked on #210 and must merge after it
- producer companion: [Fusor #61](https://github.com/photon-hq/fusor/pull/61), currently stacked on recovery [#62](https://github.com/photon-hq/fusor/pull/62)
- merge the SDK stack #195 → #210 → #211; after each squash merge, restack and retarget the next PR onto `main`
- do not publish an intermediate SDK release

## Compatibility

- dedicated chat, message, attachment, poll, and mini-app identifiers stay native
- outbound routing remains the same stable-phone model used before this migration, so persisted pre-migration spaces keep working
- shared transform v1-v3 delivery and retained shared `spc-*` identifiers are unchanged
- Spectrum Cloud supplies per-instance credentials/mapping and the existing HTTP adapter performs outbound instance routing
- no Fusor outbound gateway, Cloud resource-token endpoint, or project-scoped dedicated proxy is added

## Validation

- `bun run check`
- scoped iMessage typecheck
- Node iMessage tests: 245 passed
- Bun iMessage tests: 245 passed
- `git diff --check`

No runtime state was applied or synced. Legacy `spectrum-webhook` remains the webhook path while Fusor webhook delivery for iMessage is disabled.