### PR TITLE
fix(imessage): gate profile sharing per line

### DIFF
--- a/packages/core/src/platform/types.ts
+++ b/packages/core/src/platform/types.ts
@@ -154,8 +154,8 @@ export type EventProducer<
   /**
    * Spectrum Cloud project metadata, fetched once at `Spectrum()` init.
    * `undefined` when the instance was created without `projectId`/`projectSecret`
-   * (local-only setups). Providers read project-level toggles from
-   * `projectConfig.profile.<key>` — e.g. iMessage's `imessageSynced` flag.
+   * (local-only setups). Providers may read project-level settings from
+   * `projectConfig.profile.<key>`.
    */
   projectConfig: ProjectData | undefined;
   store: Store;

--- a/packages/core/src/utils/cloud.ts
+++ b/packages/core/src/utils/cloud.ts
@@ -24,6 +24,7 @@ export interface DedicatedTokenData {
   auth: Record<string, string>;
   expiresIn: number;
   numbers: Record<string, string | null>;
+  profileSynced?: Record<string, boolean>;
   type: "dedicated";
 }
 

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -35,13 +35,14 @@ export async function createCloudClients(
   let lastRefreshAt = Date.now();
 
   // The instanceId stays paired with each entry in this closure so renewal
-  // can rewrite `entry.phone` in place without leaking instanceId onto the
-  // public RemoteClient shape. Empty in shared mode.
+  // can rewrite the line metadata in place without leaking instanceId onto
+  // the public RemoteClient shape. Empty in shared mode.
   const records: { entry: RemoteClient; instanceId: string }[] = [];
 
-  const syncPhones = (data: DedicatedTokenData) => {
+  const syncLineMetadata = (data: DedicatedTokenData) => {
     for (const { entry, instanceId } of records) {
       entry.phone = requirePhone(data, instanceId);
+      entry.profileSynced = data.profileSynced?.[instanceId] === true;
     }
   };
 
@@ -52,7 +53,7 @@ export async function createCloudClients(
       tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
       lastRefreshAt = Date.now();
       if (tokenData.type === "dedicated") {
-        syncPhones(tokenData);
+        syncLineMetadata(tokenData);
       }
     },
   });
