### PR TITLE
fix(imessage): refresh profile share gate on demand (ENG-2085)

### DIFF
--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -91,6 +91,11 @@ import {
 import { chatTypeFromGuid, dmChatGuid } from "./remote/ids";
 import { cacheMessage } from "./remote/inbound";
 import {
+  disposeProfileSyncGate,
+  getProfileSyncGate,
+  registerProfileSyncGate,
+} from "./remote/profile-sync-gate";
+import {
   configSchema,
   type IMessageClient,
   type IMessageMessage,
@@ -470,14 +475,16 @@ export const imessage = definePlatform(IMESSAGE_PLATFORM, {
   lifecycle: {
     createClient: async ({
       config,
+      projectConfig,
       projectId,
       projectSecret,
     }): Promise<IMessageClient> => {
+      let clients: IMessageClient;
       if (config.clients) {
         const entries = Array.isArray(config.clients)
           ? config.clients
           : [config.clients];
-        return entries.map((e) => ({
+        clients = entries.map((e) => ({
           phone: e.phone,
           client: createGrpcClient({
             address: e.address,
@@ -490,18 +497,28 @@ export const imessage = definePlatform(IMESSAGE_PLATFORM, {
             token: e.token,
           }),
         }));
-      }
-
-      if (!(projectId && projectSecret)) {
+      } else if (projectId && projectSecret) {
+        clients = await createCloudClients(projectId, projectSecret);
+      } else {
         throw new Error(
           "Cloud iMessage requires projectId and projectSecret. Pass credentials to Spectrum() or provide explicit clients with imessage.config({ clients: [...] }). For local Messages access, install @spectrum-ts/imessage-local and use localIMessage.config()."
         );
       }
 
-      return await createCloudClients(projectId, projectSecret);
+      if (projectId && projectSecret && projectConfig) {
+        registerProfileSyncGate(
+          clients,
+          projectId,
+          projectSecret,
+          projectConfig
+        );
+      }
+
+      return clients;
     },
 
     destroyClient: async ({ client }) => {
+      disposeProfileSyncGate(client);
       await disposeCloudAuth(client);
       await Promise.all(client.map((entry) => entry.client.close()));
     },
@@ -602,7 +619,7 @@ export const imessage = definePlatform(IMESSAGE_PLATFORM, {
   },
 
   messages: ({ client, projectConfig }) =>
-    remoteMessages(client, projectConfig),
+    remoteMessages(client, projectConfig, getProfileSyncGate(client)),
 
   send: async ({ space, content, client }) => {
     if (content.type === "reply") {

--- a/packages/imessage/src/remote/api.ts
+++ b/packages/imessage/src/remote/api.ts
@@ -32,6 +32,7 @@ import {
   listParticipants as listRemoteParticipants,
   removeParticipants as removeRemoteParticipants,
 } from "./members";
+import type { ProfileSyncGate } from "./profile-sync-gate";
 import {
   reactToMessage as reactToRemoteMessage,
   unsendReaction as unsendRemoteReaction,
@@ -56,8 +57,10 @@ import {
 
 export const messages = (
   clients: RemoteClient[],
-  projectConfig: ProjectData | undefined
-): ManagedStream<IMessageMessage> => remoteMessages(clients, projectConfig);
+  projectConfig: ProjectData | undefined,
+  profileSyncGate?: ProfileSyncGate | undefined
+): ManagedStream<IMessageMessage> =>
+  remoteMessages(clients, projectConfig, profileSyncGate);
 
 export const setBackground = async (
   remote: AdvancedIMessage,

--- a/packages/imessage/src/remote/contact-share.ts
+++ b/packages/imessage/src/remote/contact-share.ts
@@ -46,6 +46,15 @@ export class ContactShareTracker {
   }
 
   /**
+   * Whether this line has already attempted to share with the chat during the
+   * 24-hour dedupe window. Callers use this before consulting any remote gate,
+   * so repeat inbound messages stay entirely local.
+   */
+  hasRecentlyShared(chatGuid: string): boolean {
+    return this.cache.has(chatGuid);
+  }
+
+  /**
    * Best-effort share. The cache is set eagerly so that a burst of inbound
    * messages for the same chat coalesces to a single API call. A
    * `preconditionFailed` response remains cached for the normal 24-hour TTL,

--- a/packages/imessage/src/remote/profile-sync-gate.ts
+++ b/packages/imessage/src/remote/profile-sync-gate.ts
@@ -1,0 +1,123 @@
+import { cloud, type ProjectData } from "@spectrum-ts/core";
+import { createLogger, errorAttrs } from "@spectrum-ts/core/authoring";
+import type { IMessageClient } from "../types";
+
+const PROFILE_SYNC_CACHE_TTL_MS = 60_000;
+const PROFILE_SYNC_RETRY_DELAY_MS = 30_000;
+
+const log = createLogger("spectrum.imessage.profile-sync");
+
+export interface ProfileSyncGate {
+  dispose(): void;
+  isEnabled(): Promise<boolean>;
+}
+
+interface ProfileSyncGateOptions {
+  cacheTtlMs?: number;
+  initialEnabled: boolean;
+  refresh: () => Promise<boolean>;
+  retryDelayMs?: number;
+}
+
+export const createProfileSyncGate = (
+  options: ProfileSyncGateOptions
+): ProfileSyncGate => {
+  const cacheTtlMs = options.cacheTtlMs ?? PROFILE_SYNC_CACHE_TTL_MS;
+  const retryDelayMs = options.retryDelayMs ?? PROFILE_SYNC_RETRY_DELAY_MS;
+  let cachedEnabled = options.initialEnabled;
+  let disposed = false;
+  let refreshInFlight: Promise<boolean> | undefined;
+  let retryAfter = 0;
+  let validUntil = Date.now() + cacheTtlMs;
+
+  const refreshNow = async (): Promise<boolean> => {
+    try {
+      const enabled = await options.refresh();
+      if (disposed) {
+        return false;
+      }
+      cachedEnabled = enabled;
+      retryAfter = 0;
+      validUntil = Date.now() + cacheTtlMs;
+      return enabled;
+    } catch (error) {
+      cachedEnabled = false;
+      retryAfter = Date.now() + retryDelayMs;
+      validUntil = 0;
+      log.warn(
+        "failed to refresh profile sync state; automatic contact sharing remains disabled",
+        {
+          "spectrum.imessage.profile_sync.retry_in_ms": retryDelayMs,
+          ...errorAttrs(error),
+        },
+        error
+      );
+      return false;
+    }
+  };
+
+  const coalescedRefresh = (): Promise<boolean> => {
+    if (!refreshInFlight) {
+      refreshInFlight = refreshNow().finally(() => {
+        refreshInFlight = undefined;
+      });
+    }
+    return refreshInFlight;
+  };
+
+  return {
+    dispose(): void {
+      disposed = true;
+      cachedEnabled = false;
+      validUntil = 0;
+    },
+    async isEnabled(): Promise<boolean> {
+      if (disposed) {
+        return false;
+      }
+
+      const now = Date.now();
+      if (now < validUntil) {
+        return cachedEnabled;
+      }
+      if (now < retryAfter) {
+        return false;
+      }
+      return await coalescedRefresh();
+    },
+  };
+};
+
+const gates = new WeakMap<IMessageClient, ProfileSyncGate>();
+
+const isProfileSynced = (projectConfig: ProjectData): boolean =>
+  projectConfig.profile?.imessageSynced === true;
+
+export const registerProfileSyncGate = (
+  clients: IMessageClient,
+  projectId: string,
+  projectSecret: string,
+  projectConfig: ProjectData
+): void => {
+  const previous = gates.get(clients);
+  previous?.dispose();
+
+  gates.set(
+    clients,
+    createProfileSyncGate({
+      initialEnabled: isProfileSynced(projectConfig),
+      refresh: async () =>
+        isProfileSynced(await cloud.getProject(projectId, projectSecret)),
+    })
+  );
+};
+
+export const getProfileSyncGate = (
+  clients: IMessageClient
+): ProfileSyncGate | undefined => gates.get(clients);
+
+export const disposeProfileSyncGate = (clients: IMessageClient): void => {
+  const gate = gates.get(clients);
+  gate?.dispose();
+  gates.delete(clients);
+};

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -27,7 +27,10 @@ import {
   SHARED_PHONE,
 } from "../types";
 import { isSharedMode } from "./client";
-import { getContactShareTracker } from "./contact-share";
+import {
+  type ContactShareTracker,
+  getContactShareTracker,
+} from "./contact-share";
 import {
   groupEventActor,
   groupEventMessageId,
@@ -35,6 +38,7 @@ import {
 } from "./group-events";
 import { toInboundMessages } from "./inbound";
 import { cachePollEvent, toPollDeltaMessages } from "./polls";
+import type { ProfileSyncGate } from "./profile-sync-gate";
 import { toReactionMessages } from "./reactions";
 
 // The proxy rejects an unknown/pruned resume cursor with INVALID_ARGUMENT,
@@ -396,17 +400,57 @@ const clientStream = (
   return mergeStreams(streams);
 };
 
+const shareWhenProfileSynced = (
+  tracker: ContactShareTracker,
+  gate: ProfileSyncGate,
+  chatGuid: string
+): void => {
+  // The existing 24-hour Line + chat dedupe must run before the project-level
+  // Cloud gate. Repeat inbound messages therefore stay entirely local.
+  if (tracker.hasRecentlyShared(chatGuid)) {
+    return;
+  }
+
+  gate
+    .isEnabled()
+    .then((enabled) => {
+      if (enabled) {
+        // Multiple messages may have awaited the same coalesced gate refresh.
+        // maybeShare sets its cache synchronously, so only the first continues
+        // to the RPC.
+        tracker.maybeShare(chatGuid);
+      }
+    })
+    .catch((error: unknown) => {
+      // ProfileSyncGate handles expected Cloud failures and returns false.
+      // Keep this boundary defensive so a faulty gate can never break inbound
+      // message processing or create an unhandled rejection.
+      streamLog.warn(
+        "profile sync gate failed; skipping automatic contact sharing",
+        errorAttrs(error),
+        error instanceof Error ? error : undefined
+      );
+    });
+};
+
+const contactShareHandler = (
+  tracker: ContactShareTracker,
+  profileSyncGate?: ProfileSyncGate | undefined
+): OnInboundMessage =>
+  profileSyncGate
+    ? (chatGuid) => shareWhenProfileSynced(tracker, profileSyncGate, chatGuid)
+    : (chatGuid) => tracker.maybeShare(chatGuid);
+
 export const messages = (
   clients: RemoteClient[],
-  projectConfig?: ProjectData | undefined
+  projectConfig?: ProjectData | undefined,
+  profileSyncGate?: ProfileSyncGate | undefined
 ): ManagedStream<IMessageMessage> => {
   const pollCache = getPollCache(clients);
-  // When the project profile opts in to iMessage sync, push the bot's contact
-  // card to any chat we receive a new message in (24h dedupe per chat per line,
-  // fire-and-forget). The tracker is keyed per `entry.client` — same shape as
-  // `getMessageCache` — so each line dedupes independently (a DM guid encodes
-  // the peer, not the line) and multi-Spectrum setups don't cross-pollute.
-  const shareEnabled = projectConfig?.profile?.imessageSynced === true;
+  // Direct callers retain the initialization-snapshot behavior. Cloud-backed
+  // Spectrum clients also provide a refreshable project-level gate, checked
+  // only after the 24h per-Line/chat tracker says a share is eligible.
+  const staticShareEnabled = projectConfig?.profile?.imessageSynced === true;
   // Cloud clients can re-mint a rejected token; explicit/static-token clients
   // return undefined (nothing to refresh). Shared across this client array's
   // streams so the message + poll loops coalesce onto one re-mint.
@@ -414,15 +458,16 @@ export const messages = (
   const includeGroupEvents = !isSharedMode(clients);
   return mergeStreams(
     clients.map((entry) => {
-      const tracker = shareEnabled
-        ? getContactShareTracker(entry.client)
-        : undefined;
+      const tracker =
+        staticShareEnabled || profileSyncGate
+          ? getContactShareTracker(entry.client)
+          : undefined;
       return clientStream(
         entry.client,
         pollCache,
         entry.phone,
         includeGroupEvents,
-        tracker ? (chatGuid) => tracker.maybeShare(chatGuid) : undefined,
+        tracker ? contactShareHandler(tracker, profileSyncGate) : undefined,
         recover
       );
     })

--- a/packages/imessage/test/remote/profile-sync-gate.test.ts
+++ b/packages/imessage/test/remote/profile-sync-gate.test.ts
@@ -1,0 +1,138 @@
+import { cloud, type ProjectData } from "@spectrum-ts/core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createProfileSyncGate,
+  disposeProfileSyncGate,
+  getProfileSyncGate,
+  registerProfileSyncGate,
+} from "@/remote/profile-sync-gate";
+import type { IMessageClient } from "@/types";
+
+const projectConfig = (imessageSynced: boolean): ProjectData => ({
+  id: "project-1",
+  name: "Profile Gate Test",
+  profile: { imessageSynced },
+  slug: "profile-gate-test",
+});
+
+describe("iMessage profile sync gate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("uses the initialization value until its cache expires", async () => {
+    const refresh = vi.fn(() => Promise.resolve(true));
+    const gate = createProfileSyncGate({
+      cacheTtlMs: 60_000,
+      initialEnabled: false,
+      refresh,
+    });
+
+    expect(await gate.isEnabled()).toBe(false);
+    expect(refresh).not.toHaveBeenCalled();
+
+    vi.setSystemTime(59_999);
+    expect(await gate.isEnabled()).toBe(false);
+    expect(refresh).not.toHaveBeenCalled();
+
+    vi.setSystemTime(60_000);
+    expect(await gate.isEnabled()).toBe(true);
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables sharing when a refreshed aggregate turns false", async () => {
+    const refresh = vi.fn(() => Promise.resolve(false));
+    const gate = createProfileSyncGate({
+      cacheTtlMs: 60_000,
+      initialEnabled: true,
+      refresh,
+    });
+
+    expect(await gate.isEnabled()).toBe(true);
+    expect(refresh).not.toHaveBeenCalled();
+
+    vi.setSystemTime(60_000);
+    expect(await gate.isEnabled()).toBe(false);
+    expect(refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces concurrent refreshes", async () => {
+    let resolveRefresh: ((value: boolean) => void) | undefined;
+    const refresh = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveRefresh = resolve;
+        })
+    );
+    const gate = createProfileSyncGate({
+      cacheTtlMs: 0,
+      initialEnabled: false,
+      refresh,
+    });
+
+    const first = gate.isEnabled();
+    const second = gate.isEnabled();
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    resolveRefresh?.(true);
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(true);
+  });
+
+  it("fails closed and backs off before retrying", async () => {
+    const refresh = vi
+      .fn<() => Promise<boolean>>()
+      .mockRejectedValueOnce(new Error("cloud unavailable"))
+      .mockResolvedValueOnce(true);
+    const gate = createProfileSyncGate({
+      cacheTtlMs: 0,
+      initialEnabled: true,
+      refresh,
+      retryDelayMs: 30_000,
+    });
+
+    expect(await gate.isEnabled()).toBe(false);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(29_999);
+    expect(await gate.isEnabled()).toBe(false);
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(30_000);
+    expect(await gate.isEnabled()).toBe(true);
+    expect(refresh).toHaveBeenCalledTimes(2);
+  });
+
+  it("refreshes the project aggregate with the original credentials", async () => {
+    const getProject = vi
+      .spyOn(cloud, "getProject")
+      .mockResolvedValue(projectConfig(true));
+    const clients = [] as IMessageClient;
+
+    registerProfileSyncGate(
+      clients,
+      "project-1",
+      "project-secret",
+      projectConfig(false)
+    );
+    const gate = getProfileSyncGate(clients);
+    expect(gate).toBeDefined();
+    expect(await gate?.isEnabled()).toBe(false);
+    expect(getProject).not.toHaveBeenCalled();
+
+    vi.setSystemTime(60_000);
+    expect(await gate?.isEnabled()).toBe(true);
+    expect(getProject).toHaveBeenCalledTimes(1);
+    expect(getProject).toHaveBeenCalledWith("project-1", "project-secret");
+
+    disposeProfileSyncGate(clients);
+    expect(getProfileSyncGate(clients)).toBeUndefined();
+    expect(await gate?.isEnabled()).toBe(false);
+  });
+});

--- a/packages/imessage/test/remote/stream.test.ts
+++ b/packages/imessage/test/remote/stream.test.ts
@@ -1,6 +1,7 @@
 import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
 import { flush, settleSoon } from "@spectrum-ts/test-support/timing";
 import { describe, expect, it, vi } from "vitest";
+import type { ProfileSyncGate } from "@/remote/profile-sync-gate";
 import { messages } from "@/remote/stream";
 import { type RemoteClient, SHARED_PHONE } from "@/types";
 
@@ -36,6 +37,71 @@ const idleEventStream = () => {
     },
   };
 };
+
+const pushEventStream = <T>() => {
+  let closed = false;
+  const queued: T[] = [];
+  const waiters: ((result: IteratorResult<T, undefined>) => void)[] = [];
+
+  const close = (): Promise<void> => {
+    closed = true;
+    for (const resolve of waiters.splice(0)) {
+      resolve({ done: true, value: undefined });
+    }
+    return Promise.resolve();
+  };
+
+  const stream = {
+    close,
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<T, undefined>> {
+          const value = queued.shift();
+          if (value !== undefined) {
+            return Promise.resolve({ done: false, value });
+          }
+          if (closed) {
+            return Promise.resolve({ done: true, value: undefined });
+          }
+          return new Promise((resolve) => {
+            waiters.push(resolve);
+          });
+        },
+        return(): Promise<IteratorResult<T, undefined>> {
+          return close().then(() => ({ done: true, value: undefined }));
+        },
+      };
+    },
+  };
+
+  return {
+    push(value: T): void {
+      const resolve = waiters.shift();
+      if (resolve) {
+        resolve({ done: false, value });
+      } else {
+        queued.push(value);
+      }
+    },
+    stream,
+  };
+};
+
+const inboundEvent = (sequence: number, chatGuid: string) => ({
+  type: "message.received",
+  sequence,
+  chatGuid,
+  isFromMe: false,
+  occurredAt: new Date(1_700_000_000_000 + sequence),
+  message: {
+    guid: `msg-${sequence}`,
+    chatGuids: [chatGuid],
+    content: { attachments: [], formatting: [], mentions: [], text: "hi" },
+    dateCreated: new Date(1_700_000_000_000 + sequence),
+    isFromMe: false,
+    sender: { address: "+15550111" },
+  },
+});
 
 const remoteClient = (phone: string) => {
   const subscribeToMessages = vi.fn(idleEventStream);
@@ -85,6 +151,93 @@ describe("remote iMessage streams", () => {
     expect(dedicated.subscribeToMessages).toHaveBeenCalledTimes(1);
     expect(dedicated.subscribeToPolls).toHaveBeenCalledTimes(1);
     expect(dedicated.subscribeToGroups).toHaveBeenCalledTimes(1);
+  });
+
+  it("checks the dynamic gate only after the existing chat dedupe", async () => {
+    const events = pushEventStream<ReturnType<typeof inboundEvent>>();
+    const shareContactInfo = vi.fn((_: string) => Promise.resolve());
+    const gate: ProfileSyncGate = {
+      dispose: vi.fn(),
+      isEnabled: vi.fn(() => Promise.resolve(true)),
+    };
+    const entry: RemoteClient = {
+      phone: "+15550100",
+      client: {
+        chats: { shareContactInfo },
+        groups: { subscribeEvents: idleEventStream },
+        messages: { subscribeEvents: () => events.stream },
+        polls: { subscribeEvents: idleEventStream },
+      } as unknown as AdvancedIMessage,
+    };
+    const stream = messages([entry], undefined, gate);
+    const iterator = stream[Symbol.asyncIterator]();
+
+    const firstPending = iterator.next();
+    events.push(inboundEvent(1, "chat-A"));
+    await firstPending;
+    await vi.waitFor(() => {
+      expect(shareContactInfo).toHaveBeenCalledTimes(1);
+    });
+    expect(gate.isEnabled).toHaveBeenCalledTimes(1);
+
+    const duplicatePending = iterator.next();
+    events.push(inboundEvent(2, "chat-A"));
+    await duplicatePending;
+    await flush();
+    expect(gate.isEnabled).toHaveBeenCalledTimes(1);
+    expect(shareContactInfo).toHaveBeenCalledTimes(1);
+
+    const secondChatPending = iterator.next();
+    events.push(inboundEvent(3, "chat-B"));
+    await secondChatPending;
+    await vi.waitFor(() => {
+      expect(shareContactInfo).toHaveBeenCalledTimes(2);
+    });
+    expect(gate.isEnabled).toHaveBeenCalledTimes(2);
+
+    await stream.close();
+    await settleSoon(iterator.next());
+  });
+
+  it("does not consume the chat dedupe while the dynamic gate is false", async () => {
+    const events = pushEventStream<ReturnType<typeof inboundEvent>>();
+    const shareContactInfo = vi.fn((_: string) => Promise.resolve());
+    const isEnabled = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const gate: ProfileSyncGate = {
+      dispose: vi.fn(),
+      isEnabled,
+    };
+    const entry: RemoteClient = {
+      phone: "+15550100",
+      client: {
+        chats: { shareContactInfo },
+        groups: { subscribeEvents: idleEventStream },
+        messages: { subscribeEvents: () => events.stream },
+        polls: { subscribeEvents: idleEventStream },
+      } as unknown as AdvancedIMessage,
+    };
+    const stream = messages([entry], undefined, gate);
+    const iterator = stream[Symbol.asyncIterator]();
+
+    const blockedPending = iterator.next();
+    events.push(inboundEvent(1, "chat-A"));
+    await blockedPending;
+    await flush();
+    expect(shareContactInfo).not.toHaveBeenCalled();
+
+    const enabledPending = iterator.next();
+    events.push(inboundEvent(2, "chat-A"));
+    await enabledPending;
+    await vi.waitFor(() => {
+      expect(shareContactInfo).toHaveBeenCalledTimes(1);
+    });
+    expect(isEnabled).toHaveBeenCalledTimes(2);
+
+    await stream.close();
+    await settleSoon(iterator.next());
   });
 
   it("skips an unmappable event instead of wedging the stream", async () => {


### PR DESCRIPTION
## Summary

- Replace the lifetime iMessage auto-share snapshot with a project-level gate that refreshes on demand.
- Cache `profile.imessageSynced` for 60 seconds, coalesce concurrent refreshes, and fail closed with a 30-second retry backoff.
- Preserve the existing per-Line/per-chat 24-hour contact-share dedupe and run it before consulting Cloud.
- Keep `app.config` as the initialization snapshot; only the internal automatic-share decision becomes refreshable.

## Behavior

- `false → true`: the next eligible inbound after cache expiry refreshes Project Config and can share without restarting Spectrum.
- `true → false`: the next eligible inbound after cache expiry refreshes Project Config and stops automatic sharing.
- Repeat messages in a chat already handled during the 24-hour window remain fully local and never consult the gate.
- Cloud refresh failures never block or crash inbound delivery and are treated as unsynced.

This consumes the project-level Line Profile aggregate exposed by photon-hq/spectrum-cloud#116. Profile revision-aware invalidation of the 24-hour chat cache remains intentionally out of scope.

## Testing

- Biome check on all changed files
- `tsc --noEmit` for `@spectrum-ts/imessage`
- Node Vitest: 17 files, 153 tests passed
- Bun 1.3.14 Vitest: 17 files, 153 tests passed
- iMessage build and Node smoke import

Fixes ENG-2085

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787492594&installation_model_id=19795&pr_number=220&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F220&signature=99389e7ad776626756e5c3f8970485a7140db8e09a80e8c60025b609a7ce94f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches inbound message side effects and async Cloud reads on the hot path, but failures are isolated (fail-closed, defensive catches) and core stream delivery is unchanged.
> 
> **Overview**
> Replaces the **one-time** `profile.imessageSynced` snapshot for automatic contact-card sharing with a **refreshable project gate** on Cloud-backed Spectrum clients. The gate seeds from startup `projectConfig`, then re-fetches project config via `cloud.getProject` when its **60s cache** expires, **coalesces** concurrent refreshes, and **fails closed** with a **30s backoff** if Cloud errors—without blocking inbound delivery.
> 
> Inbound auto-share still runs the existing **24h per-line/per-chat** dedupe first (`hasRecentlyShared` on `ContactShareTracker`); only eligible chats consult the gate before `maybeShare`. If the gate is off, the chat dedupe slot is **not** consumed, so a later sync-on can still share. Lifecycle **registers** the gate in `createClient` and **disposes** it in `destroyClient`; the message stream receives the gate through `remote/api`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21c620031476c6d94f2827e11d730730c7eeb194. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic controls for iMessage profile synchronization.
  * Contact sharing now checks current synchronization availability before proceeding.
  * Added caching, automatic refresh, retry handling, and safe shutdown for synchronization status.

* **Bug Fixes**
  * Prevented contact sharing when synchronization status cannot be confirmed.
  * Preserved message processing when synchronization checks fail.

* **Tests**
  * Added coverage for refresh timing, concurrent checks, failures, disposal, and message-stream behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->