### PR TITLE
Switch iMessage clients to the gRPC transport

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -131,10 +131,13 @@
       "name": "@spectrum-ts/imessage",
       "version": "12.1.0",
       "dependencies": {
-        "@photon-ai/advanced-imessage": "^1.0.0",
+        "@grpc/grpc-js": "^1.14.4",
+        "@photon-ai/advanced-imessage": "^2.0.2",
         "@photon-ai/otel": "^3.1.0",
         "lru-cache": "^11.0.0",
         "marked": "^18.0.5",
+        "nice-grpc": "^2.1.16",
+        "nice-grpc-common": "^2.0.3",
         "zod": "^4.2.1",
       },
       "devDependencies": {
@@ -400,7 +403,7 @@
 
     "@fastify/proxy-addr": ["@fastify/proxy-addr@5.1.0", "", { "dependencies": { "@fastify/forwarded": "^3.0.0", "ipaddr.js": "^2.1.0" } }, "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw=="],
 
-    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
+    "@grpc/grpc-js": ["@grpc/grpc-js@1.14.4", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ=="],
 
     "@grpc/proto-loader": ["@grpc/proto-loader@0.8.0", "", { "dependencies": { "lodash.camelcase": "^4.3.0", "long": "^5.0.0", "protobufjs": "^7.5.3", "yargs": "^17.7.2" }, "bin": { "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js" } }, "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ=="],
 
@@ -454,7 +457,7 @@
 
     "@parseaple/typedstream": ["@parseaple/typedstream@2.0.2", "", { "dependencies": { "@parseaple/bplist": "1.0.1" } }, "sha512-bzKNZjiBtZN2T2U7Nqq/hhv+EezkPnaWoB5WvPuBwNpQvOr3EI0XrDTkFnAzsA9DKdu57es/gcb1d2ctd1u8xw=="],
 
-    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@1.0.0", "", { "dependencies": { "@bufbuild/protobuf": "^2.11.0", "@grpc/grpc-js": "^1.12.6", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2" } }, "sha512-X5xaXy0SqPa9AuLxD0d/XI04e7WMO2rpXlT94TTMbtVkW0mTlb88fnp3SCwZKl/zEpCC3wQkuEfpNAM2Xgnyww=="],
+    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@2.0.2", "", { "dependencies": { "@bufbuild/protobuf": "^2.11.0" }, "peerDependencies": { "@grpc/grpc-js": "^1.12.6", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2" }, "optionalPeers": ["@grpc/grpc-js", "nice-grpc", "nice-grpc-common"] }, "sha512-2BbK2mUXPivgaeiHpN8hwF6tKW0AIeEyNiIOOYXc7h42SiPsBmlMEuKHdmCGbI+8mVb090a16HZJLOySDcg7Ug=="],
 
     "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-GGDETlRbrPXP5eaRvswaead7MCBGQkm8f7d3aVbx8+rXhB4GEyPiw7Q1/yz5ix53rmxqKRevWywOfG7n+kZDBw=="],
 
@@ -720,7 +723,7 @@
 
     "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
 
-    "cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
+    "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
@@ -1278,9 +1281,9 @@
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
-    "yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
+    "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
-    "yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
+    "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
@@ -1298,11 +1301,13 @@
 
     "@grpc/proto-loader/protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
-    "@grpc/proto-loader/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
-
     "@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.219.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-FFx7YnaYJlIjqWW/AG/yAZ0L/NEY724PipXXXQLdtZPbLwBGbUMTGL1i/esI56TWfTUXxhLfpgrnWJCG8aUJyg=="],
 
+    "@photon-ai/slack/@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
+
     "@photon-ai/slack/nice-grpc": ["nice-grpc@2.1.15", "", { "dependencies": { "@grpc/grpc-js": "^1.14.0", "abort-controller-x": "^0.5.0", "nice-grpc-common": "^2.0.3" } }, "sha512-agPIt7dtQASnN5p1X3c2S5amDhWRWRT0Jp62trmpMBKSbkm87l8bG2slqxSthlrGa4AnRPG8+lFf4y8nn+Pogw=="],
+
+    "@photon-ai/whatsapp-business/@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
 
     "@types/body-parser/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
@@ -1326,6 +1331,8 @@
 
     "cli-highlight/parse5-htmlparser2-tree-adapter": ["parse5-htmlparser2-tree-adapter@6.0.1", "", { "dependencies": { "parse5": "^6.0.1" } }, "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA=="],
 
