### PR TITLE
fix(whatsapp-business): require appSecret for inbound direct mode

### DIFF
--- a/docs/providers.mdx.vel
+++ b/docs/providers.mdx.vel
@@ -52,6 +52,7 @@ Call each provider's `config()` method and pass the results to `providers`:
       providers: [
         imessage.config(),
         whatsappBusiness.config({
+          mode: "inbound",
           accessToken: process.env.WA_TOKEN!,
           phoneNumberId: process.env.WA_NUMBER_ID!,
           appSecret: process.env.WA_SECRET!,
@@ -78,6 +79,7 @@ Call each provider's `config()` method and pass the results to `providers`:
       providers: [
         imessage.config(),
         whatsappBusiness.config({
+          mode: "inbound",
           accessToken: process.env.WA_TOKEN!,
           phoneNumberId: process.env.WA_NUMBER_ID!,
           appSecret: process.env.WA_SECRET!,

--- a/docs/providers/whatsapp-business/setup.mdx.vel
+++ b/docs/providers/whatsapp-business/setup.mdx.vel
@@ -4,17 +4,55 @@ sidebarTitle: "Setup"
 description: "Configure the WhatsApp Business provider with Meta credentials."
 ---
 
-Use `whatsappBusiness.config(...)` with credentials from Meta for Developers.
+Choose cloud, inbound direct, or outbound-only direct behavior explicitly. The
+direct modes use credentials from Meta for Developers; cloud mode uses the
+Spectrum project credentials passed to `Spectrum()`.
 
 ## Config
 
+### Cloud
+
+Omit `mode` and direct credentials to use Spectrum Cloud:
+
+```ts
+whatsappBusiness.config();
+```
+
+Cloud mode requires `projectId` and `projectSecret` on `Spectrum()` (or their
+`SPECTRUM_PROJECT_ID` and `SPECTRUM_PROJECT_SECRET` environment fallbacks).
+
+### Inbound direct
+
+Use `mode: "inbound"` to send messages and subscribe to inbound webhooks.
+`appSecret` is required because it verifies inbound webhook signatures:
+
 ```ts
 whatsappBusiness.config({
+  mode: "inbound",
   accessToken: "your-access-token",
   phoneNumberId: "your-phone-number-id",
   appSecret: "your-app-secret",
 });
 ```
+
+### Outbound-only direct
+
+Use `mode: "outbound-only"` for a send-only provider. This mode forbids
+`appSecret` and never opens an inbound subscription:
+
+```ts
+whatsappBusiness.config({
+  mode: "outbound-only",
+  accessToken: "your-access-token",
+  phoneNumberId: "your-phone-number-id",
+});
+```
+
+| Mode | Required direct credentials | Receives messages |
+|---|---|---|
+| Cloud (`mode` omitted) | None | Yes |
+| `inbound` | `accessToken`, `phoneNumberId`, `appSecret` | Yes |
+| `outbound-only` | `accessToken`, `phoneNumberId` | No |
 
 | Option | Description | Env fallback |
 |---|---|---|
@@ -22,14 +60,28 @@ whatsappBusiness.config({
 | `phoneNumberId` | The phone number ID for the business account sending messages. | `SPECTRUM_WHATSAPP_BUSINESS_PHONE_NUMBER_ID` |
 | `appSecret` | App secret used to verify webhook payload signatures. | `SPECTRUM_WHATSAPP_BUSINESS_APP_SECRET` |
 
-Each option falls back to its environment variable when omitted (an explicit
-value always wins). If you set both `SPECTRUM_WHATSAPP_BUSINESS_ACCESS_TOKEN`
-and `SPECTRUM_WHATSAPP_BUSINESS_PHONE_NUMBER_ID`, calling
-`whatsappBusiness.config()` with no arguments boots the provider in direct mode
-from the environment. A partial set (only one of the two) instead falls back to
-cloud mode, which uses your `projectId`/`projectSecret`.
+Credential values fall back to their environment variables when omitted, and
+an explicit value always wins. `mode` is behavioral, so it never comes from an
+environment variable; select a direct mode in code even when every credential
+comes from the environment:
+
+```ts
+// Reads accessToken, phoneNumberId, and appSecret from the env vars above.
+whatsappBusiness.config({ mode: "inbound" });
+```
+
+Calling `whatsappBusiness.config()` with no arguments always selects cloud mode,
+even when direct credential environment variables are present. Partial or
+ambiguous configs fail during startup instead of falling back to another mode.
 
 Find these values in your WhatsApp Business app settings on [Meta for Developers](https://developers.facebook.com/).
+
+<Warning>
+  Upgrading from the old flat direct config requires adding `mode: "inbound"`
+  (or `mode: "outbound-only"` for send-only use). An env-only
+  `whatsappBusiness.config()` now means cloud mode, and inbound mode no longer
+  accepts a missing or empty `appSecret`.
+</Warning>
 
 ## Example
 
@@ -40,6 +92,7 @@ import { whatsappBusiness } from "spectrum-ts/providers/whatsapp-business";
 const app = await Spectrum({
   providers: [
     whatsappBusiness.config({
+      mode: "inbound",
       accessToken: process.env.WA_TOKEN!,
       phoneNumberId: process.env.WA_NUMBER_ID!,
       appSecret: process.env.WA_SECRET!,

--- a/packages/core/src/platform/types.ts
+++ b/packages/core/src/platform/types.ts
@@ -929,17 +929,28 @@ export interface SpectrumLike<
 // Platform — the callable returned by definePlatform()
 // ---------------------------------------------------------------------------
 
-// Every string-leaf config field falls back to `SPECTRUM_<PLATFORM>_<KEY>` at
-// runtime (see `envAwareConfig`), so any declared field may be omitted and
-// supplied by the environment instead. `ConfigInput` reflects that by making the
-// top-level input keys optional. The conditional distributes over unions so a
-// `direct | cloud` config input isn't collapsed to its shared keys.
-type ConfigInput<Def extends AnyPlatformDef> =
-  z.input<Def["config"]> extends infer Input
-    ? Input extends unknown
-      ? { [K in keyof Input]?: Input[K] }
-      : never
+// Config fields may be supplied by the environment, so the public input keeps
+// the existing top-level optionality. A discriminated union is the exception:
+// its discriminator selects behavior rather than carrying a credential value,
+// and `envAwareConfig` never supplies it. Preserve that key's original required
+// or optional modifier while leaving every other key backward-compatible.
+type ConfigDiscriminator<Schema extends z.ZodType> =
+  Schema extends z.ZodDiscriminatedUnion<infer _Options, infer Discriminator>
+    ? Discriminator
     : never;
+
+type ConfigBranchInput<
+  Input,
+  Discriminator extends PropertyKey,
+> = Input extends unknown
+  ? Pick<Input, Extract<keyof Input, Discriminator>> &
+      Partial<Omit<Input, Extract<keyof Input, Discriminator>>>
+  : never;
+
+type ConfigInput<Def extends AnyPlatformDef> = ConfigBranchInput<
+  z.input<Def["config"]>,
+  ConfigDiscriminator<Def["config"]>
+>;
 
 export interface Platform<Def extends AnyPlatformDef> {
   config(

--- a/packages/core/src/utils/env.ts
+++ b/packages/core/src/utils/env.ts
@@ -133,8 +133,9 @@ const isStrictObject = (def: ZodInternal["def"]): boolean =>
  *   The object is only reconstructed when a field actually changed, and
  *   `.strict()` is preserved so an empty strict "cloud" branch is untouched.
  * - **union**: each option is rewritten independently, so an env value only
- *   satisfies the branch that declares that field (a direct/cloud union stays
- *   correctly discriminated).
+ *   satisfies the branch that declares that field. The original schema is
+ *   cloned with those options so discriminated unions and custom errors keep
+ *   their exact behavior.
  * - anything else is returned unchanged.
  *
  * The output type is identical to the input schema's. Only omitted fields gain
@@ -157,7 +158,7 @@ const rewrite = (prefix: string, schema: z.ZodType): z.ZodType => {
 
   if (def.type === "union" && def.options) {
     const options = def.options.map((option) => rewrite(prefix, option));
-    return z.union(options as [z.ZodType, z.ZodType, ...z.ZodType[]]);
+    return schema.clone({ ...schema.def, options } as typeof schema.def);
   }
 
   return schema;

--- a/packages/core/test/utils/env.test.ts
+++ b/packages/core/test/utils/env.test.ts
@@ -139,6 +139,7 @@ describe("envAwareConfig", () => {
     "SPECTRUM_TELEGRAM_BOT_TOKEN",
     "SPECTRUM_TELEGRAM_BASE_URL",
     "SPECTRUM_WHATSAPP_BUSINESS_ACCESS_TOKEN",
+    "SPECTRUM_WHATSAPP_BUSINESS_APP_SECRET",
     "SPECTRUM_WHATSAPP_BUSINESS_PHONE_NUMBER_ID",
     "SPECTRUM_DEMO_TOKENS",
     "SPECTRUM_DEMO_ITEMS",
@@ -251,5 +252,37 @@ describe("envAwareConfig", () => {
     delete process.env.SPECTRUM_WHATSAPP_BUSINESS_ACCESS_TOKEN;
     delete process.env.SPECTRUM_WHATSAPP_BUSINESS_PHONE_NUMBER_ID;
     expect(schema.parse({})).toEqual({});
+  });
+
+  it("preserves discriminated-union branch errors while adding env fallback", () => {
+    const appSecretRequired = "app secret required for inbound mode";
+    const schema = envAwareConfig(
+      "WhatsApp Business",
+      z.discriminatedUnion("mode", [
+        z.strictObject({
+          mode: z.literal("inbound"),
+          accessToken: z.string().min(1),
+          appSecret: z.string({ error: appSecretRequired }).min(1),
+        }),
+        z.strictObject({
+          mode: z.literal("outbound-only"),
+          accessToken: z.string().min(1),
+        }),
+        z.strictObject({ mode: z.undefined().optional() }),
+      ])
+    );
+
+    process.env.SPECTRUM_WHATSAPP_BUSINESS_ACCESS_TOKEN = "tok";
+    const result = schema.safeParse({ mode: "inbound" });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected inbound config without appSecret to fail");
+    }
+    expect(result.error.issues).toHaveLength(1);
+    expect(result.error.issues[0]).toMatchObject({
+      path: ["appSecret"],
+      message: appSecretRequired,
+    });
   });
 });

--- a/packages/whatsapp-business/src/index.ts
+++ b/packages/whatsapp-business/src/index.ts
@@ -1,10 +1,11 @@
 import { createClient } from "@photon-ai/whatsapp-business";
 import { definePlatform, UnsupportedError } from "@spectrum-ts/core";
 import { createCloudClients, disposeCloudAuth } from "./auth";
-import { messages, send } from "./messages";
+import { messages, noMessages, send } from "./messages";
 import {
   configSchema,
   isCloudConfig,
+  isOutboundOnly,
   spaceSchema,
   type WhatsAppClients,
 } from "./types";
@@ -35,7 +36,10 @@ export const whatsappBusiness = definePlatform(PLATFORM_ID, {
         return [
           createClient({
             accessToken: config.accessToken,
-            appSecret: config.appSecret ?? "",
+            // Only inbound mode carries an appSecret (its type guarantees it);
+            // outbound-only sends never verify inbound signatures, so "" is
+            // fine — it never opens a subscribe (see `messages` below).
+            appSecret: config.mode === "inbound" ? config.appSecret : "",
             phoneNumberId: config.phoneNumberId,
           }),
         ];
@@ -45,7 +49,8 @@ export const whatsappBusiness = definePlatform(PLATFORM_ID, {
         throw new Error(
           "WhatsApp Business cloud mode requires projectId and projectSecret. " +
             "Either pass credentials to Spectrum(), or provide direct credentials: " +
-            "whatsappBusiness.config({ accessToken, phoneNumberId })"
+            "whatsappBusiness.config({ mode: 'inbound', accessToken, phoneNumberId, appSecret }) " +
+            "(or mode: 'outbound-only' for send-only)."
         );
       }
 
@@ -87,7 +92,10 @@ export const whatsappBusiness = definePlatform(PLATFORM_ID, {
     },
   },
 
-  messages: ({ client }) => messages(client),
+  // Outbound-only direct mode has no appSecret to authenticate a subscribe, so
+  // it produces no inbound messages; every other mode streams live events.
+  messages: ({ client, config }) =>
+    isOutboundOnly(config) ? noMessages() : messages(client),
 
   send: async ({ space, content, client }) =>
     await send(client, space.id, content),

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -719,6 +719,12 @@ export const messages = (
   clients: WhatsAppClients
 ): ManagedStream<WhatsAppMessage> => mergeStreams(clients.map(clientStream));
 
+// Outbound-only direct mode has no appSecret, so an inbound subscribe could
+// never authenticate — surface an immediately-completed stream instead of
+// opening a subscription that would only error. Send-only, by design.
+export const noMessages = (): ManagedStream<WhatsAppMessage> =>
+  mergeStreams([]);
+
 // Meta caps media captions at 1024 characters (image/video/document docs).
 const MAX_CAPTION_LENGTH = 1024;
 

--- a/packages/whatsapp-business/src/types.ts
+++ b/packages/whatsapp-business/src/types.ts
@@ -2,28 +2,61 @@ import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
 import type { SchemaMessage } from "@spectrum-ts/core";
 import z from "zod";
 
-// Direct-mode credentials fall back to `SPECTRUM_WHATSAPP_BUSINESS_*` env vars
-// (explicit config wins), applied automatically by `definePlatform` from the
-// platform id. A complete env set — access token + phone number id — satisfies
-// `directConfig` even when `whatsappBusiness.config()` is called empty, so the
-// union resolves to direct mode; a partial set fails `directConfig` and falls
-// through to `cloudConfig`.
-const directConfig = z.object({
+// Direct-mode credential VALUES fall back to `SPECTRUM_WHATSAPP_BUSINESS_*` env
+// vars (explicit config wins), applied automatically by `definePlatform` from
+// the platform id. `mode` is the discriminator and is NOT env-backed (a literal,
+// not a string leaf), so a direct mode is always chosen explicitly in code —
+// an empty `whatsappBusiness.config()` resolves to cloud mode, never a guessed
+// direct mode with half-filled credentials.
+
+const APP_SECRET_REQUIRED =
+  "WhatsApp Business `mode: 'inbound'` requires `appSecret` (it verifies inbound webhook signatures). Provide it, or use `mode: 'outbound-only'` for send-only.";
+
+// Inbound direct mode: opens the live event stream, which needs `appSecret` to
+// authenticate/verify inbound webhooks. All three credentials are mandatory —
+// the previous optional-`appSecret`-substituted-`""` shape let inbound subscribe
+// start silently unauthenticated, which is exactly what this prevents.
+const inboundConfig = z.strictObject({
+  mode: z.literal("inbound"),
   accessToken: z.string().min(1),
-  appSecret: z.string().optional(),
+  appSecret: z.string({ error: APP_SECRET_REQUIRED }).min(1),
   phoneNumberId: z.string().min(1),
 });
 
-const cloudConfig = z.object({}).strict();
+// Outbound-only direct mode: send-only. It carries no `appSecret` and never
+// opens an inbound subscribe (see `isOutboundOnly` / the provider `messages`).
+const outboundOnlyConfig = z.strictObject({
+  mode: z.literal("outbound-only"),
+  accessToken: z.string().min(1),
+  phoneNumberId: z.string().min(1),
+});
 
-export const configSchema = z.union([directConfig, cloudConfig]);
+// Cloud mode: no direct credentials — Spectrum Cloud issues per-line tokens.
+const cloudConfig = z.strictObject({});
+
+// A discriminated union on `mode`: inbound requires `appSecret`, outbound-only
+// forbids it, cloud takes neither. A partial or ambiguous config — credentials
+// without a `mode`, or inbound without `appSecret` — matches no branch and
+// fails fast at parse (before any stream starts), so it can never silently
+// resolve to a broken inbound mode.
+export const configSchema = z.union([
+  inboundConfig,
+  outboundOnlyConfig,
+  cloudConfig,
+]);
 
 export type WhatsAppConfig = z.infer<typeof configSchema>;
 export type WhatsAppClients = WhatsAppClient[];
 
+// Cloud mode is the only branch without a `mode` discriminator.
 export const isCloudConfig = (
   config: WhatsAppConfig
-): config is z.infer<typeof cloudConfig> => !("accessToken" in config);
+): config is z.infer<typeof cloudConfig> => !("mode" in config);
+
+// Direct outbound-only mode never opens an inbound subscribe — it has no
+// `appSecret` to authenticate one — so its message stream stays empty.
+export const isOutboundOnly = (config: WhatsAppConfig): boolean =>
+  !isCloudConfig(config) && config.mode === "outbound-only";
 
 export const userSchema = z.object({});
 

--- a/packages/whatsapp-business/src/types.ts
+++ b/packages/whatsapp-business/src/types.ts
@@ -19,7 +19,9 @@ const APP_SECRET_REQUIRED =
 const inboundConfig = z.strictObject({
   mode: z.literal("inbound"),
   accessToken: z.string().min(1),
-  appSecret: z.string({ error: APP_SECRET_REQUIRED }).min(1),
+  appSecret: z
+    .string({ error: APP_SECRET_REQUIRED })
+    .min(1, { error: APP_SECRET_REQUIRED }),
   phoneNumberId: z.string().min(1),
 });
 
@@ -28,18 +30,26 @@ const inboundConfig = z.strictObject({
 const outboundOnlyConfig = z.strictObject({
   mode: z.literal("outbound-only"),
   accessToken: z.string().min(1),
+  appSecret: z.never().optional(),
   phoneNumberId: z.string().min(1),
 });
 
 // Cloud mode: no direct credentials — Spectrum Cloud issues per-line tokens.
-const cloudConfig = z.strictObject({});
+// An optional `undefined` discriminator lets Zod select this branch for `{}`
+// without adding `mode` to the parsed output.
+const cloudConfig = z.strictObject({
+  mode: z.undefined().optional(),
+  accessToken: z.never().optional(),
+  appSecret: z.never().optional(),
+  phoneNumberId: z.never().optional(),
+});
 
 // A discriminated union on `mode`: inbound requires `appSecret`, outbound-only
 // forbids it, cloud takes neither. A partial or ambiguous config — credentials
 // without a `mode`, or inbound without `appSecret` — matches no branch and
 // fails fast at parse (before any stream starts), so it can never silently
 // resolve to a broken inbound mode.
-export const configSchema = z.union([
+export const configSchema = z.discriminatedUnion("mode", [
   inboundConfig,
   outboundOnlyConfig,
   cloudConfig,
@@ -51,14 +61,14 @@ export type WhatsAppClients = WhatsAppClient[];
 // Cloud mode is the only branch without a `mode` discriminator.
 export const isCloudConfig = (
   config: WhatsAppConfig
-): config is z.infer<typeof cloudConfig> => !("mode" in config);
+): config is z.infer<typeof cloudConfig> => config.mode === undefined;
 
 // Direct outbound-only mode never opens an inbound subscribe — it has no
 // `appSecret` to authenticate one — so its message stream stays empty.
 export const isOutboundOnly = (config: WhatsAppConfig): boolean =>
   !isCloudConfig(config) && config.mode === "outbound-only";
 
-export const userSchema = z.object({});
+const userSchema = z.object({});
 
 export const spaceSchema = z.object({
   id: z.string(),

--- a/packages/whatsapp-business/test/config.test.ts
+++ b/packages/whatsapp-business/test/config.test.ts
@@ -1,5 +1,14 @@
 import { envAwareConfig } from "@spectrum-ts/core/authoring";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+} from "vitest";
+import z from "zod";
+import type { whatsappBusiness } from "@/index";
 import {
   isCloudConfig,
   isOutboundOnly,
@@ -15,9 +24,31 @@ const ACCESS_TOKEN = "SPECTRUM_WHATSAPP_BUSINESS_ACCESS_TOKEN";
 const PHONE_NUMBER_ID = "SPECTRUM_WHATSAPP_BUSINESS_PHONE_NUMBER_ID";
 const APP_SECRET = "SPECTRUM_WHATSAPP_BUSINESS_APP_SECRET";
 const ENV_KEYS = [ACCESS_TOKEN, PHONE_NUMBER_ID, APP_SECRET];
+const APP_SECRET_REQUIRED =
+  "WhatsApp Business `mode: 'inbound'` requires `appSecret` (it verifies inbound webhook signatures). Provide it, or use `mode: 'outbound-only'` for send-only.";
 
 describe("whatsapp-business config", () => {
   const saved = new Map<string, string | undefined>();
+
+  it("requires a direct mode in the public config input type", () => {
+    type ConfigInput = NonNullable<
+      Parameters<typeof whatsappBusiness.config>[0]
+    >;
+    interface LegacyFlatDirect {
+      accessToken: string;
+      appSecret: string;
+      phoneNumberId: string;
+    }
+    interface OutboundWithSecret {
+      appSecret: string;
+      mode: "outbound-only";
+    }
+
+    expectTypeOf<{ mode: "inbound" }>().toMatchTypeOf<ConfigInput>();
+    expectTypeOf<{ mode: "outbound-only" }>().toMatchTypeOf<ConfigInput>();
+    expectTypeOf<LegacyFlatDirect>().not.toMatchTypeOf<ConfigInput>();
+    expectTypeOf<OutboundWithSecret>().not.toMatchTypeOf<ConfigInput>();
+  });
 
   beforeEach(() => {
     for (const key of ENV_KEYS) {
@@ -74,13 +105,40 @@ describe("whatsapp-business config", () => {
 
   describe("partial / ambiguous configs fail fast", () => {
     it("rejects inbound mode missing appSecret with a clear message", () => {
-      expect(() =>
-        configSchema.parse({
-          mode: "inbound",
-          accessToken: "t",
-          phoneNumberId: "p",
-        })
-      ).toThrow("appSecret");
+      const result = configSchema.safeParse({
+        mode: "inbound",
+        accessToken: "t",
+        phoneNumberId: "p",
+      });
+
+      expect(result.success).toBe(false);
+      if (result.success) {
+        throw new Error("expected inbound config without appSecret to fail");
+      }
+      expect(result.error.issues).toHaveLength(1);
+      expect(result.error.issues[0]).toMatchObject({
+        path: ["appSecret"],
+        message: APP_SECRET_REQUIRED,
+      });
+      expect(z.prettifyError(result.error)).toContain(APP_SECRET_REQUIRED);
+    });
+
+    it("rejects an empty inbound appSecret with the same clear message", () => {
+      const result = configSchema.safeParse({
+        mode: "inbound",
+        accessToken: "t",
+        phoneNumberId: "p",
+        appSecret: "",
+      });
+
+      expect(result.success).toBe(false);
+      if (result.success) {
+        throw new Error("expected inbound config with empty appSecret to fail");
+      }
+      expect(result.error.issues[0]).toMatchObject({
+        path: ["appSecret"],
+        message: APP_SECRET_REQUIRED,
+      });
     });
 
     it("rejects credentials with no mode instead of inferring one", () => {

--- a/packages/whatsapp-business/test/config.test.ts
+++ b/packages/whatsapp-business/test/config.test.ts
@@ -1,6 +1,10 @@
 import { envAwareConfig } from "@spectrum-ts/core/authoring";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { isCloudConfig, configSchema as rawConfigSchema } from "@/types";
+import {
+  isCloudConfig,
+  isOutboundOnly,
+  configSchema as rawConfigSchema,
+} from "@/types";
 
 // `definePlatform("whatsapp_business", ...)` applies the env fallback from the
 // platform id; mirror that here so the test exercises the same
@@ -12,7 +16,7 @@ const PHONE_NUMBER_ID = "SPECTRUM_WHATSAPP_BUSINESS_PHONE_NUMBER_ID";
 const APP_SECRET = "SPECTRUM_WHATSAPP_BUSINESS_APP_SECRET";
 const ENV_KEYS = [ACCESS_TOKEN, PHONE_NUMBER_ID, APP_SECRET];
 
-describe("whatsapp-business config env fallback", () => {
+describe("whatsapp-business config", () => {
   const saved = new Map<string, string | undefined>();
 
   beforeEach(() => {
@@ -33,48 +37,140 @@ describe("whatsapp-business config env fallback", () => {
     }
   });
 
-  it("enables direct mode from a complete env credential set", () => {
-    process.env[ACCESS_TOKEN] = "env-token";
-    process.env[PHONE_NUMBER_ID] = "env-phone";
-    const config = configSchema.parse({});
-    expect(isCloudConfig(config)).toBe(false);
-    expect(config).toMatchObject({
-      accessToken: "env-token",
-      phoneNumberId: "env-phone",
+  describe("mode discrimination", () => {
+    it("accepts inbound mode with all three credentials", () => {
+      const config = configSchema.parse({
+        mode: "inbound",
+        accessToken: "t",
+        phoneNumberId: "p",
+        appSecret: "s",
+      });
+      expect(isCloudConfig(config)).toBe(false);
+      expect(isOutboundOnly(config)).toBe(false);
+      expect(config).toMatchObject({
+        mode: "inbound",
+        accessToken: "t",
+        phoneNumberId: "p",
+        appSecret: "s",
+      });
+    });
+
+    it("accepts outbound-only mode without an appSecret", () => {
+      const config = configSchema.parse({
+        mode: "outbound-only",
+        accessToken: "t",
+        phoneNumberId: "p",
+      });
+      expect(isCloudConfig(config)).toBe(false);
+      expect(isOutboundOnly(config)).toBe(true);
+    });
+
+    it("treats an empty config as cloud mode", () => {
+      const config = configSchema.parse({});
+      expect(isCloudConfig(config)).toBe(true);
+      expect(isOutboundOnly(config)).toBe(false);
     });
   });
 
-  it("falls back to cloud mode when the env set is partial", () => {
-    process.env[ACCESS_TOKEN] = "env-token";
-    const config = configSchema.parse({});
-    expect(isCloudConfig(config)).toBe(true);
-  });
-
-  it("lets explicit config override env credentials", () => {
-    process.env[ACCESS_TOKEN] = "env-token";
-    process.env[PHONE_NUMBER_ID] = "env-phone";
-    const config = configSchema.parse({
-      accessToken: "explicit-token",
-      phoneNumberId: "explicit-phone",
+  describe("partial / ambiguous configs fail fast", () => {
+    it("rejects inbound mode missing appSecret with a clear message", () => {
+      expect(() =>
+        configSchema.parse({
+          mode: "inbound",
+          accessToken: "t",
+          phoneNumberId: "p",
+        })
+      ).toThrow("appSecret");
     });
-    expect(config).toMatchObject({
-      accessToken: "explicit-token",
-      phoneNumberId: "explicit-phone",
+
+    it("rejects credentials with no mode instead of inferring one", () => {
+      // The old shape (accessToken + phoneNumberId, no mode) must not silently
+      // resolve to a broken inbound mode — it matches no branch.
+      expect(() =>
+        configSchema.parse({ accessToken: "t", phoneNumberId: "p" })
+      ).toThrow();
+    });
+
+    it("rejects an appSecret passed alongside outbound-only mode", () => {
+      expect(() =>
+        configSchema.parse({
+          mode: "outbound-only",
+          accessToken: "t",
+          phoneNumberId: "p",
+          appSecret: "s",
+        })
+      ).toThrow();
+    });
+
+    it("rejects inbound mode missing phoneNumberId", () => {
+      expect(() =>
+        configSchema.parse({
+          mode: "inbound",
+          accessToken: "t",
+          appSecret: "s",
+        })
+      ).toThrow();
     });
   });
 
-  it("stays cloud mode with no explicit config and no env vars", () => {
-    const config = configSchema.parse({});
-    expect(isCloudConfig(config)).toBe(true);
-  });
+  describe("credential env fallback (mode stays explicit)", () => {
+    it("fills inbound credentials from env when mode is given", () => {
+      process.env[ACCESS_TOKEN] = "env-token";
+      process.env[PHONE_NUMBER_ID] = "env-phone";
+      process.env[APP_SECRET] = "env-secret";
+      const config = configSchema.parse({ mode: "inbound" });
+      expect(config).toMatchObject({
+        mode: "inbound",
+        accessToken: "env-token",
+        phoneNumberId: "env-phone",
+        appSecret: "env-secret",
+      });
+    });
 
-  it("mixes an explicit access token with an env phone number id", () => {
-    process.env[PHONE_NUMBER_ID] = "env-phone";
-    const config = configSchema.parse({ accessToken: "explicit-token" });
-    expect(isCloudConfig(config)).toBe(false);
-    expect(config).toMatchObject({
-      accessToken: "explicit-token",
-      phoneNumberId: "env-phone",
+    it("fills outbound-only credentials from env when mode is given", () => {
+      process.env[ACCESS_TOKEN] = "env-token";
+      process.env[PHONE_NUMBER_ID] = "env-phone";
+      const config = configSchema.parse({ mode: "outbound-only" });
+      expect(isOutboundOnly(config)).toBe(true);
+      expect(config).toMatchObject({
+        mode: "outbound-only",
+        accessToken: "env-token",
+        phoneNumberId: "env-phone",
+      });
+    });
+
+    it("still requires appSecret for inbound even from env", () => {
+      process.env[ACCESS_TOKEN] = "env-token";
+      process.env[PHONE_NUMBER_ID] = "env-phone";
+      // No APP_SECRET env → inbound must still fail fast.
+      expect(() => configSchema.parse({ mode: "inbound" })).toThrow(
+        "appSecret"
+      );
+    });
+
+    it("does not flip an empty config into direct mode via env credentials", () => {
+      process.env[ACCESS_TOKEN] = "env-token";
+      process.env[PHONE_NUMBER_ID] = "env-phone";
+      process.env[APP_SECRET] = "env-secret";
+      // Without an explicit `mode`, env credentials never conjure a direct mode.
+      expect(isCloudConfig(configSchema.parse({}))).toBe(true);
+    });
+
+    it("lets explicit credentials win over env", () => {
+      process.env[ACCESS_TOKEN] = "env-token";
+      process.env[PHONE_NUMBER_ID] = "env-phone";
+      process.env[APP_SECRET] = "env-secret";
+      const config = configSchema.parse({
+        mode: "inbound",
+        accessToken: "explicit",
+        phoneNumberId: "explicit-p",
+        appSecret: "explicit-s",
+      });
+      expect(config).toMatchObject({
+        accessToken: "explicit",
+        phoneNumberId: "explicit-p",
+        appSecret: "explicit-s",
+      });
     });
   });
 });

--- a/packages/whatsapp-business/test/direct-mode.test.ts
+++ b/packages/whatsapp-business/test/direct-mode.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+import { whatsappBusiness } from "@/index";
+import type { WhatsAppClients } from "@/types";
+
+const def = whatsappBusiness.config({}).__definition;
+
+// Minimal stand-in for the SDK's `events.subscribe()` result: an immediately
+// completed async iterable that also satisfies the `.filter()` / `.close()`
+// calls `clientStream` makes on it.
+const fakeEventStream = () => {
+  const stream = {
+    [Symbol.asyncIterator]: () => ({
+      next: () => Promise.resolve({ done: true, value: undefined }),
+    }),
+    filter: () => stream,
+    close: () => Promise.resolve(),
+  };
+  return stream;
+};
+
+const drain = async (source: AsyncIterable<unknown>): Promise<unknown[]> => {
+  const out: unknown[] = [];
+  for await (const value of source) {
+    out.push(value);
+  }
+  return out;
+};
+
+const messagesCtx = (config: unknown, subscribe: () => unknown) => ({
+  client: [{ events: { subscribe } }] as unknown as WhatsAppClients,
+  config,
+  projectConfig: undefined,
+  store: undefined as never,
+});
+
+describe("whatsapp direct-mode message subscription", () => {
+  it("never opens an inbound subscribe in outbound-only mode", async () => {
+    const subscribe = vi.fn(fakeEventStream);
+    const source = def.messages(
+      messagesCtx(
+        { mode: "outbound-only", accessToken: "t", phoneNumberId: "p" },
+        subscribe
+      )
+    );
+
+    await expect(drain(source)).resolves.toEqual([]);
+    // No appSecret to authenticate a stream, so it must not even try.
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
+  it("opens the inbound subscribe in inbound mode", async () => {
+    const subscribe = vi.fn(fakeEventStream);
+    const source = def.messages(
+      messagesCtx(
+        {
+          mode: "inbound",
+          accessToken: "t",
+          phoneNumberId: "p",
+          appSecret: "s",
+        },
+        subscribe
+      )
+    );
+
+    await drain(source);
+    expect(subscribe).toHaveBeenCalled();
+  });
+});

--- a/packages/whatsapp-business/test/direct-mode.test.ts
+++ b/packages/whatsapp-business/test/direct-mode.test.ts
@@ -1,68 +1,118 @@
-import { describe, expect, it, vi } from "vitest";
-import { whatsappBusiness } from "@/index";
-import type { WhatsAppClients } from "@/types";
+import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
+import { Spectrum } from "@spectrum-ts/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const def = whatsappBusiness.config({}).__definition;
+const sdk = vi.hoisted(() => ({
+  close: vi.fn(),
+  createClient: vi.fn(),
+  send: vi.fn(),
+  subscribe: vi.fn(),
+}));
+
+vi.mock("@photon-ai/whatsapp-business", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@photon-ai/whatsapp-business")>()),
+  createClient: sdk.createClient,
+}));
+
+import { whatsappBusiness } from "@/index";
 
 // Minimal stand-in for the SDK's `events.subscribe()` result: an immediately
 // completed async iterable that also satisfies the `.filter()` / `.close()`
-// calls `clientStream` makes on it.
+// calls the provider makes on it.
 const fakeEventStream = () => {
-  const stream = {
+  const eventStream = {
     [Symbol.asyncIterator]: () => ({
       next: () => Promise.resolve({ done: true, value: undefined }),
     }),
-    filter: () => stream,
     close: () => Promise.resolve(),
+    filter: () => eventStream,
   };
-  return stream;
+  return eventStream;
 };
 
 const drain = async (source: AsyncIterable<unknown>): Promise<unknown[]> => {
-  const out: unknown[] = [];
+  const output: unknown[] = [];
   for await (const value of source) {
-    out.push(value);
+    output.push(value);
   }
-  return out;
+  return output;
 };
 
-const messagesCtx = (config: unknown, subscribe: () => unknown) => ({
-  client: [{ events: { subscribe } }] as unknown as WhatsAppClients,
-  config,
-  projectConfig: undefined,
-  store: undefined as never,
-});
-
-describe("whatsapp direct-mode message subscription", () => {
-  it("never opens an inbound subscribe in outbound-only mode", async () => {
-    const subscribe = vi.fn(fakeEventStream);
-    const source = def.messages(
-      messagesCtx(
-        { mode: "outbound-only", accessToken: "t", phoneNumberId: "p" },
-        subscribe
-      )
+describe("whatsapp direct-mode lifecycle", () => {
+  beforeEach(() => {
+    sdk.close.mockReset().mockResolvedValue(undefined);
+    sdk.send
+      .mockReset()
+      .mockResolvedValue({ messageId: "wamid.sent", messageStatus: "sent" });
+    sdk.subscribe.mockReset().mockImplementation(fakeEventStream);
+    sdk.createClient.mockReset().mockImplementation(
+      () =>
+        ({
+          close: sdk.close,
+          events: { subscribe: sdk.subscribe },
+          media: {},
+          messages: { send: sdk.send },
+          [Symbol.asyncDispose]: sdk.close,
+        }) as unknown as WhatsAppClient
     );
-
-    await expect(drain(source)).resolves.toEqual([]);
-    // No appSecret to authenticate a stream, so it must not even try.
-    expect(subscribe).not.toHaveBeenCalled();
   });
 
-  it("opens the inbound subscribe in inbound mode", async () => {
-    const subscribe = vi.fn(fakeEventStream);
-    const source = def.messages(
-      messagesCtx(
-        {
-          mode: "inbound",
-          accessToken: "t",
-          phoneNumberId: "p",
-          appSecret: "s",
-        },
-        subscribe
-      )
-    );
+  it("keeps outbound-only send-capable without opening an inbound subscribe", async () => {
+    const app = await Spectrum({
+      providers: [
+        whatsappBusiness.config({
+          mode: "outbound-only",
+          accessToken: "direct-token",
+          phoneNumberId: "direct-phone",
+        }),
+      ],
+    });
 
-    await drain(source);
-    expect(subscribe).toHaveBeenCalled();
+    try {
+      expect(sdk.createClient).toHaveBeenCalledWith({
+        accessToken: "direct-token",
+        appSecret: "",
+        phoneNumberId: "direct-phone",
+      });
+      await expect(drain(app.messages)).resolves.toEqual([]);
+      expect(sdk.subscribe).not.toHaveBeenCalled();
+
+      const space = await whatsappBusiness(app).space.create("15551234567");
+      const sent = await space.send("hello");
+      expect(sdk.send).toHaveBeenCalledWith({
+        to: "15551234567",
+        text: "hello",
+      });
+      expect(sent?.id).toBe("wamid.sent");
+    } finally {
+      await app.stop();
+    }
+
+    expect(sdk.close).toHaveBeenCalledOnce();
+  });
+
+  it("passes appSecret through and subscribes in inbound mode", async () => {
+    const app = await Spectrum({
+      providers: [
+        whatsappBusiness.config({
+          mode: "inbound",
+          accessToken: "direct-token",
+          phoneNumberId: "direct-phone",
+          appSecret: "direct-secret",
+        }),
+      ],
+    });
+
+    try {
+      expect(sdk.createClient).toHaveBeenCalledWith({
+        accessToken: "direct-token",
+        appSecret: "direct-secret",
+        phoneNumberId: "direct-phone",
+      });
+      await drain(app.messages);
+      expect(sdk.subscribe).toHaveBeenCalledOnce();
+    } finally {
+      await app.stop();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Replace the ambiguous WhatsApp Business config union with explicit `inbound`, `outbound-only`, and cloud modes.
- Require a non-empty `appSecret` for inbound direct mode with a focused Zod error.
- Keep outbound-only sending functional while preventing it from opening an inbound subscription.
- Require direct users to select `mode` explicitly, while allowing credential values to come from environment variables.
- Update the setup documentation and migration guidance.

## Why

Direct mode previously typed `appSecret` as optional and substituted `""` when it was missing. The config parsed successfully, but the provider then opened an inbound subscription without valid authentication. From the application’s perspective everything initialized normally, while inbound WhatsApp messages silently never arrived.

Missing `appSecret` now fails during config parsing with:

```text
✖ WhatsApp Business `mode: 'inbound'` requires `appSecret` (it verifies inbound webhook signatures). Provide it, or use `mode: 'outbound-only'` for send-only.
  → at appSecret
```

## Behavior change

Direct configurations must now select their behavior explicitly:

```ts
whatsappBusiness.config({
  mode: "inbound",
  accessToken,
  phoneNumberId,
  appSecret,
});
```

Send-only applications can omit `appSecret`:

```ts
whatsappBusiness.config({
  mode: "outbound-only",
  accessToken,
  phoneNumberId,
});
```

Calling `whatsappBusiness.config()` without a mode always selects cloud mode, even when direct credential environment variables are present. Existing flat or env-only direct configurations must add `mode`.

## Implementation

- Uses one Zod discriminated union on `mode`, including cloud through an optional `undefined` discriminator.
- Preserves discriminated-union behavior when `envAwareConfig` adds credential fallbacks.
- Keeps the discriminator required in the public config input type without changing exactness for unrelated provider unions.
- Uses schema-local forbidden fields so cloud and outbound-only cannot accept credentials from another branch.
- Returns an empty managed message stream for outbound-only mode, so the SDK never calls `events.subscribe()`.
- Adds public-lifecycle coverage proving outbound-only can send while recording zero subscribe calls.
- Updates provider examples and the WhatsApp Business setup guide with migration guidance.

## Verification

- `bun run check`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- `packages/whatsapp-business`: `bun run typecheck`
- `packages/whatsapp-business`: `bun run test:node` — 64 tests passed
- `npx --yes knip@latest --workspace packages/whatsapp-business`

## Release coordination

The documentation source is included in this PR. Deploy the updated docs with the package release so the public setup guide does not advertise the removed flat/env-only contract.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787260206&installation_model_id=19795&pr_number=214&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F214&signature=b6d9c4ac14e2bbde6802dca685b4022fbc98bb59f6035a803a6a0fa5db4b87e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking provider config for existing direct/env-only setups, but changes tighten webhook auth and fail fast instead of silent inbound loss; core typing/env behavior is shared infrastructure with added tests.
> 
> **Overview**
> WhatsApp Business direct setup now uses an explicit **`mode`** discriminator: **`inbound`** (send + webhooks), **`outbound-only`** (send only), or **cloud** (omit `mode` and direct credentials). Inbound direct mode **requires a non-empty `appSecret`** at parse time with a targeted Zod error, fixing the case where missing secrets still started an inbound subscribe and dropped messages silently.
> 
> **Breaking behavior:** flat `{ accessToken, phoneNumberId, … }` and env-only `whatsappBusiness.config()` no longer imply direct mode—empty config is always cloud, even when `SPECTRUM_WHATSAPP_BUSINESS_*` vars are set. Outbound-only uses an empty message stream so **`events.subscribe()` is never called**; inbound still subscribes with the real secret.
> 
> Core **`envAwareConfig`** now **clones** union schemas so discriminated-union branch errors survive env fallbacks, and **`ConfigInput`** keeps **`mode` required** on direct branches while other fields stay optionally env-backed. Docs and examples add **`mode: "inbound"`** plus migration notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a789043a2d4f0d7284d30d53c08972893533519b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit WhatsApp Business modes: cloud, inbound, and outbound-only.
  * Added credential validation and environment-variable fallback behavior by mode.
  * Outbound-only mode now supports sending messages without opening inbound subscriptions.

* **Bug Fixes**
  * Invalid or incomplete WhatsApp configurations now fail during startup with clearer guidance.

* **Documentation**
  * Updated setup guides and configuration examples to explain modes, credentials, migration considerations, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->