### PR TITLE
Expose advanced iMessage metadata through Spectrum getMessage

### DIFF
--- a/docs/providers/imessage/messaging-features.mdx.vel
+++ b/docs/providers/imessage/messaging-features.mdx.vel
@@ -408,6 +408,11 @@ inbound messages, messages returned by `space.getMessage()`, and native
 outbound results. Synthetic events such as read receipts and group changes may
 omit them.
 
+When a streamed text send requires native edits, its returned record exposes
+the final `nativeText` but omits the first-send metadata snapshot because those
+lifecycle and formatting values no longer describe the edited message. Use
+`space.getMessage()` when you need the current native state afterward.
+
 | Use case | Fields |
 |---|---|
 | Delivery and lifecycle | `isSent`, `isDelivered`, `isDeliveredQuietly`, `didNotifyRecipient`, `isDelayed`, `sendErrorCode`, and the `dateDelivered`, `dateRead`, `datePlayed`, `dateEdited`, `dateRetracted`, and `dateExpressiveSendPlayed` timestamps |

--- a/docs/providers/imessage/messaging-features.mdx.vel
+++ b/docs/providers/imessage/messaging-features.mdx.vel
@@ -400,6 +400,96 @@ This shares the bot's own contact card as it appears in iMessage. Recipients can
   <TypeTooltip name="UnsupportedError" type={`{{ unsupportedError.signature }}`} />.
 </Note>
 