@@ -103,6 +104,7 @@ export async function createCloudClients(
   for (const [instanceId, token] of Object.entries(dedicated.auth)) {
     const entry: RemoteClient = {
       phone: requirePhone(dedicated, instanceId),
+      profileSynced: dedicated.profileSynced?.[instanceId] === true,
       client: createGrpcClient({
         address: `${instanceId}.imsg.photon.codes:443`,
         autoIdempotency: true,

--- a/packages/imessage/src/content/contact-card.ts
+++ b/packages/imessage/src/content/contact-card.ts
@@ -45,9 +45,10 @@ export const isContactCard = (v: unknown): v is ContactCard =>
  * `PlatformSpace<IMessageDef>`).
  *
  * This is an explicit, on-demand share and always fires — unlike the automatic
- * best-effort share gated behind the `imessageSynced` project profile, which
- * dedupes to once per chat per 24h (see `remote/contact-share.ts`). Works in
- * both DMs and group chats; the recipient chooses whether to accept the card.
+ * best-effort share gated by the current line's reconciled profile state,
+ * which dedupes to once per chat per 24h (see `remote/contact-share.ts`).
+ * Works in both DMs and group chats; the recipient chooses whether to accept
+ * the card.
  *
  * `ContactCard` is intentionally not a member of the universal `Content`
  * union — the `as unknown as Content` cast keeps the builder shape compatible

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -601,8 +601,7 @@ export const imessage = definePlatform(IMESSAGE_PLATFORM, {
     schema: messageSchema,
   },
 
-  messages: ({ client, projectConfig }) =>
-    remoteMessages(client, projectConfig),
+  messages: ({ client }) => remoteMessages(client),
 
   send: async ({ space, content, client }) => {
     if (content.type === "reply") {

--- a/packages/imessage/src/remote/api.ts
+++ b/packages/imessage/src/remote/api.ts
@@ -8,7 +8,6 @@ import type {
   AvatarData,
   Content,
   ManagedStream,
-  ProjectData,
   RemoveMember,
   Rename,
   StreamText,
@@ -55,9 +54,8 @@ import {
 } from "./typing";
 
 export const messages = (
-  clients: RemoteClient[],
-  projectConfig: ProjectData | undefined
-): ManagedStream<IMessageMessage> => remoteMessages(clients, projectConfig);
+  clients: RemoteClient[]
+): ManagedStream<IMessageMessage> => remoteMessages(clients);
 
 export const setBackground = async (
   remote: AdvancedIMessage,

--- a/packages/imessage/src/remote/contact-card.ts
+++ b/packages/imessage/src/remote/contact-card.ts
@@ -10,8 +10,8 @@ import { toChatGuid } from "./ids";
  * the dispatcher reaches here.
  *
  * On-demand and unconditional: unlike the proactive `ContactShareTracker` in
- * `contact-share.ts` (24h dedupe, gated behind the `imessageSynced` profile),
- * this fires every time the caller asks.
+ * `contact-share.ts` (24h dedupe, gated by the current line's reconciled
+ * profile state), this fires every time the caller asks.
  */
 export const shareContactCard = async (
   remote: AdvancedIMessage,

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -7,11 +7,7 @@ import {
   ValidationError,
 } from "@photon-ai/advanced-imessage/grpc";
 import { sanitizePhone } from "@photon-ai/otel";
-import {
-  type ManagedStream,
-  mergeStreams,
-  type ProjectData,
-} from "@spectrum-ts/core";
+import { type ManagedStream, mergeStreams } from "@spectrum-ts/core";
 import {
   type CloseableAsyncIterable,
   createLogger,
@@ -397,16 +393,9 @@ const clientStream = (
 };
 
 export const messages = (
-  clients: RemoteClient[],
-  projectConfig?: ProjectData | undefined
+  clients: RemoteClient[]
 ): ManagedStream<IMessageMessage> => {
   const pollCache = getPollCache(clients);
-  // When the project profile opts in to iMessage sync, push the bot's contact
-  // card to any chat we receive a new message in (24h dedupe per chat per line,
-  // fire-and-forget). The tracker is keyed per `entry.client` — same shape as
-  // `getMessageCache` — so each line dedupes independently (a DM guid encodes
-  // the peer, not the line) and multi-Spectrum setups don't cross-pollute.
-  const shareEnabled = projectConfig?.profile?.imessageSynced === true;
   // Cloud clients can re-mint a rejected token; explicit/static-token clients
   // return undefined (nothing to refresh). Shared across this client array's
   // streams so the message + poll loops coalesce onto one re-mint.
@@ -414,15 +403,22 @@ export const messages = (
   const includeGroupEvents = !isSharedMode(clients);
   return mergeStreams(
     clients.map((entry) => {
-      const tracker = shareEnabled
-        ? getContactShareTracker(entry.client)
-        : undefined;
+      // Gate automatic contact-card sharing on this line's reconciled profile,
+      // not the legacy project profile. Read the mutable entry on every inbound
+      // so a Cloud token renewal can enable or disable sharing without
+      // rebuilding the streams. Missing metadata (shared or explicit clients,
+      // or an older Cloud response) fails closed.
+      const tracker = getContactShareTracker(entry.client);
       return clientStream(
         entry.client,
         pollCache,
         entry.phone,
         includeGroupEvents,
-        tracker ? (chatGuid) => tracker.maybeShare(chatGuid) : undefined,
+        (chatGuid) => {
+          if (entry.profileSynced === true) {
+            tracker.maybeShare(chatGuid);
+          }
+        },
         recover
       );
     })

--- a/packages/imessage/src/types.ts
+++ b/packages/imessage/src/types.ts
@@ -5,6 +5,7 @@ import z from "zod";
 export interface RemoteClient {
   client: AdvancedIMessage;
   phone: string;
+  profileSynced?: boolean;
 }
 
 export type IMessageClient = RemoteClient[];

--- a/packages/imessage/test/auth.test.ts
+++ b/packages/imessage/test/auth.test.ts
@@ -4,6 +4,7 @@ interface FakeDedicatedTokenData {
   auth: Record<string, string>;
   expiresIn: number;
   numbers: Record<string, string | null>;
+  profileSynced?: Record<string, boolean>;
   type: "dedicated";
 }
 
@@ -15,6 +16,7 @@ const initialTokenData: FakeDedicatedTokenData = {
   auth: { "instance-1": "token-1" },
   expiresIn: 3600,
   numbers: { "instance-1": "+15550000001" },
+  profileSynced: { "instance-1": false },
   type: "dedicated",
 };
 
@@ -68,6 +70,7 @@ describe("imessage cloud auth", () => {
     );
 
     const clients = await createCloudClients("project-1", "secret-1");
+    expect(clients[0]?.profileSynced).toBe(false);
     const recover = getCloudRecover(clients);
     if (!recover) {
       throw new Error("expected cloud recovery hook");
@@ -82,12 +85,14 @@ describe("imessage cloud auth", () => {
       auth: { "instance-1": "token-2" },
       expiresIn: 3600,
       numbers: { "instance-1": "+15550000002" },
+      profileSynced: { "instance-1": true },
       type: "dedicated",
     });
     await Promise.all([first, second]);
 
     expect(issueImessageTokens).toHaveBeenCalledTimes(2);
     expect(clients[0]?.phone).toBe("+15550000002");
+    expect(clients[0]?.profileSynced).toBe(true);
     expect(await clientOptions[0]?.token()).toBe("token-2");
 
     await disposeCloudAuth(clients);

--- a/packages/imessage/test/remote/stream.test.ts
+++ b/packages/imessage/test/remote/stream.test.ts
@@ -37,6 +37,71 @@ const idleEventStream = () => {
   };
 };
 
+const pushEventStream = <T>() => {
+  let closed = false;
+  const queued: T[] = [];
+  const waiters: ((result: IteratorResult<T, undefined>) => void)[] = [];
+
+  const close = (): Promise<void> => {
+    closed = true;
+    for (const resolve of waiters.splice(0)) {
+      resolve({ done: true, value: undefined });
+    }
+    return Promise.resolve();
+  };
+
+  const stream = {
+    close,
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<T, undefined>> {
+          const value = queued.shift();
+          if (value !== undefined) {
+            return Promise.resolve({ done: false, value });
+          }
+          if (closed) {
+            return Promise.resolve({ done: true, value: undefined });
+          }
+          return new Promise((resolve) => {
+            waiters.push(resolve);
+          });
+        },
+        return(): Promise<IteratorResult<T, undefined>> {
+          return close().then(() => ({ done: true, value: undefined }));
+        },
+      };
+    },
+  };
+
+  return {
+    push(value: T): void {
+      const resolve = waiters.shift();
+      if (resolve) {
+        resolve({ done: false, value });
+      } else {
+        queued.push(value);
+      }
+    },
+    stream,
+  };
+};
+
+const inboundEvent = (sequence: number, chatGuid: string) => ({
+  type: "message.received",
+  sequence,
+  chatGuid,
+  isFromMe: false,
+  occurredAt: new Date(1_700_000_000_000 + sequence),
+  message: {
+    guid: `msg-${sequence}`,
+    chatGuids: [chatGuid],
+    content: { attachments: [], formatting: [], mentions: [], text: "hi" },
+    dateCreated: new Date(1_700_000_000_000 + sequence),
+    isFromMe: false,
+    sender: { address: "+15550111" },
+  },
+});
+
 const remoteClient = (phone: string) => {
   const subscribeToMessages = vi.fn(idleEventStream);
   const subscribeToPolls = vi.fn(idleEventStream);
@@ -85,6 +150,42 @@ describe("remote iMessage streams", () => {
     expect(dedicated.subscribeToMessages).toHaveBeenCalledTimes(1);
     expect(dedicated.subscribeToPolls).toHaveBeenCalledTimes(1);
     expect(dedicated.subscribeToGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it("gates automatic contact sharing on the current line sync state", async () => {
+    const messageEvents = pushEventStream<ReturnType<typeof inboundEvent>>();
+    const shareContactInfo = vi.fn((_: string) => Promise.resolve());
+    const entry: RemoteClient = {
+      phone: "+15550100",
+      profileSynced: false,
+      client: {
+        chats: { shareContactInfo },
+        groups: { subscribeEvents: idleEventStream },
+        messages: { subscribeEvents: () => messageEvents.stream },
+        polls: { subscribeEvents: idleEventStream },
+      } as unknown as AdvancedIMessage,
+    };
+    const stream = messages([entry]);
+    const iterator = stream[Symbol.asyncIterator]();
+
+    const firstPending = iterator.next();
+    messageEvents.push(inboundEvent(1, "chat-before-sync"));
+    const first = await firstPending;
+    expect(first.value?.id).toBe("msg-1");
+    expect(shareContactInfo).not.toHaveBeenCalled();
+
+    // Token renewal mutates the existing line entry. The already-running
+    // stream must observe that change without being recreated.
+    entry.profileSynced = true;
+    const secondPending = iterator.next();
+    messageEvents.push(inboundEvent(2, "chat-after-sync"));
+    const second = await secondPending;
+    expect(second.value?.id).toBe("msg-2");
+    expect(shareContactInfo).toHaveBeenCalledTimes(1);
+    expect(shareContactInfo).toHaveBeenCalledWith("chat-after-sync");
+
+    await stream.close();
+    await settleSoon(iterator.next());
   });
 
   it("skips an unmappable event instead of wedging the stream", async () => {


### PR DESCRIPTION
## Summary

- consume the dedicated-token `profileSynced` map introduced by photon-hq/spectrum-cloud#115
- store sync readiness on each dedicated iMessage client and refresh it in place on token renewal
- gate automatic `shareContactInfo` calls on the current line instead of the one-time Project Profile config
- fail closed for shared clients, explicit clients, and older Cloud responses that do not provide line metadata
- verify a running stream observes line state changes without being recreated

## Dependency and rollout

Depends on https://github.com/photon-hq/spectrum-cloud/pull/115. Deploy the Cloud change first; until then this SDK version safely keeps automatic sharing disabled because the new field is optional and checked with `=== true`.

## Validation

- iMessage package: 16 test files, 147 tests passed with Node/Vitest
- `tsc --noEmit -p packages/imessage/tsconfig.json`
- `ultracite check` on changed files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787462536&installation_model_id=19795&pr_number=218&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F218&signature=a9b95376f3310fa73dfc7ddeb1ec5e638f076f0451be620a8301c5d84b41b756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when proactive contact info is shared to users and depends on a new Cloud token field, though missing data disables sharing and explicit shares are unaffected.
> 
> **Overview**
> Automatic iMessage contact-card sharing no longer reads the one-time **`projectConfig.profile.imessageSynced`** flag. It now uses **per-line sync readiness** from dedicated Cloud tokens (`profileSynced` per instance), stored on each `RemoteClient` and **refreshed in place** when tokens renew.
> 
> The inbound message stream always wires the contact-share tracker but only calls `maybeShare` when **`entry.profileSynced === true`** on each message, so a running stream can turn sharing on or off after renewal without being recreated. Shared clients, explicit clients, and Cloud responses without the new field **fail closed** (no automatic share). On-demand `shareContactCard` / `nativeContactCard()` is unchanged.
> 
> `messages` producers drop the `projectConfig` argument through the iMessage remote stack; core docs are generalized accordingly. Tests cover token renewal updating `profileSynced` and stream gating across sync state changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca872b5141331c9fd48b3501f6b45d9bc8f7315d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Contact card sharing is now enabled independently for each iMessage line once that line’s profile synchronization completes.
  - Dedicated token renewal/recovery now retains and refreshes per-line profile sync status alongside phone metadata.

- **Bug Fixes**
  - Prevented contact information from being shared prematurely before the corresponding line has completed profile synchronization.
  - Improved consistency of line-specific synchronization state after dedicated token refresh.

- **API Changes**
  - The iMessage `messages` stream setup no longer accepts project configuration, using only the provided client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->