### PR TITLE
Decouple deployment environment from logger level defaults

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "specturm-ts",
       "dependencies": {
-        "@photon-ai/otel": "^3.1.0",
+        "@photon-ai/otel": "^3.3.0",
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.4",
@@ -28,7 +28,7 @@
       "name": "@spectrum-ts/core",
       "version": "12.2.0",
       "dependencies": {
-        "@photon-ai/otel": "^3.1.0",
+        "@photon-ai/otel": "^3.3.0",
         "@photon-ai/proto": "^0.2.4",
         "@repeaterjs/repeater": "^3.0.6",
         "marked": "^18.0.5",
@@ -133,7 +133,7 @@
       "dependencies": {
         "@grpc/grpc-js": "^1.14.4",
         "@photon-ai/advanced-imessage": "^2.0.2",
-        "@photon-ai/otel": "^3.1.0",
+        "@photon-ai/otel": "^3.3.0",
         "lru-cache": "^11.0.0",
         "marked": "^18.0.5",
         "nice-grpc": "^2.1.16",
@@ -431,6 +431,8 @@
 
     "@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.218.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.218.0", "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/sdk-logs": "0.218.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Qx+4rpVHzgg89dawcWRHyt+XRXeLnhFz/qBtvggmjkcgPUdr+NAB0/u/eIPA8yAeJV0J80Vz43JZCh/XFvZFGw=="],
 
+    "@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-metrics": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-bV7d2OuMpZu2+gAaxUAhzfZ0h3WVZk8ETQUEE3DNSntbTaMpuITjtm8I0rNyHFdm7Ax57K6ty7SgFXlBmOLIvQ=="],
+
     "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.218.0", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/otlp-exporter-base": "0.218.0", "@opentelemetry/otlp-transformer": "0.218.0", "@opentelemetry/resources": "2.7.1", "@opentelemetry/sdk-trace-base": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-8dqezsmPhtKitIK/eTipZhYl9EX2/gNQ5zUMhaz3uxEURwfkNf8IPvo6yNfrzbxdtpAOybS/+h7wmIWYqFSpiw=="],
 
     "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.219.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.219.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-X5t7I8GyIO9rmGHwoedZLREpQqrF1WW2nxzNNym6HOKpFiE+rvqV3ngC0xcZVO2YwIGf3KKmRdWrYwdwz3H9RQ=="],
@@ -461,7 +463,7 @@
 
     "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-GGDETlRbrPXP5eaRvswaead7MCBGQkm8f7d3aVbx8+rXhB4GEyPiw7Q1/yz5ix53rmxqKRevWywOfG7n+kZDBw=="],
 
-    "@photon-ai/otel": ["@photon-ai/otel@3.1.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/api-logs": "^0.218.0", "@opentelemetry/context-async-hooks": "^2.7.1", "@opentelemetry/core": "^2.7.1", "@opentelemetry/exporter-logs-otlp-http": "^0.218.0", "@opentelemetry/exporter-trace-otlp-http": "^0.218.0", "@opentelemetry/resources": "^2.7.1", "@opentelemetry/sdk-logs": "^0.218.0", "@opentelemetry/sdk-trace-base": "^2.7.1", "@opentelemetry/semantic-conventions": "^1.41.1" }, "optionalDependencies": { "@opentelemetry/instrumentation": "^0.219.0", "@opentelemetry/instrumentation-undici": "^0.29.0" }, "peerDependencies": { "typescript": "^5 || ^6.0.0" } }, "sha512-8PvN7o3rySHlMk6+a/5X/F5/w1RqGJkFuvcdaSinhdXYCsuO24AALSFV0g8KY4jNtVDs7L3I6v6QsL7WxZECjw=="],
+    "@photon-ai/otel": ["@photon-ai/otel@3.3.0", "", { "dependencies": { "@opentelemetry/api": "^1.9.1", "@opentelemetry/api-logs": "^0.218.0", "@opentelemetry/context-async-hooks": "^2.7.1", "@opentelemetry/core": "^2.7.1", "@opentelemetry/exporter-logs-otlp-http": "^0.218.0", "@opentelemetry/exporter-metrics-otlp-http": "^0.218.0", "@opentelemetry/exporter-trace-otlp-http": "^0.218.0", "@opentelemetry/resources": "^2.7.1", "@opentelemetry/sdk-logs": "^0.218.0", "@opentelemetry/sdk-metrics": "^2.7.1", "@opentelemetry/sdk-trace-base": "^2.7.1", "@opentelemetry/semantic-conventions": "^1.41.1" }, "optionalDependencies": { "@opentelemetry/instrumentation": "^0.219.0", "@opentelemetry/instrumentation-undici": "^0.29.0" }, "peerDependencies": { "typescript": "^5 || ^6.0.0" } }, "sha512-EkFX+CkLzDiwWwp7BaX3eqNjaCT8e1lrrYzhsVT+NWW1wSlULgsIjjsMrBCR32VHTIRZQ0FOzbasJGq3Sx+pVg=="],
 
     "@photon-ai/proto": ["@photon-ai/proto@0.2.4", "", { "dependencies": { "@bufbuild/protobuf": "^2.12.0", "nice-grpc-common": "^2.0.3" } }, "sha512-DQANEp0gHvtwqpMGEF0ufa0hs1nniRdsSuo0Q/TG6GoL1WjC5tp59tHFSLUeIm6fvnAuRjREsGzURz3+/69g7g=="],
 