+## Native message metadata
+
+Cloud iMessage messages include a curated set of native metadata in addition
+to Spectrum's cross-platform fields. The same fields are available on ordinary
+inbound messages, messages returned by `space.getMessage()`, and native
+outbound results. Synthetic events such as read receipts and group changes may
+omit them.
+
+| Use case | Fields |
+|---|---|
+| Delivery and lifecycle | `isSent`, `isDelivered`, `isDeliveredQuietly`, `didNotifyRecipient`, `isDelayed`, `sendErrorCode`, and the `dateDelivered`, `dateRead`, `datePlayed`, `dateEdited`, `dateRetracted`, and `dateExpressiveSendPlayed` timestamps |
+| Native text | `nativeText`, `formatting`, `mentions`, `subject`, `balloonBundleId`, and `expressiveSendStyleId` |
+| Attachments | `attachmentMetadata`, including transfer state, UTI, sticker/hidden status, original GUID, and Live Photo companion kind |
+| Reactions and stickers | `appliedReactions`, `placedStickers`, and `reactionRecord` when the native row is itself a tapback |
+| Classification | `itemType`, `groupTitle`, `partCount`, `isAutoReply`, `isCorrupt`, `isExpirable`, `isServiceMessage`, `isSpam`, and `isSystemMessage` |
+
+Use `imessage.is()` when consuming the unified Spectrum message stream. It
+narrows the message to the iMessage-specific type:
+
+```ts
+import { imessage } from "spectrum-ts/providers/imessage";
+
+const message = await space.getMessage(messageId);
+
+if (message && imessage.is(message)) {
+  if ((message.sendErrorCode ?? 0) !== 0) {
+    console.error("Apple send error", message.sendErrorCode);
+  }
+
+  console.log({
+    sent: message.isSent,
+    delivered: message.isDelivered,
+    deliveredAt: message.dateDelivered,
+    readAt: message.dateRead,
+    editedAt: message.dateEdited,
+    retractedAt: message.dateRetracted,
+  });
+}
+```
+
+The same guard works inside `for await (const [, message] of
+spectrum.messages)`.
+
+`nativeText` preserves Apple's original text because formatting and mention
+ranges use UTF-16 offsets into that string. Spectrum can split native
+multipart content into grouped messages, so rebuilding these offsets from
+`message.content` is not reliable:
+
+```ts
+if (message && imessage.is(message)) {
+  const text = message.nativeText;
+
+  for (const mention of message.mentions ?? []) {
+    console.log({
+      address: mention.address,
+      value: text?.slice(
+        mention.start,
+        mention.start + mention.length
+      ),
+    });
+  }
+}
+```
+
+Attachment metadata describes Apple's transfer record; attachment bytes still
+live in Spectrum attachment content:
+
+```ts
+if (message && imessage.is(message)) {
+  for (const attachment of message.attachmentMetadata ?? []) {
+    if (attachment.transferState === "failed") {
+      console.error(
+        `Attachment ${attachment.guid} failed to transfer`
+      );
+    }
+  }
+
+  for (const applied of message.appliedReactions ?? []) {
+    console.log(
+      applied.sender?.address,
+      applied.reaction.kind
+    );
+  }
+}
+```
+
+`sendErrorCode === 0` means Apple recorded no send error. The metadata is
+intentionally curated: Spectrum does not expose the raw Advanced iMessage
+database row or unstable Apple-private fields.
+
 ## Fetching attachments
 
 {% set attachmentType = symbol("ts:spectrum-ts#Attachment") %}

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -10,8 +10,9 @@ import {
   type Attachment,
   type Avatar,
   type Content,
-  definePlatform,
+  definePlatform as defineCorePlatform,
   type Edit,
+  type Platform,
   type RemoveMember,
   type Rename,
   type Space,
@@ -35,6 +36,17 @@ export {
   customizedMiniApp,
 } from "./content/customized-mini-app";
 export { effect, type IMessageMessageEffect } from "./content/effect";
+export type {
+  IMessageAppliedReaction,
+  IMessageAttachmentMetadata,
+  IMessageMention,
+  IMessageMessage,
+  IMessagePlacedSticker,
+  IMessageReaction,
+  IMessageReactionRecord,
+  IMessageStickerPlacement,
+  IMessageTextFormat,
+} from "./types";
 
 import { createCloudClients, disposeCloudAuth } from "./auth";
 import { getMessageCache } from "./cache";
@@ -463,7 +475,7 @@ const remoteForMessageTarget = (
   return clientForPhone(client, space.phone);
 };
 
-export const imessage = definePlatform(IMESSAGE_PLATFORM, {
+const definedIMessage = defineCorePlatform(IMESSAGE_PLATFORM, {
   config: configSchema,
 
   static: {
@@ -807,3 +819,29 @@ export const imessage = definePlatform(IMESSAGE_PLATFORM, {
     },
   },
 });
+
+type DefinedIMessagePlatform = typeof definedIMessage;
+type DefinedIMessageDefinition =
+  DefinedIMessagePlatform extends Platform<infer Definition>
+    ? Definition
+    : never;
+type IMessageDefinition = Omit<DefinedIMessageDefinition, "message"> & {
+  message: NonNullable<DefinedIMessageDefinition["message"]> & {
+    schema: typeof messageSchema;
+  };
+};
+type PublicIMessagePlatform = Platform<IMessageDefinition> &
+  Pick<DefinedIMessagePlatform, "effect">;
+
+/**
+ * Retain iMessage's required message-schema slot in the public platform type.
+ * The manifest generator also validates the canonical
+ * `export const imessage = definePlatform(...)` form, so this provider-local
+ * helper performs the type refinement while preserving that export contract.
+ */
+const definePlatform = (
+  _platformId: typeof IMESSAGE_PLATFORM,
+  platform: DefinedIMessagePlatform
+): PublicIMessagePlatform => platform as PublicIMessagePlatform;
+
+export const imessage = definePlatform(IMESSAGE_PLATFORM, definedIMessage);

--- a/packages/imessage/src/remote/inbound.ts
+++ b/packages/imessage/src/remote/inbound.ts
@@ -36,6 +36,7 @@ import {
   parseChildId,
   toMessageGuid,
 } from "./ids";
+import { toMessageMetadata } from "./message-metadata";
 
 const log = createLogger("spectrum.imessage.inbound");
 
@@ -121,6 +122,7 @@ export const buildMessageBase = (
 ): RemoteMessageBase => {
   const chat = resolveChatGuid(message, chatGuidHint);
   return {
+    ...toMessageMetadata(message),
     direction: message.isFromMe ? "outbound" : "inbound",
     sender: toSenderRef(message.sender),
     space: {
@@ -247,6 +249,9 @@ const buildOrderedPartMessage = async (
         part.attachment.guid === voiceAttachmentGuid
       );
 
+const unsupportedMessageContent = (): Content =>
+  asCustom({ imessage_type: "unsupported-message" });
+
 const buildUnwrappedContentMessage = async (
   client: AdvancedIMessage,
   base: RemoteMessageBase,
@@ -263,7 +268,7 @@ const buildUnwrappedContentMessage = async (
     return {
       ...base,
       id: messageGuidStr,
-      content: text ? asText(text) : asCustom(message),
+      content: text ? asText(text) : unsupportedMessageContent(),
     };
   }
 
@@ -273,7 +278,7 @@ const buildUnwrappedContentMessage = async (
     return {
       ...base,
       id: messageGuidStr,
-      content: asCustom(message),
+      content: unsupportedMessageContent(),
     };
   }
 

--- a/packages/imessage/src/remote/message-metadata.ts
+++ b/packages/imessage/src/remote/message-metadata.ts
@@ -1,0 +1,158 @@
+import type {
+  Message as AdvancedIMessageMessage,
+  AttachmentInfo,
+  MessageAppliedReaction,
+  MessageMention,
+  MessagePlacedSticker,
+  MessageReaction,
+  SingleServiceAddressInfo,
+  StickerPlacement,
+  TextFormat,
+} from "@photon-ai/advanced-imessage/grpc";
+import type {
+  IMessageAppliedReaction,
+  IMessageAttachmentMetadata,
+  IMessageMention,
+  IMessageNativeMessageMetadata,
+  IMessagePlacedSticker,
+  IMessageReaction,
+  IMessageReactionRecord,
+  IMessageStickerPlacement,
+  IMessageTextFormat,
+} from "../types";
+
+const toTextFormat = (format: TextFormat): IMessageTextFormat => ({
+  effectName: format.effectName,
+  length: format.length,
+  start: format.start,
+  type: format.type,
+});
+
+const toMention = (mention: MessageMention): IMessageMention => ({
+  address: mention.address,
+  length: mention.length,
+  start: mention.start,
+});
+
+const toAttachmentMetadata = (
+  attachment: AttachmentInfo
+): IMessageAttachmentMetadata => ({
+  companionKind: attachment.companionKind,
+  fileName: attachment.fileName,
+  guid: attachment.guid,
+  isHidden: attachment.isHidden,
+  isSticker: attachment.isSticker,
+  mimeType: attachment.mimeType,
+  originalGuid: attachment.originalGuid,
+  totalBytes: attachment.totalBytes,
+  transferState: attachment.transferState,
+  uti: attachment.uti,
+});
+
+const toServiceAddress = (
+  sender: SingleServiceAddressInfo
+): NonNullable<IMessageAppliedReaction["sender"]> => ({
+  address: sender.address,
+  country: sender.country,
+  service: sender.service,
+});
+
+const toReaction = (reaction: MessageReaction): IMessageReaction => ({
+  emoji: reaction.emoji,
+  kind: reaction.kind,
+});
+
+const toAppliedReaction = (
+  applied: MessageAppliedReaction
+): IMessageAppliedReaction => ({
+  dateCreated: applied.dateCreated,
+  isFromMe: applied.isFromMe,
+  messageGuid: applied.messageGuid,
+  reaction: toReaction(applied.reaction),
+  sender: applied.sender ? toServiceAddress(applied.sender) : undefined,
+  targetPartIndex: applied.targetPartIndex,
+});
+
+const toStickerPlacement = (
+  placement: StickerPlacement
+): IMessageStickerPlacement => ({
+  rotation: placement.rotation,
+  scale: placement.scale,
+  width: placement.width,
+  x: placement.x,
+  y: placement.y,
+});
+
+const toPlacedSticker = (
+  placed: MessagePlacedSticker
+): IMessagePlacedSticker => ({
+  dateCreated: placed.dateCreated,
+  isFromMe: placed.isFromMe,
+  messageGuid: placed.messageGuid,
+  placement: placed.placement
+    ? toStickerPlacement(placed.placement)
+    : undefined,
+  sender: placed.sender ? toServiceAddress(placed.sender) : undefined,
+  sticker: placed.sticker ? toAttachmentMetadata(placed.sticker) : undefined,
+  targetPartIndex: placed.targetPartIndex,
+});
+
+const toReactionRecord = (
+  message: AdvancedIMessageMessage
+): IMessageReactionRecord | undefined => {
+  if (!(message.reaction && message.reactionTargetGuid)) {
+    return;
+  }
+  return {
+    reaction: toReaction(message.reaction),
+    selected: message.reactionSelected,
+    targetGuid: message.reactionTargetGuid,
+    targetPartIndex: message.reactionTargetPartIndex,
+  };
+};
+
+/**
+ * Copy the curated, developer-actionable subset of an Advanced iMessage
+ * message into Spectrum-owned data. Keeping this mapper at the native boundary
+ * prevents private Apple fields from leaking through normal messages.
+ */
+export const toMessageMetadata = (
+  native: AdvancedIMessageMessage
+): IMessageNativeMessageMetadata => ({
+  dateDelivered: native.dateDelivered,
+  dateEdited: native.dateEdited,
+  dateExpressiveSendPlayed: native.dateExpressiveSendPlayed,
+  datePlayed: native.datePlayed,
+  dateRead: native.dateRead,
+  dateRetracted: native.dateRetracted,
+
+  isSent: native.isSent,
+  isDelivered: native.isDelivered,
+  isDeliveredQuietly: native.isDeliveredQuietly,
+  didNotifyRecipient: native.didNotifyRecipient,
+  isDelayed: native.isDelayed,
+  sendErrorCode: native.sendErrorCode,
+
+  nativeText: native.content?.text,
+  formatting: native.content?.formatting?.map(toTextFormat),
+  mentions: native.content?.mentions?.map(toMention),
+  subject: native.subject,
+  balloonBundleId: native.content?.balloonBundleId,
+  expressiveSendStyleId: native.content?.expressiveSendStyleId,
+  attachmentMetadata: native.content?.attachments?.map(toAttachmentMetadata),
+
+  appliedReactions: native.appliedReactions?.map(toAppliedReaction),
+  placedStickers: native.placedStickers?.map(toPlacedSticker),
+  reactionRecord: toReactionRecord(native),
+
+  itemType: native.itemType,
+  groupTitle: native.groupTitle,
+  partCount: native.partCount,
+
+  isAutoReply: native.isAutoReply,
+  isCorrupt: native.isCorrupt,
+  isExpirable: native.isExpirable,
+  isServiceMessage: native.isServiceMessage,
+  isSpam: native.isSpam,
+  isSystemMessage: native.isSystemMessage,
+});

--- a/packages/imessage/src/remote/message-metadata.ts
+++ b/packages/imessage/src/remote/message-metadata.ts
@@ -134,15 +134,16 @@ export const toMessageMetadata = (
   sendErrorCode: native.sendErrorCode,
 
   nativeText: native.content?.text,
-  formatting: native.content?.formatting?.map(toTextFormat),
-  mentions: native.content?.mentions?.map(toMention),
+  formatting: native.content?.formatting?.map(toTextFormat) ?? [],
+  mentions: native.content?.mentions?.map(toMention) ?? [],
   subject: native.subject,
   balloonBundleId: native.content?.balloonBundleId,
   expressiveSendStyleId: native.content?.expressiveSendStyleId,
-  attachmentMetadata: native.content?.attachments?.map(toAttachmentMetadata),
+  attachmentMetadata:
+    native.content?.attachments?.map(toAttachmentMetadata) ?? [],
 
-  appliedReactions: native.appliedReactions?.map(toAppliedReaction),
-  placedStickers: native.placedStickers?.map(toPlacedSticker),
+  appliedReactions: native.appliedReactions?.map(toAppliedReaction) ?? [],
+  placedStickers: native.placedStickers?.map(toPlacedSticker) ?? [],
   reactionRecord: toReactionRecord(native),
 
   itemType: native.itemType,

--- a/packages/imessage/src/remote/reactions.ts
+++ b/packages/imessage/src/remote/reactions.ts
@@ -16,6 +16,7 @@ import {
   resolveTargetMessage,
   toSenderRef,
 } from "./inbound";
+import { toMessageMetadata } from "./message-metadata";
 
 type ReactionAddedEvent = Extract<
   MessageEvent,
@@ -171,6 +172,7 @@ export const reactToMessage = async (
   // Apple removes tapbacks via `setReaction(..., false)`, not by retracting
   // the tapback message itself.
   return {
+    ...toMessageMetadata(sent),
     id: sent.guid,
     content: asProviderReaction(reaction, target),
     direction: "outbound",

--- a/packages/imessage/src/remote/send.ts
+++ b/packages/imessage/src/remote/send.ts
@@ -28,6 +28,7 @@ import {
   type IMessageRenderedMarkdown,
   markdownToIMessageText,
 } from "./markdown";
+import { toMessageMetadata } from "./message-metadata";
 
 const GROUP_ITEM_ALLOWED: ReadonlySet<Content["type"]> = new Set([
   "text",
@@ -44,13 +45,17 @@ const GROUP_TEXT_TYPES: ReadonlySet<Content["type"]> = new Set([
 const MAX_GROUP_TEXT_ITEMS = 1;
 
 type ReplyTarget = SendOptions["replyTo"];
+type OutboundMessageExtras = Omit<
+  Partial<IMessageMessage>,
+  "content" | "direction" | "id" | "sender" | "space" | "timestamp"
+>;
 
 const outboundRecord = (
   spaceId: string,
   id: string,
   content: Content,
   timestamp: Date,
-  extras?: Pick<IMessageMessage, "partIndex" | "parentId">
+  extras?: OutboundMessageExtras
 ): ProviderMessageRecord => ({
   id,
   content,
@@ -66,9 +71,11 @@ const outboundGroupItem = (
   content: Content,
   timestamp: Date,
   partIndex: number,
-  parentId: string
+  parentId: string,
+  metadata: OutboundMessageExtras
 ): IMessageMessage =>
   outboundRecord(spaceId, id, content, timestamp, {
+    ...metadata,
     partIndex,
     parentId,
   }) as IMessageMessage;
@@ -124,7 +131,13 @@ const outboundMessage = (
   message: SDKMessage,
   content: Content
 ): ProviderMessageRecord =>
-  outboundRecord(spaceId, message.guid, content, message.dateCreated);
+  outboundRecord(
+    spaceId,
+    message.guid,
+    content,
+    message.dateCreated,
+    toMessageMetadata(message)
+  );
 
 const outboundPoll = (
   spaceId: string,
@@ -341,6 +354,7 @@ export const send = async (
     );
     const parentGuid = message.guid;
     const timestamp = message.dateCreated;
+    const metadata = toMessageMetadata(message);
 
     const items = content.items.map((sub, idx) =>
       outboundGroupItem(
@@ -349,11 +363,18 @@ export const send = async (
         sub.content,
         timestamp,
         idx,
-        parentGuid
+        parentGuid,
+        metadata
       )
     );
 
-    return outboundRecord(spaceId, parentGuid, providerGroup(items), timestamp);
+    return outboundRecord(
+      spaceId,
+      parentGuid,
+      providerGroup(items),
+      timestamp,
+      metadata
+    );
   }
 
   return sendContent(remote, spaceId, chat, content);

--- a/packages/imessage/src/remote/stream-text.ts
+++ b/packages/imessage/src/remote/stream-text.ts
@@ -9,6 +9,7 @@ import {
 } from "@spectrum-ts/core/authoring";
 import { unsupportedRemoteContent } from "../shared/errors";
 import { toChatGuid, toMessageGuid } from "./ids";
+import { toMessageMetadata } from "./message-metadata";
 
 // Delivery pacing is fixed logic, not configurable. iMessage's native edit
 // replaces the whole message body, so each update sends the full accumulated
@@ -103,9 +104,11 @@ export const sendStreamText = async (
   await flushEdit(full);
 
   return {
+    ...toMessageMetadata(sent),
     id: sent.guid,
     content: asText(full),
     direction: "outbound",
+    nativeText: full,
     space: { id: spaceId },
     timestamp: sent.dateCreated,
   };

--- a/packages/imessage/src/remote/stream-text.ts
+++ b/packages/imessage/src/remote/stream-text.ts
@@ -103,8 +103,13 @@ export const sendStreamText = async (
   // Always finish on the complete text (no-op if the last edit already had it).
   await flushEdit(full);
 
+  // The first-chunk response is authoritative only when no edit occurred.
+  // After an edit, its delivery, lifecycle, formatting, and native text fields
+  // are stale; omit that snapshot and retain the final text we know locally.
+  const metadata = editCount === 0 ? toMessageMetadata(sent) : {};
+
   return {
-    ...toMessageMetadata(sent),
+    ...metadata,
     id: sent.guid,
     content: asText(full),
     direction: "outbound",

--- a/packages/imessage/src/types.ts
+++ b/packages/imessage/src/types.ts
@@ -57,8 +57,161 @@ const miniAppCardSessionSchema = z.object({
   targetMessageGuid: z.string(),
 });
 
+const textFormatSchema = z
+  .object({
+    effectName: z.string().optional(),
+    length: z.number().int().nonnegative(),
+    start: z.number().int().nonnegative(),
+    type: z.string(),
+  })
+  .readonly();
+
+const mentionSchema = z
+  .object({
+    address: z.string(),
+    length: z.number().int().nonnegative(),
+    start: z.number().int().nonnegative(),
+  })
+  .readonly();
+
+const attachmentMetadataSchema = z
+  .object({
+    companionKind: z.enum(["live-photo-video", "unknown"]).optional(),
+    fileName: z.string(),
+    guid: z.string(),
+    isHidden: z.boolean(),
+    isSticker: z.boolean(),
+    mimeType: z.string(),
+    originalGuid: z.string().optional(),
+    totalBytes: z.number().nonnegative(),
+    transferState: z.enum([
+      "pending",
+      "transferring",
+      "failed",
+      "finished",
+      "unknown",
+    ]),
+    uti: z.string(),
+  })
+  .readonly();
+
+const serviceAddressSchema = z
+  .object({
+    address: z.string(),
+    country: z.string().optional(),
+    service: z.enum(SERVICE_VALUES),
+  })
+  .readonly();
+
+const reactionSchema = z
+  .object({
+    emoji: z.string().optional(),
+    kind: z.enum([
+      "love",
+      "like",
+      "dislike",
+      "laugh",
+      "emphasize",
+      "question",
+      "emoji",
+      "sticker",
+      "unknown",
+    ]),
+  })
+  .readonly();
+
+const appliedReactionSchema = z
+  .object({
+    dateCreated: z.date(),
+    isFromMe: z.boolean(),
+    messageGuid: z.string(),
+    reaction: reactionSchema,
+    sender: serviceAddressSchema.optional(),
+    targetPartIndex: z.number().int().nonnegative().optional(),
+  })
+  .readonly();
+
+const stickerPlacementSchema = z
+  .object({
+    rotation: z.number().optional(),
+    scale: z.number().optional(),
+    width: z.number().nonnegative().optional(),
+    x: z.number(),
+    y: z.number(),
+  })
+  .readonly();
+
+const placedStickerSchema = z
+  .object({
+    dateCreated: z.date(),
+    isFromMe: z.boolean(),
+    messageGuid: z.string(),
+    placement: stickerPlacementSchema.optional(),
+    sender: serviceAddressSchema.optional(),
+    sticker: attachmentMetadataSchema.optional(),
+    targetPartIndex: z.number().int().nonnegative().optional(),
+  })
+  .readonly();
+
+const reactionRecordSchema = z
+  .object({
+    reaction: reactionSchema,
+    selected: z.boolean().optional(),
+    targetGuid: z.string(),
+    targetPartIndex: z.number().int().nonnegative().optional(),
+  })
+  .readonly();
+
+export const nativeMessageMetadataSchema = z.object({
+  dateDelivered: z.date().optional(),
+  dateEdited: z.date().optional(),
+  dateExpressiveSendPlayed: z.date().optional(),
+  datePlayed: z.date().optional(),
+  dateRead: z.date().optional(),
+  dateRetracted: z.date().optional(),
+
+  isSent: z.boolean(),
+  isDelivered: z.boolean(),
+  isDeliveredQuietly: z.boolean(),
+  didNotifyRecipient: z.boolean(),
+  isDelayed: z.boolean(),
+  sendErrorCode: z.number().int(),
+
+  nativeText: z.string().optional(),
+  formatting: z.array(textFormatSchema).readonly(),
+  mentions: z.array(mentionSchema).readonly(),
+  subject: z.string().optional(),
+  balloonBundleId: z.string().optional(),
+  expressiveSendStyleId: z.string().optional(),
+  attachmentMetadata: z.array(attachmentMetadataSchema).readonly(),
+
+  appliedReactions: z.array(appliedReactionSchema).readonly(),
+  placedStickers: z.array(placedStickerSchema).readonly(),
+  reactionRecord: reactionRecordSchema.optional(),
+
+  itemType: z.enum([
+    "normal",
+    "groupNameChange",
+    "participantChange",
+    "chatAction",
+    "unknown",
+  ]),
+  groupTitle: z.string().optional(),
+  partCount: z.number().int().nonnegative().optional(),
+
+  isAutoReply: z.boolean(),
+  isCorrupt: z.boolean(),
+  isExpirable: z.boolean(),
+  isServiceMessage: z.boolean(),
+  isSpam: z.boolean(),
+  isSystemMessage: z.boolean(),
+});
+
 /**
  * iMessage-specific per-message metadata surfaced on `IMessageMessage`.
+ * Native metadata is optional because synthetic event records do not carry a
+ * complete Advanced iMessage message.
+ *
  * - `partIndex`: ordered part index within a multi-part message. Text and
  *   attachment parts both consume an index (0 for bare or single-part
  *   messages; 0..N-1 for a group's sub-items).
@@ -67,18 +220,30 @@ const miniAppCardSessionSchema = z.object({
  * - `miniAppCardSession`: stable handle returned by mini-app card sends and
  *   updates. It is required to update the card in place later.
  */
-export const messageSchema = z.object({
+export const messageSchema = nativeMessageMetadataSchema.partial().extend({
   miniAppCardSession: miniAppCardSessionSchema.optional(),
   partIndex: z.number().int().nonnegative().optional(),
   parentId: z.string().optional(),
 });
 
+export type IMessageAppliedReaction = z.infer<typeof appliedReactionSchema>;
+export type IMessageAttachmentMetadata = z.infer<
+  typeof attachmentMetadataSchema
+>;
+export type IMessageMention = z.infer<typeof mentionSchema>;
+export type IMessageNativeMessageMetadata = z.infer<
+  typeof nativeMessageMetadataSchema
+>;
+export type IMessagePlacedSticker = z.infer<typeof placedStickerSchema>;
+export type IMessageReaction = z.infer<typeof reactionSchema>;
+export type IMessageReactionRecord = z.infer<typeof reactionRecordSchema>;
+export type IMessageStickerPlacement = z.infer<typeof stickerPlacementSchema>;
+export type IMessageTextFormat = z.infer<typeof textFormatSchema>;
+
 export type IMessageMessage = SchemaMessage<
   typeof userSchema,
   typeof spaceSchema
-> & {
-  direction?: "inbound" | "outbound";
-  miniAppCardSession?: z.infer<typeof miniAppCardSessionSchema>;
-  partIndex?: number;
-  parentId?: string;
-};
+> &
+  z.infer<typeof messageSchema> & {
+    direction?: "inbound" | "outbound";
+  };

--- a/packages/imessage/test/remote/message-metadata-integration.test.ts
+++ b/packages/imessage/test/remote/message-metadata-integration.test.ts
@@ -1,0 +1,282 @@
+import type {
+  AdvancedIMessage,
+  MessageEvent,
+  Message as SDKMessage,
+} from "@photon-ai/advanced-imessage/grpc";
+import type { Content, Message } from "@spectrum-ts/core";
+import { asAttachment, asGroup, asText } from "@spectrum-ts/core/authoring";
+import { describe, expect, it, vi } from "vitest";
+import { MessageCache } from "@/cache";
+import {
+  getMessage,
+  type ReceivedEvent,
+  toInboundMessages,
+} from "@/remote/inbound";
+import { send } from "@/remote/send";
+import type { IMessageMessage } from "@/types";
+
+const CREATED_AT = new Date("2026-02-03T04:05:06.000Z");
+const DELIVERED_AT = new Date("2026-02-03T04:05:07.000Z");
+const READ_AT = new Date("2026-02-03T04:05:08.000Z");
+const ATTACHMENT_PLACEHOLDER = "\uFFFC";
+
+const nativeAttachment = (
+  guid = "attachment-guid"
+): SDKMessage["content"]["attachments"][number] => ({
+  fileName: "photo.png",
+  guid,
+  isHidden: false,
+  isOutgoing: false,
+  isSticker: false,
+  mimeType: "image/png",
+  totalBytes: 256,
+  transferState: "transferring",
+  uti: "public.png",
+});
+
+const nativeMessage = (overrides: Partial<SDKMessage> = {}): SDKMessage => ({
+  appliedReactions: [],
+  chatGuids: ["iMessage;+;chat-guid"],
+  content: {
+    attachments: [],
+    formatting: [{ length: 5, start: 0, type: "bold" }],
+    mentions: [{ address: "+15551230002", length: 7, start: 6 }],
+    text: "Hello @Taylor",
+  },
+  dataDetectorResultsPresent: false,
+  dateCreated: CREATED_AT,
+  dateDelivered: DELIVERED_AT,
+  dateRead: READ_AT,
+  didNotifyRecipient: true,
+  guid: "message-guid",
+  isArchived: false,
+  isAudioMessage: false,
+  isAutoReply: false,
+  isCorrupt: false,
+  isDelayed: false,
+  isDelivered: true,
+  isDeliveredQuietly: false,
+  isExpirable: false,
+  isForward: false,
+  isFromMe: false,
+  isSent: true,
+  isServiceMessage: false,
+  isSpam: false,
+  isSystemMessage: false,
+  itemType: "normal",
+  placedStickers: [],
+  sendErrorCode: 0,
+  sender: {
+    address: "+15551230001",
+    country: "US",
+    service: "iMessage",
+  },
+  ...overrides,
+});
+
+const receivedEvent = (message: SDKMessage): ReceivedEvent =>
+  ({
+    chatGuid: "iMessage;+;chat-guid",
+    isFromMe: message.isFromMe,
+    message,
+    occurredAt: CREATED_AT,
+    sequence: 1,
+    type: "message.received",
+  }) as Extract<MessageEvent, { type: "message.received" }>;
+
+const groupOf = (...contents: Content[]): Content =>
+  asGroup({
+    items: contents.map(
+      (content) => ({ content, id: "" }) as unknown as Message
+    ),
+  });
+
+describe("curated metadata across native message paths", () => {
+  it("includes metadata on ordinary inbound messages without extra RPCs", async () => {
+    const get = vi.fn();
+    const remote = { messages: { get } } as unknown as AdvancedIMessage;
+
+    const [message] = await toInboundMessages(
+      remote,
+      new MessageCache(),
+      receivedEvent(nativeMessage()),
+      "+15550000000"
+    );
+
+    expect(get).not.toHaveBeenCalled();
+    expect(message).toMatchObject({
+      dateDelivered: DELIVERED_AT,
+      dateRead: READ_AT,
+      formatting: [{ length: 5, start: 0, type: "bold" }],
+      isDelivered: true,
+      mentions: [{ address: "+15551230002", length: 7, start: 6 }],
+      nativeText: "Hello @Taylor",
+      sendErrorCode: 0,
+    });
+  });
+
+  it("includes metadata on getMessage and preserves cache-first behavior", async () => {
+    const get = vi.fn(() => Promise.resolve(nativeMessage()));
+    const remote = {
+      messages: { get },
+    } as unknown as AdvancedIMessage;
+
+    const first = await getMessage(
+      remote,
+      "iMessage;+;chat-guid",
+      "message-guid",
+      "+15550000000"
+    );
+    const second = await getMessage(
+      remote,
+      "iMessage;+;chat-guid",
+      "message-guid",
+      "+15550000000"
+    );
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(first?.dateDelivered).toEqual(DELIVERED_AT);
+    expect(first?.nativeText).toBe("Hello @Taylor");
+    expect(second).toBe(first);
+  });
+
+  it("computes multipart metadata once and carries it to every child", async () => {
+    const attachment = nativeAttachment();
+    const [parent] = await toInboundMessages(
+      { messages: {} } as unknown as AdvancedIMessage,
+      new MessageCache(),
+      receivedEvent(
+        nativeMessage({
+          content: {
+            attachments: [attachment],
+            formatting: [],
+            mentions: [],
+            text: `before ${ATTACHMENT_PLACEHOLDER} after`,
+          },
+          partCount: 3,
+        })
+      ),
+      "+15550000000"
+    );
+
+    expect(parent?.content.type).toBe("group");
+    if (parent?.content.type !== "group") {
+      throw new Error("expected multipart group");
+    }
+
+    expect(parent.partCount).toBe(3);
+    expect(parent.attachmentMetadata).toEqual([
+      {
+        companionKind: undefined,
+        fileName: "photo.png",
+        guid: "attachment-guid",
+        isHidden: false,
+        isSticker: false,
+        mimeType: "image/png",
+        originalGuid: undefined,
+        totalBytes: 256,
+        transferState: "transferring",
+        uti: "public.png",
+      },
+    ]);
+    for (const [partIndex, item] of parent.content.items.entries()) {
+      const child = item as unknown as IMessageMessage;
+      expect(child.parentId).toBe("message-guid");
+      expect(child.partIndex).toBe(partIndex);
+      expect(child.attachmentMetadata).toEqual(parent.attachmentMetadata);
+    }
+  });
+
+  it("includes metadata on native regular and multipart outbound results", async () => {
+    const singleNative = nativeMessage({
+      guid: "single-guid",
+      isFromMe: true,
+    });
+    const multipartNative = nativeMessage({
+      content: {
+        attachments: [nativeAttachment()],
+        formatting: [],
+        mentions: [],
+        text: `hello ${ATTACHMENT_PLACEHOLDER}`,
+      },
+      guid: "multipart-guid",
+      isFromMe: true,
+      partCount: 2,
+    });
+    const sendText = vi.fn(() => Promise.resolve(singleNative));
+    const sendMultipart = vi.fn(() => Promise.resolve(multipartNative));
+    const upload = vi.fn(() =>
+      Promise.resolve({ attachment: { guid: "uploaded-guid" } })
+    );
+    const remote = {
+      attachments: { upload },
+      messages: { sendMultipart, sendText },
+    } as unknown as AdvancedIMessage;
+    const attachment = asAttachment({
+      mimeType: "image/png",
+      name: "photo.png",
+      read: () => Promise.resolve(Buffer.from("photo")),
+    });
+
+    const single = (await send(
+      remote,
+      "iMessage;+;chat-guid",
+      asText("Hello")
+    )) as IMessageMessage;
+    const multipart = (await send(
+      remote,
+      "iMessage;+;chat-guid",
+      groupOf(asText("hello"), attachment)
+    )) as IMessageMessage;
+
+    expect(single).toMatchObject({
+      dateDelivered: DELIVERED_AT,
+      isDelivered: true,
+      nativeText: "Hello @Taylor",
+      sendErrorCode: 0,
+    });
+    expect(multipart.partCount).toBe(2);
+    expect(multipart.content.type).toBe("group");
+    if (multipart.content.type !== "group") {
+      throw new Error("expected multipart group");
+    }
+    for (const item of multipart.content.items) {
+      expect((item as unknown as IMessageMessage).attachmentMetadata).toEqual(
+        multipart.attachmentMetadata
+      );
+    }
+  });
+
+  it("does not leak an unsupported Advanced message through custom content", async () => {
+    const [message] = await toInboundMessages(
+      { messages: {} } as unknown as AdvancedIMessage,
+      new MessageCache(),
+      receivedEvent(
+        nativeMessage({
+          content: {
+            attachments: [],
+            formatting: [],
+            mentions: [],
+            text: undefined,
+          },
+          itemType: "chatAction",
+        })
+      ),
+      "+15550000000"
+    );
+
+    expect(message?.content).toEqual({
+      raw: {
+        imessage_type: "unsupported-message",
+      },
+      type: "custom",
+    });
+    if (message?.content.type !== "custom") {
+      throw new Error("expected custom fallback");
+    }
+    expect(message.itemType).toBe("chatAction");
+    expect(message.content.raw).not.toHaveProperty("guid");
+    expect(message.content.raw).not.toHaveProperty("content");
+    expect(message.content.raw).not.toHaveProperty("chatGuids");
+  });
+});

--- a/packages/imessage/test/remote/message-metadata.test.ts
+++ b/packages/imessage/test/remote/message-metadata.test.ts
@@ -362,6 +362,31 @@ describe("curated Advanced iMessage metadata", () => {
     });
   });
 
+  it("defaults required native collections when a row omits them", () => {
+    const complete = completeAdvancedMessage();
+    const sparse = {
+      ...complete,
+      appliedReactions: undefined,
+      content: {
+        ...complete.content,
+        attachments: undefined,
+        formatting: undefined,
+        mentions: undefined,
+      },
+      placedStickers: undefined,
+    } as unknown as AdvancedIMessageMessage;
+    const metadata = toMessageMetadata(sparse);
+
+    expect(metadata).toMatchObject({
+      appliedReactions: [],
+      attachmentMetadata: [],
+      formatting: [],
+      mentions: [],
+      placedStickers: [],
+    });
+    expect(nativeMessageMetadataSchema.parse(metadata)).toEqual(metadata);
+  });
+
   it("keeps metadata platform-specific until imessage.is narrows a message", () => {
     type GenericHasDeliveryMetadata = "dateDelivered" extends keyof Message
       ? true

--- a/packages/imessage/test/remote/message-metadata.test.ts
+++ b/packages/imessage/test/remote/message-metadata.test.ts
@@ -1,0 +1,386 @@
+import type { Message as AdvancedIMessageMessage } from "@photon-ai/advanced-imessage/grpc";
+import type { Message } from "@spectrum-ts/core";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import { imessage } from "@/index";
+import { toMessageMetadata } from "@/remote/message-metadata";
+import {
+  type IMessageMessage,
+  messageSchema,
+  nativeMessageMetadataSchema,
+} from "@/types";
+
+const CREATED_AT = new Date("2026-01-02T03:04:05.000Z");
+const DELIVERED_AT = new Date("2026-01-02T03:04:06.000Z");
+const READ_AT = new Date("2026-01-02T03:04:07.000Z");
+const EDITED_AT = new Date("2026-01-02T03:04:08.000Z");
+const PLAYED_AT = new Date("2026-01-02T03:04:09.000Z");
+const EXPRESSIVE_PLAYED_AT = new Date("2026-01-02T03:04:10.000Z");
+const RETRACTED_AT = new Date("2026-01-02T03:04:11.000Z");
+
+const completeAdvancedMessage = (): AdvancedIMessageMessage => ({
+  appliedReactions: [
+    {
+      dateCreated: CREATED_AT,
+      isFromMe: false,
+      messageGuid: "reaction-guid",
+      reaction: { kind: "emoji", emoji: "🔥" },
+      sender: {
+        address: "+15551230001",
+        country: "US",
+        service: "iMessage",
+      },
+      targetPartIndex: 2,
+    },
+  ],
+  cachedRoomNames: "Stale room name",
+  chatActionType: 42,
+  chatGuids: ["iMessage;+;chat-guid", "iMessage;+;joined-chat-guid"],
+  content: {
+    attachments: [
+      {
+        companionKind: "live-photo-video",
+        fileName: "IMG_1000.HEIC",
+        guid: "attachment-guid",
+        isHidden: false,
+        isOutgoing: true,
+        isSticker: false,
+        mimeType: "image/heic",
+        originalGuid: "original-attachment-guid",
+        totalBytes: 4096,
+        transferState: "failed",
+        uti: "public.heic",
+      },
+    ],
+    balloonBundleId: "com.apple.messages.URLBalloonProvider",
+    expressiveSendStyleId: "com.apple.messages.effect.CKConfettiEffect",
+    formatting: [
+      {
+        effectName: "big",
+        length: 5,
+        start: 0,
+        type: "bold",
+      },
+    ],
+    mentions: [{ address: "+15551230002", length: 12, start: 6 }],
+    text: "Hello @Taylor",
+  },
+  dataDetectorResultsPresent: true,
+  dateCreated: CREATED_AT,
+  dateDelivered: DELIVERED_AT,
+  dateEdited: EDITED_AT,
+  dateExpressiveSendPlayed: EXPRESSIVE_PLAYED_AT,
+  datePlayed: PLAYED_AT,
+  dateRead: READ_AT,
+  dateRetracted: RETRACTED_AT,
+  destinationCallerId: "P:+15550000000",
+  didNotifyRecipient: false,
+  groupTitle: "Current title",
+  guid: "message-guid",
+  isArchived: true,
+  isAudioMessage: false,
+  isAutoReply: true,
+  isCorrupt: false,
+  isDelayed: true,
+  isDelivered: true,
+  isDeliveredQuietly: true,
+  isExpirable: true,
+  isForward: true,
+  isFromMe: true,
+  isSent: true,
+  isServiceMessage: false,
+  isSpam: true,
+  isSystemMessage: false,
+  itemType: "participantChange",
+  partCount: 3,
+  placedStickers: [
+    {
+      dateCreated: CREATED_AT,
+      isFromMe: true,
+      messageGuid: "sticker-message-guid",
+      placement: {
+        rotation: 0.25,
+        scale: 1.5,
+        width: 120,
+        x: 0.4,
+        y: 0.7,
+      },
+      sender: {
+        address: "+15551230003",
+        service: "SMS",
+      },
+      sticker: {
+        fileName: "sticker.heic",
+        guid: "sticker-guid",
+        isHidden: true,
+        isOutgoing: true,
+        isSticker: true,
+        mimeType: "image/heic",
+        totalBytes: 512,
+        transferState: "finished",
+        uti: "com.apple.sticker",
+      },
+      targetPartIndex: 1,
+    },
+  ],
+  reaction: { kind: "like" },
+  reactionSelected: true,
+  reactionTargetGuid: "reaction-target-guid",
+  reactionTargetPartIndex: 4,
+  replyTargetGuid: "reply-target-guid",
+  sendErrorCode: 17,
+  sender: {
+    address: "+15551230004",
+    country: "US",
+    service: "iMessage",
+  },
+  shareDirection: 1,
+  shareStatus: 2,
+  subject: "Native subject",
+  threadOriginatorGuid: "thread-originator-guid",
+  threadOriginatorPart: "0:0/0",
+});
+
+const advancedMessageFieldPolicy = {
+  appliedReactions: "expose",
+  cachedRoomNames: "omit",
+  chatActionType: "omit",
+  chatGuids: "omit",
+  content: "transform",
+  dataDetectorResultsPresent: "omit",
+  dateCreated: "omit",
+  dateDelivered: "expose",
+  dateEdited: "expose",
+  dateExpressiveSendPlayed: "expose",
+  datePlayed: "expose",
+  dateRead: "expose",
+  dateRetracted: "expose",
+  destinationCallerId: "omit",
+  didNotifyRecipient: "expose",
+  groupTitle: "expose",
+  guid: "omit",
+  isArchived: "omit",
+  isAudioMessage: "omit",
+  isAutoReply: "expose",
+  isCorrupt: "expose",
+  isDelayed: "expose",
+  isDelivered: "expose",
+  isDeliveredQuietly: "expose",
+  isExpirable: "expose",
+  isForward: "omit",
+  isFromMe: "omit",
+  isSent: "expose",
+  isServiceMessage: "expose",
+  isSpam: "expose",
+  isSystemMessage: "expose",
+  itemType: "expose",
+  partCount: "expose",
+  placedStickers: "expose",
+  reaction: "transform",
+  reactionSelected: "transform",
+  reactionTargetGuid: "transform",
+  reactionTargetPartIndex: "transform",
+  replyTargetGuid: "omit",
+  sendErrorCode: "expose",
+  sender: "omit",
+  shareDirection: "omit",
+  shareStatus: "omit",
+  subject: "expose",
+  threadOriginatorGuid: "omit",
+  threadOriginatorPart: "omit",
+} as const satisfies Record<
+  keyof AdvancedIMessageMessage,
+  "expose" | "transform" | "omit"
+>;
+
+describe("curated Advanced iMessage metadata", () => {
+  it("maps delivery and lifecycle diagnostics", () => {
+    const metadata = toMessageMetadata(completeAdvancedMessage());
+
+    expect(metadata).toMatchObject({
+      dateDelivered: DELIVERED_AT,
+      dateEdited: EDITED_AT,
+      dateExpressiveSendPlayed: EXPRESSIVE_PLAYED_AT,
+      datePlayed: PLAYED_AT,
+      dateRead: READ_AT,
+      dateRetracted: RETRACTED_AT,
+      didNotifyRecipient: false,
+      isDelayed: true,
+      isDelivered: true,
+      isDeliveredQuietly: true,
+      isSent: true,
+      sendErrorCode: 17,
+    });
+  });
+
+  it("maps native text, formatting, mentions, subjects, and effects", () => {
+    const metadata = toMessageMetadata(completeAdvancedMessage());
+
+    expect(metadata).toMatchObject({
+      balloonBundleId: "com.apple.messages.URLBalloonProvider",
+      expressiveSendStyleId: "com.apple.messages.effect.CKConfettiEffect",
+      formatting: [
+        {
+          effectName: "big",
+          length: 5,
+          start: 0,
+          type: "bold",
+        },
+      ],
+      mentions: [{ address: "+15551230002", length: 12, start: 6 }],
+      nativeText: "Hello @Taylor",
+      subject: "Native subject",
+    });
+  });
+
+  it("maps actionable attachment transfer metadata without direction", () => {
+    const [attachment] = toMessageMetadata(
+      completeAdvancedMessage()
+    ).attachmentMetadata;
+
+    expect(attachment).toEqual({
+      companionKind: "live-photo-video",
+      fileName: "IMG_1000.HEIC",
+      guid: "attachment-guid",
+      isHidden: false,
+      isSticker: false,
+      mimeType: "image/heic",
+      originalGuid: "original-attachment-guid",
+      totalBytes: 4096,
+      transferState: "failed",
+      uti: "public.heic",
+    });
+    expect(attachment).not.toHaveProperty("isOutgoing");
+  });
+
+  it("maps aggregated reactions, placed stickers, and tapback rows", () => {
+    const metadata = toMessageMetadata(completeAdvancedMessage());
+
+    expect(metadata.appliedReactions).toEqual([
+      {
+        dateCreated: CREATED_AT,
+        isFromMe: false,
+        messageGuid: "reaction-guid",
+        reaction: { emoji: "🔥", kind: "emoji" },
+        sender: {
+          address: "+15551230001",
+          country: "US",
+          service: "iMessage",
+        },
+        targetPartIndex: 2,
+      },
+    ]);
+    expect(metadata.placedStickers).toEqual([
+      {
+        dateCreated: CREATED_AT,
+        isFromMe: true,
+        messageGuid: "sticker-message-guid",
+        placement: {
+          rotation: 0.25,
+          scale: 1.5,
+          width: 120,
+          x: 0.4,
+          y: 0.7,
+        },
+        sender: {
+          address: "+15551230003",
+          country: undefined,
+          service: "SMS",
+        },
+        sticker: {
+          companionKind: undefined,
+          fileName: "sticker.heic",
+          guid: "sticker-guid",
+          isHidden: true,
+          isSticker: true,
+          mimeType: "image/heic",
+          originalGuid: undefined,
+          totalBytes: 512,
+          transferState: "finished",
+          uti: "com.apple.sticker",
+        },
+        targetPartIndex: 1,
+      },
+    ]);
+    expect(metadata.reactionRecord).toEqual({
+      reaction: { emoji: undefined, kind: "like" },
+      selected: true,
+      targetGuid: "reaction-target-guid",
+      targetPartIndex: 4,
+    });
+  });
+
+  it("maps classification and multipart state", () => {
+    expect(toMessageMetadata(completeAdvancedMessage())).toMatchObject({
+      groupTitle: "Current title",
+      isAutoReply: true,
+      isCorrupt: false,
+      isExpirable: true,
+      isServiceMessage: false,
+      isSpam: true,
+      isSystemMessage: false,
+      itemType: "participantChange",
+      partCount: 3,
+    });
+  });
+
+  it("does not expose excluded native row fields", () => {
+    const metadata = toMessageMetadata(completeAdvancedMessage());
+    const omittedFields = Object.entries(advancedMessageFieldPolicy)
+      .filter(([, policy]) => policy === "omit")
+      .map(([field]) => field);
+
+    for (const field of omittedFields) {
+      expect(metadata).not.toHaveProperty(field);
+    }
+    expect(metadata).not.toHaveProperty("content");
+  });
+
+  it("parses complete native metadata and metadata-free synthetic records", () => {
+    const metadata = toMessageMetadata(completeAdvancedMessage());
+
+    expect(nativeMessageMetadataSchema.parse(metadata)).toEqual(metadata);
+    expect(
+      messageSchema.parse({
+        miniAppCardSession: {
+          chatGuid: "chat-guid",
+          messageGuid: "message-guid",
+          sessionId: "session-id",
+          targetMessageGuid: "target-message-guid",
+        },
+        parentId: "parent-guid",
+        partIndex: 0,
+      })
+    ).toEqual({
+      miniAppCardSession: {
+        chatGuid: "chat-guid",
+        messageGuid: "message-guid",
+        sessionId: "session-id",
+        targetMessageGuid: "target-message-guid",
+      },
+      parentId: "parent-guid",
+      partIndex: 0,
+    });
+  });
+
+  it("keeps metadata platform-specific until imessage.is narrows a message", () => {
+    type GenericHasDeliveryMetadata = "dateDelivered" extends keyof Message
+      ? true
+      : false;
+
+    expectTypeOf<GenericHasDeliveryMetadata>().toEqualTypeOf<false>();
+
+    const assertNarrowedMetadata = (message: Message): void => {
+      if (imessage.is(message)) {
+        expectTypeOf(message.dateDelivered).toEqualTypeOf<Date | undefined>();
+        expectTypeOf(message.attachmentMetadata).toEqualTypeOf<
+          IMessageMessage["attachmentMetadata"]
+        >();
+      }
+
+      const narrowed = imessage(message);
+      expectTypeOf(narrowed.dateDelivered).toEqualTypeOf<Date | undefined>();
+    };
+
+    expectTypeOf(assertNarrowedMetadata).toBeFunction();
+  });
+});

--- a/packages/imessage/test/remote/reactions.test.ts
+++ b/packages/imessage/test/remote/reactions.test.ts
@@ -15,8 +15,17 @@ const SENT_DATE = new Date(1_700_000_000_000);
 
 const makeRemote = () => {
   const tapback = {
-    guid: "tapback-1",
+    content: {
+      attachments: [],
+      formatting: [],
+      mentions: [],
+      text: "Liked “hi”",
+    },
     dateCreated: SENT_DATE,
+    dateDelivered: SENT_DATE,
+    guid: "tapback-1",
+    isDelivered: true,
+    sendErrorCode: 0,
   } as unknown as SDKMessage;
   const setReaction = vi.fn(
     (
@@ -112,6 +121,12 @@ describe("iMessage remote reactToMessage", () => {
     expect(record.id).toBe("tapback-1");
     expect(record.timestamp).toEqual(SENT_DATE);
     expect(record.space).toEqual({ id: "s1" });
+    expect(record).toMatchObject({
+      dateDelivered: SENT_DATE,
+      isDelivered: true,
+      nativeText: "Liked “hi”",
+      sendErrorCode: 0,
+    });
     const content = record.content as { type: string; emoji: string };
     expect(content.type).toBe("reaction");
     expect(content.emoji).toBe("👍");

--- a/packages/imessage/test/remote/stream-text.test.ts
+++ b/packages/imessage/test/remote/stream-text.test.ts
@@ -24,8 +24,16 @@ afterEach(() => {
 
 const makeRemote = () => {
   const reply = {
-    guid: "msg-guid",
+    content: {
+      attachments: [],
+      formatting: [{ length: 5, start: 0, type: "bold" }],
+      mentions: [],
+      text: "Hello",
+    },
     dateCreated: SENT_DATE,
+    dateDelivered: SENT_DATE,
+    guid: "msg-guid",
+    isDelivered: true,
   } as unknown as SDKMessage;
   const editTimes: number[] = [];
   const sendText = vi.fn((_chat: string, _text: string) =>
@@ -106,6 +114,9 @@ describe("sendStreamText", () => {
     expect(result.content).toEqual({ type: "text", text: "Hello world" });
     expect(result.space).toEqual({ id: "chat" });
     expect((result as { nativeText?: string }).nativeText).toBe("Hello world");
+    expect(result).not.toHaveProperty("dateDelivered");
+    expect(result).not.toHaveProperty("isDelivered");
+    expect(result).not.toHaveProperty("formatting");
   });
 
   it("sends a single message and no edit for a one-delta stream", async () => {
@@ -121,6 +132,11 @@ describe("sendStreamText", () => {
     expect(sendText.mock.calls[0]).toEqual(["chat", "hi"]);
     expect(edit).not.toHaveBeenCalled();
     expect(result.content).toEqual({ type: "text", text: "hi" });
+    expect(result).toMatchObject({
+      dateDelivered: SENT_DATE,
+      isDelivered: true,
+      formatting: [{ length: 5, start: 0, type: "bold" }],
+    });
   });
 
   it("backs off, stays within the edit budget, and lands the complete text", async () => {

--- a/packages/imessage/test/remote/stream-text.test.ts
+++ b/packages/imessage/test/remote/stream-text.test.ts
@@ -105,6 +105,7 @@ describe("sendStreamText", () => {
     expect(result.timestamp).toEqual(SENT_DATE);
     expect(result.content).toEqual({ type: "text", text: "Hello world" });
     expect(result.space).toEqual({ id: "chat" });
+    expect((result as { nativeText?: string }).nativeText).toBe("Hello world");
   });
 
   it("sends a single message and no edit for a one-delta stream", async () => {


### PR DESCRIPTION
## Summary

- Expose advanced iMessage metadata through `getMessage` and related remote message APIs
- Add support for reactions, message metadata, and streamed text handling
- Update iMessage types and messaging feature documentation
- Add unit and integration coverage for metadata, reactions, and stream text behavior

## Testing

- Added and updated iMessage remote unit and integration tests
- Not run (not requested)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788053575&installation_model_id=19795&pr_number=225&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F225&signature=4fe718c51972d16aa6978ded47a4dcf9b02268e84e771878677921510534f481"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core iMessage message mapping and public `IMessageMessage` shape across inbound, outbound, reactions, and streaming; behavior change for unsupported inbound content could affect consumers that relied on raw custom payloads.
> 
> **Overview**
> Adds **curated Apple/iMessage metadata** to `IMessageMessage` (delivery timestamps, `sendErrorCode`, `nativeText`, formatting/mentions, attachment transfer metadata, reactions/stickers, classification flags) via a new `toMessageMetadata` mapper at the Advanced iMessage boundary so private native fields do not leak through normal messages.
> 
> Metadata is attached on **inbound** (`buildMessageBase`), **outbound** send/multipart/reactions, and **single-chunk** streamed text; **edited** streamed sends return final `nativeText` but drop the first-send metadata snapshot (docs note using `space.getMessage()` for current state). **Unsupported** inbound rows no longer surface the raw Advanced message as custom content—they use a small `unsupported-message` custom marker while metadata like `itemType` can still be present.
> 
> Public **types and Zod schemas** (`nativeMessageMetadataSchema`, exported metadata types) back the fields; `imessage.is()` remains the narrowing guard. Platform export wiring uses an internal `defineCorePlatform` plus a local type-refining `definePlatform` wrapper. Documentation adds a **Native message metadata** section with field tables and examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82b60ec151ea0f9360bcddb3dc601c767d762d47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added curated native iMessage metadata for inbound, retrieved, outbound, streamed, multipart, and reaction messages.
  * Added support for text formatting, mentions, attachments, reactions, stickers, delivery status, and message classification.
  * Added public iMessage metadata types and platform-aware message narrowing.
  * Added documentation covering available metadata, lifecycle details, and send-error behavior.

* **Bug Fixes**
  * Unsupported messages now use a safe, concise content marker instead of exposing raw message data.
  * Complete streamed message text is preserved, while stale initial metadata is omitted after edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->