### PR TITLE
Avoid retrying contact sharing after precondition failures

### DIFF
--- a/packages/imessage/src/remote/contact-share.ts
+++ b/packages/imessage/src/remote/contact-share.ts
@@ -1,4 +1,7 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
+import {
+  type AdvancedIMessage,
+  ErrorCode,
+} from "@photon-ai/advanced-imessage/grpc";
 import {
   createLogger,
   errorAttrs,
@@ -10,6 +13,12 @@ const log = createLogger("spectrum.imessage.contact");
 
 const SHARE_TTL_MS = 24 * 60 * 60 * 1000;
 const MAX_TRACKED_CHATS = 10_000;
+
+const isPreconditionFailure = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  error.code === ErrorCode.preconditionFailed;
 
 /**
  * Tracks which chats this bot's line has already proactively pushed its contact
@@ -38,10 +47,12 @@ export class ContactShareTracker {
 
   /**
    * Best-effort share. The cache is set eagerly so that a burst of inbound
-   * messages for the same chat coalesces to a single API call. On failure the
-   * entry is evicted so the next inbound retries — transient errors don't
-   * permanently mute the feature for a chat. Never awaits and never throws:
-   * the receive stream must not crash on share failures.
+   * messages for the same chat coalesces to a single API call. A
+   * `preconditionFailed` response remains cached for the normal 24-hour TTL,
+   * avoiding repeated attempts when the account cannot currently share its
+   * profile. Other failures evict the entry so the next inbound retries.
+   * Never awaits and never throws: the receive stream must not crash on share
+   * failures.
    */
   maybeShare(chatGuid: string): void {
     if (this.cache.has(chatGuid)) {
@@ -58,7 +69,9 @@ export class ContactShareTracker {
         });
       })
       .catch((error: unknown) => {
-        this.cache.delete(chatGuid);
+        if (!isPreconditionFailure(error)) {
+          this.cache.delete(chatGuid);
+        }
         log.warn(
           "failed to share contact card",
           {

--- a/packages/imessage/test/remote/contact-share.test.ts
+++ b/packages/imessage/test/remote/contact-share.test.ts
@@ -1,4 +1,7 @@
-import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
+import {
+  type AdvancedIMessage,
+  ValidationError,
+} from "@photon-ai/advanced-imessage/grpc";
 import { flush } from "@spectrum-ts/test-support/timing";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -92,6 +95,26 @@ describe("ContactShareTracker", () => {
     tracker.maybeShare("chat-retry");
     await flush();
     expect(share).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps precondition failures cached instead of retrying", async () => {
+    const error = new ValidationError("profile is not ready", {
+      code: "preconditionFailed",
+      context: {},
+      grpcCode: 9,
+      retryable: false,
+    });
+    const share = vi.fn((_: string) => Promise.reject(error));
+    const tracker = new ContactShareTracker(makeClient(share));
+
+    tracker.maybeShare("chat-precondition");
+    await flush();
+    expect(share).toHaveBeenCalledTimes(1);
+
+    // The retained entry uses ContactShareTracker's normal 24-hour cache TTL.
+    tracker.maybeShare("chat-precondition");
+    await flush();
+    expect(share).toHaveBeenCalledTimes(1);
   });
 
   it("never throws synchronously even when shareContactInfo rejects", async () => {


### PR DESCRIPTION
## Summary

- Keep contact-share cache entries for `preconditionFailed` responses.
- Continue evicting entries for other failures so transient errors can retry.
- Add coverage verifying precondition failures are not retried within the cache TTL.

## Testing

- Added and ran the contact-share tracker test for retained precondition failures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787283434&installation_model_id=19795&pr_number=216&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F216&signature=85b78b226c3808d79a9dab5ea7ccb3c626b03c2f622c93c73f12db1aeca6ac93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change in best-effort iMessage contact sharing with explicit tests; no auth or data-path impact.
> 
> **Overview**
> **Contact share dedupe** now treats `preconditionFailed` from `shareContactInfo` differently from other errors.
> 
> When proactive contact-card sharing fails with a precondition failure (e.g. profile not ready), `ContactShareTracker` **keeps** the per-chat cache entry for the usual 24-hour window instead of evicting it. That stops every new inbound message in the same chat from triggering another share attempt until the TTL expires. **Transient and other failures** still clear the cache so the next inbound can retry, unchanged from before.
> 
> Implementation adds `isPreconditionFailure` using `ErrorCode.preconditionFailed` from the gRPC client, and a unit test asserts a precondition rejection is not retried within the cache window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1ad5781fc34b2db657d12df7ce610b6203a50a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contact-sharing retry behavior by preventing repeated attempts after non-retryable validation failures.
  * Transient failures can still be retried on subsequent contact-sharing attempts.
  * Added coverage to verify failure caching and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->