--- a/docs/getting-started.mdx.vel
+++ b/docs/getting-started.mdx.vel
@@ -175,7 +175,7 @@ Messages from every provider merge into the single `app.messages` stream. The `m
 
 ## Logging
 
-Spectrum emits structured logs across the core runtime and providers. Control the verbosity with `logLevel`:
+Spectrum emits structured logs across the core runtime and providers. The default log level is `info`. Control the verbosity with `logLevel`:
 
 ```ts
 const app = await Spectrum({
@@ -185,6 +185,8 @@ const app = await Spectrum({
   options: { logLevel: "debug" },
 });
 ```
+
+An explicit `logLevel` takes precedence over the `LOG_LEVEL` environment variable.
 
 Log output is sanitized — sensitive fields like tokens and secrets are redacted from error attributes before they reach any log destination.
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "examples/*"
   ],
   "dependencies": {
-    "@photon-ai/otel": "^3.1.0"
+    "@photon-ai/otel": "^3.3.0"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@photon-ai/otel": "^3.1.0",
+    "@photon-ai/otel": "^3.3.0",
     "@photon-ai/proto": "^0.2.4",
     "@repeaterjs/repeater": "^3.0.6",
     "marked": "^18.0.5",

--- a/packages/core/src/spectrum.ts
+++ b/packages/core/src/spectrum.ts
@@ -153,10 +153,10 @@ export interface SpectrumOptions {
 
   /**
    * Minimum severity emitted by the SDK's structured logger (to both the
-   * console and, when telemetry is on, OTLP). Applies process-wide. The
-   * `LOG_LEVEL` environment variable still takes precedence.
+   * console and, when telemetry is on, OTLP). Applies process-wide and takes
+   * precedence over the `LOG_LEVEL` environment variable when provided.
    *
-   * @default "debug" in development, "info" otherwise (via `DEPLOYMENT_ENV`)
+   * @default "info"
    */
   logLevel?: LogLevel;
 }
@@ -303,8 +303,8 @@ export async function Spectrum<
   } = options;
   const flattenGroups = runtimeOptions?.flattenGroups ?? false;
   // Honor an explicit log-level override before anything logs. Applies even
-  // when telemetry is off (the console logger respects it too); the LOG_LEVEL
-  // env var still wins inside @photon-ai/otel.
+  // when telemetry is off (the console logger respects it too) and takes
+  // precedence over LOG_LEVEL inside @photon-ai/otel.
   applyLogLevel(runtimeOptions?.logLevel);
   // The per-webhook signing secret for native Spectrum webhooks. Explicit option
   // wins; otherwise fall back to the env var so deployments can inject it.

--- a/packages/imessage/package.json
+++ b/packages/imessage/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.14.4",
     "@photon-ai/advanced-imessage": "^2.0.2",
-    "@photon-ai/otel": "^3.1.0",
+    "@photon-ai/otel": "^3.3.0",
     "lru-cache": "^11.0.0",
     "marked": "^18.0.5",
     "nice-grpc": "^2.1.16",


### PR DESCRIPTION
## Summary

- Set the default logger level to `info` regardless of deployment environment
- Ensure explicit `logLevel` options take precedence over `LOG_LEVEL`
- Upgrade `@photon-ai/otel` to 3.3.0 and document the updated behavior

## Testing

Not run (not requested)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787265934&installation_model_id=19795&pr_number=215&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F215&signature=6eb556839640aa5e860052e8548fd0c9fb08199d1c476c40408ba3c61e6c7b98"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes (defaults and docs); local dev may see less `debug` output unless `logLevel` or `LOG_LEVEL` is set.
> 
> **Overview**
> **Default logging** is now always `info`, removing the previous behavior where development (`DEPLOYMENT_ENV`) could default to `debug`.
> 
> **Precedence** for severity is clarified in code and docs: an explicit `options.logLevel` on `Spectrum()` wins over the `LOG_LEVEL` environment variable (via `@photon-ai/otel`), including when telemetry is off.
> 
> **Dependency bump**: `@photon-ai/otel` is upgraded from `^3.1.0` to `^3.3.0` across the root, core, and imessage packages (lockfile also pulls in OTLP metrics export support from that release). Getting started docs note the `info` default and the `logLevel` vs `LOG_LEVEL` ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82897cba3b5ee6f20dcad8bdcf819ae0a8952a35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the default logging level is `info`.
  * Documented that an explicitly configured `logLevel` takes precedence over the `LOG_LEVEL` environment variable.

* **Behavior**
  * Explicit log-level settings now consistently override environment-based logging configuration, including when telemetry is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->