### PR TITLE
fix(imessage): gate automatic profile sharing per line

### DIFF
--- a/packages/core/src/platform/types.ts
+++ b/packages/core/src/platform/types.ts
@@ -154,8 +154,8 @@ export type EventProducer<
   /**
    * Spectrum Cloud project metadata, fetched once at `Spectrum()` init.
    * `undefined` when the instance was created without `projectId`/`projectSecret`
-   * (local-only setups). Providers read project-level toggles from
-   * `projectConfig.profile.<key>` — e.g. iMessage's `imessageSynced` flag.
+   * (local-only setups). Providers may read project-level settings from
+   * `projectConfig.profile.<key>`.
    */
   projectConfig: ProjectData | undefined;
   store: Store;

--- a/packages/core/src/utils/cloud.ts
+++ b/packages/core/src/utils/cloud.ts
@@ -24,6 +24,7 @@ export interface DedicatedTokenData {
   auth: Record<string, string>;
   expiresIn: number;
   numbers: Record<string, string | null>;
+  profileSynced?: Record<string, boolean>;
   type: "dedicated";
 }
 

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -35,14 +35,14 @@ export async function createCloudClients(
   let lastRefreshAt = Date.now();
 
   // The instanceId stays paired with each entry in this closure so renewal
-  // can rewrite the line metadata in place without leaking instanceId onto
-  // the public RemoteClient shape. Empty in shared mode.
+  // can rewrite the phone in place without leaking instanceId onto the public
+  // RemoteClient shape. The automatic-share decision is deliberately an
+  // initialization snapshot and is not refreshed with auth tokens.
   const records: { entry: RemoteClient; instanceId: string }[] = [];
 
-  const syncLineMetadata = (data: DedicatedTokenData) => {
+  const syncPhones = (data: DedicatedTokenData) => {
     for (const { entry, instanceId } of records) {
       entry.phone = requirePhone(data, instanceId);
-      entry.profileSynced = data.profileSynced?.[instanceId] === true;
     }
   };
 
@@ -53,7 +53,7 @@ export async function createCloudClients(
       tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
       lastRefreshAt = Date.now();
       if (tokenData.type === "dedicated") {
-        syncLineMetadata(tokenData);
+        syncPhones(tokenData);
       }
     },
   });