+    "cli-highlight/yargs": ["yargs@16.2.0", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw=="],
+
     "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
@@ -1339,6 +1346,8 @@
     "marked-terminal/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "marked-terminal/marked": ["marked@9.1.6", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q=="],
+
+    "nice-grpc/@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
 
     "node-abi/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -1368,10 +1377,6 @@
 
     "@grpc/proto-loader/protobufjs/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
-    "@grpc/proto-loader/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
-
-    "@grpc/proto-loader/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
-
     "@types/body-parser/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "@types/connect/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
@@ -1389,6 +1394,10 @@
     "bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "cli-highlight/parse5-htmlparser2-tree-adapter/parse5": ["parse5@6.0.1", "", {}, "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw=="],
+
+    "cli-highlight/yargs/cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
+
+    "cli-highlight/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/packages/imessage/package.json
+++ b/packages/imessage/package.json
@@ -45,10 +45,13 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@photon-ai/advanced-imessage": "^1.0.0",
+    "@grpc/grpc-js": "^1.14.4",
+    "@photon-ai/advanced-imessage": "^2.0.2",
     "@photon-ai/otel": "^3.1.0",
     "lru-cache": "^11.0.0",
     "marked": "^18.0.5",
+    "nice-grpc": "^2.1.16",
+    "nice-grpc-common": "^2.0.3",
     "zod": "^4.2.1"
   },
   "peerDependencies": {

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -1,4 +1,4 @@
-import { createClient } from "@photon-ai/advanced-imessage";
+import { createGrpcClient } from "@photon-ai/advanced-imessage/grpc";
 import {
   cloud,
   type DedicatedTokenData,
@@ -77,7 +77,7 @@ export async function createCloudClients(
     const entries: RemoteClient[] = [
       {
         phone: SHARED_PHONE,
-        client: createClient({
+        client: createGrpcClient({
           address,
           // Auto-retry transient unary failures so a brief server blip during
           // an outbound action (send/react/reply) doesn't surface as an
@@ -103,7 +103,7 @@ export async function createCloudClients(
   for (const [instanceId, token] of Object.entries(dedicated.auth)) {
     const entry: RemoteClient = {
       phone: requirePhone(dedicated, instanceId),
-      client: createClient({
+      client: createGrpcClient({
         address: `${instanceId}.imsg.photon.codes:443`,
         autoIdempotency: true,
         retry: true,

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -1,8 +1,8 @@
 import {
   type AdvancedIMessage,
-  createClient,
+  createGrpcClient,
   type MiniAppCardSession,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import { withSpan } from "@photon-ai/otel";
 import {
   type AddMember,
@@ -479,7 +479,7 @@ export const imessage = definePlatform(IMESSAGE_PLATFORM, {
           : [config.clients];
         return entries.map((e) => ({
           phone: e.phone,
-          client: createClient({
+          client: createGrpcClient({
             address: e.address,
             // Auto-retry transient unary failures (idempotency-keyed so retries
             // can't double-apply) so a server blip during an outbound action

--- a/packages/imessage/src/remote/api.ts
+++ b/packages/imessage/src/remote/api.ts
@@ -1,7 +1,7 @@
 import type {
   AdvancedIMessage,
   MiniAppCardSession,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import type {
   AddMember,
   Avatar,

--- a/packages/imessage/src/remote/attachments.ts
+++ b/packages/imessage/src/remote/attachments.ts
@@ -1,7 +1,7 @@
 import {
   type AdvancedIMessage,
   NotFoundError,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import type { Attachment } from "@spectrum-ts/core";
 import { asAttachment } from "@spectrum-ts/core/authoring";
 import { normalizeAppleAttachmentMimeType } from "../shared/audio";

--- a/packages/imessage/src/remote/avatar.ts
+++ b/packages/imessage/src/remote/avatar.ts
@@ -1,7 +1,7 @@
 import {
   type AdvancedIMessage,
   NotFoundError,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import type { Avatar, AvatarData } from "@spectrum-ts/core";
 import { toChatGuid } from "./ids";
 

--- a/packages/imessage/src/remote/background.ts
+++ b/packages/imessage/src/remote/background.ts
@@ -1,4 +1,4 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import type { Background } from "../content/background";
 import { toChatGuid } from "./ids";
 

--- a/packages/imessage/src/remote/client.ts
+++ b/packages/imessage/src/remote/client.ts
@@ -1,4 +1,4 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import { type RemoteClient, SHARED_PHONE } from "../types";
 
 export const isSharedMode = (clients: RemoteClient[]): boolean =>

--- a/packages/imessage/src/remote/contact-card.ts
+++ b/packages/imessage/src/remote/contact-card.ts
@@ -1,4 +1,4 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import { toChatGuid } from "./ids";
 
 /**

--- a/packages/imessage/src/remote/contact-share.ts
+++ b/packages/imessage/src/remote/contact-share.ts
@@ -1,4 +1,4 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import {
   createLogger,
   errorAttrs,

--- a/packages/imessage/src/remote/customized-mini-app.ts
+++ b/packages/imessage/src/remote/customized-mini-app.ts
@@ -2,7 +2,7 @@ import type {
   AdvancedIMessage,
   MiniAppCardSession,
   MiniAppMessageResult,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import type { Content } from "@spectrum-ts/core";
 import type { ProviderMessageRecord } from "@spectrum-ts/core/authoring";
 import type { CustomizedMiniApp } from "../content/customized-mini-app";

--- a/packages/imessage/src/remote/group-events.ts
+++ b/packages/imessage/src/remote/group-events.ts
@@ -2,7 +2,7 @@ import type {
   AdvancedIMessage,
   GroupEvent,
   SingleServiceAddressInfo,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import type { Content } from "@spectrum-ts/core";
 import {
   addMemberSchema,

--- a/packages/imessage/src/remote/inbound.ts
+++ b/packages/imessage/src/remote/inbound.ts
@@ -4,7 +4,7 @@ import {
   type MessageEvent,
   NotFoundError,
   type SingleServiceAddressInfo,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import { type Content, fromVCard, type Group } from "@spectrum-ts/core";
 import {
   asAttachment,

--- a/packages/imessage/src/remote/markdown.ts
+++ b/packages/imessage/src/remote/markdown.ts
@@ -1,4 +1,4 @@
-import type { TextFormatInput } from "@photon-ai/advanced-imessage";
+import type { TextFormatInput } from "@photon-ai/advanced-imessage/grpc";
 import { Marked, type MarkedToken, type Token, type Tokens } from "marked";
 
 // Private instance: immune to host apps reconfiguring the global `marked`

--- a/packages/imessage/src/remote/members.ts
+++ b/packages/imessage/src/remote/members.ts
@@ -1,7 +1,7 @@
 import type {
   AdvancedIMessage,
   ChatServiceType,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import type { AddMember, RemoveMember } from "@spectrum-ts/core";
 import { toChatGuid } from "./ids";
 

--- a/packages/imessage/src/remote/polls.ts
+++ b/packages/imessage/src/remote/polls.ts
@@ -4,7 +4,7 @@ import type {
   PollOption as IMessagePollOption,
   PollChangeDelta,
   PollEvent,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import type { PollChoice } from "@spectrum-ts/core";
 import {
   asPoll,

--- a/packages/imessage/src/remote/reactions.ts
+++ b/packages/imessage/src/remote/reactions.ts
@@ -2,7 +2,7 @@ import type {
   AdvancedIMessage,
   MessageEvent,
   SettableMessageReaction,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import type { Reaction as ReactionContent } from "@spectrum-ts/core";
 import {
   type ProviderMessageRecord,

--- a/packages/imessage/src/remote/read.ts
+++ b/packages/imessage/src/remote/read.ts
@@ -1,4 +1,4 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import { toChatGuid } from "./ids";
 
 /**

--- a/packages/imessage/src/remote/rename.ts
+++ b/packages/imessage/src/remote/rename.ts
@@ -1,4 +1,4 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import type { Rename } from "@spectrum-ts/core";
 import { toChatGuid } from "./ids";
 

--- a/packages/imessage/src/remote/send.ts
+++ b/packages/imessage/src/remote/send.ts
@@ -6,7 +6,7 @@ import type {
   Message as SDKMessage,
   SendOptions,
   TextFormatInput,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import { type Content, type Message, toVCard } from "@spectrum-ts/core";
 import {
   asGroup,

--- a/packages/imessage/src/remote/stream-text.ts
+++ b/packages/imessage/src/remote/stream-text.ts
@@ -1,7 +1,7 @@
 import type {
   AdvancedIMessage,
   Message as SDKMessage,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import type { StreamText } from "@spectrum-ts/core";
 import {
   asText,

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -5,7 +5,7 @@ import {
   type MessageEvent,
   type PollEvent,
   ValidationError,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import { sanitizePhone } from "@photon-ai/otel";
 import {
   type ManagedStream,

--- a/packages/imessage/src/remote/typing.ts
+++ b/packages/imessage/src/remote/typing.ts
@@ -1,4 +1,4 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import { toChatGuid } from "./ids";
 
 export const startTyping = async (

--- a/packages/imessage/src/types.ts
+++ b/packages/imessage/src/types.ts
@@ -1,4 +1,4 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import type { SchemaMessage } from "@spectrum-ts/core";
 import z from "zod";
 

--- a/packages/imessage/test/auth.test.ts
+++ b/packages/imessage/test/auth.test.ts
@@ -20,7 +20,7 @@ const initialTokenData: FakeDedicatedTokenData = {
 
 const issueImessageTokens = vi.fn(() => Promise.resolve(initialTokenData));
 const clientOptions: FakeClientOptions[] = [];
-const createClient = vi.fn((options: FakeClientOptions) => {
+const createGrpcClient = vi.fn((options: FakeClientOptions) => {
   clientOptions.push(options);
   return {};
 });
@@ -33,7 +33,7 @@ vi.doMock("@spectrum-ts/core", async (importOriginal) => {
   };
 });
 
-vi.doMock("@photon-ai/advanced-imessage", () => ({ createClient }));
+vi.doMock("@photon-ai/advanced-imessage/grpc", () => ({ createGrpcClient }));
 
 const { createCloudClients, disposeCloudAuth, getCloudRecover } = await import(
   "@/auth"
@@ -43,7 +43,7 @@ describe("imessage cloud auth", () => {
   beforeEach(() => {
     issueImessageTokens.mockReset();
     issueImessageTokens.mockResolvedValue(initialTokenData);
-    createClient.mockClear();
+    createGrpcClient.mockClear();
     clientOptions.length = 0;
   });
 

--- a/packages/imessage/test/contact-card.test.ts
+++ b/packages/imessage/test/contact-card.test.ts
@@ -1,4 +1,4 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import type { Space } from "@spectrum-ts/core";
 import { describe, expect, it, vi } from "vitest";
 import { isContactCard } from "@/content/contact-card";

--- a/packages/imessage/test/membership.test.ts
+++ b/packages/imessage/test/membership.test.ts
@@ -1,4 +1,4 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import { addMember, leaveSpace, removeMember } from "@spectrum-ts/core";
 import { describe, expect, it, vi } from "vitest";
 import { imessage } from "@/index";

--- a/packages/imessage/test/read-actions.test.ts
+++ b/packages/imessage/test/read-actions.test.ts
@@ -1,7 +1,7 @@
 import {
   type AdvancedIMessage,
   NotFoundError,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import type { AvatarData } from "@spectrum-ts/core";
 import { describe, expect, it, vi } from "vitest";
 import { imessage } from "@/index";

--- a/packages/imessage/test/remote/app.test.ts
+++ b/packages/imessage/test/remote/app.test.ts
@@ -2,7 +2,7 @@ import type {
   AdvancedIMessage,
   MiniAppCardSession,
   MiniAppMessageResult,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import type { Content } from "@spectrum-ts/core";
 import { describe, expect, it, vi } from "vitest";
 import { asCustomizedMiniApp } from "@/content/customized-mini-app";

--- a/packages/imessage/test/remote/contact-share.test.ts
+++ b/packages/imessage/test/remote/contact-share.test.ts
@@ -1,4 +1,4 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import { flush } from "@spectrum-ts/test-support/timing";
 import { describe, expect, it, vi } from "vitest";
 import {

--- a/packages/imessage/test/remote/group-events.test.ts
+++ b/packages/imessage/test/remote/group-events.test.ts
@@ -3,8 +3,8 @@ import type {
   GroupChange,
   GroupEvent,
   GroupIcon,
-} from "@photon-ai/advanced-imessage";
-import { NotFoundError } from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
+import { NotFoundError } from "@photon-ai/advanced-imessage/grpc";
 import { describe, expect, it, vi } from "vitest";
 import { toGroupEventMessages } from "@/remote/group-events";
 

--- a/packages/imessage/test/remote/inbound.test.ts
+++ b/packages/imessage/test/remote/inbound.test.ts
@@ -2,7 +2,7 @@ import {
   type AdvancedIMessage,
   type MessageEvent,
   NotFoundError,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import { describe, expect, it } from "vitest";
 import { MessageCache } from "@/cache";
 import { toInboundMessages } from "@/remote/inbound";

--- a/packages/imessage/test/remote/reactions.test.ts
+++ b/packages/imessage/test/remote/reactions.test.ts
@@ -3,7 +3,7 @@ import type {
   MessageEvent,
   Message as SDKMessage,
   SettableMessageReaction,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import { text } from "@spectrum-ts/core";
 import { describe, expect, it, vi } from "vitest";
 import { getMessageCache, MessageCache } from "@/cache";

--- a/packages/imessage/test/remote/send-markdown.test.ts
+++ b/packages/imessage/test/remote/send-markdown.test.ts
@@ -1,7 +1,7 @@
 import type {
   AdvancedIMessage,
   Message as SDKMessage,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import {
   type Content,
   type Message,

--- a/packages/imessage/test/remote/stream-text.test.ts
+++ b/packages/imessage/test/remote/stream-text.test.ts
@@ -1,7 +1,7 @@
 import type {
   AdvancedIMessage,
   Message as SDKMessage,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import {
   markdown,
   type StreamText,

--- a/packages/imessage/test/remote/stream.test.ts
+++ b/packages/imessage/test/remote/stream.test.ts
@@ -1,4 +1,4 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import { flush, settleSoon } from "@spectrum-ts/test-support/timing";
 import { describe, expect, it, vi } from "vitest";
 import { messages } from "@/remote/stream";

--- a/packages/imessage/test/remote/unsend.test.ts
+++ b/packages/imessage/test/remote/unsend.test.ts
@@ -2,7 +2,7 @@ import type {
   AdvancedIMessage,
   Message as SDKMessage,
   SettableMessageReaction,
-} from "@photon-ai/advanced-imessage";
+} from "@photon-ai/advanced-imessage/grpc";
 import { describe, expect, it, vi } from "vitest";
 import { formatChildId } from "@/remote/ids";
 import { unsendReaction } from "@/remote/reactions";

--- a/packages/imessage/test/space.test.ts
+++ b/packages/imessage/test/space.test.ts
@@ -1,4 +1,4 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage";
+import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import { describe, expect, it } from "vitest";
 import { imessage } from "@/index";
 import type { RemoteClient } from "@/types";

--- a/packages/spectrum-ts/test/imessage-package-boundary.test.ts
+++ b/packages/spectrum-ts/test/imessage-package-boundary.test.ts
@@ -34,6 +34,17 @@ describe("iMessage package boundary", () => {
     expect(manifest.dependencies).not.toHaveProperty("better-sqlite3");
   });
 
+  it("installs the Advanced iMessage gRPC transport", async () => {
+    const manifest = await readManifest("imessage");
+
+    expect(manifest.dependencies).toMatchObject({
+      "@grpc/grpc-js": "^1.14.4",
+      "@photon-ai/advanced-imessage": "^2.0.2",
+      "nice-grpc": "^2.1.16",
+      "nice-grpc-common": "^2.0.3",
+    });
+  });
+
   it("installs imessage-kit only with the explicit local provider", async () => {
     const manifest = await readManifest("imessage-local");
 


### PR DESCRIPTION
## Summary
- Upgrade Advanced iMessage to v2.0.2 and use its gRPC client API
- Add explicit gRPC transport dependencies for the iMessage package
- Update mocks, types, and package-boundary coverage

## Testing
- Not run (not requested)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787130118&installation_id=127326493&pr_number=212&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F212&signature=5c17dc38a8c6e4d750f29d29ab22472f5b2fc11b2764af2d7d84827f09b7a766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ca99ec22807f91959c470304d4a3724dc9a6ff02. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * iMessage connectivity now uses the updated gRPC transport, improving compatibility with the latest messaging capabilities.
* **Bug Fixes**
  * Preserved existing authentication, retry, token refresh, messaging, and media behavior while transitioning transports.
* **Tests**
  * Added coverage to verify the required gRPC transport components are installed and configured correctly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->