### PR TITLE
feat(imessage): surface inbound read receipts as messages (ENG-2101)

### DIFF
--- a/docs/content/read.mdx.vel
+++ b/docs/content/read.mdx.vel
@@ -1,0 +1,78 @@
+---
+title: "Read"
+description: "Mark a conversation as read, and observe when a recipient reads what you sent."
+---
+
+import { TypeTooltip } from "/snippets/type-tooltip.mdx";
+
+Use `read()` to mark a conversation as read up to a message, surfacing a read receipt to the sender where the platform supports one. It is fire-and-forget: `space.send(...)` resolves to `undefined`.
+
+```ts
+import { read } from "spectrum-ts";
+
+await space.send(read(message));
+```
+
+`message.read()` and `space.read(message)` are sugar for the canonical form above.
+
+```ts
+await message.read();
+await space.read(message);
+```
+
+Only inbound messages can be marked read; passing an outbound message throws at build time, before the send pipeline runs.
+
+Granularity is per-platform:
+
+- **WhatsApp Business** — a per-message receipt, which also marks every earlier message in the conversation as read.
+- **iMessage** (remote) — chat-level: the target only identifies the chat, and **every** unread message in it is marked read. Local mode rejects with an <TypeTooltip name="UnsupportedError" type={`{{ symbol("ts:spectrum-ts#UnsupportedError").signature }}`} />.
+- **Telegram / Slack** — silently no-op. Neither surfaces read state for bot conversations, so the signal is vacuously satisfied — the same best-effort contract as `typing`.
+
+## Inbound read receipts
+
+{% set messageType = symbol("ts:spectrum-ts#Message") %}
+When a recipient reads a message the agent sent, the same content type arrives as an inbound <TypeTooltip name="Message" type={`{{ messageType.signature }}`} /> on `app.messages`. iMessage (dedicated and shared lines) reports these today.
+
+```ts
+for await (const [space, message] of app.messages) {
+  if (message.content.type === "read") {
+    const target = message.content.target; // the message YOU sent
+    console.log(
+      `${message.sender?.id} read "${target.id}" at ${message.timestamp.toISOString()}`
+    );
+  }
+}
+```
+
+The envelope carries the event semantics:
+
+- `message.sender` is the **reader**; `message.content.target` is the message **you** sent. Never the other way round.
+- The target is a fully-built `Message` with `direction: "outbound"`, so `target.content`, `target.edit(...)`, and `target.unsend()` are all available on it.
+- `message.timestamp` is when the reader's device marked it read — not when your process observed the event. The two diverge when a receipt arrives late via Continuity sync.
+- `message.sender` is always present on an inbound read receipt. Receipts the platform could not attribute to a reader are dropped rather than surfaced with an unknown sender, so a "who has read this" tally never counts phantom readers.
+- **Direct messages are the reliable case today.** iMessage does not report the reader's identity on a read event — it names the receiving line instead — so in a DM the reader is recovered from the conversation itself. A group conversation carries no such information, so a group receipt is dropped unless the platform names a reader other than your own line. Treat group read receipts as best-effort.
+- Where a group does report readers, it emits one message per reader, all sharing the same `content.target.id`. Aggregate by that id against `space.getMembers()` to answer "has everyone read it".
+- The agent's own actions are suppressed: `space.read(...)` does not echo back as an inbound event.
+- No direction check is needed. Outbound `read` is fire-and-forget and produces no `Message`, so `content.type === "read"` on `app.messages` is always a receipt.
+
+Aggregating across a group:
+
+```ts
+const readers = new Map<string, Set<string>>(); // target id -> reader ids
+
+for await (const [space, message] of app.messages) {
+  if (message.content.type !== "read") continue;
+
+  const targetId = message.content.target.id;
+  const seen = readers.get(targetId) ?? new Set();
+  seen.add(message.sender?.id ?? "");
+  readers.set(targetId, seen);
+
+  const members = await space.getMembers();
+  if (seen.size >= members.length - 1) {
+    console.log(`everyone read ${targetId}`);
+  }
+}
+```
+
+See [iMessage messaging features](/spectrum-ts/providers/imessage/messaging-features) for the per-provider volume and delivery caveats.

--- a/docs/custom-events-and-lifecycle.mdx.vel
+++ b/docs/custom-events-and-lifecycle.mdx.vel
@@ -7,7 +7,7 @@ import { TypeTooltip } from "/snippets/type-tooltip.mdx";
 
 ## Custom events
 
-Platform providers can emit events beyond messages — typing indicators, read receipts, delivery status, whatever the provider chooses to surface. Spectrum exposes each event as a flat async iterable on the app instance:
+Platform providers can emit events beyond messages — typing indicators, presence, delivery status, whatever the provider chooses to surface. Spectrum exposes each event as a flat async iterable on the app instance:
 
 ```ts
 for await (const event of app.typing) {
@@ -39,7 +39,7 @@ Use the flat form on `app` when you want a merged feed across platforms; use the
 ### Fusor custom events
 
 {% set fusorEventType = symbol("ts:spectrum-ts#FusorEvent") %}
-Fusor-backed providers can emit non-message events (presence, read receipts, delivery status) into typed event streams using `fusorEvent`. The helper returns a <TypeTooltip name="FusorEvent" type={`{{ fusorEventType.signature }}`} /> envelope. Return a `fusorEvent(name, data)` from a Fusor `messages` handler to push it into an `app.<name>` stream:
+Fusor-backed providers can emit non-message events (presence, delivery status) into typed event streams using `fusorEvent`. The helper returns a <TypeTooltip name="FusorEvent" type={`{{ fusorEventType.signature }}`} /> envelope. Return a `fusorEvent(name, data)` from a Fusor `messages` handler to push it into an `app.<name>` stream:
 
 ```ts
 import { fusorEvent } from "spectrum-ts";

