### PR TITLE
fix(imessage,whatsapp): reconcile cloud lines on token renewal (ENG-2102)

### DIFF
--- a/docs/providers/imessage.mdx.vel
+++ b/docs/providers/imessage.mdx.vel
@@ -47,6 +47,9 @@ import { imessage } from "@spectrum-ts/imessage";
 
 Cloud mode discovers every line owned by the project and renews its tokens
 automatically. Most applications should use the empty `imessage.config()` call.
+Lines provisioned while the app is running are picked up at the next token
+renewal — see [when line changes reach a running
+app](/providers/imessage/connection-and-routing#when-line-changes-reach-a-running-app).
 
 ### Explicit cloud clients
 

--- a/docs/providers/imessage.mdx.vel
+++ b/docs/providers/imessage.mdx.vel
@@ -49,7 +49,7 @@ Cloud mode discovers every line owned by the project and renews its tokens
 automatically. Most applications should use the empty `imessage.config()` call.
 Lines provisioned while the app is running are picked up at the next token
 renewal — see [when line changes reach a running
-app](/providers/imessage/connection-and-routing#when-line-changes-reach-a-running-app).
+app](/spectrum-ts/providers/imessage/connection-and-routing#when-line-changes-reach-a-running-app).
 
 ### Explicit cloud clients
 

--- a/docs/providers/imessage/connection-and-routing.mdx.vel
+++ b/docs/providers/imessage/connection-and-routing.mdx.vel
@@ -99,10 +99,12 @@ The SDK learns about your lines from the credentials it mints, and it re-mints t
 Until that renewal lands, a newly provisioned line is invisible to the process: it receives no inbound messages, and `space.create()` cannot route through it. Messages sent to it in that window are not delayed, they are not delivered to your app at all. Restart the process if you need a new line to take effect right away.
 
 <Note>
-  Two routing behaviors change the moment a second line appears, whether that happens at startup or mid-run:
+  On dedicated lines, two routing behaviors change the moment a second line appears, whether that happens at startup or mid-run:
 
-  - `space.get(chatGuid)` starts requiring `params.phone`. With exactly one line the SDK can infer it; with two or more it cannot.
+  - `space.get(chatGuid)` starts requiring `params.phone`. With exactly one dedicated line the SDK can infer it; with two or more it cannot.
   - `space.create()` without an explicit `phone` starts picking at random from the larger set.
+
+  Neither applies to shared-pool mode, which always routes through a single shared identity.
 </Note>
 
 <Note>
@@ -183,7 +185,14 @@ To look up an existing conversation by its chat GUID, use `space.get(id)`:
 
 ```ts
 const existing = await im.space.get("any;-;+15551111111");
+
+// With two or more dedicated lines, name the line that owns the conversation.
+const onLine = await im.space.get("any;-;+15551111111", {
+  phone: "+15559999999",
+});
 ```
+
+The first form works in shared-pool mode and on a single dedicated line, where the SDK can infer the line. With multiple dedicated lines it throws — pass `params.phone`, as covered in [per-phone routing](#per-phone-routing).
 
 DM creation works with the cloud package. The local package can construct a
 deterministic DM reference, but it cannot create a group because the local

--- a/docs/providers/imessage/connection-and-routing.mdx.vel
+++ b/docs/providers/imessage/connection-and-routing.mdx.vel
@@ -92,6 +92,19 @@ DM delivery is identical across both cloud line models. The developer-facing dif
 
 When traffic to a dedicated line approaches its per-line capacity, Spectrum can automatically provision an additional line so deliverability isn't affected. Auto-scale is an opt-in feature on the Business plan. Enable it in your project settings if you'd rather not get paged when a line saturates.
 
+### When line changes reach a running app
+
+The SDK learns about your lines from the credentials it mints, and it re-mints them on a schedule — so a line provisioned (or deprovisioned) while your app is running is picked up at the next token renewal, not immediately.
+
+Until that renewal lands, a newly provisioned line is invisible to the process: it receives no inbound messages, and `space.create()` cannot route through it. Messages sent to it in that window are not delayed, they are not delivered to your app at all. Restart the process if you need a new line to take effect right away.
+
+<Note>
+  Two routing behaviors change the moment a second line appears, whether that happens at startup or mid-run:
+
+  - `space.get(chatGuid)` starts requiring `params.phone`. With exactly one line the SDK can infer it; with two or more it cannot.
+  - `space.create()` without an explicit `phone` starts picking at random from the larger set.
+</Note>
+
 <Note>
   These are Spectrum Cloud features. With `@spectrum-ts/imessage-local`, you
   provide the Messages account on the Mac and managed-line concepts do not

--- a/docs/providers/whatsapp-business/setup.mdx.vel
+++ b/docs/providers/whatsapp-business/setup.mdx.vel
@@ -31,6 +31,14 @@ cloud mode, which uses your `projectId`/`projectSecret`.
 
 Find these values in your WhatsApp Business app settings on [Meta for Developers](https://developers.facebook.com/).
 
+## Line discovery in cloud mode
+
+Cloud mode discovers every line owned by the project from the credentials it
+mints, and re-mints them on a schedule. A line added to (or removed from) the
+project while your app is running is therefore picked up at the next token
+renewal, not immediately — until then a newly added line receives no inbound
+messages. Restart the process if you need a new line to take effect right away.
+
 ## Example
 
 ```ts

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -82,6 +82,16 @@ export {
   type ResumableStreamItem,
   resumableOrderedStream,
 } from "./utils/resumable-stream";
+// Fan-in over a source set that changes while the stream runs — the shape a
+// provider needs when its line/workspace inventory is discovered at runtime
+// rather than fixed at startup. Use `mergeStreams` for a fixed set; see the
+// contract comparison on `createStreamGroup`.
+export {
+  createStreamGroup,
+  type StreamGroup,
+  type StreamGroupOptions,
+  type StreamGroupSource,
+} from "./utils/stream-group";
 export { errorAttrs } from "./utils/telemetry";
 export {
   createTokenRenewal,

--- a/packages/core/src/utils/stream-group.ts
+++ b/packages/core/src/utils/stream-group.ts
@@ -133,6 +133,13 @@ export function createStreamGroup<T>(
     }
 
     return async () => {
+      // Teardown is terminal, and it also runs when the consumer simply walks
+      // away from the iterator — a path that never goes through `close()`. Mark
+      // the group closed and drop `spawn` here so a late `add` can neither
+      // build a source nor hand one an `emit` that is already dead.
+      closed = true;
+      spawn = undefined;
+
       const attached = Array.from(members.values());
       // Teardown is not a fault. Marking every member detached first keeps a
       // normal shutdown — `close()` or the consumer walking away — from

--- a/packages/core/src/utils/stream-group.ts
+++ b/packages/core/src/utils/stream-group.ts
@@ -1,0 +1,189 @@
+import { createLogger } from "@photon-ai/otel";
+import { type ManagedStream, stream } from "./stream";
+import { errorAttrs } from "./telemetry";
+
+const groupLog = createLogger("spectrum.stream");
+
+/**
+ * Builds a member stream. Invoked once per attach — and again on re-attach, so
+ * a member that faulted can be revived by adding its key back.
+ */
+export type StreamGroupSource<T> = () => ManagedStream<T>;
+
+export interface StreamGroupOptions {
+  /** Log provenance, e.g. `"imessage.messages"`. */
+  label?: string;
+}
+
+export interface StreamGroup<T> extends ManagedStream<T> {
+  /**
+   * Attach `key`. Returns false — without invoking `source`, which typically
+   * opens a subscription — when the key is already attached or the group is
+   * closed. Safe before the group has a consumer: the factory runs when the
+   * group first starts.
+   */
+  add(key: string, source: StreamGroupSource<T>): boolean;
+  has(key: string): boolean;
+  /** Attached keys, in attach order. */
+  keys(): string[];
+  /**
+   * Detach `key` and close its source. Resolves once that source's own
+   * `close()` settles; it deliberately does not wait on the member's worker,
+   * which unparks only when the group's consumer pulls. Returns false when the
+   * key was not attached.
+   */
+  remove(key: string): Promise<boolean>;
+}
+
+interface Member<T> {
+  detached: boolean;
+  factory: StreamGroupSource<T>;
+  source?: ManagedStream<T>;
+  worker?: Promise<void>;
+}
+
+/**
+ * A merged stream whose membership can change while it runs.
+ *
+ * Sibling of `mergeStreams`, with a deliberately different lifetime contract —
+ * pick by whether the source set is fixed:
+ *
+ *   - `mergeStreams` merges a *fixed* set. Its result represents all of them:
+ *     it ends when they have all ended (immediately, for an empty set) and one
+ *     member's error ends the whole merge.
+ *   - `createStreamGroup` owns a *mutable* set. It ends only via `close()` —
+ *     zero members parks the consumer rather than ending it, so a set that is
+ *     briefly empty mid-reconcile does not terminate the stream — and a member
+ *     that fails is logged and dropped while its siblings keep running.
+ *
+ * Dropping a faulted member (rather than restarting it here) keeps retry policy
+ * with the caller that knows the real inventory: `keys()` stops reporting it, so
+ * the caller's next reconcile re-adds it through `add`.
+ */
+export function createStreamGroup<T>(
+  options: StreamGroupOptions = {}
+): StreamGroup<T> {
+  const label = options.label ?? "stream-group";
+  const members = new Map<string, Member<T>>();
+  let closed = false;
+  // Assigned when the underlying stream starts, since `emit` only exists inside
+  // the setup callback. Its absence is what makes pre-start `add` calls lazy.
+  let spawn: ((key: string, member: Member<T>) => void) | undefined;
+
+  const memberAttrs = (key: string) => ({
+    "spectrum.stream.group": label,
+    "spectrum.stream.member": key,
+  });
+
+  // A member only reaches here by ending or throwing on its own, which for a
+  // reconnecting source means a bug — never a detach, which exits silently.
+  const reportMemberExit = (
+    key: string,
+    member: Member<T>,
+    error?: unknown
+  ): void => {
+    if (member.detached) {
+      return;
+    }
+    if (error === undefined) {
+      groupLog.error(
+        "stream group member ended unexpectedly",
+        memberAttrs(key)
+      );
+      return;
+    }
+    groupLog.error(
+      "stream group member failed",
+      { ...memberAttrs(key), ...errorAttrs(error) },
+      error instanceof Error ? error : undefined
+    );
+  };
+
+  const runMember = async (
+    key: string,
+    member: Member<T>,
+    emit: (value: T) => Promise<void>
+  ): Promise<void> => {
+    try {
+      const source = member.factory();
+      member.source = source;
+      for await (const value of source) {
+        await emit(value);
+      }
+      reportMemberExit(key, member);
+    } catch (error) {
+      reportMemberExit(key, member, error ?? new Error("unknown stream error"));
+    } finally {
+      // Drop the faulted member so `keys()` reports the truth and the caller's
+      // next reconcile can re-add it. Guarded against a re-add that already
+      // replaced this member under the same key.
+      if (members.get(key) === member) {
+        members.delete(key);
+      }
+    }
+  };
+
+  const base = stream<T>((emit) => {
+    spawn = (key, member) => {
+      member.worker = runMember(key, member, emit);
+    };
+
+    for (const [key, member] of members) {
+      spawn(key, member);
+    }
+
+    return async () => {
+      const attached = Array.from(members.values());
+      // Teardown is not a fault. Marking every member detached first keeps a
+      // normal shutdown — `close()` or the consumer walking away — from
+      // reporting one bogus member failure per source.
+      for (const member of attached) {
+        member.detached = true;
+      }
+      // Sources first, then workers: a worker parked on `emit` unparks only
+      // once the stream has stopped, which has already happened by the time
+      // cleanup runs. Members detached earlier are deliberately absent — their
+      // workers are not awaited.
+      await Promise.allSettled(
+        attached.map((member) => member.source?.close())
+      );
+      await Promise.allSettled(attached.map((member) => member.worker));
+    };
+  });
+
+  const closeBase = base.close.bind(base);
+
+  return Object.assign(base, {
+    add: (key: string, source: StreamGroupSource<T>): boolean => {
+      if (closed || members.has(key)) {
+        return false;
+      }
+      const member: Member<T> = { detached: false, factory: source };
+      members.set(key, member);
+      spawn?.(key, member);
+      return true;
+    },
+
+    close: async (): Promise<void> => {
+      closed = true;
+      await closeBase();
+    },
+
+    has: (key: string): boolean => members.has(key),
+
+    keys: (): string[] => Array.from(members.keys()),
+
+    remove: async (key: string): Promise<boolean> => {
+      const member = members.get(key);
+      if (!member) {
+        return false;
+      }
+      // Marked before the delete so the worker's exit reads as intentional and
+      // stays silent.
+      member.detached = true;
+      members.delete(key);
+      await member.source?.close();
+      return true;
+    },
+  });
+}

--- a/packages/core/src/utils/stream.ts
+++ b/packages/core/src/utils/stream.ts
@@ -107,6 +107,15 @@ export function stream<T>(
   });
 }
 
+/**
+ * Merges a fixed set of streams. The result represents all of them: it ends
+ * once every member has ended — immediately, for an empty set — and one
+ * member's error ends the whole merge.
+ *
+ * For a set that changes while the stream runs, use `createStreamGroup`
+ * (`@spectrum-ts/core/authoring`), which ends only on `close()` and drops a
+ * failed member instead of tearing down its siblings.
+ */
 export function mergeStreams<T>(
   streams: readonly ManagedStream<T>[]
 ): ManagedStream<T> {

--- a/packages/core/test/utils/collect-until-idle.test.ts
+++ b/packages/core/test/utils/collect-until-idle.test.ts
@@ -1,0 +1,43 @@
+import { collectUntilIdle } from "@spectrum-ts/test-support/timing";
+import { describe, expect, it } from "vitest";
+import type { ManagedStream } from "@/utils/stream";
+
+// `collectUntilIdle` ships in @spectrum-ts/test-support, which has no runner of
+// its own. It is covered here because it consumes core's ManagedStream contract.
+
+const trackedSource = <T>(
+  next: () => Promise<IteratorResult<T, undefined>>
+) => {
+  let closeCalls = 0;
+  const source: ManagedStream<T> = {
+    close: () => {
+      closeCalls += 1;
+      return Promise.resolve();
+    },
+    [Symbol.asyncIterator]: () => ({ next }),
+  };
+  return { closeCalls: () => closeCalls, source };
+};
+
+describe("collectUntilIdle", () => {
+  it("closes the source when iteration rejects, then propagates", async () => {
+    const failure = new Error("boom");
+    const tracked = trackedSource<string>(() => Promise.reject(failure));
+
+    await expect(collectUntilIdle(tracked.source)).rejects.toThrow("boom");
+    expect(tracked.closeCalls()).toBe(1);
+  });
+
+  it("collects what arrived and closes once when the source goes idle", async () => {
+    const queued = ["a", "b"];
+    const tracked = trackedSource<string>(() => {
+      const value = queued.shift();
+      return value === undefined
+        ? new Promise<IteratorResult<string, undefined>>(() => undefined)
+        : Promise.resolve({ done: false, value });
+    });
+
+    expect(await collectUntilIdle(tracked.source)).toEqual(["a", "b"]);
+    expect(tracked.closeCalls()).toBe(1);
+  });
+});

--- a/packages/core/test/utils/stream-group.test.ts
+++ b/packages/core/test/utils/stream-group.test.ts
@@ -332,6 +332,27 @@ describe("createStreamGroup", () => {
     spy.mockRestore();
   });
 
+  it("refuses to add after the consumer walks away", async () => {
+    const a = controllable<string>();
+    const group = createStreamGroup<string>();
+    group.add("a", () => a.source);
+
+    const iterator = group[Symbol.asyncIterator]();
+    a.push("a1");
+    expect((await takeNext(iterator)).value).toBe("a1");
+
+    // Teardown without close(): the consumer abandoning the iterator stops the
+    // stream, so `emit` is dead even though close() was never called.
+    await iterator.return?.(undefined);
+
+    const b = controllable<string>();
+    const factory = vi.fn(() => b.source);
+    expect(group.add("b", factory)).toBe(false);
+    expect(factory).not.toHaveBeenCalled();
+
+    await group.close();
+  });
+
   it("refuses to add after close and never builds the source", async () => {
     const a = controllable<string>();
     const factory = vi.fn(() => a.source);

--- a/packages/core/test/utils/stream-group.test.ts
+++ b/packages/core/test/utils/stream-group.test.ts
@@ -1,0 +1,365 @@
+import {
+  flush,
+  NO_MESSAGE_WAIT_MS,
+  withinMs,
+} from "@spectrum-ts/test-support/timing";
+import { describe, expect, it, vi } from "vitest";
+import type { ManagedStream } from "@/utils/stream";
+import { createStreamGroup } from "@/utils/stream-group";
+
+// A ManagedStream the test drives by hand. `end()` simulates the source
+// finishing on its own (no close call), which the group must treat as a fault;
+// `close()` is what the group itself calls, and is counted separately.
+const controllable = <T>() => {
+  const queued: T[] = [];
+  const waiters: {
+    reject: (error: unknown) => void;
+    resolve: (result: IteratorResult<T, undefined>) => void;
+  }[] = [];
+  let closeCalls = 0;
+  let done = false;
+  let nextCalls = 0;
+  let pendingFailure: { error: unknown } | undefined;
+
+  const settleDone = (): void => {
+    done = true;
+    for (const waiter of waiters.splice(0)) {
+      waiter.resolve({ done: true, value: undefined });
+    }
+  };
+
+  const close = (): Promise<void> => {
+    closeCalls += 1;
+    settleDone();
+    return Promise.resolve();
+  };
+
+  const source: ManagedStream<T> = {
+    close,
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<T, undefined>> {
+          nextCalls += 1;
+          const value = queued.shift();
+          if (value !== undefined) {
+            return Promise.resolve({ done: false, value });
+          }
+          if (pendingFailure) {
+            const { error } = pendingFailure;
+            pendingFailure = undefined;
+            return Promise.reject(error);
+          }
+          if (done) {
+            return Promise.resolve({ done: true, value: undefined });
+          }
+          return new Promise((resolve, reject) => {
+            waiters.push({ reject, resolve });
+          });
+        },
+        return(): Promise<IteratorResult<T, undefined>> {
+          return close().then(() => ({ done: true, value: undefined }));
+        },
+      };
+    },
+  };
+
+  return {
+    closeCalls: () => closeCalls,
+    end: settleDone,
+    fail(error: unknown): void {
+      const waiter = waiters.shift();
+      if (waiter) {
+        waiter.reject(error);
+      } else {
+        pendingFailure = { error };
+      }
+    },
+    nextCalls: () => nextCalls,
+    push(value: T): void {
+      const waiter = waiters.shift();
+      if (waiter) {
+        waiter.resolve({ done: false, value });
+      } else {
+        queued.push(value);
+      }
+    },
+    source,
+  };
+};
+
+const takeNext = <T>(iterator: AsyncIterator<T>): Promise<IteratorResult<T>> =>
+  iterator.next() as Promise<IteratorResult<T>>;
+
+describe("createStreamGroup", () => {
+  it("delivers values from every attached member", async () => {
+    const a = controllable<string>();
+    const b = controllable<string>();
+    const group = createStreamGroup<string>({ label: "test" });
+    group.add("a", () => a.source);
+    group.add("b", () => b.source);
+
+    const iterator = group[Symbol.asyncIterator]();
+    a.push("a1");
+    b.push("b1");
+
+    const received = [
+      (await takeNext(iterator)).value,
+      (await takeNext(iterator)).value,
+    ];
+    expect(received.sort()).toEqual(["a1", "b1"]);
+
+    await group.close();
+  });
+
+  it("does not build a member until the group is iterated", async () => {
+    const a = controllable<string>();
+    const factory = vi.fn(() => a.source);
+    const group = createStreamGroup<string>();
+    group.add("a", factory);
+
+    await flush();
+    expect(factory).not.toHaveBeenCalled();
+
+    const iterator = group[Symbol.asyncIterator]();
+    const pending = takeNext(iterator);
+    a.push("a1");
+    expect((await pending).value).toBe("a1");
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    await group.close();
+  });
+
+  it("delivers from a member added while the group is running", async () => {
+    const a = controllable<string>();
+    const b = controllable<string>();
+    const group = createStreamGroup<string>();
+    group.add("a", () => a.source);
+
+    const iterator = group[Symbol.asyncIterator]();
+    a.push("a1");
+    expect((await takeNext(iterator)).value).toBe("a1");
+
+    group.add("b", () => b.source);
+    b.push("b1");
+    expect((await takeNext(iterator)).value).toBe("b1");
+    expect(group.keys()).toEqual(["a", "b"]);
+
+    await group.close();
+  });
+
+  it("parks with no members instead of ending, then delivers once one is added", async () => {
+    const group = createStreamGroup<string>();
+    const iterator = group[Symbol.asyncIterator]();
+    const pending = takeNext(iterator);
+
+    expect(await withinMs(pending, NO_MESSAGE_WAIT_MS)).toBe("timeout");
+
+    const a = controllable<string>();
+    group.add("a", () => a.source);
+    a.push("a1");
+    expect((await pending).value).toBe("a1");
+
+    await group.close();
+  });
+
+  it("closes only the removed member and keeps the rest running", async () => {
+    const a = controllable<string>();
+    const b = controllable<string>();
+    const group = createStreamGroup<string>();
+    group.add("a", () => a.source);
+    group.add("b", () => b.source);
+
+    const iterator = group[Symbol.asyncIterator]();
+    a.push("a1");
+    expect((await takeNext(iterator)).value).toBe("a1");
+
+    expect(await group.remove("a")).toBe(true);
+    expect(a.closeCalls()).toBe(1);
+    expect(b.closeCalls()).toBe(0);
+    expect(group.has("a")).toBe(false);
+    expect(await group.remove("a")).toBe(false);
+
+    b.push("b1");
+    expect((await takeNext(iterator)).value).toBe("b1");
+
+    await group.close();
+  });
+
+  it("stays open after its last member is removed", async () => {
+    const a = controllable<string>();
+    const group = createStreamGroup<string>();
+    group.add("a", () => a.source);
+
+    const iterator = group[Symbol.asyncIterator]();
+    a.push("a1");
+    expect((await takeNext(iterator)).value).toBe("a1");
+
+    await group.remove("a");
+    expect(group.keys()).toEqual([]);
+
+    const pending = takeNext(iterator);
+    expect(await withinMs(pending, NO_MESSAGE_WAIT_MS)).toBe("timeout");
+
+    const b = controllable<string>();
+    group.add("b", () => b.source);
+    b.push("b1");
+    expect((await pending).value).toBe("b1");
+
+    await group.close();
+  });
+
+  it("drops a member that throws without disturbing its siblings", async () => {
+    const a = controllable<string>();
+    const b = controllable<string>();
+    const group = createStreamGroup<string>();
+    group.add("a", () => a.source);
+    group.add("b", () => b.source);
+
+    const iterator = group[Symbol.asyncIterator]();
+    b.push("b1");
+    expect((await takeNext(iterator)).value).toBe("b1");
+
+    a.fail(new Error("boom"));
+    await flush();
+    expect(group.has("a")).toBe(false);
+    expect(group.keys()).toEqual(["b"]);
+
+    b.push("b2");
+    expect((await takeNext(iterator)).value).toBe("b2");
+
+    await group.close();
+  });
+
+  it("drops a member that ends on its own without ending the group", async () => {
+    const a = controllable<string>();
+    const group = createStreamGroup<string>();
+    group.add("a", () => a.source);
+
+    const iterator = group[Symbol.asyncIterator]();
+    a.push("a1");
+    expect((await takeNext(iterator)).value).toBe("a1");
+
+    // Pull again first: a worker parked in `emit` unparks only when the
+    // consumer pulls, so it cannot observe its source ending until then.
+    const pending = takeNext(iterator);
+    await flush();
+    a.end();
+    await flush();
+    expect(group.has("a")).toBe(false);
+
+    expect(await withinMs(pending, NO_MESSAGE_WAIT_MS)).toBe("timeout");
+
+    await group.close();
+    await pending;
+  });
+
+  it("re-attaches a key after its member faulted", async () => {
+    const first = controllable<string>();
+    const second = controllable<string>();
+    const group = createStreamGroup<string>();
+    group.add("a", () => first.source);
+
+    const iterator = group[Symbol.asyncIterator]();
+    first.push("a1");
+    expect((await takeNext(iterator)).value).toBe("a1");
+
+    // Pull again so the worker unparks from `emit` and is waiting on its
+    // source, which is what `fail` rejects.
+    const pending = takeNext(iterator);
+    await flush();
+    first.fail(new Error("boom"));
+    await flush();
+
+    expect(group.add("a", () => second.source)).toBe(true);
+    second.push("a2");
+    expect((await pending).value).toBe("a2");
+
+    await group.close();
+  });
+
+  it("rejects a duplicate key without building a second source", async () => {
+    const a = controllable<string>();
+    const group = createStreamGroup<string>();
+    const factory = vi.fn(() => a.source);
+    expect(group.add("a", factory)).toBe(true);
+    expect(group.add("a", factory)).toBe(false);
+
+    const iterator = group[Symbol.asyncIterator]();
+    a.push("a1");
+    expect((await takeNext(iterator)).value).toBe("a1");
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    await group.close();
+  });
+
+  it("closes every attached source and ends the consumer on close", async () => {
+    const a = controllable<string>();
+    const b = controllable<string>();
+    const group = createStreamGroup<string>();
+    group.add("a", () => a.source);
+    group.add("b", () => b.source);
+
+    const iterator = group[Symbol.asyncIterator]();
+    a.push("a1");
+    expect((await takeNext(iterator)).value).toBe("a1");
+
+    await group.close();
+
+    expect(a.closeCalls()).toBeGreaterThanOrEqual(1);
+    expect(b.closeCalls()).toBeGreaterThanOrEqual(1);
+    expect((await takeNext(iterator)).done).toBe(true);
+  });
+
+  it("does not report its members as failed when the group is torn down", async () => {
+    const errors: string[] = [];
+    const spy = vi
+      .spyOn(console, "error")
+      .mockImplementation((message: unknown) => {
+        errors.push(String(message));
+      });
+    const a = controllable<string>();
+    const group = createStreamGroup<string>({ label: "teardown" });
+    group.add("a", () => a.source);
+
+    const iterator = group[Symbol.asyncIterator]();
+    a.push("a1");
+    expect((await takeNext(iterator)).value).toBe("a1");
+
+    await group.close();
+    await flush();
+
+    expect(errors.join("\n")).not.toContain("stream group member");
+    spy.mockRestore();
+  });
+
+  it("refuses to add after close and never builds the source", async () => {
+    const a = controllable<string>();
+    const factory = vi.fn(() => a.source);
+    const group = createStreamGroup<string>();
+
+    await group.close();
+
+    expect(group.add("a", factory)).toBe(false);
+    expect(factory).not.toHaveBeenCalled();
+    expect(group.keys()).toEqual([]);
+  });
+
+  it("applies backpressure instead of draining a member eagerly", async () => {
+    const a = controllable<string>();
+    const group = createStreamGroup<string>();
+    group.add("a", () => a.source);
+
+    for (let i = 0; i < 5; i += 1) {
+      a.push(`a${i}`);
+    }
+
+    const iterator = group[Symbol.asyncIterator]();
+    expect((await takeNext(iterator)).value).toBe("a0");
+    await flush();
+
+    // An unbounded pump would have drained all five by now.
+    expect(a.nextCalls()).toBeLessThan(5);
+
+    await group.close();
+  });
+});

--- a/packages/core/test/utils/stream.test.ts
+++ b/packages/core/test/utils/stream.test.ts
@@ -1,0 +1,140 @@
+import {
+  flush,
+  NO_MESSAGE_WAIT_MS,
+  settleSoon,
+  withinMs,
+} from "@spectrum-ts/test-support/timing";
+import { describe, expect, it } from "vitest";
+import { type ManagedStream, mergeStreams, stream } from "@/utils/stream";
+
+// Characterization tests for the semantics that make `mergeStreams` unsuitable
+// for a source set that changes at runtime. `createStreamGroup` deliberately
+// diverges on all three; see stream-group.test.ts for the opposite assertions.
+
+const controllable = <T>() => {
+  const queued: T[] = [];
+  const waiters: {
+    reject: (error: unknown) => void;
+    resolve: (result: IteratorResult<T, undefined>) => void;
+  }[] = [];
+  let done = false;
+
+  const close = (): Promise<void> => {
+    done = true;
+    for (const waiter of waiters.splice(0)) {
+      waiter.resolve({ done: true, value: undefined });
+    }
+    return Promise.resolve();
+  };
+
+  const source: ManagedStream<T> = {
+    close,
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<T, undefined>> {
+          const value = queued.shift();
+          if (value !== undefined) {
+            return Promise.resolve({ done: false, value });
+          }
+          if (done) {
+            return Promise.resolve({ done: true, value: undefined });
+          }
+          return new Promise((resolve, reject) => {
+            waiters.push({ reject, resolve });
+          });
+        },
+        return(): Promise<IteratorResult<T, undefined>> {
+          return close().then(() => ({ done: true, value: undefined }));
+        },
+      };
+    },
+  };
+
+  return {
+    end: close,
+    fail(error: unknown): void {
+      const waiter = waiters.shift();
+      waiter?.reject(error);
+    },
+    push(value: T): void {
+      const waiter = waiters.shift();
+      if (waiter) {
+        waiter.resolve({ done: false, value });
+      } else {
+        queued.push(value);
+      }
+    },
+    source,
+  };
+};
+
+describe("stream", () => {
+  it("runs setup lazily and cleans up on close", async () => {
+    let started = false;
+    let cleaned = false;
+    let emitValue: ((value: string) => Promise<void>) | undefined;
+    const managed = stream<string>((emit) => {
+      started = true;
+      emitValue = emit;
+      return () => {
+        cleaned = true;
+      };
+    });
+
+    expect(started).toBe(false);
+
+    const iterator = managed[Symbol.asyncIterator]();
+    const pending = iterator.next();
+    await flush();
+    expect(started).toBe(true);
+
+    const delivered = emitValue?.("first");
+    expect((await pending).value).toBe("first");
+
+    await managed.close();
+    expect(cleaned).toBe(true);
+    await settleSoon(delivered);
+  });
+});
+
+describe("mergeStreams", () => {
+  it("ends immediately when given no sources", async () => {
+    const merged = mergeStreams<string>([]);
+    const iterator = merged[Symbol.asyncIterator]();
+
+    expect((await iterator.next()).done).toBe(true);
+  });
+
+  it("ends once every source has ended", async () => {
+    const a = controllable<string>();
+    const b = controllable<string>();
+    const merged = mergeStreams([a.source, b.source]);
+    const iterator = merged[Symbol.asyncIterator]();
+
+    a.push("a1");
+    expect((await iterator.next()).value).toBe("a1");
+
+    a.end();
+    const pending = iterator.next();
+    // One source ending is not enough — the merge represents all of them.
+    expect(await withinMs(pending, NO_MESSAGE_WAIT_MS)).toBe("timeout");
+
+    b.end();
+    expect((await pending).done).toBe(true);
+  });
+
+  it("ends the whole merge when a single source fails", async () => {
+    const a = controllable<string>();
+    const b = controllable<string>();
+    const merged = mergeStreams([a.source, b.source]);
+    const iterator = merged[Symbol.asyncIterator]();
+
+    b.push("b1");
+    expect((await iterator.next()).value).toBe("b1");
+
+    const failure = new Error("boom");
+    a.fail(failure);
+
+    await expect(iterator.next()).rejects.toThrow("boom");
+  });
+});

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -4,13 +4,25 @@ import {
   type DedicatedTokenData,
   type SharedTokenData,
 } from "@spectrum-ts/core";
-import { createTokenRenewal } from "@spectrum-ts/core/authoring";
+import {
+  createLogger,
+  createTokenRenewal,
+  errorAttrs,
+} from "@spectrum-ts/core/authoring";
+import {
+  clearLineObservers,
+  notifyLineAttached,
+  notifyLineDetached,
+  setLineId,
+} from "./lines";
 import { type RemoteClient, SHARED_PHONE } from "./types";
 
 // Floor between forced re-mints so a stream reconnect storm can't hammer the
 // cloud token endpoint — well below any token TTL, just enough to coalesce the
 // message + poll streams asking at nearly the same instant.
 const FORCE_REFRESH_MIN_INTERVAL_MS = 5000;
+
+const authLog = createLogger("spectrum.imessage.auth");
 
 interface CloudAuth {
   dispose: () => void;
@@ -19,13 +31,9 @@ interface CloudAuth {
 
 const cloudAuthState = new WeakMap<RemoteClient[], CloudAuth>();
 
-const requirePhone = (data: DedicatedTokenData, instanceId: string): string => {
-  const phone = data.numbers?.[instanceId];
-  if (!phone) {
-    throw new Error(`iMessage instance ${instanceId} has no phone assigned`);
-  }
-  return phone;
-};
+const instanceAttrs = (instanceId: string) => ({
+  "spectrum.imessage.instance": instanceId,
+});
 
 export async function createCloudClients(
   projectId: string,
@@ -34,14 +42,130 @@ export async function createCloudClients(
   let tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
   let lastRefreshAt = Date.now();
 
-  // The instanceId stays paired with each entry in this closure so renewal
-  // can rewrite `entry.phone` in place without leaking instanceId onto the
-  // public RemoteClient shape. Empty in shared mode.
-  const records: { entry: RemoteClient; instanceId: string }[] = [];
+  // This array object is never replaced — only `push`/`splice`. Routing helpers
+  // read it live on every call, and three WeakMaps (cloud auth, poll cache,
+  // profile-sync gate) plus core's own platform state are keyed by its identity,
+  // so swapping it in would silently orphan all of them.
+  const entries: RemoteClient[] = [];
+  // instanceId -> entry, so a refresh can tell an existing line from a newly
+  // provisioned one without leaking instanceId onto the public shape.
+  const records = new Map<string, RemoteClient>();
 
-  const syncPhones = (data: DedicatedTokenData) => {
-    for (const { entry, instanceId } of records) {
-      entry.phone = requirePhone(data, instanceId);
+  const buildEntry = (
+    instanceId: string,
+    phone: string,
+    initialToken: string
+  ): RemoteClient => ({
+    phone,
+    client: createGrpcClient({
+      address: `${instanceId}.imsg.photon.codes:443`,
+      autoIdempotency: true,
+      retry: true,
+      tls: true,
+      token: async () => {
+        await renewal.refreshIfNeeded();
+        const data = tokenData as DedicatedTokenData;
+        return data.auth[instanceId] ?? initialToken;
+      },
+    }),
+  });
+
+  // Detach the stream before closing the channel: closing it under a live
+  // subscription produces a reconnect-warn storm until the detach lands. Never
+  // awaited by `refresh` — a wedged channel must not stall token renewal.
+  const retire = async (entry: RemoteClient): Promise<void> => {
+    await Promise.allSettled(notifyLineDetached(entries, entry));
+    await entry.client.close();
+  };
+
+  const removeMissing = (data: DedicatedTokenData): number => {
+    let removed = 0;
+    for (const [instanceId, entry] of records) {
+      if (data.auth[instanceId]) {
+        continue;
+      }
+      records.delete(instanceId);
+      const index = entries.indexOf(entry);
+      if (index >= 0) {
+        entries.splice(index, 1);
+      }
+      removed += 1;
+      retire(entry).catch((error: unknown) => {
+        authLog.warn(
+          "failed to retire imessage line",
+          { ...instanceAttrs(instanceId), ...errorAttrs(error) },
+          error instanceof Error ? error : undefined
+        );
+      });
+    }
+    return removed;
+  };
+
+  const addOrSync = (data: DedicatedTokenData): number => {
+    let added = 0;
+    for (const [instanceId, token] of Object.entries(data.auth)) {
+      const phone = data.numbers?.[instanceId];
+      const existing = records.get(instanceId);
+      if (existing) {
+        if (phone) {
+          existing.phone = phone;
+        } else {
+          authLog.warn(
+            "imessage line lost its phone number; keeping the last known number",
+            instanceAttrs(instanceId)
+          );
+        }
+        // Re-assert the subscription rather than assuming it survived. The
+        // stream layer drops a line whose stream died, and attaching is
+        // idempotent, so this is what revives it — otherwise a dropped line
+        // would stay dark for the life of the process.
+        notifyLineAttached(entries, existing);
+        continue;
+      }
+      if (!phone) {
+        // A line can exist before a number is assigned to it. Skipping keeps
+        // startup alive and lets a later refresh pick the line up, where the
+        // old behavior threw and took the whole client down with it.
+        authLog.warn(
+          "skipping imessage line without a phone number",
+          instanceAttrs(instanceId)
+        );
+        continue;
+      }
+      const entry = buildEntry(instanceId, phone, token);
+      setLineId(entry, instanceId);
+      records.set(instanceId, entry);
+      entries.push(entry);
+      // Synchronous, and adjacent to the push, so an observer can never see a
+      // half-applied array.
+      notifyLineAttached(entries, entry);
+      added += 1;
+    }
+    return added;
+  };
+
+  /**
+   * Brings the client set in line with the token payload, which is the only
+   * inventory the cloud exposes: keys present but untracked are newly
+   * provisioned, tracked keys that vanished were deprovisioned.
+   */
+  const reconcile = (data: DedicatedTokenData): void => {
+    if (Object.keys(data.auth ?? {}).length === 0) {
+      // Never wipe a working set on a degenerate response. At startup `records`
+      // is empty, so this still yields an empty array.
+      authLog.warn(
+        "imessage token response contained no lines; keeping the current set"
+      );
+      return;
+    }
+    const removed = removeMissing(data);
+    const added = addOrSync(data);
+    if (added > 0 || removed > 0) {
+      authLog.info("imessage lines reconciled", {
+        "spectrum.imessage.lines.added": added,
+        "spectrum.imessage.lines.removed": removed,
+        "spectrum.imessage.lines.total": entries.length,
+      });
     }
   };
 
@@ -51,8 +175,20 @@ export async function createCloudClients(
     refresh: async () => {
       tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
       lastRefreshAt = Date.now();
-      if (tokenData.type === "dedicated") {
-        syncPhones(tokenData);
+      if (tokenData.type !== "dedicated") {
+        return;
+      }
+      try {
+        reconcile(tokenData);
+      } catch (error) {
+        // Rejecting here would leave the renewal's expiry unadvanced, and since
+        // `refreshIfNeeded` runs on every RPC, every call on every line would
+        // then re-enter the refresh. Reconcile failures stay contained.
+        authLog.error(
+          "imessage line reconcile failed",
+          errorAttrs(error),
+          error instanceof Error ? error : undefined
+        );
       }
     },
   });
@@ -74,50 +210,32 @@ export async function createCloudClients(
     const address =
       process.env.SPECTRUM_IMESSAGE_ADDRESS ??
       "imessage.spectrum.photon.codes:443";
-    const entries: RemoteClient[] = [
-      {
-        phone: SHARED_PHONE,
-        client: createGrpcClient({
-          address,
-          // Auto-retry transient unary failures so a brief server blip during
-          // an outbound action (send/react/reply) doesn't surface as an
-          // uncaught error. `autoIdempotency` attaches an x-idempotency-key to
-          // mutating RPCs so the retry can't double-apply.
-          autoIdempotency: true,
-          retry: true,
-          tls: true,
-          token: async () => {
-            await renewal.refreshIfNeeded();
-            return (tokenData as SharedTokenData).token;
-          },
-        }),
-      },
-    ];
+    entries.push({
+      phone: SHARED_PHONE,
+      client: createGrpcClient({
+        address,
+        // Auto-retry transient unary failures so a brief server blip during
+        // an outbound action (send/react/reply) doesn't surface as an
+        // uncaught error. `autoIdempotency` attaches an x-idempotency-key to
+        // mutating RPCs so the retry can't double-apply.
+        autoIdempotency: true,
+        retry: true,
+        tls: true,
+        token: async () => {
+          await renewal.refreshIfNeeded();
+          return (tokenData as SharedTokenData).token;
+        },
+      }),
+    });
 
     cloudAuthState.set(entries, cloudAuth);
 
     return entries;
   }
 
-  const dedicated = tokenData;
-  for (const [instanceId, token] of Object.entries(dedicated.auth)) {
-    const entry: RemoteClient = {
-      phone: requirePhone(dedicated, instanceId),
-      client: createGrpcClient({
-        address: `${instanceId}.imsg.photon.codes:443`,
-        autoIdempotency: true,
-        retry: true,
-        tls: true,
-        token: async () => {
-          await renewal.refreshIfNeeded();
-          const data = tokenData as DedicatedTokenData;
-          return data.auth[instanceId] ?? token;
-        },
-      }),
-    };
-    records.push({ entry, instanceId });
-  }
-  const entries = records.map((r) => r.entry);
+  // Startup is the same reconcile against an empty set, so there is one code
+  // path building lines and one place that decides what a line needs.
+  reconcile(tokenData);
 
   cloudAuthState.set(entries, cloudAuth);
 
@@ -125,6 +243,7 @@ export async function createCloudClients(
 }
 
 export async function disposeCloudAuth(clients: RemoteClient[]): Promise<void> {
+  clearLineObservers(clients);
   const auth = cloudAuthState.get(clients);
   if (auth) {
     auth.dispose();

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -153,16 +153,14 @@ export async function createCloudClients(
    * Brings the client set in line with the token payload, which is the only
    * inventory the cloud exposes: keys present but untracked are newly
    * provisioned, tracked keys that vanished were deprovisioned.
+   *
+   * An empty payload means the project has no lines, not that the response is
+   * suspect — keeping entries the payload no longer covers would leave the
+   * client routing through channels whose tokens have stopped being refreshed.
+   * A genuinely malformed payload (no `auth` at all) throws instead, which the
+   * caller contains before any line is removed.
    */
   const reconcile = (data: DedicatedTokenData): void => {
-    if (Object.keys(data.auth ?? {}).length === 0) {
-      // Never wipe a working set on a degenerate response. At startup `records`
-      // is empty, so this still yields an empty array.
-      authLog.warn(
-        "imessage token response contained no lines; keeping the current set"
-      );
-      return;
-    }
     const removed = removeMissing(data);
     const added = addOrSync(data);
     if (added > 0 || removed > 0) {

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -64,8 +64,13 @@ export async function createCloudClients(
       tls: true,
       token: async () => {
         await renewal.refreshIfNeeded();
-        const data = tokenData as DedicatedTokenData;
-        return data.auth[instanceId] ?? initialToken;
+        // Narrowed, not asserted: a refresh can in principle come back shared
+        // (a plan change), where `auth` does not exist at all — reading through
+        // it would reject every RPC on this line.
+        if (tokenData.type !== "dedicated") {
+          return initialToken;
+        }
+        return tokenData.auth[instanceId] ?? initialToken;
       },
     }),
   });

--- a/packages/imessage/src/lines.ts
+++ b/packages/imessage/src/lines.ts
@@ -48,16 +48,31 @@ export const lineKey = (entry: RemoteClient): string => {
   return generated;
 };
 
+/**
+ * Registers `observer` and returns a disposer that removes just this one, so a
+ * closed message stream stops being called into. `clearLineObservers` remains
+ * the whole-array teardown used when the client itself is destroyed.
+ */
 export const addLineObserver = (
   clients: RemoteClient[],
   observer: LineObserver
-): void => {
+): (() => void) => {
   const existing = observers.get(clients);
   if (existing) {
     existing.add(observer);
-    return;
+  } else {
+    observers.set(clients, new Set([observer]));
   }
-  observers.set(clients, new Set([observer]));
+
+  return () => {
+    const current = observers.get(clients);
+    if (!current?.delete(observer)) {
+      return;
+    }
+    if (current.size === 0) {
+      observers.delete(clients);
+    }
+  };
 };
 
 export const clearLineObservers = (clients: RemoteClient[]): void => {

--- a/packages/imessage/src/lines.ts
+++ b/packages/imessage/src/lines.ts
@@ -1,0 +1,111 @@
+import { createLogger, errorAttrs } from "@spectrum-ts/core/authoring";
+import type { RemoteClient } from "./types";
+
+const linesLog = createLogger("spectrum.imessage.lines");
+
+/**
+ * Notified when the cloud token refresh discovers that a line was provisioned
+ * or deprovisioned. Registered by the message stream so a reconciled line is
+ * subscribed (or unsubscribed) without rebuilding the client array — which is
+ * not an option, since three WeakMaps and core's own references are keyed by
+ * that array's identity.
+ *
+ * `attach` means "ensure this line is subscribed" and must be idempotent: every
+ * refresh re-asserts it for every known line, which is what revives a line
+ * whose stream died.
+ */
+export interface LineObserver {
+  attach(entry: RemoteClient): void;
+  detach(entry: RemoteClient): Promise<void> | void;
+}
+
+const observers = new WeakMap<RemoteClient[], Set<LineObserver>>();
+const lineIds = new WeakMap<RemoteClient, string>();
+
+let fallbackKeys = 0;
+
+/** Pairs an entry with the cloud instance it was built from. */
+export const setLineId = (entry: RemoteClient, instanceId: string): void => {
+  lineIds.set(entry, instanceId);
+};
+
+export const getLineId = (entry: RemoteClient): string | undefined =>
+  lineIds.get(entry);
+
+/**
+ * Stable per-entry key. Falls back to a generated id for explicitly-configured
+ * clients, which carry no instance id and may legitimately repeat a phone
+ * number — phone alone would collide.
+ */
+export const lineKey = (entry: RemoteClient): string => {
+  const existing = lineIds.get(entry);
+  if (existing) {
+    return existing;
+  }
+  fallbackKeys += 1;
+  const generated = `line-${fallbackKeys}`;
+  lineIds.set(entry, generated);
+  return generated;
+};
+
+export const addLineObserver = (
+  clients: RemoteClient[],
+  observer: LineObserver
+): void => {
+  const existing = observers.get(clients);
+  if (existing) {
+    existing.add(observer);
+    return;
+  }
+  observers.set(clients, new Set([observer]));
+};
+
+export const clearLineObservers = (clients: RemoteClient[]): void => {
+  observers.delete(clients);
+};
+
+/**
+ * Synchronous by contract: `reconcile` calls this immediately after pushing the
+ * entry, with no await in between, so an observer can never see a half-applied
+ * array. A throwing observer is contained — it must not be able to reject the
+ * token refresh, which would stall renewal for every line.
+ */
+export const notifyLineAttached = (
+  clients: RemoteClient[],
+  entry: RemoteClient
+): void => {
+  for (const observer of observers.get(clients) ?? []) {
+    try {
+      observer.attach(entry);
+    } catch (error) {
+      linesLog.warn(
+        "imessage line observer failed to attach",
+        errorAttrs(error),
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+};
+
+/**
+ * Returns each observer's detach promise so the caller can settle them off the
+ * refresh path — a wedged stream close must not stall token renewal.
+ */
+export const notifyLineDetached = (
+  clients: RemoteClient[],
+  entry: RemoteClient
+): Promise<void>[] => {
+  const pending: Promise<void>[] = [];
+  for (const observer of observers.get(clients) ?? []) {
+    try {
+      pending.push(Promise.resolve(observer.detach(entry)));
+    } catch (error) {
+      linesLog.warn(
+        "imessage line observer failed to detach",
+        errorAttrs(error),
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+  return pending;
+};

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -540,14 +540,24 @@ export const messages = (
     group.add(lineKey(entry), build(entry));
   }
 
-  if (!shared) {
-    addLineObserver(clients, {
-      attach: (entry) => {
-        group.add(lineKey(entry), build(entry));
-      },
-      detach: (entry) => group.remove(lineKey(entry)).then(() => undefined),
-    });
+  if (shared) {
+    return group;
   }
 
-  return group;
+  const disposeObserver = addLineObserver(clients, {
+    attach: (entry) => {
+      group.add(lineKey(entry), build(entry));
+    },
+    detach: (entry) => group.remove(lineKey(entry)).then(() => undefined),
+  });
+
+  // Drop the observer when the stream closes: it holds this group, and a later
+  // reconcile must not keep calling into a group that can no longer emit.
+  const closeGroup = group.close.bind(group);
+  return Object.assign(group, {
+    close: async (): Promise<void> => {
+      disposeObserver();
+      await closeGroup();
+    },
+  });
 };

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -16,12 +16,14 @@ import {
 import {
   type CloseableAsyncIterable,
   createLogger,
+  createStreamGroup,
   errorAttrs,
   type ResumableStreamItem,
   resumableOrderedStream,
 } from "@spectrum-ts/core/authoring";
 import { getCloudRecover } from "../auth";
 import { getMessageCache, getPollCache, type PollCache } from "../cache";
+import { addLineObserver, lineKey } from "../lines";
 import {
   type IMessageMessage,
   type RemoteClient,
@@ -508,21 +510,44 @@ export const messages = (
   // return undefined (nothing to refresh). Shared across this client array's
   // streams so the message + poll loops coalesce onto one re-mint.
   const recover = getCloudRecover(clients);
-  const includeGroupEvents = !isSharedMode(clients);
-  return mergeStreams(
-    clients.map((entry) => {
-      const tracker =
-        staticShareEnabled || profileSyncGate
-          ? getContactShareTracker(entry.client)
-          : undefined;
-      return clientStream(
-        entry.client,
-        pollCache,
-        entry.phone,
-        includeGroupEvents,
-        tracker ? contactShareHandler(tracker, profileSyncGate) : undefined,
-        recover
-      );
-    })
-  );
+  const shared = isSharedMode(clients);
+  // Frozen for the life of the stream, which is correct: only a shared array
+  // makes this false, and a shared array never reconciles.
+  const includeGroupEvents = !shared;
+
+  const build = (entry: RemoteClient) => (): ManagedStream<IMessageMessage> => {
+    const tracker =
+      staticShareEnabled || profileSyncGate
+        ? getContactShareTracker(entry.client)
+        : undefined;
+    return clientStream(
+      entry.client,
+      pollCache,
+      entry.phone,
+      includeGroupEvents,
+      tracker ? contactShareHandler(tracker, profileSyncGate) : undefined,
+      recover
+    );
+  };
+
+  // A group rather than `mergeStreams`, because the line set changes underneath
+  // us: the cloud token refresh reconciles newly provisioned and deprovisioned
+  // lines into the same array, and those have to reach a running stream.
+  const group = createStreamGroup<IMessageMessage>({
+    label: "imessage.messages",
+  });
+  for (const entry of clients) {
+    group.add(lineKey(entry), build(entry));
+  }
+
+  if (!shared) {
+    addLineObserver(clients, {
+      attach: (entry) => {
+        group.add(lineKey(entry), build(entry));
+      },
+      detach: (entry) => group.remove(lineKey(entry)).then(() => undefined),
+    });
+  }
+
+  return group;
 };

--- a/packages/imessage/test/auth.test.ts
+++ b/packages/imessage/test/auth.test.ts
@@ -7,8 +7,24 @@ interface FakeDedicatedTokenData {
   type: "dedicated";
 }
 
+interface FakeSharedTokenData {
+  expiresIn: number;
+  token: string;
+  type: "shared";
+}
+
+type FakeTokenData = FakeDedicatedTokenData | FakeSharedTokenData;
+
 interface FakeClientOptions {
+  address: string;
+  autoIdempotency?: boolean;
+  retry?: boolean;
+  tls?: boolean;
   token: () => Promise<string>;
+}
+
+interface FakeClient {
+  close: ReturnType<typeof vi.fn>;
 }
 
 const initialTokenData: FakeDedicatedTokenData = {
@@ -18,11 +34,29 @@ const initialTokenData: FakeDedicatedTokenData = {
   type: "dedicated",
 };
 
-const issueImessageTokens = vi.fn(() => Promise.resolve(initialTokenData));
+// Builds a dedicated payload from instanceId -> phone, so each test reads as
+// the line inventory it is asserting against.
+const dedicated = (
+  numbers: Record<string, string | null>
+): FakeDedicatedTokenData => ({
+  auth: Object.fromEntries(
+    Object.keys(numbers).map((id) => [id, `token-${id}`])
+  ),
+  expiresIn: 3600,
+  numbers,
+  type: "dedicated",
+});
+
+const issueImessageTokens = vi.fn(
+  (): Promise<FakeTokenData> => Promise.resolve(initialTokenData)
+);
 const clientOptions: FakeClientOptions[] = [];
+const fakeClients: FakeClient[] = [];
 const createGrpcClient = vi.fn((options: FakeClientOptions) => {
   clientOptions.push(options);
-  return {};
+  const client: FakeClient = { close: vi.fn(() => Promise.resolve()) };
+  fakeClients.push(client);
+  return client;
 });
 
 vi.doMock("@spectrum-ts/core", async (importOriginal) => {
@@ -38,6 +72,32 @@ vi.doMock("@photon-ai/advanced-imessage/grpc", () => ({ createGrpcClient }));
 const { createCloudClients, disposeCloudAuth, getCloudRecover } = await import(
   "@/auth"
 );
+const { addLineObserver } = await import("@/lines");
+
+// The recover hook runs the same closure the renewal timer does, so it is the
+// cheapest way to drive a refresh. It is throttled to one re-mint per 5s.
+const FORCE_REFRESH_FLOOR_MS = 5000;
+
+const startClients = async (initial: FakeTokenData) => {
+  vi.useFakeTimers();
+  vi.setSystemTime(0);
+  issueImessageTokens.mockResolvedValueOnce(initial);
+  const clients = await createCloudClients("project-1", "secret-1");
+  const recover = getCloudRecover(clients);
+  if (!recover) {
+    throw new Error("expected cloud recovery hook");
+  }
+
+  const refresh = async (next: FakeTokenData): Promise<void> => {
+    issueImessageTokens.mockResolvedValueOnce(next);
+    await vi.advanceTimersByTimeAsync(FORCE_REFRESH_FLOOR_MS);
+    await recover();
+    // Settle the fire-and-forget retire of any removed line.
+    await vi.advanceTimersByTimeAsync(0);
+  };
+
+  return { clients, refresh };
+};
 
 describe("imessage cloud auth", () => {
   beforeEach(() => {
@@ -45,6 +105,7 @@ describe("imessage cloud auth", () => {
     issueImessageTokens.mockResolvedValue(initialTokenData);
     createGrpcClient.mockClear();
     clientOptions.length = 0;
+    fakeClients.length = 0;
   });
 
   afterEach(() => {
@@ -92,5 +153,185 @@ describe("imessage cloud auth", () => {
 
     await disposeCloudAuth(clients);
     expect(getCloudRecover(clients)).toBeUndefined();
+  });
+
+  it("attaches a line provisioned after startup", async () => {
+    const { clients, refresh } = await startClients(
+      dedicated({ "instance-1": "+15550000001" })
+    );
+    const arrayRef = clients;
+
+    await refresh(
+      dedicated({ "instance-1": "+15550000001", "instance-2": "+15550000002" })
+    );
+
+    expect(clients).toHaveLength(2);
+    expect(clients.map((entry) => entry.phone)).toEqual([
+      "+15550000001",
+      "+15550000002",
+    ]);
+    expect(createGrpcClient).toHaveBeenCalledTimes(2);
+    // The array is mutated, never replaced: the cloud-auth, poll-cache, and
+    // profile-sync WeakMaps are all keyed by its identity.
+    expect(clients).toBe(arrayRef);
+    expect(getCloudRecover(arrayRef)).toBeDefined();
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("builds an added line with the same client options as startup", async () => {
+    const { clients, refresh } = await startClients(
+      dedicated({ "instance-1": "+15550000001" })
+    );
+
+    await refresh(
+      dedicated({ "instance-1": "+15550000001", "instance-2": "+15550000002" })
+    );
+
+    const [first, second] = clientOptions;
+    const transport = (options?: FakeClientOptions) => ({
+      autoIdempotency: options?.autoIdempotency,
+      retry: options?.retry,
+      tls: options?.tls,
+    });
+    expect(transport(second)).toEqual(transport(first));
+    expect(second?.address).toBe("instance-2.imsg.photon.codes:443");
+    expect(await second?.token()).toBe("token-instance-2");
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("detaches a deprovisioned line and closes its channel", async () => {
+    const { clients, refresh } = await startClients(
+      dedicated({ "instance-1": "+15550000001", "instance-2": "+15550000002" })
+    );
+    expect(clients).toHaveLength(2);
+
+    await refresh(dedicated({ "instance-2": "+15550000002" }));
+
+    expect(clients).toHaveLength(1);
+    expect(clients[0]?.phone).toBe("+15550000002");
+    expect(fakeClients[0]?.close).toHaveBeenCalledTimes(1);
+    expect(fakeClients[1]?.close).not.toHaveBeenCalled();
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("skips a line without a phone number instead of failing startup", async () => {
+    const { clients } = await startClients(dedicated({ "instance-1": null }));
+
+    expect(clients).toEqual([]);
+    expect(createGrpcClient).not.toHaveBeenCalled();
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("picks up a line once its number is assigned", async () => {
+    const { clients, refresh } = await startClients(
+      dedicated({ "instance-1": null })
+    );
+    expect(clients).toEqual([]);
+
+    await refresh(dedicated({ "instance-1": "+15550000001" }));
+
+    expect(clients).toHaveLength(1);
+    expect(clients[0]?.phone).toBe("+15550000001");
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("keeps a known line usable when it loses its number mid-refresh", async () => {
+    const { clients, refresh } = await startClients(
+      dedicated({ "instance-1": "+15550000001" })
+    );
+
+    await refresh(dedicated({ "instance-1": null }));
+
+    expect(clients).toHaveLength(1);
+    expect(clients[0]?.phone).toBe("+15550000001");
+
+    // The refresh must have completed normally: a rejected refresh leaves the
+    // token deadline unadvanced, and `refreshIfNeeded` runs on every RPC, so
+    // every call on every line would re-mint.
+    const calls = issueImessageTokens.mock.calls.length;
+    expect(await clientOptions[0]?.token()).toBe("token-instance-1");
+    expect(issueImessageTokens).toHaveBeenCalledTimes(calls);
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("keeps the current set when the response reports no lines", async () => {
+    const { clients, refresh } = await startClients(
+      dedicated({ "instance-1": "+15550000001" })
+    );
+
+    await refresh(dedicated({}));
+
+    expect(clients).toHaveLength(1);
+    expect(clients[0]?.phone).toBe("+15550000001");
+    expect(fakeClients[0]?.close).not.toHaveBeenCalled();
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("leaves shared mode untouched across a refresh", async () => {
+    const shared: FakeSharedTokenData = {
+      expiresIn: 3600,
+      token: "shared-1",
+      type: "shared",
+    };
+    const { clients, refresh } = await startClients(shared);
+    expect(clients).toHaveLength(1);
+    expect(clients[0]?.phone).toBe("shared");
+
+    await refresh({ ...shared, token: "shared-2" });
+
+    expect(clients).toHaveLength(1);
+    expect(createGrpcClient).toHaveBeenCalledTimes(1);
+    expect(await clientOptions[0]?.token()).toBe("shared-2");
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("re-asserts every known line on refresh so a dropped stream revives", async () => {
+    const { clients, refresh } = await startClients(
+      dedicated({ "instance-1": "+15550000001" })
+    );
+    const attached: string[] = [];
+    addLineObserver(clients, {
+      attach: (entry) => {
+        attached.push(entry.phone);
+      },
+      detach: () => Promise.resolve(),
+    });
+
+    // Same line set: the stream layer drops a line whose stream died, so the
+    // refresh must re-assert it rather than assume it is still subscribed.
+    await refresh(dedicated({ "instance-1": "+15550000001" }));
+
+    expect(attached).toEqual(["+15550000001"]);
+    expect(clients).toHaveLength(1);
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("survives an observer that throws while attaching", async () => {
+    const { clients, refresh } = await startClients(
+      dedicated({ "instance-1": "+15550000001" })
+    );
+    addLineObserver(clients, {
+      attach: () => {
+        throw new Error("observer boom");
+      },
+      detach: () => Promise.resolve(),
+    });
+
+    await refresh(
+      dedicated({ "instance-1": "+15550000001", "instance-2": "+15550000002" })
+    );
+
+    expect(clients).toHaveLength(2);
+
+    await disposeCloudAuth(clients);
   });
 });

--- a/packages/imessage/test/auth.test.ts
+++ b/packages/imessage/test/auth.test.ts
@@ -260,16 +260,17 @@ describe("imessage cloud auth", () => {
     await disposeCloudAuth(clients);
   });
 
-  it("keeps the current set when the response reports no lines", async () => {
+  it("removes every line when the response reports no lines", async () => {
     const { clients, refresh } = await startClients(
       dedicated({ "instance-1": "+15550000001" })
     );
 
+    // No lines is a real inventory, not a suspect response: holding the entry
+    // would keep routing through a channel whose token no longer refreshes.
     await refresh(dedicated({}));
 
-    expect(clients).toHaveLength(1);
-    expect(clients[0]?.phone).toBe("+15550000001");
-    expect(fakeClients[0]?.close).not.toHaveBeenCalled();
+    expect(clients).toEqual([]);
+    expect(fakeClients[0]?.close).toHaveBeenCalledTimes(1);
 
     await disposeCloudAuth(clients);
   });

--- a/packages/imessage/test/remote/stream.test.ts
+++ b/packages/imessage/test/remote/stream.test.ts
@@ -1,6 +1,12 @@
 import type { AdvancedIMessage } from "@photon-ai/advanced-imessage/grpc";
-import { flush, settleSoon } from "@spectrum-ts/test-support/timing";
+import {
+  flush,
+  NO_MESSAGE_WAIT_MS,
+  settleSoon,
+  withinMs,
+} from "@spectrum-ts/test-support/timing";
 import { describe, expect, it, vi } from "vitest";
+import { notifyLineAttached, notifyLineDetached } from "@/lines";
 import type { ProfileSyncGate } from "@/remote/profile-sync-gate";
 import { messages } from "@/remote/stream";
 import { type RemoteClient, SHARED_PHONE } from "@/types";
@@ -549,5 +555,189 @@ describe("remote iMessage streams", () => {
 
     await stream.close();
     await settleSoon(iterator.next());
+  });
+});
+
+// A line whose message events the test drives by hand.
+const pushableClient = (phone: string) => {
+  const events = pushEventStream<ReturnType<typeof inboundEvent>>();
+  const subscribeToMessages = vi.fn(() => events.stream);
+  const subscribeToPolls = vi.fn(idleEventStream);
+  const subscribeToGroups = vi.fn(idleEventStream);
+  const entry: RemoteClient = {
+    phone,
+    client: {
+      groups: { subscribeEvents: subscribeToGroups },
+      messages: { subscribeEvents: subscribeToMessages },
+      polls: { subscribeEvents: subscribeToPolls },
+    } as unknown as AdvancedIMessage,
+  };
+
+  return { entry, push: events.push, subscribeToMessages };
+};
+
+// The reconcile contract from `auth.ts`: the array is mutated in place, then
+// observers are notified synchronously.
+const attachLine = (
+  clients: RemoteClient[],
+  entry: RemoteClient
+): RemoteClient[] => {
+  clients.push(entry);
+  notifyLineAttached(clients, entry);
+  return clients;
+};
+
+const detachLine = async (
+  clients: RemoteClient[],
+  entry: RemoteClient
+): Promise<void> => {
+  const index = clients.indexOf(entry);
+  if (index >= 0) {
+    clients.splice(index, 1);
+  }
+  await Promise.all(notifyLineDetached(clients, entry));
+};
+
+describe("iMessage line reconciliation", () => {
+  it("subscribes and delivers from a line attached while running", async () => {
+    const first = pushableClient("+15550100");
+    const second = pushableClient("+15550200");
+    const clients = [first.entry];
+
+    const stream = messages(clients);
+    const iterator = stream[Symbol.asyncIterator]();
+
+    const firstPending = iterator.next();
+    first.push(inboundEvent(1, "chat-A"));
+    expect((await firstPending).value?.space).toMatchObject({
+      phone: "+15550100",
+    });
+
+    attachLine(clients, second.entry);
+    await vi.waitFor(() => {
+      expect(second.subscribeToMessages).toHaveBeenCalledTimes(1);
+    });
+
+    const secondPending = iterator.next();
+    second.push(inboundEvent(2, "chat-B"));
+    expect((await secondPending).value?.space).toMatchObject({
+      phone: "+15550200",
+    });
+
+    await stream.close();
+    await settleSoon(iterator.next());
+  });
+
+  it("subscribes a line attached before the stream is first pulled", async () => {
+    const first = pushableClient("+15550100");
+    const second = pushableClient("+15550200");
+    const clients = [first.entry];
+
+    const stream = messages(clients);
+    attachLine(clients, second.entry);
+
+    const iterator = stream[Symbol.asyncIterator]();
+    const pending = iterator.next();
+    await flush();
+
+    expect(first.subscribeToMessages).toHaveBeenCalledTimes(1);
+    expect(second.subscribeToMessages).toHaveBeenCalledTimes(1);
+
+    await stream.close();
+    await settleSoon(pending);
+  });
+
+  it("stops delivering from a detached line without disturbing the rest", async () => {
+    const kept = pushableClient("+15550100");
+    const removed = pushableClient("+15550200");
+    const clients = [kept.entry, removed.entry];
+
+    const stream = messages(clients);
+    const iterator = stream[Symbol.asyncIterator]();
+
+    const primed = iterator.next();
+    kept.push(inboundEvent(1, "chat-A"));
+    await primed;
+
+    await detachLine(clients, removed.entry);
+
+    const afterDetach = iterator.next();
+    removed.push(inboundEvent(2, "chat-B"));
+    expect(await withinMs(afterDetach, NO_MESSAGE_WAIT_MS)).toBe("timeout");
+
+    kept.push(inboundEvent(3, "chat-A"));
+    expect((await afterDetach).value?.space).toMatchObject({
+      phone: "+15550100",
+    });
+
+    await stream.close();
+    await settleSoon(iterator.next());
+  });
+
+  it("stays open after its last line is detached", async () => {
+    const only = pushableClient("+15550100");
+    const clients = [only.entry];
+
+    const stream = messages(clients);
+    const iterator = stream[Symbol.asyncIterator]();
+
+    const primed = iterator.next();
+    only.push(inboundEvent(1, "chat-A"));
+    await primed;
+
+    await detachLine(clients, only.entry);
+
+    // `mergeStreams` would have ended here — the whole point of the group.
+    const pending = iterator.next();
+    expect(await withinMs(pending, NO_MESSAGE_WAIT_MS)).toBe("timeout");
+
+    const replacement = pushableClient("+15550300");
+    attachLine(clients, replacement.entry);
+    replacement.push(inboundEvent(2, "chat-C"));
+    expect((await pending).value?.space).toMatchObject({
+      phone: "+15550300",
+    });
+
+    await stream.close();
+    await settleSoon(iterator.next());
+  });
+
+  it("ignores line notifications in shared mode", async () => {
+    const shared = pushableClient(SHARED_PHONE);
+    const extra = pushableClient("+15550100");
+    const clients = [shared.entry];
+
+    const stream = messages(clients);
+    const iterator = stream[Symbol.asyncIterator]();
+    const pending = iterator.next();
+    await flush();
+
+    attachLine(clients, extra.entry);
+    await flush();
+
+    expect(extra.subscribeToMessages).not.toHaveBeenCalled();
+
+    await stream.close();
+    await settleSoon(pending);
+  });
+
+  it("subscribes a line once when attached twice", async () => {
+    const first = pushableClient("+15550100");
+    const second = pushableClient("+15550200");
+    const clients = [first.entry];
+
+    const stream = messages(clients);
+    const iterator = stream[Symbol.asyncIterator]();
+    const pending = iterator.next();
+    await flush();
+
+    attachLine(clients, second.entry);
+    notifyLineAttached(clients, second.entry);
+    await flush();
+
+    expect(second.subscribeToMessages).toHaveBeenCalledTimes(1);
+
+    await stream.close();
+    await settleSoon(pending);
   });
 });

--- a/packages/imessage/test/remote/stream.test.ts
+++ b/packages/imessage/test/remote/stream.test.ts
@@ -6,7 +6,11 @@ import {
   withinMs,
 } from "@spectrum-ts/test-support/timing";
 import { describe, expect, it, vi } from "vitest";
-import { notifyLineAttached, notifyLineDetached } from "@/lines";
+import {
+  addLineObserver,
+  notifyLineAttached,
+  notifyLineDetached,
+} from "@/lines";
 import type { ProfileSyncGate } from "@/remote/profile-sync-gate";
 import { messages } from "@/remote/stream";
 import { type RemoteClient, SHARED_PHONE } from "@/types";
@@ -719,6 +723,51 @@ describe("iMessage line reconciliation", () => {
 
     await stream.close();
     await settleSoon(pending);
+  });
+
+  it("disposes only the observer that registered it", () => {
+    const clients: RemoteClient[] = [];
+    const kept: string[] = [];
+    const dropped: string[] = [];
+    const disposeDropped = addLineObserver(clients, {
+      attach: (entry) => {
+        dropped.push(entry.phone);
+      },
+      detach: () => undefined,
+    });
+    addLineObserver(clients, {
+      attach: (entry) => {
+        kept.push(entry.phone);
+      },
+      detach: () => undefined,
+    });
+
+    disposeDropped();
+    notifyLineAttached(clients, pushableClient("+15550100").entry);
+
+    expect(dropped).toEqual([]);
+    expect(kept).toEqual(["+15550100"]);
+  });
+
+  it("stops observing lines once the stream is closed", async () => {
+    const first = pushableClient("+15550100");
+    const later = pushableClient("+15550200");
+    const clients = [first.entry];
+
+    const stream = messages(clients);
+    const iterator = stream[Symbol.asyncIterator]();
+    const pending = iterator.next();
+    await flush();
+
+    await stream.close();
+    await settleSoon(pending);
+
+    // The observer holds the closed group; a reconcile after teardown must not
+    // reach it, and must never open a subscription that nothing will close.
+    attachLine(clients, later.entry);
+    await flush();
+
+    expect(later.subscribeToMessages).not.toHaveBeenCalled();
   });
 
   it("subscribes a line once when attached twice", async () => {

--- a/packages/test-support/src/timing.ts
+++ b/packages/test-support/src/timing.ts
@@ -38,3 +38,28 @@ export const settleSoon = (
 // promises (e.g. a tracker's background share) settle before assertions.
 export const flush = (): Promise<void> =>
   new Promise((resolve) => setImmediate(resolve));
+
+// Drain a stream until it goes idle, then close it. For streams whose lifetime
+// is owned by the holder rather than its sources (createStreamGroup), "no more
+// messages" cannot be observed as EOF — a provider's line ending must not end
+// the app's stream — so idleness is the terminator.
+export const collectUntilIdle = async <T>(
+  source: AsyncIterable<T> & { close(): Promise<void> }
+): Promise<T[]> => {
+  const iterator = source[Symbol.asyncIterator]();
+  const received: T[] = [];
+  for (;;) {
+    const next = iterator.next();
+    if ((await withinMs(next, NO_MESSAGE_WAIT_MS)) === "timeout") {
+      await source.close();
+      await settleSoon(next);
+      break;
+    }
+    const result = await next;
+    if (result.done) {
+      break;
+    }
+    received.push(result.value);
+  }
+  return received;
+};

--- a/packages/test-support/src/timing.ts
+++ b/packages/test-support/src/timing.ts
@@ -48,18 +48,36 @@ export const collectUntilIdle = async <T>(
 ): Promise<T[]> => {
   const iterator = source[Symbol.asyncIterator]();
   const received: T[] = [];
-  for (;;) {
-    const next = iterator.next();
-    if ((await withinMs(next, NO_MESSAGE_WAIT_MS)) === "timeout") {
-      await source.close();
-      await settleSoon(next);
-      break;
+  let closed = false;
+  // Idempotent: the timeout path closes, and a `next` that rejects afterwards
+  // reaches the catch below, which must not close a second time.
+  const close = async (): Promise<void> => {
+    if (closed) {
+      return;
     }
-    const result = await next;
-    if (result.done) {
-      break;
+    closed = true;
+    await source.close();
+  };
+
+  try {
+    for (;;) {
+      const next = iterator.next();
+      if ((await withinMs(next, NO_MESSAGE_WAIT_MS)) === "timeout") {
+        await close();
+        await settleSoon(next);
+        break;
+      }
+      const result = await next;
+      if (result.done) {
+        break;
+      }
+      received.push(result.value);
     }
-    received.push(result.value);
+  } catch (error) {
+    // A failing stream still has to be released, or the caller leaks it and the
+    // real failure gets buried under a hanging suite.
+    await close();
+    throw error;
   }
   return received;
 };

--- a/packages/whatsapp-business/src/auth.ts
+++ b/packages/whatsapp-business/src/auth.ts
@@ -11,10 +11,21 @@ import {
   createTokenRenewal,
   errorAttrs,
 } from "@spectrum-ts/core/authoring";
+import {
+  clearLineObservers,
+  notifyLineAttached,
+  notifyLineDetached,
+  setLineId,
+} from "./lines";
 
 const streamLog = createLogger("spectrum.whatsapp.stream");
+const authLog = createLogger("spectrum.whatsapp.auth");
 
 const RESUBSCRIBE_BACKOFF_MS = 500;
+
+const lineAttrs = (phoneNumberId: string) => ({
+  "spectrum.whatsapp.line": phoneNumberId,
+});
 
 const ignoreCleanupError = () => undefined;
 
@@ -47,6 +58,12 @@ export async function createCloudClients(
   );
 
   const lines = new Map<string, LineState>();
+  // This array object is never replaced — only `push`/`splice`. Callers read it
+  // live, and the cloud-auth state is keyed by its identity.
+  const clients: WhatsAppClient[] = [];
+  // phoneNumberId -> the public proxy, so a refresh can tell an existing line
+  // from a newly provisioned one.
+  const records = new Map<string, WhatsAppClient>();
 
   const buildRawClient = (phoneNumberId: string): WhatsAppClient => {
     const accessToken = tokenData.auth[phoneNumberId];
@@ -56,6 +73,92 @@ export async function createCloudClients(
       );
     }
     return createClient({ accessToken, appSecret: "", phoneNumberId });
+  };
+
+  const attachLine = (phoneNumberId: string): void => {
+    const state: LineState = {
+      current: buildRawClient(phoneNumberId),
+      subscriptions: new Set(),
+    };
+    lines.set(phoneNumberId, state);
+    const proxy = buildClientProxy(state, renewal.refreshIfNeeded);
+    setLineId(proxy, phoneNumberId);
+    records.set(phoneNumberId, proxy);
+    clients.push(proxy);
+    // Synchronous, and adjacent to the push, so an observer can never see a
+    // half-applied array.
+    notifyLineAttached(clients, proxy);
+  };
+
+  // Detach the stream before closing the line: the proxy's close tears down its
+  // subscriptions and underlying client. Never awaited by the refresh — a
+  // wedged close must not stall token renewal.
+  const retire = async (proxy: WhatsAppClient): Promise<void> => {
+    await Promise.allSettled(notifyLineDetached(clients, proxy));
+    await proxy.close();
+  };
+
+  const removeMissing = (auth: Record<string, string>): number => {
+    let removed = 0;
+    for (const [phoneNumberId, proxy] of records) {
+      if (auth[phoneNumberId]) {
+        continue;
+      }
+      records.delete(phoneNumberId);
+      lines.delete(phoneNumberId);
+      const index = clients.indexOf(proxy);
+      if (index >= 0) {
+        clients.splice(index, 1);
+      }
+      removed += 1;
+      retire(proxy).catch((error: unknown) => {
+        authLog.warn(
+          "failed to retire whatsapp line",
+          { ...lineAttrs(phoneNumberId), ...errorAttrs(error) },
+          error instanceof Error ? error : undefined
+        );
+      });
+    }
+    return removed;
+  };
+
+  /**
+   * Brings the client set in line with the token payload, which is the only
+   * line inventory the cloud exposes: keys present but untracked are newly
+   * provisioned, tracked keys that vanished were deprovisioned.
+   */
+  const reconcile = (auth: Record<string, string>): void => {
+    const next = Object.keys(auth ?? {});
+    if (next.length === 0) {
+      // Never wipe a working set on a degenerate response. At startup `records`
+      // is empty, so this still yields an empty array.
+      authLog.warn(
+        "whatsapp token response contained no lines; keeping the current set"
+      );
+      return;
+    }
+    const removed = removeMissing(auth);
+    let added = 0;
+    for (const phoneNumberId of next) {
+      const existing = records.get(phoneNumberId);
+      if (existing) {
+        // Re-assert the subscription rather than assuming it survived. The
+        // stream layer drops a line whose stream died, and attaching is
+        // idempotent, so this is what revives it — otherwise a dropped line
+        // would stay dark for the life of the process.
+        notifyLineAttached(clients, existing);
+        continue;
+      }
+      attachLine(phoneNumberId);
+      added += 1;
+    }
+    if (added > 0 || removed > 0) {
+      authLog.info("whatsapp lines reconciled", {
+        "spectrum.whatsapp.lines.added": added,
+        "spectrum.whatsapp.lines.removed": removed,
+        "spectrum.whatsapp.lines.total": clients.length,
+      });
+    }
   };
 
   const refreshTokens = async (): Promise<void> => {
@@ -75,6 +178,19 @@ export async function createCloudClients(
       }
       await old.close().catch(() => undefined);
     }
+
+    try {
+      reconcile(tokenData.auth);
+    } catch (error) {
+      // Rejecting here would leave the renewal's expiry unadvanced, and
+      // `refreshIfNeeded` runs before every RPC, so every call on every line
+      // would then re-enter the refresh. Reconcile failures stay contained.
+      authLog.error(
+        "whatsapp line reconcile failed",
+        errorAttrs(error),
+        error instanceof Error ? error : undefined
+      );
+    }
   };
 
   const renewal = createTokenRenewal({
@@ -83,16 +199,9 @@ export async function createCloudClients(
     refresh: refreshTokens,
   });
 
-  const clients: WhatsAppClient[] = Object.keys(tokenData.auth).map(
-    (phoneNumberId) => {
-      const state: LineState = {
-        current: buildRawClient(phoneNumberId),
-        subscriptions: new Set(),
-      };
-      lines.set(phoneNumberId, state);
-      return buildClientProxy(state, renewal.refreshIfNeeded);
-    }
-  );
+  // Startup is the same reconcile against an empty set, so there is one code
+  // path building lines.
+  reconcile(tokenData.auth);
 
   cloudAuthState.set(clients, {
     dispose: async () => {
@@ -115,6 +224,7 @@ export async function createCloudClients(
 export async function disposeCloudAuth(
   clients: WhatsAppClient[]
 ): Promise<void> {
+  clearLineObservers(clients);
   const auth = cloudAuthState.get(clients);
   if (!auth) {
     return;

--- a/packages/whatsapp-business/src/auth.ts
+++ b/packages/whatsapp-business/src/auth.ts
@@ -126,17 +126,15 @@ export async function createCloudClients(
    * Brings the client set in line with the token payload, which is the only
    * line inventory the cloud exposes: keys present but untracked are newly
    * provisioned, tracked keys that vanished were deprovisioned.
+   *
+   * An empty payload means the project has no lines, not that the response is
+   * suspect — keeping entries the payload no longer covers would leave the
+   * client routing through lines whose tokens have stopped being refreshed. A
+   * genuinely malformed payload (no `auth` at all) throws instead, which the
+   * caller contains before any line is removed.
    */
   const reconcile = (auth: Record<string, string>): void => {
-    const next = Object.keys(auth ?? {});
-    if (next.length === 0) {
-      // Never wipe a working set on a degenerate response. At startup `records`
-      // is empty, so this still yields an empty array.
-      authLog.warn(
-        "whatsapp token response contained no lines; keeping the current set"
-      );
-      return;
-    }
+    const next = Object.keys(auth);
     const removed = removeMissing(auth);
     let added = 0;
     for (const phoneNumberId of next) {

--- a/packages/whatsapp-business/src/lines.ts
+++ b/packages/whatsapp-business/src/lines.ts
@@ -46,16 +46,31 @@ export const lineKey = (client: WhatsAppClient): string => {
   return generated;
 };
 
+/**
+ * Registers `observer` and returns a disposer that removes just this one, so a
+ * closed message stream stops being called into. `clearLineObservers` remains
+ * the whole-array teardown used when the client itself is destroyed.
+ */
 export const addLineObserver = (
   clients: WhatsAppClient[],
   observer: LineObserver
-): void => {
+): (() => void) => {
   const existing = observers.get(clients);
   if (existing) {
     existing.add(observer);
-    return;
+  } else {
+    observers.set(clients, new Set([observer]));
   }
-  observers.set(clients, new Set([observer]));
+
+  return () => {
+    const current = observers.get(clients);
+    if (!current?.delete(observer)) {
+      return;
+    }
+    if (current.size === 0) {
+      observers.delete(clients);
+    }
+  };
 };
 
 export const clearLineObservers = (clients: WhatsAppClient[]): void => {

--- a/packages/whatsapp-business/src/lines.ts
+++ b/packages/whatsapp-business/src/lines.ts
@@ -1,0 +1,109 @@
+import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
+import { createLogger, errorAttrs } from "@spectrum-ts/core/authoring";
+
+const linesLog = createLogger("spectrum.whatsapp.lines");
+
+/**
+ * Notified when the cloud token refresh discovers that a line was provisioned
+ * or deprovisioned. Registered by the message stream so a reconciled line is
+ * subscribed (or unsubscribed) without rebuilding the client array, whose
+ * identity keys the cloud-auth state.
+ *
+ * `attach` means "ensure this line is subscribed" and must be idempotent: every
+ * refresh re-asserts it for every known line, which is what revives a line
+ * whose stream died.
+ */
+export interface LineObserver {
+  attach(client: WhatsAppClient): void;
+  detach(client: WhatsAppClient): Promise<void> | void;
+}
+
+const observers = new WeakMap<WhatsAppClient[], Set<LineObserver>>();
+const lineIds = new WeakMap<WhatsAppClient, string>();
+
+let fallbackKeys = 0;
+
+/** Pairs a client with the phone number id it was built for. */
+export const setLineId = (
+  client: WhatsAppClient,
+  phoneNumberId: string
+): void => {
+  lineIds.set(client, phoneNumberId);
+};
+
+/**
+ * Stable per-client key. Falls back to a generated id for directly-configured
+ * clients, which are not built from a token payload and carry no line id.
+ */
+export const lineKey = (client: WhatsAppClient): string => {
+  const existing = lineIds.get(client);
+  if (existing) {
+    return existing;
+  }
+  fallbackKeys += 1;
+  const generated = `line-${fallbackKeys}`;
+  lineIds.set(client, generated);
+  return generated;
+};
+
+export const addLineObserver = (
+  clients: WhatsAppClient[],
+  observer: LineObserver
+): void => {
+  const existing = observers.get(clients);
+  if (existing) {
+    existing.add(observer);
+    return;
+  }
+  observers.set(clients, new Set([observer]));
+};
+
+export const clearLineObservers = (clients: WhatsAppClient[]): void => {
+  observers.delete(clients);
+};
+
+/**
+ * Synchronous by contract: the reconcile calls this immediately after pushing
+ * the client, with no await in between, so an observer can never see a
+ * half-applied array. A throwing observer is contained — it must not be able to
+ * reject the token refresh, which would stall renewal for every line.
+ */
+export const notifyLineAttached = (
+  clients: WhatsAppClient[],
+  client: WhatsAppClient
+): void => {
+  for (const observer of observers.get(clients) ?? []) {
+    try {
+      observer.attach(client);
+    } catch (error) {
+      linesLog.warn(
+        "whatsapp line observer failed to attach",
+        errorAttrs(error),
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+};
+
+/**
+ * Returns each observer's detach promise so the caller can settle them off the
+ * refresh path — a wedged stream close must not stall token renewal.
+ */
+export const notifyLineDetached = (
+  clients: WhatsAppClient[],
+  client: WhatsAppClient
+): Promise<void>[] => {
+  const pending: Promise<void>[] = [];
+  for (const observer of observers.get(clients) ?? []) {
+    try {
+      pending.push(Promise.resolve(observer.detach(client)));
+    } catch (error) {
+      linesLog.warn(
+        "whatsapp line observer failed to detach",
+        errorAttrs(error),
+        error instanceof Error ? error : undefined
+      );
+    }
+  }
+  return pending;
+};

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -10,7 +10,6 @@ import {
   type Content,
   type Group,
   type ManagedStream,
-  mergeStreams,
   type Poll,
   type Reaction,
   type ContactAddress as SpectrumContactAddress,
@@ -34,6 +33,7 @@ import {
   asUnsend,
   asVoice,
   createLogger,
+  createStreamGroup,
   errorAttrs,
   type ProviderMessageRecord,
   tracedFetch,
@@ -41,6 +41,7 @@ import {
 import { extension as mimeExtension } from "mime-types";
 import { isWhatsAppTemplate, type WhatsAppTemplate } from "./content/template";
 import { WhatsAppPartialSendError } from "./errors/partial-send";
+import { addLineObserver, lineKey } from "./lines";
 import { pollOptionId, pollToInteractive } from "./poll";
 import type { WhatsAppClients, WhatsAppMessage } from "./types";
 
@@ -715,9 +716,28 @@ const clientStream = (
   });
 };
 
+// A group rather than `mergeStreams`, because the line set changes underneath
+// us: the cloud token refresh reconciles newly provisioned and deprovisioned
+// lines into the same array, and those have to reach a running stream.
 export const messages = (
   clients: WhatsAppClients
-): ManagedStream<WhatsAppMessage> => mergeStreams(clients.map(clientStream));
+): ManagedStream<WhatsAppMessage> => {
+  const group = createStreamGroup<WhatsAppMessage>({
+    label: "whatsapp.messages",
+  });
+  for (const client of clients) {
+    group.add(lineKey(client), () => clientStream(client));
+  }
+
+  addLineObserver(clients, {
+    attach: (client) => {
+      group.add(lineKey(client), () => clientStream(client));
+    },
+    detach: (client) => group.remove(lineKey(client)).then(() => undefined),
+  });
+
+  return group;
+};
 
 // Meta caps media captions at 1024 characters (image/video/document docs).
 const MAX_CAPTION_LENGTH = 1024;

--- a/packages/whatsapp-business/src/messages.ts
+++ b/packages/whatsapp-business/src/messages.ts
@@ -729,14 +729,22 @@ export const messages = (
     group.add(lineKey(client), () => clientStream(client));
   }
 
-  addLineObserver(clients, {
+  const disposeObserver = addLineObserver(clients, {
     attach: (client) => {
       group.add(lineKey(client), () => clientStream(client));
     },
     detach: (client) => group.remove(lineKey(client)).then(() => undefined),
   });
 
-  return group;
+  // Drop the observer when the stream closes: it holds this group, and a later
+  // reconcile must not keep calling into a group that can no longer emit.
+  const closeGroup = group.close.bind(group);
+  return Object.assign(group, {
+    close: async (): Promise<void> => {
+      disposeObserver();
+      await closeGroup();
+    },
+  });
 };
 
 // Meta caps media captions at 1024 characters (image/video/document docs).

--- a/packages/whatsapp-business/test/auth.test.ts
+++ b/packages/whatsapp-business/test/auth.test.ts
@@ -327,15 +327,20 @@ describe("whatsapp cloud line reconciliation", () => {
     await disposeCloudAuth(clients);
   });
 
-  it("keeps the current set when the response reports no lines", async () => {
+  it("removes every line when the response reports no lines", async () => {
     respondWith({ "phone-1": "token-1" });
     const clients = await createCloudClients("project-1", "secret-1");
 
+    // No lines is a real inventory, not a suspect response: holding the entry
+    // would keep routing through a line whose token no longer refreshes.
     respondWith({});
     await clients[0]?.messages.markRead("wamid.1");
 
-    expect(clients).toHaveLength(1);
-    expect(rawClients[0]?.close).not.toHaveBeenCalled();
+    expect(clients).toEqual([]);
+    await waitFor(
+      () => rawClients[0]?.close.mock.calls.length === 1,
+      "removed line was not closed"
+    );
 
     await disposeCloudAuth(clients);
   });

--- a/packages/whatsapp-business/test/auth.test.ts
+++ b/packages/whatsapp-business/test/auth.test.ts
@@ -133,6 +133,7 @@ vi.doMock("@photon-ai/whatsapp-business", () => ({
 }));
 
 const { createCloudClients, disposeCloudAuth } = await import("@/auth");
+const { addLineObserver } = await import("@/lines");
 
 const waitFor = async (
   predicate: () => boolean,
@@ -265,6 +266,108 @@ describe("whatsapp cloud auth stream renewal", () => {
     expect(createClient).toHaveBeenCalledTimes(2);
     expect(rawClients[0]?.close).toHaveBeenCalledTimes(1);
     expect(rawClients[1]?.options.accessToken).toBe("token-2");
+
+    await disposeCloudAuth(clients);
+  });
+});
+
+describe("whatsapp cloud line reconciliation", () => {
+  beforeEach(() => {
+    rawClients.length = 0;
+    tokenIssueCount = 0;
+    issueWhatsappBusinessTokens.mockReset();
+    createClient.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // `expiresIn: 0` makes every proxied RPC refresh, so `markRead` is the cheapest
+  // way to drive the same closure the renewal timer runs.
+  const respondWith = (auth: Record<string, string>): void => {
+    issueWhatsappBusinessTokens.mockImplementation(async () => ({
+      auth,
+      expiresIn: 0,
+    }));
+  };
+
+  it("attaches a line provisioned after startup", async () => {
+    respondWith({ "phone-1": "token-1" });
+    const clients = await createCloudClients("project-1", "secret-1");
+    const arrayRef = clients;
+    expect(clients).toHaveLength(1);
+
+    respondWith({ "phone-1": "token-1b", "phone-2": "token-2" });
+    await clients[0]?.messages.markRead("wamid.1");
+
+    expect(clients).toHaveLength(2);
+    // The array is mutated, never replaced: the cloud-auth state is keyed by
+    // its identity.
+    expect(clients).toBe(arrayRef);
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("detaches a deprovisioned line and closes it", async () => {
+    respondWith({ "phone-1": "token-1", "phone-2": "token-2" });
+    const clients = await createCloudClients("project-1", "secret-1");
+    expect(clients).toHaveLength(2);
+
+    respondWith({ "phone-1": "token-1b" });
+    await clients[0]?.messages.markRead("wamid.1");
+
+    expect(clients).toHaveLength(1);
+    // rawClients[1] is the deprovisioned line's underlying client.
+    await waitFor(
+      () => rawClients[1]?.close.mock.calls.length === 1,
+      "deprovisioned line was not closed"
+    );
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("keeps the current set when the response reports no lines", async () => {
+    respondWith({ "phone-1": "token-1" });
+    const clients = await createCloudClients("project-1", "secret-1");
+
+    respondWith({});
+    await clients[0]?.messages.markRead("wamid.1");
+
+    expect(clients).toHaveLength(1);
+    expect(rawClients[0]?.close).not.toHaveBeenCalled();
+
+    await disposeCloudAuth(clients);
+  });
+
+  it("notifies observers about attached and detached lines", async () => {
+    respondWith({ "phone-1": "token-1" });
+    const clients = await createCloudClients("project-1", "secret-1");
+    // Records whether the array already agreed with the notification when the
+    // observer ran — an observer must never see a half-applied array.
+    const attached: boolean[] = [];
+    const detached: boolean[] = [];
+    addLineObserver(clients, {
+      attach: (client) => {
+        attached.push(clients.includes(client));
+      },
+      detach: (client) => {
+        detached.push(clients.includes(client));
+      },
+    });
+
+    respondWith({ "phone-1": "token-1b", "phone-2": "token-2" });
+    await clients[0]?.messages.markRead("wamid.1");
+    // Both lines are attached: the existing one is re-asserted (which is what
+    // revives a line whose stream died) and the new one is added.
+    expect(attached).toEqual([true, true]);
+
+    respondWith({ "phone-2": "token-2b" });
+    await clients[0]?.messages.markRead("wamid.2");
+    await waitFor(() => detached.length === 1, "detach was not observed");
+    // Spliced out before the observer runs, mirroring the attach ordering.
+    expect(detached).toEqual([false]);
+    expect(clients).toHaveLength(1);
 
     await disposeCloudAuth(clients);
   });

--- a/packages/whatsapp-business/test/reaction-removal.test.ts
+++ b/packages/whatsapp-business/test/reaction-removal.test.ts
@@ -1,4 +1,9 @@
 import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
+import {
+  NO_MESSAGE_WAIT_MS,
+  settleSoon,
+  withinMs,
+} from "@spectrum-ts/test-support/timing";
 import { describe, expect, it } from "vitest";
 import { messages } from "@/messages";
 import type { WhatsAppMessage } from "@/types";
@@ -40,12 +45,27 @@ const textEvent = (id: string, body: string) => ({
   content: { type: "text", body },
 });
 
+// The messages stream deliberately stays open when a line's event stream ends
+// — a deprovisioned line must not end the whole app's stream — so collect until
+// it goes idle rather than waiting for EOF.
 const receiveAll = async (
   client: WhatsAppClient
 ): Promise<WhatsAppMessage[]> => {
+  const stream = messages([client]);
+  const iterator = stream[Symbol.asyncIterator]();
   const received: WhatsAppMessage[] = [];
-  for await (const m of messages([client])) {
-    received.push(m);
+  for (;;) {
+    const next = iterator.next();
+    if ((await withinMs(next, NO_MESSAGE_WAIT_MS)) === "timeout") {
+      await stream.close();
+      await settleSoon(next);
+      break;
+    }
+    const result = await next;
+    if (result.done) {
+      break;
+    }
+    received.push(result.value);
   }
   return received;
 };

--- a/packages/whatsapp-business/test/reaction-removal.test.ts
+++ b/packages/whatsapp-business/test/reaction-removal.test.ts
@@ -1,9 +1,5 @@
 import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
-import {
-  NO_MESSAGE_WAIT_MS,
-  settleSoon,
-  withinMs,
-} from "@spectrum-ts/test-support/timing";
+import { collectUntilIdle } from "@spectrum-ts/test-support/timing";
 import { describe, expect, it } from "vitest";
 import { messages } from "@/messages";
 import type { WhatsAppMessage } from "@/types";
@@ -48,27 +44,8 @@ const textEvent = (id: string, body: string) => ({
 // The messages stream deliberately stays open when a line's event stream ends
 // — a deprovisioned line must not end the whole app's stream — so collect until
 // it goes idle rather than waiting for EOF.
-const receiveAll = async (
-  client: WhatsAppClient
-): Promise<WhatsAppMessage[]> => {
-  const stream = messages([client]);
-  const iterator = stream[Symbol.asyncIterator]();
-  const received: WhatsAppMessage[] = [];
-  for (;;) {
-    const next = iterator.next();
-    if ((await withinMs(next, NO_MESSAGE_WAIT_MS)) === "timeout") {
-      await stream.close();
-      await settleSoon(next);
-      break;
-    }
-    const result = await next;
-    if (result.done) {
-      break;
-    }
-    received.push(result.value);
-  }
-  return received;
-};
+const receiveAll = (client: WhatsAppClient): Promise<WhatsAppMessage[]> =>
+  collectUntilIdle(messages([client]));
 
 describe("whatsapp reaction removal", () => {
   it("surfaces an emoji reaction as reaction content", async () => {

--- a/packages/whatsapp-business/test/reply-context.test.ts
+++ b/packages/whatsapp-business/test/reply-context.test.ts
@@ -1,4 +1,9 @@
 import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
+import {
+  NO_MESSAGE_WAIT_MS,
+  settleSoon,
+  withinMs,
+} from "@spectrum-ts/test-support/timing";
 import { describe, expect, it } from "vitest";
 import { messages } from "@/messages";
 import type { WhatsAppMessage } from "@/types";
@@ -164,9 +169,24 @@ describe("whatsapp inbound quoted-reply context", () => {
       events: { subscribe: () => ({ filter: () => filtered }) },
     } as unknown as WhatsAppClient;
 
+    // The stream deliberately stays open when a line's event stream ends — a
+    // deprovisioned line must not end the whole app's stream — so collect until
+    // it goes idle rather than waiting for EOF.
+    const stream = messages([client]);
+    const iterator = stream[Symbol.asyncIterator]();
     const received: WhatsAppMessage[] = [];
-    for await (const m of messages([client])) {
-      received.push(m);
+    for (;;) {
+      const next = iterator.next();
+      if ((await withinMs(next, NO_MESSAGE_WAIT_MS)) === "timeout") {
+        await stream.close();
+        await settleSoon(next);
+        break;
+      }
+      const result = await next;
+      if (result.done) {
+        break;
+      }
+      received.push(result.value);
     }
 
     expect(received).toHaveLength(1);

--- a/packages/whatsapp-business/test/reply-context.test.ts
+++ b/packages/whatsapp-business/test/reply-context.test.ts
@@ -1,9 +1,5 @@
 import type { WhatsAppClient } from "@photon-ai/whatsapp-business";
-import {
-  NO_MESSAGE_WAIT_MS,
-  settleSoon,
-  withinMs,
-} from "@spectrum-ts/test-support/timing";
+import { collectUntilIdle } from "@spectrum-ts/test-support/timing";
 import { describe, expect, it } from "vitest";
 import { messages } from "@/messages";
 import type { WhatsAppMessage } from "@/types";
@@ -172,22 +168,7 @@ describe("whatsapp inbound quoted-reply context", () => {
     // The stream deliberately stays open when a line's event stream ends — a
     // deprovisioned line must not end the whole app's stream — so collect until
     // it goes idle rather than waiting for EOF.
-    const stream = messages([client]);
-    const iterator = stream[Symbol.asyncIterator]();
-    const received: WhatsAppMessage[] = [];
-    for (;;) {
-      const next = iterator.next();
-      if ((await withinMs(next, NO_MESSAGE_WAIT_MS)) === "timeout") {
-        await stream.close();
-        await settleSoon(next);
-        break;
-      }
-      const result = await next;
-      if (result.done) {
-        break;
-      }
-      received.push(result.value);
-    }
+    const received = await collectUntilIdle(messages([client]));
 
     expect(received).toHaveLength(1);
     expect(received[0]?.id).toBe("wamid.OK1");


### PR DESCRIPTION
## Summary

- A line provisioned while the app is running is now picked up at the next token renewal instead of staying invisible until restart. Deprovisioned lines are detached and their channels closed.
- Adds `createStreamGroup` to `@spectrum-ts/core/authoring` — a merged stream whose member set can change while it runs. `mergeStreams` fixes its worker set at construction, which is why mutating the client array previously could not spawn a subscription.
- Cloud auth in both providers now **reconciles** against the token payload rather than syncing phones on a startup snapshot. Startup is the same reconcile against an empty set, so there is one code path that builds a line.
- A `LineObserver` + `lines.ts` module per provider wires reconcile events into the running message stream's `add`/`remove`, without rebuilding the client array — three WeakMaps and core's own platform state are keyed by that array's identity.
- A dedicated line with no phone number assigned is now skipped with a warning instead of throwing and taking the whole client down at startup.
- Docs for both providers state the discovery window and its consequences explicitly; it was previously a silent failure with no signal.

## Usage

No app-facing API change — a running app just starts seeing the new line:

```ts
const app = await Spectrum({ providers: [imessage.config()] });

// Provision a line in the dashboard while this loop is running.
// At the next token renewal it starts delivering here, and
// space.create({ phone: "+1555…" }) starts routing through it.
for await (const [space, message] of app.messages) {
  await message.reply("Hello from Spectrum.");
}
```

For provider authors, the new primitive:

```ts
import { createStreamGroup } from "@spectrum-ts/core/authoring";

const group = createStreamGroup<Event>({ label: "imessage.messages" });
group.add("line-a", () => clientStream(a)); // false if already attached or closed
await group.remove("line-a");               // closes just that member
```

## Behavior

- **Pickup latency is the token TTL.** Reconcile runs on renewal, not on a push. Until it lands a new line receives no inbound messages and cannot be routed to — documented on both providers, with "restart if you need it now."
- **Stream lifetime changed.** The provider messages stream now ends only on `close()`. Zero members parks the consumer rather than ending it, so a set that is briefly empty mid-reconcile does not kill the app's stream — and the last line being deprovisioned doesn't either. Two WhatsApp tests that read to EOF were rewritten to collect until idle.
- **A faulted member is dropped, not restarted.** Retry policy stays with the caller that knows the real inventory: `keys()` stops reporting it, and the next reconcile re-adds it. This is why `attach` is idempotent and re-asserted for **every** known line on every refresh — that re-assert is what revives a line whose stream died, rather than leaving it dark for the life of the process.
- **Degenerate responses never wipe a working set.** An `auth` payload with no lines is logged and ignored. At startup `records` is empty, so it still yields an empty array.
- **Reconcile failures are contained.** A throw is logged, not rethrown. Rejecting would leave the renewal's expiry unadvanced, and since `refreshIfNeeded` runs on every RPC, every call on every line would then re-enter the refresh.
- **Detach precedes close, and neither blocks renewal.** Closing a channel under a live subscription produces a reconnect-warn storm, so the stream is detached first; `retire` is never awaited by `refresh`, so a wedged channel cannot stall token renewal. Observer callbacks are likewise contained — a throwing observer warns instead of rejecting the refresh.
- **Attach is notified synchronously**, adjacent to the array push with no await between, so an observer can never see a half-applied array.
- **Phone reassignment** still applies in place; a known line that *loses* its number now keeps the last known number with a warning instead of throwing.
- **Shared mode is untouched** — one sentinel client regardless of line count, no observer registered, no reconcile.
- **Teardown is not a fault.** Members are marked detached before close, so a normal shutdown doesn't log one bogus member failure per source.

## Changes

| File | Change |
|---|---|
| `packages/core/src/utils/stream-group.ts` | **New.** `createStreamGroup` — lazy member construction (the factory runs when the group first starts, so a pre-start `add` opens no subscription), `add`/`has`/`keys`/`remove`, faulted-member drop with `spectrum.stream.group`/`.member` log attrs, and a cleanup that closes sources before awaiting workers. |
| `packages/core/src/utils/stream.ts` | Doc `mergeStreams`' contract and point at `createStreamGroup` for a mutable set. |
| `packages/core/src/authoring.ts` | Export `createStreamGroup` + its types, with a note on which of the two to pick. |
| `packages/imessage/src/auth.ts` | `syncPhones` → `reconcile`: `removeMissing` + `addOrSync` over `tokenData.auth`, `records` becomes a `Map<instanceId, RemoteClient>`, entry construction extracted to `buildEntry`, and startup routed through the same reconcile. Empty-payload and no-phone guards replace the old throwing `requirePhone`. |
| `packages/imessage/src/lines.ts` | **New.** `LineObserver`, observer registry and `lineId`/`lineKey` WeakMaps (with a generated fallback key, since explicitly-configured clients carry no instance id and may repeat a phone), plus contained `notifyLineAttached`/`notifyLineDetached`. |
| `packages/imessage/src/remote/stream.ts` | `mergeStreams` → `createStreamGroup`; register a line observer in dedicated mode that adds/removes members as lines reconcile. |
| `packages/whatsapp-business/src/auth.ts` | Same reconcile shape keyed by `phoneNumberId`: `attachLine`/`retire`/`removeMissing`, `records` map, startup through reconcile, and the reconcile call appended to `refreshTokens`. |
| `packages/whatsapp-business/src/lines.ts` | **New.** The `WhatsAppClient` counterpart of the iMessage lines module. |
| `packages/whatsapp-business/src/messages.ts` | `mergeStreams` → `createStreamGroup` + line observer. |
| `docs/providers/imessage/connection-and-routing.mdx.vel` | New "When line changes reach a running app" section, including the two routing behaviors that flip the moment a second line appears (`space.get` starts requiring `params.phone`; `space.create` picks at random from the larger set). |
| `docs/providers/imessage.mdx.vel`, `docs/providers/whatsapp-business/setup.mdx.vel` | Point at the discovery window from the cloud-config sections. |

## Test plan

- [x] `packages/core/test/utils/stream-group.test.ts` (new, 14 cases) — laziness before first pull, add/remove while running, parks-when-empty and stays-open-after-last-removal, faulted and self-ended members dropped without disturbing siblings, re-attach after fault, duplicate key rejected without building a second source, add-after-close refused, silent teardown, and backpressure (no eager member drain).
- [x] `packages/core/test/utils/stream.test.ts` (new, 4 cases) — characterize the contrasting `mergeStreams` contract: ends immediately when empty, ends once all sources end, one source's failure ends the merge.
- [x] `packages/imessage/test/auth.test.ts` (10 new cases) — line attached/detached across a refresh, added line built with the same client options as startup, no-phone line skipped then picked up once assigned, known line keeps its number when it disappears mid-refresh, empty payload keeps the current set, shared mode untouched, every known line re-asserted on refresh, throwing observer survived.
- [x] `packages/imessage/test/remote/stream.test.ts` (6 new cases) — delivery from a line attached while running and from one attached before the first pull, detached line stops delivering without disturbing the rest, stream stays open after the last line goes, shared mode ignores notifications, double attach subscribes once.
- [x] `packages/whatsapp-business/test/auth.test.ts` (4 new cases) — attach, detach + close, empty-payload guard, observer notification.
- [x] `packages/whatsapp-business/test/{reaction-removal,reply-context}.test.ts` — collect-until-idle instead of read-to-EOF, matching the new stream lifetime.
- [x] Node Vitest: core 35 files / 314 tests, iMessage 18 / 190, WhatsApp 13 / 57 — all 20 packages green.
- [x] Bun 1.3.5 Vitest: same suites, 20/20 green.
- [x] `bun run typecheck` (13 tasks) and `bun x ultracite check` (334 files) clean.

Fixes ENG-2102

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787868617&installation_model_id=19795&pr_number=223&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F223&signature=ca460b770c1a4e133bab193612f5cb9daf257d996e4556bf4b3c135d6817fa0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes inbound message routing and stream lifetime for cloud iMessage/WhatsApp; mis-reconcile could drop lines or miss inbound until renewal, but failures are contained and shared mode is unchanged.
> 
> **Overview**
> Cloud iMessage and WhatsApp Business clients now **reconcile** line inventory on each token renewal instead of freezing the startup snapshot. New lines attach to the same client array (WeakMaps stay valid); removed lines detach subscriptions and close channels. Dedicated iMessage lines without a phone are skipped with a warning instead of failing startup.
> 
> **`createStreamGroup`** in `@spectrum-ts/core/authoring` replaces `mergeStreams` for provider message streams: membership can `add`/`remove` while running, the consumer parks when empty (no EOF on last line), and a failed member is dropped so siblings keep going. Per-provider **`lines.ts`** observers wire reconcile into the running stream.
> 
> Docs now describe pickup at the next renewal (not instant), restart if needed, and multi-line routing (`space.get` needs `phone`, `space.create` random pick). Tests use **`collectUntilIdle`** where streams no longer end at EOF.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14edb312e98a284e7a9f17d6856dba8b16894d7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iMessage and WhatsApp Business cloud connections now reconcile line inventory on token renewal.
  * Message streams dynamically subscribe/unsubscribe as lines are provisioned or removed, without recreating streams.
  * Added a stream-group capability to combine changing sets of streams.
* **Documentation**
  * Clarified cloud discovery/renewal timing and iMessage multi-line routing/conversation lookup behavior.
* **Bug Fixes**
  * Improved resilience so line-specific failures, reconciliation issues, and missing line details don’t break other active lines.
* **Tests**
  * Added coverage for dynamic stream grouping, line reconciliation, and idle-based collection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->