@@ -104,7 +104,7 @@ export async function createCloudClients(
   for (const [instanceId, token] of Object.entries(dedicated.auth)) {
     const entry: RemoteClient = {
       phone: requirePhone(dedicated, instanceId),
-      profileSynced: dedicated.profileSynced?.[instanceId] === true,
+      autoShareEnabled: dedicated.profileSynced?.[instanceId] === true,
       client: createGrpcClient({
         address: `${instanceId}.imsg.photon.codes:443`,
         autoIdempotency: true,

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -35,13 +35,14 @@ export async function createCloudClients(
   let lastRefreshAt = Date.now();
 
   // The instanceId stays paired with each entry in this closure so renewal
-  // can rewrite `entry.phone` in place without leaking instanceId onto the
-  // public RemoteClient shape. Empty in shared mode.
+  // can rewrite the line metadata in place without leaking instanceId onto
+  // the public RemoteClient shape. Empty in shared mode.
   const records: { entry: RemoteClient; instanceId: string }[] = [];
 
-  const syncPhones = (data: DedicatedTokenData) => {
+  const syncLineMetadata = (data: DedicatedTokenData) => {
     for (const { entry, instanceId } of records) {
       entry.phone = requirePhone(data, instanceId);
+      entry.profileSynced = data.profileSynced?.[instanceId] === true;
     }
   };
 
@@ -52,7 +53,7 @@ export async function createCloudClients(
       tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
       lastRefreshAt = Date.now();
       if (tokenData.type === "dedicated") {
-        syncPhones(tokenData);
+        syncLineMetadata(tokenData);
       }
     },
   });
@@ -103,6 +104,7 @@ export async function createCloudClients(
   for (const [instanceId, token] of Object.entries(dedicated.auth)) {
     const entry: RemoteClient = {
       phone: requirePhone(dedicated, instanceId),
+      profileSynced: dedicated.profileSynced?.[instanceId] === true,
       client: createGrpcClient({
         address: `${instanceId}.imsg.photon.codes:443`,
         autoIdempotency: true,

--- a/packages/imessage/src/content/contact-card.ts
+++ b/packages/imessage/src/content/contact-card.ts
@@ -45,9 +45,10 @@ export const isContactCard = (v: unknown): v is ContactCard =>
  * `PlatformSpace<IMessageDef>`).
  *
  * This is an explicit, on-demand share and always fires — unlike the automatic
- * best-effort share gated behind the `imessageSynced` project profile, which
- * dedupes to once per chat per 24h (see `remote/contact-share.ts`). Works in
- * both DMs and group chats; the recipient chooses whether to accept the card.
+ * best-effort share gated by the current line's reconciled profile state,
+ * which dedupes to once per chat per 24h (see `remote/contact-share.ts`).
+ * Works in both DMs and group chats; the recipient chooses whether to accept
+ * the card.
  *
  * `ContactCard` is intentionally not a member of the universal `Content`
  * union — the `as unknown as Content` cast keeps the builder shape compatible

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -601,8 +601,7 @@ export const imessage = definePlatform(IMESSAGE_PLATFORM, {
     schema: messageSchema,
   },
 
-  messages: ({ client, projectConfig }) =>
-    remoteMessages(client, projectConfig),
+  messages: ({ client }) => remoteMessages(client),
 
   send: async ({ space, content, client }) => {
     if (content.type === "reply") {

--- a/packages/imessage/src/remote/api.ts
+++ b/packages/imessage/src/remote/api.ts
@@ -8,7 +8,6 @@ import type {
   AvatarData,
   Content,
   ManagedStream,
-  ProjectData,
   RemoveMember,
   Rename,
   StreamText,
@@ -55,9 +54,8 @@ import {
 } from "./typing";
 
 export const messages = (
-  clients: RemoteClient[],
-  projectConfig: ProjectData | undefined
-): ManagedStream<IMessageMessage> => remoteMessages(clients, projectConfig);
+  clients: RemoteClient[]
+): ManagedStream<IMessageMessage> => remoteMessages(clients);
 
 export const setBackground = async (
   remote: AdvancedIMessage,

--- a/packages/imessage/src/remote/contact-card.ts
+++ b/packages/imessage/src/remote/contact-card.ts
@@ -10,8 +10,8 @@ import { toChatGuid } from "./ids";
  * the dispatcher reaches here.
  *
  * On-demand and unconditional: unlike the proactive `ContactShareTracker` in
- * `contact-share.ts` (24h dedupe, gated behind the `imessageSynced` profile),
- * this fires every time the caller asks.
+ * `contact-share.ts` (24h dedupe, gated by the current line's reconciled
+ * profile state), this fires every time the caller asks.
  */
 export const shareContactCard = async (
   remote: AdvancedIMessage,

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -404,21 +404,20 @@ export const messages = (
   return mergeStreams(
     clients.map((entry) => {
       // Gate automatic contact-card sharing on this line's reconciled profile,
-      // not the legacy project profile. Read the mutable entry on every inbound
-      // so a Cloud token renewal can enable or disable sharing without
-      // rebuilding the streams. Missing metadata (shared or explicit clients,
-      // or an older Cloud response) fails closed.
-      const tracker = getContactShareTracker(entry.client);
+      // not the legacy project profile. This is the snapshot captured when the
+      // SDK initialized; auth-token renewal does not change it. Missing
+      // metadata (shared or explicit clients, or an older Cloud response)
+      // fails closed.
+      const tracker =
+        entry.autoShareEnabled === true
+          ? getContactShareTracker(entry.client)
+          : undefined;
       return clientStream(
         entry.client,
         pollCache,
         entry.phone,
         includeGroupEvents,
-        (chatGuid) => {
-          if (entry.profileSynced === true) {
-            tracker.maybeShare(chatGuid);
-          }
-        },
+        tracker ? (chatGuid) => tracker.maybeShare(chatGuid) : undefined,
         recover
       );
     })

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -7,11 +7,7 @@ import {
   ValidationError,
 } from "@photon-ai/advanced-imessage/grpc";
 import { sanitizePhone } from "@photon-ai/otel";
-import {
-  type ManagedStream,
-  mergeStreams,
-  type ProjectData,
-} from "@spectrum-ts/core";
+import { type ManagedStream, mergeStreams } from "@spectrum-ts/core";
 import {
   type CloseableAsyncIterable,
   createLogger,
@@ -397,16 +393,9 @@ const clientStream = (
 };
 
 export const messages = (
-  clients: RemoteClient[],
-  projectConfig?: ProjectData | undefined
+  clients: RemoteClient[]
 ): ManagedStream<IMessageMessage> => {
   const pollCache = getPollCache(clients);
-  // When the project profile opts in to iMessage sync, push the bot's contact
-  // card to any chat we receive a new message in (24h dedupe per chat per line,
-  // fire-and-forget). The tracker is keyed per `entry.client` — same shape as
-  // `getMessageCache` — so each line dedupes independently (a DM guid encodes
-  // the peer, not the line) and multi-Spectrum setups don't cross-pollute.
-  const shareEnabled = projectConfig?.profile?.imessageSynced === true;
   // Cloud clients can re-mint a rejected token; explicit/static-token clients
   // return undefined (nothing to refresh). Shared across this client array's
   // streams so the message + poll loops coalesce onto one re-mint.
@@ -414,15 +403,22 @@ export const messages = (
   const includeGroupEvents = !isSharedMode(clients);
   return mergeStreams(
     clients.map((entry) => {
-      const tracker = shareEnabled
-        ? getContactShareTracker(entry.client)
-        : undefined;
+      // Gate automatic contact-card sharing on this line's reconciled profile,
+      // not the legacy project profile. Read the mutable entry on every inbound
+      // so a Cloud token renewal can enable or disable sharing without
+      // rebuilding the streams. Missing metadata (shared or explicit clients,
+      // or an older Cloud response) fails closed.
+      const tracker = getContactShareTracker(entry.client);
       return clientStream(
         entry.client,
         pollCache,
         entry.phone,
         includeGroupEvents,
-        tracker ? (chatGuid) => tracker.maybeShare(chatGuid) : undefined,
+        (chatGuid) => {
+          if (entry.profileSynced === true) {
+            tracker.maybeShare(chatGuid);
+          }
+        },
         recover
       );
     })

--- a/packages/imessage/src/types.ts
+++ b/packages/imessage/src/types.ts
@@ -3,9 +3,9 @@ import type { SchemaMessage } from "@spectrum-ts/core";
 import z from "zod";
 
 export interface RemoteClient {
+  autoShareEnabled?: boolean;
   client: AdvancedIMessage;
   phone: string;
-  profileSynced?: boolean;
 }
 
 export type IMessageClient = RemoteClient[];

--- a/packages/imessage/src/types.ts
+++ b/packages/imessage/src/types.ts
@@ -5,6 +5,7 @@ import z from "zod";
 export interface RemoteClient {
   client: AdvancedIMessage;
   phone: string;
+  profileSynced?: boolean;
 }
 
 export type IMessageClient = RemoteClient[];

--- a/packages/imessage/test/auth.test.ts
+++ b/packages/imessage/test/auth.test.ts
@@ -4,6 +4,7 @@ interface FakeDedicatedTokenData {
   auth: Record<string, string>;
   expiresIn: number;
   numbers: Record<string, string | null>;
+  profileSynced?: Record<string, boolean>;
   type: "dedicated";
 }
 
@@ -15,6 +16,7 @@ const initialTokenData: FakeDedicatedTokenData = {
   auth: { "instance-1": "token-1" },
   expiresIn: 3600,
   numbers: { "instance-1": "+15550000001" },
+  profileSynced: { "instance-1": false },
   type: "dedicated",
 };
 
@@ -68,6 +70,7 @@ describe("imessage cloud auth", () => {
     );
 
     const clients = await createCloudClients("project-1", "secret-1");
+    expect(clients[0]?.profileSynced).toBe(false);
     const recover = getCloudRecover(clients);
     if (!recover) {
       throw new Error("expected cloud recovery hook");
@@ -82,12 +85,14 @@ describe("imessage cloud auth", () => {
       auth: { "instance-1": "token-2" },
       expiresIn: 3600,
       numbers: { "instance-1": "+15550000002" },
+      profileSynced: { "instance-1": true },
       type: "dedicated",
     });
     await Promise.all([first, second]);
 
     expect(issueImessageTokens).toHaveBeenCalledTimes(2);
     expect(clients[0]?.phone).toBe("+15550000002");
+    expect(clients[0]?.profileSynced).toBe(true);
     expect(await clientOptions[0]?.token()).toBe("token-2");
 
     await disposeCloudAuth(clients);

--- a/packages/imessage/test/auth.test.ts
+++ b/packages/imessage/test/auth.test.ts
@@ -70,7 +70,7 @@ describe("imessage cloud auth", () => {
     );
 
     const clients = await createCloudClients("project-1", "secret-1");
-    expect(clients[0]?.profileSynced).toBe(false);
+    expect(clients[0]?.autoShareEnabled).toBe(false);
     const recover = getCloudRecover(clients);
     if (!recover) {
       throw new Error("expected cloud recovery hook");
@@ -92,7 +92,9 @@ describe("imessage cloud auth", () => {
 
     expect(issueImessageTokens).toHaveBeenCalledTimes(2);
     expect(clients[0]?.phone).toBe("+15550000002");
-    expect(clients[0]?.profileSynced).toBe(true);
+    // Profile sync is sampled only during initialization. Token renewal must
+    // not silently change runtime sharing behavior.
+    expect(clients[0]?.autoShareEnabled).toBe(false);
     expect(await clientOptions[0]?.token()).toBe("token-2");
 
     await disposeCloudAuth(clients);

--- a/packages/imessage/test/remote/stream.test.ts
+++ b/packages/imessage/test/remote/stream.test.ts
@@ -37,6 +37,71 @@ const idleEventStream = () => {
   };
 };
 
+const pushEventStream = <T>() => {
+  let closed = false;
+  const queued: T[] = [];
+  const waiters: ((result: IteratorResult<T, undefined>) => void)[] = [];
+
+  const close = (): Promise<void> => {
+    closed = true;
+    for (const resolve of waiters.splice(0)) {
+      resolve({ done: true, value: undefined });
+    }
+    return Promise.resolve();
+  };
+
+  const stream = {
+    close,
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<T, undefined>> {
+          const value = queued.shift();
+          if (value !== undefined) {
+            return Promise.resolve({ done: false, value });
+          }
+          if (closed) {
+            return Promise.resolve({ done: true, value: undefined });
+          }
+          return new Promise((resolve) => {
+            waiters.push(resolve);
+          });
+        },
+        return(): Promise<IteratorResult<T, undefined>> {
+          return close().then(() => ({ done: true, value: undefined }));
+        },
+      };
+    },
+  };
+
+  return {
+    push(value: T): void {
+      const resolve = waiters.shift();
+      if (resolve) {
+        resolve({ done: false, value });
+      } else {
+        queued.push(value);
+      }
+    },
+    stream,
+  };
+};
+
+const inboundEvent = (sequence: number, chatGuid: string) => ({
+  type: "message.received",
+  sequence,
+  chatGuid,
+  isFromMe: false,
+  occurredAt: new Date(1_700_000_000_000 + sequence),
+  message: {
+    guid: `msg-${sequence}`,
+    chatGuids: [chatGuid],
+    content: { attachments: [], formatting: [], mentions: [], text: "hi" },
+    dateCreated: new Date(1_700_000_000_000 + sequence),
+    isFromMe: false,
+    sender: { address: "+15550111" },
+  },
+});
+
 const remoteClient = (phone: string) => {
   const subscribeToMessages = vi.fn(idleEventStream);
   const subscribeToPolls = vi.fn(idleEventStream);
@@ -85,6 +150,42 @@ describe("remote iMessage streams", () => {
     expect(dedicated.subscribeToMessages).toHaveBeenCalledTimes(1);
     expect(dedicated.subscribeToPolls).toHaveBeenCalledTimes(1);
     expect(dedicated.subscribeToGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it("gates automatic contact sharing on the current line sync state", async () => {
+    const messageEvents = pushEventStream<ReturnType<typeof inboundEvent>>();
+    const shareContactInfo = vi.fn((_: string) => Promise.resolve());
+    const entry: RemoteClient = {
+      phone: "+15550100",
+      profileSynced: false,
+      client: {
+        chats: { shareContactInfo },
+        groups: { subscribeEvents: idleEventStream },
+        messages: { subscribeEvents: () => messageEvents.stream },
+        polls: { subscribeEvents: idleEventStream },
+      } as unknown as AdvancedIMessage,
+    };
+    const stream = messages([entry]);
+    const iterator = stream[Symbol.asyncIterator]();
+
+    const firstPending = iterator.next();
+    messageEvents.push(inboundEvent(1, "chat-before-sync"));
+    const first = await firstPending;
+    expect(first.value?.id).toBe("msg-1");
+    expect(shareContactInfo).not.toHaveBeenCalled();
+
+    // Token renewal mutates the existing line entry. The already-running
+    // stream must observe that change without being recreated.
+    entry.profileSynced = true;
+    const secondPending = iterator.next();
+    messageEvents.push(inboundEvent(2, "chat-after-sync"));
+    const second = await secondPending;
+    expect(second.value?.id).toBe("msg-2");
+    expect(shareContactInfo).toHaveBeenCalledTimes(1);
+    expect(shareContactInfo).toHaveBeenCalledWith("chat-after-sync");
+
+    await stream.close();
+    await settleSoon(iterator.next());
   });
 
   it("skips an unmappable event instead of wedging the stream", async () => {

--- a/packages/imessage/test/remote/stream.test.ts
+++ b/packages/imessage/test/remote/stream.test.ts
@@ -152,40 +152,57 @@ describe("remote iMessage streams", () => {
     expect(dedicated.subscribeToGroups).toHaveBeenCalledTimes(1);
   });
 
-  it("gates automatic contact sharing on the current line sync state", async () => {
-    const messageEvents = pushEventStream<ReturnType<typeof inboundEvent>>();
-    const shareContactInfo = vi.fn((_: string) => Promise.resolve());
-    const entry: RemoteClient = {
+  it("gates automatic contact sharing on each line's initialization state", async () => {
+    const disabledEvents = pushEventStream<ReturnType<typeof inboundEvent>>();
+    const disabledShare = vi.fn((_: string) => Promise.resolve());
+    const disabledEntry: RemoteClient = {
+      autoShareEnabled: false,
       phone: "+15550100",
-      profileSynced: false,
       client: {
-        chats: { shareContactInfo },
+        chats: { shareContactInfo: disabledShare },
         groups: { subscribeEvents: idleEventStream },
-        messages: { subscribeEvents: () => messageEvents.stream },
+        messages: { subscribeEvents: () => disabledEvents.stream },
         polls: { subscribeEvents: idleEventStream },
       } as unknown as AdvancedIMessage,
     };
-    const stream = messages([entry]);
-    const iterator = stream[Symbol.asyncIterator]();
+    const disabledStream = messages([disabledEntry]);
+    const disabledIterator = disabledStream[Symbol.asyncIterator]();
 
-    const firstPending = iterator.next();
-    messageEvents.push(inboundEvent(1, "chat-before-sync"));
+    const firstPending = disabledIterator.next();
+    disabledEvents.push(inboundEvent(1, "chat-disabled"));
     const first = await firstPending;
     expect(first.value?.id).toBe("msg-1");
-    expect(shareContactInfo).not.toHaveBeenCalled();
+    expect(disabledShare).not.toHaveBeenCalled();
 
-    // Token renewal mutates the existing line entry. The already-running
-    // stream must observe that change without being recreated.
-    entry.profileSynced = true;
-    const secondPending = iterator.next();
-    messageEvents.push(inboundEvent(2, "chat-after-sync"));
+    await disabledStream.close();
+    await settleSoon(disabledIterator.next());
+
+    const enabledEvents = pushEventStream<ReturnType<typeof inboundEvent>>();
+    const enabledShare = vi.fn((_: string) => Promise.resolve());
+    const enabledEntry: RemoteClient = {
+      autoShareEnabled: true,
+      phone: "+15550200",
+      client: {
+        chats: { shareContactInfo: enabledShare },
+        groups: { subscribeEvents: idleEventStream },
+        messages: { subscribeEvents: () => enabledEvents.stream },
+        polls: { subscribeEvents: idleEventStream },
+      } as unknown as AdvancedIMessage,
+    };
+    const enabledStream = messages([enabledEntry]);
+    const enabledIterator = enabledStream[Symbol.asyncIterator]();
+
+    const secondPending = enabledIterator.next();
+    enabledEvents.push(inboundEvent(2, "chat-enabled"));
     const second = await secondPending;
     expect(second.value?.id).toBe("msg-2");
-    expect(shareContactInfo).toHaveBeenCalledTimes(1);
-    expect(shareContactInfo).toHaveBeenCalledWith("chat-after-sync");
+    await vi.waitFor(() => {
+      expect(enabledShare).toHaveBeenCalledTimes(1);
+    });
+    expect(enabledShare).toHaveBeenCalledWith("chat-enabled");
 
-    await stream.close();
-    await settleSoon(iterator.next());
+    await enabledStream.close();
+    await settleSoon(enabledIterator.next());
   });
 
   it("skips an unmappable event instead of wedging the stream", async () => {


### PR DESCRIPTION
## Summary

- remove the legacy projectConfig.profile.imessageSynced gate from iMessage streams
- derive autoShareEnabled separately for each dedicated line from the Cloud token response
- keep the existing lifecycle: the decision is captured once during SDK initialization
- keep auth-token renewal separate; renewal updates credentials and phone metadata but never changes the automatic-share decision
- fail closed for shared mode, explicit clients, and older Cloud responses without per-line metadata

Depends on photon-hq/spectrum-cloud#116.

## Validation

- all 147 iMessage tests pass under Node Vitest
- iMessage package typecheck passes
- Biome check passes for every changed file
- Core package standalone typecheck is blocked by the local install missing @spectrum-ts/test-support workspace links; the changed Core field is covered by the iMessage typecheck

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787464589&installation_model_id=19795&pr_number=219&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F219&signature=130763ad1fa16373954c3d9cb8323a0f72a7bbe40b1eaff6190c1ce8fdcf2ff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when proactive contact cards are sent on inbound messages (user-visible iMessage behavior) and depends on a new Cloud API field; behavior is intentionally frozen after init and fails closed when metadata is absent.
> 
> **Overview**
> **Automatic iMessage contact-card sharing** no longer reads the legacy project flag `projectConfig.profile.imessageSynced`. Each dedicated cloud line now gets `autoShareEnabled` from Spectrum Cloud’s dedicated token payload (`profileSynced` per instance), captured once when clients are created.
> 
> The inbound message stream wires `ContactShareTracker` only when `entry.autoShareEnabled === true`; shared mode, explicit/static clients, and token responses without per-line metadata stay off (**fail closed**). Token renewal still refreshes auth and phone numbers but **does not** flip `autoShareEnabled`, so runtime sharing behavior cannot change mid-session after a re-mint.
> 
> `DedicatedTokenData` gains optional `profileSynced`; `RemoteClient` gains `autoShareEnabled`. The iMessage `messages` producer no longer takes `projectConfig`. Tests cover init vs renewal for profile sync and per-line gating on inbound messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b1311f048c86e79c6f869f37d3e1e337dee8357. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatic contact-card sharing is now configured independently for each iMessage line.
  - Contact-card sharing remains limited to once per chat within a 24-hour period.
  - Profile synchronization status is preserved consistently during authentication recovery.

- **Improvements**
  - iMessage message retrieval no longer depends on project-level configuration, improving per-line behavior and simplifying operation.

- **Documentation**
  - Updated guidance clarifies how local profile settings affect contact sharing and provider behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->