--- a/docs/messages.mdx.vel
+++ b/docs/messages.mdx.vel
@@ -103,7 +103,7 @@ for await (const [space, message] of app.messages) {
   | `"reply"` | `content:` <TypeTooltip name="Content" type={`{{ content.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} />, `target:` <TypeTooltip name="Message" type={`{{ message.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} /> — threaded reply wrapping inner content |
   | `"edit"` | `content:` <TypeTooltip name="Content" type={`{{ content.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} />, `target:` <TypeTooltip name="Message" type={`{{ message.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} /> — rewrite of a previously-sent message |
   | `"unsend"` | `target:` <TypeTooltip name="Message" type={`{{ message.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} /> — retraction of a previously-sent message |
-  | `"read"` | `target:` <TypeTooltip name="Message" type={`{{ message.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} /> — mark the conversation read through the target message |
+  | `"read"` | `target:` <TypeTooltip name="Message" type={`{{ message.signature | replace("\n", " ") | replace("|", "\\u007C") }}`} /> — outbound: mark the conversation read through the target. Inbound: `sender` read `target`, a message you sent |
   | `"typing"` | `state: "start" \| "stop"` — typing indicator signal |
   | `"streamText"` | `stream: () => AsyncIterable<string>`, `format?: "plain" \| "markdown"` — streaming text content |
   | `"app"` | `url()`, `layout()`, `live?: boolean` — app-style link card |
@@ -113,6 +113,8 @@ for await (const [space, message] of app.messages) {
 Outgoing-only variants like `"effect"` (an iMessage screen effect wrapping inner content) appear on messages you sent and are echoed by the platform; see [iMessage](/spectrum-ts/providers/imessage) for the builder.
 
 Group-management events (`rename`, `avatar`, `addMember`, `removeMember`, `leaveSpace`) arrive with `message.sender` set to the acting user — or `undefined` when the platform recorded no actor — so narrow with `message.sender?.id`. The agent's own actions (e.g. `space.add(...)`) are not echoed back.
+
+`read` is the other bidirectional arm: inbound, it means someone read a message you sent, with `message.sender` the reader and `content.target` your message. See [Read](/spectrum-ts/content/read).
 
 ## Filtering out your own messages
 

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -35,6 +35,7 @@
         "spectrum-ts/content/replies",
         "spectrum-ts/content/edits",
         "spectrum-ts/content/unsend",
+        "spectrum-ts/content/read",
         "spectrum-ts/content/typing-indicators",
         "spectrum-ts/content/rename",
         "spectrum-ts/content/avatar",

--- a/docs/providers/imessage.mdx.vel
+++ b/docs/providers/imessage.mdx.vel
@@ -123,7 +123,8 @@ optional dependencies, install `better-sqlite3` explicitly.
 | Existing DMs and group chats | Yes | Yes |
 | Create a DM | Yes | Deterministic local reference |
 | Create a group | Dedicated lines only | No |
-| Reactions, replies, edits, unsend, read receipts, and effects | Yes | No |
+| Reactions, replies, edits, unsend, sending read receipts, and effects | Yes | No |
+| Inbound read receipts (someone read what you sent) | Yes | No |
 | Streaming text and typing indicators | Yes | Typing is a no-op; streaming is unsupported |
 | Rename, avatar, membership, and group events | Dedicated lines only | No |
 | Backgrounds, mini-app cards, and native contact-card sharing | Yes | No |

--- a/docs/providers/imessage/connection-and-routing.mdx.vel
+++ b/docs/providers/imessage/connection-and-routing.mdx.vel
@@ -65,10 +65,10 @@ can register both when it needs both transports.
     <Note>
       Local iMessage supports receiving and sending text, attachments, and
       contacts. Universal app content degrades to its URL. Reactions, threaded
-      replies, edits, unsend, read receipts, effects, group creation, streaming
-      text, chat backgrounds, renaming, avatars, contact-card sharing, and
-      membership operations are unavailable. Typing signals are accepted as a
-      no-op.
+      replies, edits, unsend, read receipts (both sending them and observing
+      inbound ones), effects, group creation, streaming text, chat backgrounds,
+      renaming, avatars, contact-card sharing, and membership operations are
+      unavailable. Typing signals are accepted as a no-op.
     </Note>
   </Tab>
 </Tabs>

--- a/docs/providers/imessage/messaging-features.mdx.vel
+++ b/docs/providers/imessage/messaging-features.mdx.vel
@@ -177,6 +177,42 @@ Semantics to rely on:
 - Icon-change events carry a snapshot of the icon fetched at event time; an icon that was already replaced or removed by then is skipped (the follow-up event carries the current state).
 - On dedicated lines, group events ride the same durable catch-up log as messages and polls, so changes that happen while the app is down are replayed on reconnect. After a cursor gap, reconcile with `space.getMembers()` / `space.getAvatar()`.
 
+## Inbound read receipts
+
+When someone reads a message the agent sent, it arrives on `app.messages` as a `read` message. Unlike group events this needs no dedicated line — receipts ride the message stream that every mode already consumes.
+
+<Warning>
+  Read receipts are high-volume. A group emits **one message per reader per
+  message read**, and because marking a chat read clears *every* unread message
+  in it, one recipient opening a chat with several unread agent messages can
+  produce a burst. Make sure your `for await` loop handles `"read"` explicitly —
+  a `default:` arm that replies to the user will reply to every receipt.
+</Warning>
+
+| Someone… | `content.type` | `message.sender` | `message.content.target` |
+|---|---|---|---|
+| reads a message you sent | `"read"` | the reader | the message that was read (`direction: "outbound"`) |
+
+```ts
+for await (const [space, message] of app.messages) {
+  if (message.content.type === "read") {
+    const target = message.content.target;
+    console.log(`${message.sender?.id} read ${target.id} at ${message.timestamp.toISOString()}`);
+  }
+}
+```
+
+Semantics to rely on:
+
+- `message.sender` is the **reader** and is always present — receipts Apple could not attribute are dropped rather than surfaced with an unknown sender. `message.content.target` is always *your* message.
+- **DMs are the reliable case.** Apple does not name the reader on a read event: the event's actor is the *receiving line*, not the person who read. In a DM the reader is recovered from the conversation, which is unambiguous. A group conversation carries no participant information, so a group receipt is dropped unless Apple names an actor other than your own line — treat group read receipts as best-effort.
+- `message.timestamp` is the reader's read time, propagated from their device — not when your process observed the event.
+- Where readers are reported, it is one message per reader. Aggregate by `message.content.target.id` against `space.getMembers()` to answer "has everyone read it".
+
+If receipts are not arriving, run with `LOG_LEVEL=debug` (or `Spectrum({ options: { logLevel: "debug" } })`). Every receipt logs its outcome under `spectrum.imessage.read`, and each drop states its reason — no reader identified, target unresolved, or a target that is not one of yours. If nothing logs at all, the platform is not sending the event: check that the recipient has **Send Read Receipts** enabled on their device, which is off by default and is what Apple gates the whole signal on.
+- The agent's own reads never echo back: `space.read(...)` and `message.read()` are suppressed from the inbound stream.
+- Receipts ride the same durable catch-up log as messages, so those that arrive while the app is down are replayed on reconnect. A receipt whose target can no longer be resolved (an old message evicted from the in-process cache and since deleted upstream) is dropped rather than surfaced with a stub.
+
 ## Chat backgrounds
 
 Set or clear the chat background image. Import `background` from the iMessage provider and use the sugar method on a narrowed space:

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -50,7 +50,7 @@ export {
 } from "./content/membership";
 export { asPoll, asPollOption } from "./content/poll";
 export { asReaction, reactionSchema } from "./content/reaction";
-export { asRead } from "./content/read";
+export { asRead, readSchema } from "./content/read";
 export { renameSchema } from "./content/rename";
 export { asReply, replySchema } from "./content/reply";
 export { asRichlink } from "./content/richlink";

--- a/packages/core/src/platform/build.ts
+++ b/packages/core/src/platform/build.ts
@@ -582,6 +582,25 @@ const wrapNestedContent = (
     }
     return content;
   }
+  if (content.type === "read") {
+    const target = content.target as unknown;
+    if (isRawProviderRecord(target)) {
+      // A read receipt's target is always one of *our* messages — the one the
+      // reader just read — so wrap it outbound, same as `edit`, and its
+      // `.edit`/`.unsend` affordances stay available downstream. Providers that
+      // resolved the real target set `target.direction` and
+      // `wrapProviderMessage` honors it; the literal here is the fallback for
+      // providers (e.g. the native webhook) that only have a stub.
+      //
+      // Inert on the outbound path: `read(message)` always targets an
+      // already-built Message, which `isRawProviderRecord` rejects.
+      return {
+        ...content,
+        target: wrapProviderMessage(target, ctx, "outbound"),
+      };
+    }
+    return content;
+  }
   if (content.type === "group") {
     const items = content.items.map((item) => {
       const raw = item as unknown;

--- a/packages/core/src/webhook/deserialize.ts
+++ b/packages/core/src/webhook/deserialize.ts
@@ -139,6 +139,8 @@ const mapContent = (
       return deserializeContact(raw);
     case "reaction":
       return deserializeReaction(raw, spaceRef);
+    case "read":
+      return deserializeRead(raw, spaceRef);
     case "reply":
       return deserializeReply(raw, platform, spaceRef, ctx);
     case "group":
@@ -276,6 +278,22 @@ const deserializeReaction = (
     type: "reaction",
     emoji: asString(raw.emoji),
     target: buildTargetRecord(raw.target, spaceRef),
+  }) as unknown as Content;
+
+const deserializeRead = (
+  raw: Record<string, unknown>,
+  spaceRef: SpaceRef
+): Content =>
+  // An inbound read receipt: someone read a message *we* sent. The reader
+  // rides on the envelope (`message.sender`); `target` is our message.
+  // `direction: "outbound"` marks it as ours so `wrapNestedContent`'s read arm
+  // builds it with the outbound affordances.
+  ({
+    type: "read",
+    target: {
+      ...buildTargetRecord(raw.target, spaceRef),
+      direction: "outbound" as const,
+    },
   }) as unknown as Content;
 
 const deserializeReply = (

--- a/packages/core/test/content/read.test.ts
+++ b/packages/core/test/content/read.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { edit } from "@/content/edit";
-import { type Read, read } from "@/content/read";
+import { type Read, read, readSchema } from "@/content/read";
 import { reply } from "@/content/reply";
 import type { Message } from "@/types/message";
 
@@ -43,5 +43,29 @@ describe("read builder", () => {
     await expect(edit(inner, makeMessage("outbound")).build()).rejects.toThrow(
       EDIT_CANNOT_WRAP
     );
+  });
+});
+
+describe("readSchema", () => {
+  it("accepts a raw provider record as target", () => {
+    // Providers surfacing inbound read receipts parse raw records directly
+    // rather than going through the `read()` builder — the `isMessage` guard
+    // only requires `id` + `content`. Pinned so a future tightening of that
+    // guard can't silently break the provider path.
+    const raw = {
+      id: "m-out",
+      content: { type: "text", text: "hi" },
+      direction: "outbound",
+    };
+    const parsed = readSchema.parse({ type: "read", target: raw });
+
+    expect(parsed.type).toBe("read");
+    expect(parsed.target).toBe(raw);
+  });
+
+  it("rejects a target that is not message-shaped", () => {
+    expect(() =>
+      readSchema.parse({ type: "read", target: { id: "m1" } })
+    ).toThrow();
   });
 });

--- a/packages/core/test/core/receive-read.test.ts
+++ b/packages/core/test/core/receive-read.test.ts
@@ -1,0 +1,135 @@
+import { stubCloud } from "@spectrum-ts/test-support/cloud";
+import { baseConfig, makeQueue } from "@spectrum-ts/test-support/platform";
+import { describe, expect, it } from "vitest";
+import z from "zod";
+import { definePlatform } from "@/platform/define";
+import type { ProviderMessage } from "@/platform/types";
+import { Spectrum } from "@/spectrum";
+import type { Message } from "@/types/message";
+
+stubCloud();
+
+const READ_AT = new Date(789);
+
+type InboundRecord = ProviderMessage<{ id: string }, { id: string }>;
+
+// Providers surface a read receipt as an inbound record whose content is
+// `read`, with the target being one of *our* outbound messages. The target
+// arrives as a raw record; `wrapNestedContent` is what turns it into a Message.
+const makeInboundProvider = (name: string, records: InboundRecord[]) => {
+  const queue = makeQueue<InboundRecord>();
+  for (const item of records) {
+    queue.push(item);
+  }
+  queue.close();
+  return definePlatform(name, {
+    config: z.object({}),
+    lifecycle: {
+      createClient: () => Promise.resolve({}),
+    },
+    user: { resolve: ({ input }) => Promise.resolve({ id: input.userID }) },
+    space: {
+      create: ({ input }) =>
+        Promise.resolve({ id: input.users[0]?.id ?? "s1" }),
+    },
+    messages: () => queue.iter,
+    send: () => Promise.resolve(undefined),
+  });
+};
+
+const firstMessage = async (app: Awaited<ReturnType<typeof Spectrum>>) => {
+  const iterator = app.messages[Symbol.asyncIterator]();
+  const first = await iterator.next();
+  if (first.done) {
+    throw new Error("expected an inbound message");
+  }
+  return first.value;
+};
+
+const rawTarget = {
+  id: "m-out",
+  content: { type: "text", text: "hi" },
+  direction: "outbound",
+  space: { id: "s1" },
+  timestamp: new Date(123),
+};
+
+const readRecord = (content: unknown): InboundRecord =>
+  ({
+    id: "evt-read-1",
+    content,
+    sender: { id: "+15550111" },
+    space: { id: "s1" },
+    timestamp: READ_AT,
+  }) as unknown as InboundRecord;
+
+describe("inbound read receipts", () => {
+  it("builds the target as an outbound Message", async () => {
+    const provider = makeInboundProvider("read_inbound", [
+      readRecord({ type: "read", target: rawTarget }),
+    ]);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [space, message] = await firstMessage(app);
+
+      expect(message.direction).toBe("inbound");
+      expect(message.content.type).toBe("read");
+      expect(message.timestamp).toEqual(READ_AT);
+
+      const target = (message.content as { target: Message }).target;
+      // The whole point of the `wrapNestedContent` read arm: the target is a
+      // fully-built Message, not the raw record the provider handed over.
+      expect(typeof target.reply).toBe("function");
+      expect(typeof target.unsend).toBe("function");
+      expect(target.direction).toBe("outbound");
+      expect(target.platform).toBe("read_inbound");
+      expect(target.id).toBe("m-out");
+      expect(target.content).toEqual({ type: "text", text: "hi" });
+      expect(target.space).toBe(space);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("tags the reader as the message sender", async () => {
+    const provider = makeInboundProvider("read_inbound_sender", [
+      readRecord({ type: "read", target: rawTarget }),
+    ]);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [, message] = await firstMessage(app);
+      expect(message.sender?.id).toBe("+15550111");
+    } finally {
+      await app.stop();
+    }
+  });
+
+  it("leaves an already-built target untouched", async () => {
+    // Pins that the new arm is inert whenever the target is not a raw record —
+    // `isRawProviderRecord` rejects anything carrying `react`/`reply`.
+    const built = {
+      ...rawTarget,
+      react: () => Promise.resolve(undefined),
+      reply: () => Promise.resolve(undefined),
+    };
+    const provider = makeInboundProvider("read_inbound_built", [
+      readRecord({ type: "read", target: built }),
+    ]);
+    const app = await Spectrum({
+      ...baseConfig,
+      providers: [provider.config({})],
+    });
+    try {
+      const [, message] = await firstMessage(app);
+      expect((message.content as { target: unknown }).target).toBe(built);
+    } finally {
+      await app.stop();
+    }
+  });
+});

--- a/packages/core/test/webhook/deserialize.test.ts
+++ b/packages/core/test/webhook/deserialize.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { Attachment } from "@/content/attachment";
 import type { Reaction } from "@/content/reaction";
+import type { Read } from "@/content/read";
 import type { Reply } from "@/content/reply";
 import type { Voice } from "@/content/voice";
 import {
@@ -298,6 +299,32 @@ describe("deserializeSpectrumMessage", () => {
   it("maps leaveSpace content", () => {
     const { record } = deserialize({ type: "leaveSpace" });
     expect(record.content).toEqual({ type: "leaveSpace" });
+  });
+
+  it("maps read content with a stub target marked outbound", () => {
+    const { record } = deserialize({
+      type: "read",
+      target: { id: "m-out", contentPreview: "hello" },
+    });
+
+    expect(record.content.type).toBe("read");
+    const target = (record.content as unknown as { target: Read["target"] })
+      .target;
+    expect(target.id).toBe("m-out");
+    expect(target.content).toEqual({ type: "text", text: "hello" });
+    // Marks the target as ours so `wrapNestedContent` builds it outbound.
+    expect(target.direction).toBe("outbound");
+    expect(target.space).toEqual({ id: "s1", platform: PLATFORM });
+  });
+
+  it("defaults a read target with no contentPreview to empty text", () => {
+    // Must not throw through to the `custom` degradation.
+    const { record } = deserialize({ type: "read", target: { id: "m-out" } });
+
+    expect(record.content.type).toBe("read");
+    const target = (record.content as unknown as { target: Read["target"] })
+      .target;
+    expect(target.content).toEqual({ type: "text", text: "" });
   });
 
   it("maps rename content and degrades an empty displayName to custom", () => {

--- a/packages/imessage/src/remote/ids.ts
+++ b/packages/imessage/src/remote/ids.ts
@@ -11,6 +11,20 @@ export const dmChatGuid = (address: string): ChatGuid => `any;-;${address}`;
 export const chatTypeFromGuid = (guid: ChatGuid): "dm" | "group" =>
   guid.includes(";+;") ? "group" : "dm";
 
+// Inverse of `dmChatGuid`: the peer's address out of a DM chat guid
+// (`any;-;+15551234567` -> `+15551234567`). Group guids and malformed DM guids
+// yield `undefined` — a group's participants are not encoded in its guid.
+export const dmPeerFromChatGuid = (guid: ChatGuid): string | undefined => {
+  if (chatTypeFromGuid(guid) !== "dm") {
+    return;
+  }
+  const separator = guid.indexOf(";-;");
+  if (separator < 0) {
+    return;
+  }
+  return guid.slice(separator + 3) || undefined;
+};
+
 export const toChatGuid = (value: string): ChatGuid => value;
 
 export const toMessageGuid = (value: string): MessageGuid => value;

--- a/packages/imessage/src/remote/inbound.ts
+++ b/packages/imessage/src/remote/inbound.ts
@@ -458,6 +458,58 @@ export const cacheMessage = (
   }
 };
 
+/**
+ * Resolve a guid to the spectrum message it maps to, for events that reference
+ * their target only by guid (reactions, read receipts). Cache first — outbound
+ * sends are cached at send time by `cacheRemoteOutbound`, inbound messages when
+ * they are converted — then one `messages.get` + rebuild, which also warms the
+ * cache so sibling events for the same guid (a group's other participants) are
+ * free.
+ *
+ * Any failure drops the event: these are secondary signals and must never wedge
+ * the stream. Deliberately unlike `getMessage` below (the public
+ * `space.getMessage` action), which rethrows non-`NotFoundError` failures; and
+ * unlike it this never resolves `p:N/guid` child ids, because event payloads
+ * always carry the parent guid.
+ */
+export const resolveTargetMessage = async (
+  client: AdvancedIMessage,
+  cache: MessageCache,
+  chatGuid: string,
+  targetGuid: string,
+  phone: string
+): Promise<IMessageMessage | undefined> => {
+  const cached = cache.get(targetGuid);
+  if (cached) {
+    return cached;
+  }
+  try {
+    const fetched = await client.messages.get(toMessageGuid(targetGuid));
+    const rebuilt = await rebuildFromAppleMessage(
+      client,
+      fetched,
+      phone,
+      chatGuid
+    );
+    cacheMessage(cache, rebuilt);
+    return rebuilt;
+  } catch (error) {
+    // The drop is intentional (a secondary signal must never wedge the
+    // stream), but silently swallowing the cause makes an unresolvable target
+    // indistinguishable from a mapping bug — log it before returning.
+    log.debug(
+      "event target could not be resolved; dropping the event",
+      {
+        "spectrum.imessage.target_guid": targetGuid,
+        "spectrum.imessage.chat_guid": chatGuid,
+        ...errorAttrs(error),
+      },
+      error instanceof Error ? error : undefined
+    );
+    return;
+  }
+};
+
 export const toInboundMessages = async (
   client: AdvancedIMessage,
   cache: MessageCache,

--- a/packages/imessage/src/remote/reactions.ts
+++ b/packages/imessage/src/remote/reactions.ts
@@ -12,9 +12,8 @@ import type { MessageCache } from "../cache";
 import type { IMessageMessage } from "../types";
 import { chatTypeFromGuid, toChatGuid, toMessageGuid } from "./ids";
 import {
-  cacheMessage,
   isIMessageMessage,
-  rebuildFromAppleMessage,
+  resolveTargetMessage,
   toSenderRef,
 } from "./inbound";
 
@@ -63,16 +62,19 @@ const resolveReactionTarget = async (
   partIndex: number | undefined,
   phone: string
 ): Promise<IMessageMessage | undefined> => {
-  let candidate = cache.get(targetGuid);
+  const candidate = await resolveTargetMessage(
+    client,
+    cache,
+    chat,
+    targetGuid,
+    phone
+  );
   if (!candidate) {
-    try {
-      const fetched = await client.messages.get(toMessageGuid(targetGuid));
-      candidate = await rebuildFromAppleMessage(client, fetched, phone, chat);
-      cacheMessage(cache, candidate);
-    } catch {
-      return;
-    }
+    return;
   }
+  // Tapbacks address an ordered part inside a multi-part message; read
+  // receipts have no `targetPartIndex`, so part drilling stays here rather
+  // than in the shared resolver.
   if (candidate.content.type === "group") {
     const items = candidate.content.items;
     if (!Array.isArray(items)) {

--- a/packages/imessage/src/remote/read-receipts.ts
+++ b/packages/imessage/src/remote/read-receipts.ts
@@ -1,0 +1,152 @@
+import type {
+  AdvancedIMessage,
+  MessageEvent,
+} from "@photon-ai/advanced-imessage/grpc";
+import { sanitizePhone } from "@photon-ai/otel";
+import type { Read as ReadContent } from "@spectrum-ts/core";
+import { createLogger, readSchema } from "@spectrum-ts/core/authoring";
+import type { MessageCache } from "../cache";
+import type { IMessageMessage } from "../types";
+import { chatTypeFromGuid, dmPeerFromChatGuid } from "./ids";
+import { resolveTargetMessage, toSenderRef } from "./inbound";
+
+const log = createLogger("spectrum.imessage.read");
+
+type ReadEvent = Extract<MessageEvent, { type: "message.read" }>;
+
+/**
+ * Synthetic id for a `message.read` event — shared between the stream item
+ * (the dedup key across live/catch-up) and the surfaced message. `sequence` is
+ * monotonic per line, so N participants reading the same message produce N
+ * distinct ids, and the same event replayed through catch-up produces the id
+ * it produced live.
+ */
+export const readReceiptMessageId = (event: ReadEvent): string =>
+  `${event.messageGuid}:read:${event.sequence}`;
+
+const asProviderRead = (target: IMessageMessage): ReadContent =>
+  readSchema.parse({ target, type: "read" });
+
+/**
+ * Identify the reader.
+ *
+ * `event.actor` is **not** the reader on this arm. Verified against a live
+ * line: in a DM where the peer read our message, `actor` came back as *our
+ * own* line's address, not theirs. So `actor` is only trusted when it names
+ * somebody other than us — the shape a group receipt would need if the
+ * platform ever populates it — and otherwise the reader is the DM peer
+ * encoded in the chat guid.
+ *
+ * A group receipt whose actor is us (or absent) is not attributable at all:
+ * a group guid carries no participant list. Those are dropped rather than
+ * surfaced with a wrong or missing reader, because the reader's identity is
+ * the entire payload of a receipt.
+ */
+const toReader = (
+  event: ReadEvent,
+  phone: string
+): ReturnType<typeof toSenderRef> | undefined => {
+  const actor = event.actor;
+  if (actor?.address && actor.address !== phone) {
+    return toSenderRef(actor);
+  }
+  const peer = dmPeerFromChatGuid(event.chatGuid);
+  return peer ? { id: peer, address: peer } : undefined;
+};
+
+/**
+ * Convert a `message.read` event into an inbound `read` message — someone read
+ * a message the agent sent. `sender` is the reader; `content.target` is ours.
+ *
+ * Two guards, cheapest first:
+ *
+ * 1. **No actor -> drop.** Unlike a membership change (where the state change
+ *    itself is the payload and `sender: undefined` still carries meaning), the
+ *    reader's identity *is* the payload of a receipt. A senderless receipt in a
+ *    group is indistinguishable noise and would corrupt any "N of M have read"
+ *    tally. Same call as `toReactionMessages`.
+ *
+ * 2. **The target must be one of ours.** `event.isFromMe` is not trustworthy
+ *    here: the proto carries no comment for it on this arm, and it most
+ *    plausibly describes the *underlying message* — which for a genuine
+ *    receipt is ours, i.e. `true` — so keying self-suppression off it would
+ *    suppress every receipt worth surfacing. The durable invariant is that a
+ *    peer's receipt always points at a message we sent, so the resolved target
+ *    must be `direction: "outbound"`. That one check also suppresses the echo
+ *    of our own `chats.markRead()`, which marks *their* inbound messages and
+ *    therefore resolves `direction: "inbound"`.
+ */
+export const toReadReceiptMessages = async (
+  client: AdvancedIMessage,
+  cache: MessageCache,
+  event: ReadEvent,
+  phone: string
+): Promise<IMessageMessage[]> => {
+  const reader = toReader(event, phone);
+  if (!reader) {
+    log.debug("read receipt dropped: reader could not be identified", {
+      "spectrum.imessage.read.message_guid": event.messageGuid,
+      "spectrum.imessage.read.sequence": event.sequence,
+      "spectrum.imessage.read.chat_guid": event.chatGuid,
+      "spectrum.imessage.read.has_actor": event.actor?.address !== undefined,
+    });
+    return [];
+  }
+
+  const target = await resolveTargetMessage(
+    client,
+    cache,
+    event.chatGuid,
+    event.messageGuid,
+    phone
+  );
+  if (!target) {
+    log.debug("read receipt dropped: target message could not be resolved", {
+      "spectrum.imessage.read.message_guid": event.messageGuid,
+      "spectrum.imessage.read.sequence": event.sequence,
+    });
+    return [];
+  }
+  if (target.direction !== "outbound") {
+    // Either our own `chats.markRead()` echoing back (it marks *their*
+    // messages) or a receipt for a message we did not send. Neither is a
+    // signal a consumer can act on.
+    log.debug("read receipt dropped: target is not one of ours", {
+      "spectrum.imessage.read.message_guid": event.messageGuid,
+      "spectrum.imessage.read.sequence": event.sequence,
+      "spectrum.imessage.read.target_direction": target.direction ?? "unset",
+    });
+    return [];
+  }
+
+  // `readAt` is when the reader's device marked it read; `occurredAt` is when
+  // the bridge observed the event. Prefer the former — the entire value of a
+  // receipt is *when* — and fall back only if an unset proto timestamp decoded
+  // to `undefined` despite the non-optional type, the same defensive shape as
+  // `dateCreated` in inbound.ts.
+  const readAt: Date | undefined = event.readAt;
+
+  log.debug("read receipt surfaced", {
+    "spectrum.imessage.read.message_guid": event.messageGuid,
+    "spectrum.imessage.read.sequence": event.sequence,
+    "spectrum.imessage.read.reader": sanitizePhone(reader.id),
+    "spectrum.imessage.read.used_read_at": readAt !== undefined,
+  });
+
+  return [
+    {
+      // No `direction` on the envelope: the stream path defaults provider
+      // records to inbound. The *target* keeps its own `direction: "outbound"`,
+      // which `wrapProviderMessage` honors via `rawDirection`.
+      id: readReceiptMessageId(event),
+      content: asProviderRead(target),
+      sender: reader,
+      space: {
+        id: event.chatGuid,
+        type: chatTypeFromGuid(event.chatGuid),
+        phone,
+      },
+      timestamp: readAt ?? event.occurredAt,
+    },
+  ];
+};

--- a/packages/imessage/src/remote/read-receipts.ts
+++ b/packages/imessage/src/remote/read-receipts.ts
@@ -28,30 +28,53 @@ const asProviderRead = (target: IMessageMessage): ReadContent =>
   readSchema.parse({ target, type: "read" });
 
 /**
+ * Whether the reader could be identified at all, decided without resolving
+ * the target. A DM always can (the peer is in the guid); a group only if the
+ * platform named an actor. Lets an unattributable group receipt drop before
+ * paying for an RPC.
+ */
+const isAttributable = (event: ReadEvent): boolean =>
+  dmPeerFromChatGuid(event.chatGuid) !== undefined ||
+  event.actor?.address !== undefined;
+
+/**
  * Identify the reader.
  *
  * `event.actor` is **not** the reader on this arm. Verified against a live
  * line: in a DM where the peer read our message, `actor` came back as *our
- * own* line's address, not theirs. So `actor` is only trusted when it names
- * somebody other than us — the shape a group receipt would need if the
- * platform ever populates it — and otherwise the reader is the DM peer
- * encoded in the chat guid.
+ * own* line's address, not theirs.
  *
- * A group receipt whose actor is us (or absent) is not attributable at all:
- * a group guid carries no participant list. Those are dropped rather than
- * surfaced with a wrong or missing reader, because the reader's identity is
- * the entire payload of a receipt.
+ * So the chat guid comes first. In a DM there are exactly two participants
+ * and the target is already known to be ours, which makes the reader
+ * definitionally the other one — no address comparison needed, and therefore
+ * correct on pooled lines too, where `phone` is the `"shared"` sentinel and
+ * comparing it against a real address is meaningless.
+ *
+ * A group guid carries no participant list, so there `actor` is the only
+ * possible attribution. It is trusted only when it names neither this line
+ * nor the target's own sender; the latter is what catches the shared-mode
+ * case, since the sentinel never equals a real address. An unattributable
+ * receipt is dropped rather than surfaced with a wrong reader — the reader's
+ * identity is the entire payload.
  */
 const toReader = (
   event: ReadEvent,
+  target: IMessageMessage,
   phone: string
 ): ReturnType<typeof toSenderRef> | undefined => {
+  const peer = dmPeerFromChatGuid(event.chatGuid);
+  if (peer) {
+    return { id: peer, address: peer };
+  }
   const actor = event.actor;
-  if (actor?.address && actor.address !== phone) {
+  if (
+    actor?.address &&
+    actor.address !== phone &&
+    actor.address !== target.sender?.address
+  ) {
     return toSenderRef(actor);
   }
-  const peer = dmPeerFromChatGuid(event.chatGuid);
-  return peer ? { id: peer, address: peer } : undefined;
+  return;
 };
 
 /**
@@ -60,11 +83,12 @@ const toReader = (
  *
  * Two guards, cheapest first:
  *
- * 1. **No actor -> drop.** Unlike a membership change (where the state change
- *    itself is the payload and `sender: undefined` still carries meaning), the
- *    reader's identity *is* the payload of a receipt. A senderless receipt in a
- *    group is indistinguishable noise and would corrupt any "N of M have read"
- *    tally. Same call as `toReactionMessages`.
+ * 1. **The reader must be identifiable -> else drop.** Unlike a membership
+ *    change (where the state change itself is the payload and
+ *    `sender: undefined` still carries meaning), the reader's identity *is*
+ *    the payload of a receipt. An unattributed receipt in a group is
+ *    indistinguishable noise and would corrupt any "N of M have read" tally.
+ *    Same call as `toReactionMessages`. See `toReader`.
  *
  * 2. **The target must be one of ours.** `event.isFromMe` is not trustworthy
  *    here: the proto carries no comment for it on this arm, and it most
@@ -82,13 +106,12 @@ export const toReadReceiptMessages = async (
   event: ReadEvent,
   phone: string
 ): Promise<IMessageMessage[]> => {
-  const reader = toReader(event, phone);
-  if (!reader) {
+  if (!isAttributable(event)) {
     log.debug("read receipt dropped: reader could not be identified", {
       "spectrum.imessage.read.message_guid": event.messageGuid,
       "spectrum.imessage.read.sequence": event.sequence,
       "spectrum.imessage.read.chat_guid": event.chatGuid,
-      "spectrum.imessage.read.has_actor": event.actor?.address !== undefined,
+      "spectrum.imessage.read.has_actor": false,
     });
     return [];
   }
@@ -115,6 +138,19 @@ export const toReadReceiptMessages = async (
       "spectrum.imessage.read.message_guid": event.messageGuid,
       "spectrum.imessage.read.sequence": event.sequence,
       "spectrum.imessage.read.target_direction": target.direction ?? "unset",
+    });
+    return [];
+  }
+
+  // Resolved after the target: validating a group's `actor` needs the target's
+  // own sender to compare against (see `toReader`).
+  const reader = toReader(event, target, phone);
+  if (!reader) {
+    log.debug("read receipt dropped: reader could not be identified", {
+      "spectrum.imessage.read.message_guid": event.messageGuid,
+      "spectrum.imessage.read.sequence": event.sequence,
+      "spectrum.imessage.read.chat_guid": event.chatGuid,
+      "spectrum.imessage.read.has_actor": true,
     });
     return [];
   }

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -4,6 +4,7 @@ import {
   type GroupEvent,
   type MessageEvent,
   type PollEvent,
+  type SingleServiceAddressInfo,
   ValidationError,
 } from "@photon-ai/advanced-imessage/grpc";
 import { sanitizePhone } from "@photon-ai/otel";
@@ -40,6 +41,7 @@ import { toInboundMessages } from "./inbound";
 import { cachePollEvent, toPollDeltaMessages } from "./polls";
 import type { ProfileSyncGate } from "./profile-sync-gate";
 import { toReactionMessages } from "./reactions";
+import { readReceiptMessageId, toReadReceiptMessages } from "./read-receipts";
 
 // The proxy rejects an unknown/pruned resume cursor with INVALID_ARGUMENT,
 // which the client surfaces as ValidationError — the only ValidationError the
@@ -53,14 +55,23 @@ const streamLabel = (
 ): string =>
   `imessage.${kind}:${phone === SHARED_PHONE ? phone : sanitizePhone(phone)}`;
 
+// The acting party's identity, without the `isFromMe` half. Split out because
+// `message.read`'s `isFromMe` is undocumented and most plausibly describes the
+// *underlying message* — ours, for a genuine receipt — so trusting it there
+// would suppress every receipt worth surfacing. Vacuous in shared mode: the
+// sentinel never matches a real address.
+const isActorCurrentAccount = (
+  actor: SingleServiceAddressInfo | undefined,
+  phone: string
+): boolean =>
+  phone !== SHARED_PHONE &&
+  actor?.address !== undefined &&
+  actor.address === phone;
+
 const isEventFromCurrentAccount = (
   event: Pick<MessageEvent | PollEvent | GroupEvent, "actor" | "isFromMe">,
   phone: string
-): boolean =>
-  event.isFromMe ||
-  (phone !== SHARED_PHONE &&
-    event.actor?.address !== undefined &&
-    event.actor.address === phone);
+): boolean => event.isFromMe || isActorCurrentAccount(event.actor, phone);
 
 const streamLog = createLogger("spectrum.imessage.stream");
 
@@ -152,6 +163,48 @@ const toMessageItem = async (
       values: await toReactionMessages(client, cache, event, phone),
     };
   }
+
+  if (event.type === "message.read") {
+    const id = readReceiptMessageId(event);
+    // Logged before any filtering: if this never fires, the upstream stream is
+    // not delivering `message.read` at all and nothing downstream can be at
+    // fault. Every drop below logs its own reason.
+    streamLog.debug("received a read event", {
+      "spectrum.imessage.read.message_guid": event.messageGuid,
+      "spectrum.imessage.read.sequence": event.sequence,
+      "spectrum.imessage.read.chat_guid": event.chatGuid,
+      "spectrum.imessage.read.actor": event.actor?.address
+        ? sanitizePhone(event.actor.address)
+        : "none",
+      "spectrum.imessage.read.is_from_me": event.isFromMe,
+      "spectrum.imessage.read.line": phone,
+    });
+    // No actor-based self-check here, unlike reactions. Verified against a
+    // live line: on this arm `actor` is *our own* line's address even when the
+    // peer is the one who read, so `isEventFromCurrentAccount` (or its actor
+    // half) would suppress every genuine receipt. `isFromMe` is no better —
+    // it came back `false` for a peer read, the opposite of the reaction arm.
+    //
+    // Self-suppression is instead carried entirely by `toReadReceiptMessages`,
+    // which requires the resolved target to be one of *our* outbound messages.
+    // That holds regardless of what `actor`/`isFromMe` mean: our own
+    // `chats.markRead()` marks *their* inbound messages, so its echo resolves
+    // to an inbound target and is dropped.
+    const cache = getMessageCache(client);
+    return {
+      cursor,
+      id,
+      values: await toReadReceiptMessages(client, cache, event, phone),
+    };
+  }
+
+  // Consumed for the cursor but not surfaced (edits, unsends, sticker
+  // placements, reaction removals). Logged so "the stream is alive but this
+  // event type never arrives" is distinguishable from "the stream is dead".
+  streamLog.debug("message event consumed without mapping", {
+    "spectrum.imessage.event_type": event.type,
+    "spectrum.imessage.sequence": event.sequence,
+  });
 
   return {
     cursor,

--- a/packages/imessage/test/remote/reactions.test.ts
+++ b/packages/imessage/test/remote/reactions.test.ts
@@ -163,6 +163,24 @@ describe("iMessage remote toReactionMessages", () => {
     }
   });
 
+  it("drops the reaction when the target cannot be fetched", async () => {
+    // Regression guard for the shared `resolveTargetMessage` extraction: a
+    // failed fetch must keep dropping the event rather than propagating.
+    const get = vi.fn((_message: string) => Promise.reject(new Error("gone")));
+    const remote = {
+      messages: { get },
+    } as unknown as AdvancedIMessage;
+
+    const messages = await toReactionMessages(
+      remote,
+      new MessageCache(),
+      reactionEvent(),
+      "+15551234567"
+    );
+
+    expect(messages).toEqual([]);
+  });
+
   it("carries the actor's address, country, and service onto the reaction sender", async () => {
     const get = vi.fn((_message: string) => Promise.resolve(sdkMessage()));
     const remote = {

--- a/packages/imessage/test/remote/read-receipts.test.ts
+++ b/packages/imessage/test/remote/read-receipts.test.ts
@@ -6,7 +6,7 @@ import type {
 import { describe, expect, it, vi } from "vitest";
 import { MessageCache } from "@/cache";
 import { toReadReceiptMessages } from "@/remote/read-receipts";
-import type { IMessageMessage } from "@/types";
+import { type IMessageMessage, SHARED_PHONE } from "@/types";
 
 const SENT_DATE = new Date(1_700_000_000_000);
 const READ_DATE = new Date(1_700_000_600_000);
@@ -166,9 +166,29 @@ describe("iMessage remote toReadReceiptMessages", () => {
     expect(messages[0]?.sender?.id).toBe("+15559998888");
   });
 
-  it("drops a group receipt with no identifiable reader", async () => {
-    // A group guid carries no participant list, so an actor of our own line
-    // leaves the reader unknown — and the reader is the whole payload.
+  it("attributes a shared-mode DM receipt to the peer, not the pool line", async () => {
+    // On a pooled line `phone` is the "shared" sentinel, so `actor.address !==
+    // phone` is vacuously true and an actor-first lookup would name our own
+    // pool line as the reader. The DM guid has to win outright.
+    const remote = remoteWith(() => Promise.resolve(sdkMessage()));
+
+    const messages = await toReadReceiptMessages(
+      remote,
+      new MessageCache(),
+      readEvent({
+        actor: { address: "+14155956063" },
+        chatGuid: "any;-;+13322593374",
+      } as Partial<ReadEvent>),
+      SHARED_PHONE
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.sender?.id).toBe("+13322593374");
+  });
+
+  it("drops a group receipt whose actor is this line", async () => {
+    // A group guid carries no participant list, so an actor naming our own
+    // line leaves the reader unknown — and the reader is the whole payload.
     const remote = remoteWith(() => Promise.resolve(sdkMessage()));
 
     const messages = await toReadReceiptMessages(
@@ -182,8 +202,67 @@ describe("iMessage remote toReadReceiptMessages", () => {
     );
 
     expect(messages).toEqual([]);
-    // The reader guard must short-circuit before the RPC.
+  });
+
+  it("drops a shared-mode group receipt whose actor is the sending line", async () => {
+    // The sentinel never equals a real address, so the `phone` comparison
+    // cannot catch this — the target's own sender is what identifies the
+    // actor as us.
+    const remote = remoteWith(() =>
+      Promise.resolve(
+        sdkMessage({
+          sender: { address: "+14155956063" },
+        } as Partial<SDKMessage>)
+      )
+    );
+
+    const messages = await toReadReceiptMessages(
+      remote,
+      new MessageCache(),
+      readEvent({
+        actor: { address: "+14155956063" },
+        chatGuid: "iMessage;+;chat9",
+      } as Partial<ReadEvent>),
+      SHARED_PHONE
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("drops a group receipt with no actor before resolving the target", async () => {
+    const remote = remoteWith(() => Promise.resolve(sdkMessage()));
+
+    const messages = await toReadReceiptMessages(
+      remote,
+      new MessageCache(),
+      readEvent({
+        actor: undefined,
+        chatGuid: "iMessage;+;chat9",
+      } as Partial<ReadEvent>),
+      PHONE
+    );
+
+    expect(messages).toEqual([]);
+    // Unattributable without an actor, so it must not pay for an RPC.
     expect(getMock(remote)).not.toHaveBeenCalled();
+  });
+
+  it("attributes a group receipt to a third-party actor", async () => {
+    const remote = remoteWith(() => Promise.resolve(sdkMessage()));
+
+    const messages = await toReadReceiptMessages(
+      remote,
+      new MessageCache(),
+      readEvent({
+        actor: { address: "+15559998888" },
+        chatGuid: "iMessage;+;chat9",
+      } as Partial<ReadEvent>),
+      PHONE
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.sender?.id).toBe("+15559998888");
+    expect(messages[0]?.space.type).toBe("group");
   });
 
   it("drops a receipt whose target is one of their inbound messages", async () => {

--- a/packages/imessage/test/remote/read-receipts.test.ts
+++ b/packages/imessage/test/remote/read-receipts.test.ts
@@ -1,0 +1,299 @@
+import type {
+  AdvancedIMessage,
+  MessageEvent,
+  Message as SDKMessage,
+} from "@photon-ai/advanced-imessage/grpc";
+import { describe, expect, it, vi } from "vitest";
+import { MessageCache } from "@/cache";
+import { toReadReceiptMessages } from "@/remote/read-receipts";
+import type { IMessageMessage } from "@/types";
+
+const SENT_DATE = new Date(1_700_000_000_000);
+const READ_DATE = new Date(1_700_000_600_000);
+const PHONE = "+15551234567";
+
+type ReadEvent = Extract<MessageEvent, { type: "message.read" }>;
+
+// Default `isFromMe: true` — the message the peer read is one we sent, which
+// is exactly the target a genuine receipt points at.
+const sdkMessage = (overrides: Partial<SDKMessage> = {}): SDKMessage =>
+  ({
+    guid: "msg-guid",
+    chatGuids: ["s1"],
+    content: {
+      attachments: [],
+      formatting: [],
+      mentions: [],
+      text: "from the bot",
+    },
+    dateCreated: SENT_DATE,
+    isFromMe: true,
+    sender: { address: PHONE },
+    ...overrides,
+  }) as unknown as SDKMessage;
+
+const readEvent = (overrides: Partial<ReadEvent> = {}): ReadEvent =>
+  ({
+    actor: { address: "user@example.com" },
+    chatGuid: "s1",
+    isFromMe: true,
+    messageGuid: "msg-guid",
+    occurredAt: SENT_DATE,
+    readAt: READ_DATE,
+    sequence: 1,
+    type: "message.read",
+    ...overrides,
+  }) as unknown as ReadEvent;
+
+const remoteWith = (get: (message: string) => Promise<SDKMessage>) =>
+  ({ messages: { get: vi.fn(get) } }) as unknown as AdvancedIMessage;
+
+const getMock = (remote: AdvancedIMessage) =>
+  remote.messages.get as unknown as ReturnType<typeof vi.fn>;
+
+describe("iMessage remote toReadReceiptMessages", () => {
+  it("emits a read receipt with the reader as sender and our message as target", async () => {
+    const remote = remoteWith(() => Promise.resolve(sdkMessage()));
+
+    const messages = await toReadReceiptMessages(
+      remote,
+      new MessageCache(),
+      readEvent(),
+      PHONE
+    );
+
+    expect(messages).toHaveLength(1);
+    const message = messages[0];
+    expect(message?.id).toBe("msg-guid:read:1");
+    expect(message?.sender?.id).toBe("user@example.com");
+    expect(message?.space).toEqual({ id: "s1", type: "dm", phone: PHONE });
+    expect(message?.content.type).toBe("read");
+    if (message?.content.type === "read") {
+      expect(message.content.target.id).toBe("msg-guid");
+      expect(message.content.target.direction).toBe("outbound");
+    }
+  });
+
+  it("carries the actor's address, country, and service onto the reader", async () => {
+    const remote = remoteWith(() => Promise.resolve(sdkMessage()));
+
+    const messages = await toReadReceiptMessages(
+      remote,
+      new MessageCache(),
+      readEvent({
+        actor: {
+          address: "+15557654321",
+          country: "ca",
+          service: "iMessage",
+        },
+      } as Partial<ReadEvent>),
+      PHONE
+    );
+
+    expect(messages[0]?.sender).toEqual({
+      id: "+15557654321",
+      address: "+15557654321",
+      country: "ca",
+      service: "iMessage",
+    });
+  });
+
+  it("uses readAt, not occurredAt, for the timestamp", async () => {
+    const remote = remoteWith(() => Promise.resolve(sdkMessage()));
+
+    const messages = await toReadReceiptMessages(
+      remote,
+      new MessageCache(),
+      readEvent(),
+      PHONE
+    );
+
+    // The whole value of a receipt is *when* it was read. `occurredAt` is when
+    // the bridge observed the event, which lags on Continuity sync.
+    expect(messages[0]?.timestamp).toEqual(READ_DATE);
+    expect(messages[0]?.timestamp).not.toEqual(SENT_DATE);
+  });
+
+  it("falls back to occurredAt when readAt is absent", async () => {
+    const remote = remoteWith(() => Promise.resolve(sdkMessage()));
+
+    const messages = await toReadReceiptMessages(
+      remote,
+      new MessageCache(),
+      readEvent({ readAt: undefined } as Partial<ReadEvent>),
+      PHONE
+    );
+
+    expect(messages[0]?.timestamp).toEqual(SENT_DATE);
+  });
+
+  it("recovers the reader from the DM chat guid when the actor is our own line", async () => {
+    // Real-line shape (ENG-2101): on `message.read` the platform reports
+    // `actor` as *our own* line even when the peer did the reading. Trusting
+    // it would attribute every DM receipt to ourselves.
+    const remote = remoteWith(() => Promise.resolve(sdkMessage()));
+
+    const messages = await toReadReceiptMessages(
+      remote,
+      new MessageCache(),
+      readEvent({
+        actor: { address: PHONE },
+        chatGuid: "any;-;+15559998888",
+      } as Partial<ReadEvent>),
+      PHONE
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.sender).toEqual({
+      id: "+15559998888",
+      address: "+15559998888",
+    });
+  });
+
+  it("recovers the reader from the DM chat guid when there is no actor", async () => {
+    const remote = remoteWith(() => Promise.resolve(sdkMessage()));
+
+    const messages = await toReadReceiptMessages(
+      remote,
+      new MessageCache(),
+      readEvent({
+        actor: undefined,
+        chatGuid: "any;-;+15559998888",
+      } as Partial<ReadEvent>),
+      PHONE
+    );
+
+    expect(messages[0]?.sender?.id).toBe("+15559998888");
+  });
+
+  it("drops a group receipt with no identifiable reader", async () => {
+    // A group guid carries no participant list, so an actor of our own line
+    // leaves the reader unknown — and the reader is the whole payload.
+    const remote = remoteWith(() => Promise.resolve(sdkMessage()));
+
+    const messages = await toReadReceiptMessages(
+      remote,
+      new MessageCache(),
+      readEvent({
+        actor: { address: PHONE },
+        chatGuid: "iMessage;+;chat9",
+      } as Partial<ReadEvent>),
+      PHONE
+    );
+
+    expect(messages).toEqual([]);
+    // The reader guard must short-circuit before the RPC.
+    expect(getMock(remote)).not.toHaveBeenCalled();
+  });
+
+  it("drops a receipt whose target is one of their inbound messages", async () => {
+    // This is the echo of our own `chats.markRead()`: it marks *their*
+    // messages, so the resolved target is inbound and must not surface.
+    const remote = remoteWith(() =>
+      Promise.resolve(sdkMessage({ isFromMe: false }))
+    );
+
+    const messages = await toReadReceiptMessages(
+      remote,
+      new MessageCache(),
+      readEvent(),
+      PHONE
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("emits regardless of isFromMe", async () => {
+    // `isFromMe` is undocumented on this arm and most plausibly describes the
+    // underlying message — ours, for a genuine receipt. Behavior must not
+    // depend on it either way.
+    for (const isFromMe of [true, false]) {
+      const remote = remoteWith(() => Promise.resolve(sdkMessage()));
+
+      const messages = await toReadReceiptMessages(
+        remote,
+        new MessageCache(),
+        readEvent({ isFromMe } as Partial<ReadEvent>),
+        PHONE
+      );
+
+      expect(messages).toHaveLength(1);
+    }
+  });
+
+  it("drops the receipt when the target cannot be fetched", async () => {
+    const remote = remoteWith(() => Promise.reject(new Error("gone")));
+
+    const messages = await toReadReceiptMessages(
+      remote,
+      new MessageCache(),
+      readEvent(),
+      PHONE
+    );
+
+    expect(messages).toEqual([]);
+  });
+
+  it("resolves the target once and warms the cache for sibling receipts", async () => {
+    const remote = remoteWith(() => Promise.resolve(sdkMessage()));
+    const cache = new MessageCache();
+
+    const first = await toReadReceiptMessages(
+      remote,
+      cache,
+      readEvent({
+        actor: { address: "a@example.com" },
+        sequence: 1,
+      } as Partial<ReadEvent>),
+      PHONE
+    );
+    const second = await toReadReceiptMessages(
+      remote,
+      cache,
+      readEvent({
+        actor: { address: "b@example.com" },
+        sequence: 2,
+      } as Partial<ReadEvent>),
+      PHONE
+    );
+
+    expect(first).toHaveLength(1);
+    expect(second).toHaveLength(1);
+    // Amplification is O(distinct messages read), not O(messages x readers).
+    expect(getMock(remote)).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits one message per participant in a group", async () => {
+    const remote = remoteWith(() =>
+      Promise.resolve(sdkMessage({ chatGuids: ["iMessage;+;chat123"] }))
+    );
+    const cache = new MessageCache();
+    const readers = ["a@example.com", "b@example.com", "c@example.com"];
+
+    const messages: IMessageMessage[] = [];
+    for (const [index, address] of readers.entries()) {
+      messages.push(
+        ...(await toReadReceiptMessages(
+          remote,
+          cache,
+          readEvent({
+            actor: { address },
+            chatGuid: "iMessage;+;chat123",
+            sequence: index + 1,
+          } as Partial<ReadEvent>),
+          PHONE
+        ))
+      );
+    }
+
+    expect(messages).toHaveLength(3);
+    expect(new Set(messages.map((m) => m.id)).size).toBe(3);
+    expect(messages.map((m) => m.sender?.id)).toEqual(readers);
+    for (const message of messages) {
+      expect(message.space.type).toBe("group");
+      if (message.content.type === "read") {
+        expect(message.content.target.id).toBe("msg-guid");
+      }
+    }
+  });
+});

--- a/packages/imessage/test/remote/stream.test.ts
+++ b/packages/imessage/test/remote/stream.test.ts
@@ -103,6 +103,79 @@ const inboundEvent = (sequence: number, chatGuid: string) => ({
   },
 });
 
+const READ_DATE = new Date(1_700_000_600_000);
+
+const readEvent = (
+  sequence: number,
+  chatGuid: string,
+  actorAddress: string,
+  messageGuid = "msg-out"
+) => ({
+  type: "message.read",
+  sequence,
+  chatGuid,
+  // Deliberately `true`: for a genuine receipt the underlying message is ours.
+  // Nothing may key self-suppression off this flag.
+  isFromMe: true,
+  actor: { address: actorAddress },
+  occurredAt: new Date(1_700_000_000_000 + sequence),
+  messageGuid,
+  readAt: READ_DATE,
+});
+
+// Delivers a finite list of events, then idles so the stream stays open.
+const finiteEventStream = (events: unknown[]) => {
+  let index = 0;
+  const idle = idleEventStream();
+  return {
+    close: idle.close,
+    [Symbol.asyncIterator]() {
+      const idleIterator = idle[Symbol.asyncIterator]();
+      return {
+        next(): Promise<IteratorResult<unknown, undefined>> {
+          if (index < events.length) {
+            const value = events[index];
+            index += 1;
+            return Promise.resolve({ done: false, value });
+          }
+          return idleIterator.next();
+        },
+        return(): Promise<IteratorResult<unknown, undefined>> {
+          return idleIterator.return();
+        },
+      };
+    },
+  };
+};
+
+// An outbound message of ours, as `messages.get` returns it.
+const sentMessage = (guid: string) => ({
+  guid,
+  chatGuids: ["s1"],
+  content: { attachments: [], formatting: [], mentions: [], text: "from us" },
+  dateCreated: new Date(1_700_000_000_000),
+  isFromMe: true,
+  sender: { address: "+15550100" },
+});
+
+const readReceiptClient = (phone: string, events: unknown[]) => {
+  const get = vi.fn((_message: string) =>
+    Promise.resolve(sentMessage("msg-out"))
+  );
+  const entry: RemoteClient = {
+    phone,
+    client: {
+      messages: {
+        get,
+        subscribeEvents: () => finiteEventStream(events),
+      },
+      polls: { subscribeEvents: idleEventStream },
+      groups: { subscribeEvents: idleEventStream },
+    } as unknown as AdvancedIMessage,
+  };
+  return { entry, get };
+};
+
 const remoteClient = (phone: string) => {
   const subscribeToMessages = vi.fn(idleEventStream);
   const subscribeToPolls = vi.fn(idleEventStream);
@@ -378,4 +451,103 @@ describe("remote iMessage streams", () => {
     await stream.close();
     await settleSoon(iterator.next());
   }, 15_000);
+
+  it("surfaces an inbound read receipt", async () => {
+    const { entry } = readReceiptClient("+15550100", [
+      readEvent(1, "s1", "+15550111"),
+    ]);
+
+    const stream = messages([entry]);
+    const iterator = stream[Symbol.asyncIterator]();
+    const first = await iterator.next();
+
+    expect(first.done).toBe(false);
+    expect(first.value?.id).toBe("msg-out:read:1");
+    expect(first.value?.sender?.id).toBe("+15550111");
+    expect(first.value?.timestamp).toEqual(READ_DATE);
+    expect(first.value?.content.type).toBe("read");
+    if (first.value?.content.type === "read") {
+      expect(first.value.content.target.id).toBe("msg-out");
+      expect(first.value.content.target.direction).toBe("outbound");
+    }
+
+    await stream.close();
+    await settleSoon(iterator.next());
+  });
+
+  it("surfaces a DM receipt whose actor is the line's own address", async () => {
+    // Real-line shape (ENG-2101): on `message.read` the platform reports
+    // `actor` as *our own* line even when the peer did the reading. Suppressing
+    // on that would drop every genuine receipt, so the peer is recovered from
+    // the DM chat guid instead.
+    const { entry } = readReceiptClient("+15550100", [
+      readEvent(1, "any;-;+15550111", "+15550100"),
+    ]);
+
+    const stream = messages([entry]);
+    const iterator = stream[Symbol.asyncIterator]();
+    const first = await iterator.next();
+
+    expect(first.value?.content.type).toBe("read");
+    expect(first.value?.sender?.id).toBe("+15550111");
+
+    await stream.close();
+    await settleSoon(iterator.next());
+  });
+
+  it("advances the cursor past a receipt with no identifiable reader", async () => {
+    // A dropped receipt must not wedge the stream: the event after it still
+    // has to be delivered. Same shape as the unmappable-event test above.
+    // A group guid carries no participants, so an actor of our own line leaves
+    // the reader unknown.
+    const { entry } = readReceiptClient("+15550100", [
+      readEvent(1, "iMessage;+;chat9", "+15550100"),
+      inboundEvent(2, "s1"),
+    ]);
+
+    const stream = messages([entry]);
+    const iterator = stream[Symbol.asyncIterator]();
+    const first = await iterator.next();
+
+    expect(first.done).toBe(false);
+    expect(first.value?.content).toMatchObject({ type: "text", text: "hi" });
+
+    await stream.close();
+    await settleSoon(iterator.next());
+  });
+
+  it("drops a receipt targeting one of their inbound messages", async () => {
+    // The echo of our own `chats.markRead()`: it marks *their* messages, so
+    // the resolved target is inbound and must not surface.
+    const entry: RemoteClient = {
+      phone: "+15550100",
+      client: {
+        messages: {
+          get: vi.fn((_message: string) =>
+            Promise.resolve({
+              ...sentMessage("msg-theirs"),
+              isFromMe: false,
+              sender: { address: "+15550111" },
+            })
+          ),
+          subscribeEvents: () =>
+            finiteEventStream([
+              readEvent(1, "s1", "+15550111", "msg-theirs"),
+              inboundEvent(2, "s1"),
+            ]),
+        },
+        polls: { subscribeEvents: idleEventStream },
+        groups: { subscribeEvents: idleEventStream },
+      } as unknown as AdvancedIMessage,
+    };
+
+    const stream = messages([entry]);
+    const iterator = stream[Symbol.asyncIterator]();
+    const first = await iterator.next();
+
+    expect(first.value?.id).toBe("msg-2");
+
+    await stream.close();
+    await settleSoon(iterator.next());
+  });
 });


### PR DESCRIPTION
## Summary

- Surface the advanced-iMessage `message.read` event on `app.messages` as an inbound `read` message: `message.sender` is the reader, `message.content.target` is the outbound message they read.
- Recover the reader from the DM chat guid, because on this arm the platform reports `actor` as *our own* line even when the peer did the reading.
- Drop receipts that cannot be attributed to a reader or resolved to an outbound target — the second check is also what suppresses the echo of our own `chats.markRead()`.
- Extract `resolveTargetMessage` out of reactions into a shared inbound helper so both event types resolve targets the same way and warm the same cache.
- Build the target as a fully-afforded outbound `Message` via a new `wrapNestedContent` arm, so `target.content`, `target.edit(...)`, and `target.unsend()` all work.

## Usage

```ts
for await (const [space, message] of app.messages) {
  if (message.content.type === "read") {
    const target = message.content.target; // the message YOU sent
    console.log(
      `${message.sender?.id} read ${target.id} at ${message.timestamp.toISOString()}`
    );
  }
}
```

`read` becomes the second bidirectional content type (after the group-management arms). Outbound `read` stays fire-and-forget and produces no `Message`, so `content.type === "read"` on `app.messages` is always a receipt — no direction check needed.

## Behavior

- **Reader identity.** `event.actor` is trusted only when it names somebody other than our own line. Otherwise the reader is the DM peer decoded from the chat guid (`any;-;+1555…`). A group receipt whose actor is us — or absent — is dropped: a group guid carries no participant list, and the reader's identity is the entire payload of a receipt. **Group receipts are therefore best-effort; DMs are the reliable case today.**
- **Self-suppression.** Not keyed off `actor` or `isFromMe` — both were verified wrong on this arm against a live line (`actor` = our own address, `isFromMe` = `false` for a peer read). It rides entirely on the resolved target having `direction: "outbound"`: our own `chats.markRead()` marks *their* inbound messages, so its echo resolves inbound and is dropped.
- **Timestamp.** Prefers `readAt` (when the reader's device marked it read) over `occurredAt` (when the bridge observed it). The two diverge on Continuity sync.
- **Amplification.** `resolveTargetMessage` warms the message cache, so N readers of the same message cost one `messages.get` — O(distinct messages read), not O(messages × readers).
- **Cursor safety.** A dropped receipt still advances the cursor; a resolution failure can never wedge the stream. Every outcome logs under `spectrum.imessage.read`, and each drop states its reason.
- **Volume.** Receipts are high-volume: one message per reader per message read, and marking a chat read clears *every* unread message in it. Documented with a warning, since a `default:` arm that replies to the user would now reply to every receipt.
- Unchanged: local iMessage does not support this (documented), and outbound `read()` semantics are untouched.

## Changes

| File | Change |
|---|---|
| `packages/imessage/src/remote/read-receipts.ts` | **New.** `toReadReceiptMessages` + `readReceiptMessageId` (`{guid}:read:{sequence}`, stable across live/catch-up dedup) and the reader-resolution rules. |
| `packages/imessage/src/remote/stream.ts` | Route `message.read` through the new mapper; split `isActorCurrentAccount` out of `isEventFromCurrentAccount` so the read arm can skip the untrustworthy `isFromMe`; debug-log every read event before filtering and every unmapped message event. |
| `packages/imessage/src/remote/inbound.ts` | Add shared `resolveTargetMessage` (cache → `messages.get` → rebuild → cache), which now logs the cause before dropping. |
| `packages/imessage/src/remote/reactions.ts` | Use the shared resolver; part-index drilling stays reaction-local. |
| `packages/imessage/src/remote/ids.ts` | Add `dmPeerFromChatGuid`, the inverse of `dmChatGuid`; `undefined` for group/malformed guids. |
| `packages/core/src/platform/build.ts` | `wrapNestedContent` arm for `read` — wraps a raw target record as an outbound `Message`. Inert on the outbound path. |
| `packages/core/src/webhook/deserialize.ts` | `mapContent` case for `read`, marking the stub target `direction: "outbound"`. |
| `packages/core/src/authoring.ts` | Export `readSchema` for provider-side parsing. |
| `docs/` | New `content/read` page (+ nav entry), inbound-receipt section in iMessage messaging features, provider feature-table and local-mode rows, `messages.mdx` bidirectional note. |

## Test plan

- [x] `packages/imessage/test/remote/read-receipts.test.ts` (new, 11 cases) — reader from actor vs. DM guid, group drop, inbound-target drop, `readAt` vs `occurredAt`, cache warming (1 RPC for 3 readers), one message per participant, and emission regardless of `isFromMe`.
- [x] `packages/imessage/test/remote/stream.test.ts` — end-to-end surfacing, the own-line-actor DM case, cursor advancing past a dropped receipt, and the `markRead()` echo drop.
- [x] `packages/core/test/core/receive-read.test.ts` (new) — target built as an outbound `Message` with affordances, reader tagged as sender, already-built targets left untouched.
- [x] `packages/core/test/webhook/deserialize.test.ts`, `packages/core/test/content/read.test.ts` — webhook stub target and `readSchema` raw-record acceptance.
- [x] `packages/imessage/test/remote/reactions.test.ts` — regression guard that the extracted resolver still drops on a failed fetch.
- [x] Node Vitest: iMessage 18 files / 170 tests, core 33 files / 296 tests, all packages green.
- [x] Bun 1.3.14 Vitest: same suites, all green.
- [x] `bun run typecheck` (13 tasks) and `bun x ultracite check` (329 files) clean.

Fixes ENG-2101

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787796852&installation_model_id=19795&pr_number=222&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F222&signature=2410016aab70dfdf4aa0b2f646966a536330f8efcf9cd8c563ae7501780d81a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the inbound message stream contract and adds high-volume receipt traffic; reader attribution and drop rules are platform-specific and easy to mis-handle in consumer loops.
> 
> **Overview**
> Inbound **read receipts** now appear on `app.messages` as `content.type === "read"`: **`message.sender`** is the reader and **`message.content.target`** is the outbound message they read (with full `Message` affordances on the target).
> 
> **iMessage remote** maps `message.read` through new `toReadReceiptMessages`, with reader identity taken from the **DM chat guid** when the platform’s `actor` names your own line. Group receipts without a trustworthy third-party actor are **dropped**; receipts whose resolved target is not **outbound** are dropped (including echoes of your own `chats.markRead()`). Target resolution is shared via **`resolveTargetMessage`** (cache → `messages.get` → rebuild), reused from reactions.
> 
> **Core** adds a `wrapNestedContent` arm for `read`, webhook **`deserializeRead`** (stub target marked outbound), and exports **`readSchema`** for provider parsing.
> 
> Docs add a **Read** content page, iMessage volume/semantics warnings, and clarify bidirectional `read` vs outbound fire-and-forget `read()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d88ea07e77b242a0049634d09d4a7ae7445f80f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inbound read receipt support for iMessage, surfacing who read a message, when it was read, and which outbound message was marked read.
  * Read receipt events now preserve message affordances on the referenced target (such as edit/unsend).
  * Improved best-effort behavior for group receipts and enhanced event replay handling.

* **Documentation**
  * Added comprehensive documentation for the “read” API, including inbound vs outbound semantics, platform-specific behavior, and event payload guidance.
  * Updated navigation and iMessage read-receipt capability notes to reflect inbound vs sending support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->