### PR TITLE
docs(voice): document TLS signaling support

### DIFF
--- a/docs/introduction.mdx.vel
+++ b/docs/introduction.mdx.vel
@@ -132,7 +132,7 @@ You do not have to manage Spectrum only from the dashboard. Use the dashboard fo
     Receive messages via HTTP with native and Fusor webhook support, plus Hono, Express, and Elysia adapters.
   </Card>
   <Card title="Voice calls" icon="phone" href="/spectrum-ts/providers/voice">
-    Configure inbound and outbound calling over SIP with TCP transport.
+    Configure inbound and outbound SIP signaling over TLS or TCP.
   </Card>
   <Card title="Build a custom platform" icon="blocks" href="/spectrum-ts/custom-platforms">
     Add a new interface with Spectrum's provider model.

--- a/docs/introduction.mdx.vel
+++ b/docs/introduction.mdx.vel
@@ -132,7 +132,7 @@ You do not have to manage Spectrum only from the dashboard. Use the dashboard fo
     Receive messages via HTTP with native and Fusor webhook support, plus Hono, Express, and Elysia adapters.
   </Card>
   <Card title="Voice calls" icon="phone" href="/spectrum-ts/providers/voice">
-    Configure inbound and outbound SIP signaling over TLS or TCP.
+    Place and receive calls with SIP over TLS or TCP.
   </Card>
   <Card title="Build a custom platform" icon="blocks" href="/spectrum-ts/custom-platforms">
     Add a new interface with Spectrum's provider model.

--- a/docs/providers/voice.mdx.vel
+++ b/docs/providers/voice.mdx.vel
@@ -3,13 +3,36 @@ title: "Voice"
 description: "Add inbound and outbound voice calls to a Spectrum iMessage line over SIP."
 ---
 
-Spectrum Voice lets a SIP application, PBX, or voice agent place and receive
-live calls through a Spectrum iMessage line.
+Spectrum Voice connects a SIP application or phone system to a Spectrum
+iMessage line. The application can place calls from that line and receive calls
+made to it.
 
 <Note>
   This guide is about live calls. To send an audio recording inside a message,
   use the [`voice()` content builder](/spectrum-ts/content/voice).
 </Note>
+
+## What inbound and outbound mean
+
+- An **outbound call** starts in your SIP application. Spectrum places the call
+  from your iMessage line to the phone number you dial.
+- An **inbound call** starts when someone calls your iMessage line. Spectrum
+  sends the call to your SIP application.
+
+You can set up either direction or both.
+
+## How a call connects
+
+A call uses two kinds of network traffic:
+
+- **SIP signaling** contains the instructions to start, answer, and end a call.
+  SIP stands for Session Initiation Protocol.
+- **TLS** creates an encrypted connection for SIP signaling. Use TLS when you
+  want those call instructions protected in transit.
+- **TCP** can also carry SIP signaling, but without encryption.
+- **RTP audio** carries the voices you hear during the call. Spectrum currently
+  uses RTP, not its encrypted form, SRTP. This means the audio on the SIP side
+  of the call is not encrypted.
 
 ## What is supported
 
@@ -30,14 +53,16 @@ live calls through a Spectrum iMessage line.
 | SRTP audio | Not supported |
 
 <Note>
-  To connect to Spectrum over TLS, use **Spectrum destination port 5061**. TCP
-  on Spectrum destination port 5060 remains supported for compatibility. Your
-  SIP application does not need to bind or listen on either port when it
-  initiates a call; it can use an available local source port. UDP is not
-  supported.
+  Inbound and outbound calls have separate settings:
 
-  TLS protects SIP signaling such as call setup and hangup. Call audio
-  currently uses unencrypted RTP, not SRTP.
+  - For **outbound calls**, your application connects to Spectrum. Use TLS and
+    Spectrum server port 5061. TCP on Spectrum server port 5060 remains
+    available for compatibility, but it does not encrypt SIP signaling.
+  - For **inbound calls**, Spectrum connects to the SIP address you save in the
+    dashboard. A `sips:` address selects TLS; a `sip:` address selects TCP. You
+    can choose the port on which your application listens.
+
+  Spectrum does not support SIP signaling over UDP.
 </Note>
 
 ## Choose a setup path
@@ -64,12 +89,16 @@ For outbound calls, configure your SIP application with these values:
 | Username | Your Spectrum project ID |
 | Password | Your Spectrum project secret |
 | Recommended transport | `TLS` |
-| Spectrum TLS destination port | `5061` |
-| Spectrum TCP destination port | `5060` |
-| Audio transport | RTP |
+| Spectrum server port | `5061` |
+| Audio | RTP (not encrypted) |
 
 You can find the project ID and project secret in your project settings in the
 [Spectrum dashboard](https://app.photon.codes).
+
+Port 5061 is the server port to enter in your SIP application. Your application
+does not need to use 5061 as its own local or listening port. To keep an
+existing TCP configuration, use Spectrum server port 5060 instead. TLS is
+recommended because TCP does not encrypt SIP signaling.
 
 For inbound calls, register the inbound route in the dashboard. The dashboard
 connects the iMessage line to your SIP application.
@@ -97,9 +126,10 @@ it does not yet use a `voice.config()` SDK provider.
 
 Today, your application connects directly through SIP:
 
-- Use SIP over TLS or TCP for inbound and outbound calls.
-- Prefer Spectrum's TLS destination port 5061 to encrypt SIP signaling. TCP on
-  Spectrum destination port 5060 remains available for existing integrations.
+- For outbound calls, connect your application to Spectrum using TLS on server
+  port 5061. TCP on server port 5060 remains available for compatibility.
+- For inbound calls, save a `sips:` address for TLS or a `sip:` address for TCP.
+  This setting is independent of the outbound connection.
 - Allow RTP media traffic for call audio. SIP TLS does not encrypt the RTP
   audio stream.
 - Use the dashboard to manage the project, business profile, line, and inbound

--- a/docs/providers/voice.mdx.vel
+++ b/docs/providers/voice.mdx.vel
@@ -30,8 +30,11 @@ live calls through a Spectrum iMessage line.
 | SRTP audio | Not supported |
 
 <Note>
-  Use **TLS on port 5061** when your SIP application supports it. TCP on port
-  5060 remains supported for compatibility. UDP is not supported.
+  To connect to Spectrum over TLS, use **Spectrum destination port 5061**. TCP
+  on Spectrum destination port 5060 remains supported for compatibility. Your
+  SIP application does not need to bind or listen on either port when it
+  initiates a call; it can use an available local source port. UDP is not
+  supported.
 
   TLS protects SIP signaling such as call setup and hangup. Call audio
   currently uses unencrypted RTP, not SRTP.
@@ -61,8 +64,8 @@ For outbound calls, configure your SIP application with these values:
 | Username | Your Spectrum project ID |
 | Password | Your Spectrum project secret |
 | Recommended transport | `TLS` |
-| TLS port | `5061` |
-| TCP compatibility port | `5060` |
+| Spectrum TLS destination port | `5061` |
+| Spectrum TCP destination port | `5060` |
 | Audio transport | RTP |
 
 You can find the project ID and project secret in your project settings in the
@@ -95,8 +98,8 @@ it does not yet use a `voice.config()` SDK provider.
 Today, your application connects directly through SIP:
 
 - Use SIP over TLS or TCP for inbound and outbound calls.
-- Prefer TLS on port 5061 to encrypt SIP signaling. TCP on port 5060 remains
-  available for existing integrations.
+- Prefer Spectrum's TLS destination port 5061 to encrypt SIP signaling. TCP on
+  Spectrum destination port 5060 remains available for existing integrations.
 - Allow RTP media traffic for call audio. SIP TLS does not encrypt the RTP
   audio stream.
 - Use the dashboard to manage the project, business profile, line, and inbound

--- a/docs/providers/voice.mdx.vel
+++ b/docs/providers/voice.mdx.vel
@@ -23,13 +23,19 @@ live calls through a Spectrum iMessage line.
 | SIP | Supported |
 | Webhooks | Coming soon |
 | `spectrum-ts` SDK call control | Coming soon |
-| TCP transport | Supported |
-| UDP or TLS transport | Not supported |
+| SIP over TLS | Supported |
+| SIP over TCP | Supported |
+| SIP over UDP | Not supported |
+| RTP audio | Supported |
+| SRTP audio | Not supported |
 
-<Warning>
-  Configure your SIP application to use **TCP**. Spectrum Voice does not
-  currently accept UDP, TLS, or `sips:` connections.
-</Warning>
+<Note>
+  Use **TLS on port 5061** when your SIP application supports it. TCP on port
+  5060 remains supported for compatibility. UDP is not supported.
+
+  TLS protects SIP signaling such as call setup and hangup. Call audio
+  currently uses unencrypted RTP, not SRTP.
+</Note>
 
 ## Choose a setup path
 
@@ -51,10 +57,13 @@ For outbound calls, configure your SIP application with these values:
 
 | Setting | Value |
 |---|---|
-| SIP server or URI | `sip.spectrum.photon.codes` |
+| SIP server | `sip.spectrum.photon.codes` |
 | Username | Your Spectrum project ID |
 | Password | Your Spectrum project secret |
-| Transport | `TCP` |
+| Recommended transport | `TLS` |
+| TLS port | `5061` |
+| TCP compatibility port | `5060` |
+| Audio transport | RTP |
 
 You can find the project ID and project secret in your project settings in the
 [Spectrum dashboard](https://app.photon.codes).
@@ -85,10 +94,14 @@ it does not yet use a `voice.config()` SDK provider.
 
 Today, your application connects directly through SIP:
 
-- Use SIP over TCP for inbound and outbound calls.
+- Use SIP over TLS or TCP for inbound and outbound calls.
+- Prefer TLS on port 5061 to encrypt SIP signaling. TCP on port 5060 remains
+  available for existing integrations.
+- Allow RTP media traffic for call audio. SIP TLS does not encrypt the RTP
+  audio stream.
 - Use the dashboard to manage the project, business profile, line, and inbound
   route.
 - Do not expect voice calls in `app.messages` or `app.webhook()`.
 
-Webhook delivery, SDK call control, TLS transport, and voice-only lines are on
-the roadmap. No release dates are promised yet.
+Webhook delivery, SDK call control, and voice-only lines are on the roadmap. No
+release dates are promised yet.

--- a/docs/providers/voice/inbound-calls.mdx.vel
+++ b/docs/providers/voice/inbound-calls.mdx.vel
@@ -15,11 +15,18 @@ You need:
 
 - A Spectrum project.
 - An iMessage line in that project.
-- A SIP client, PBX, or voice application that can receive calls over TLS or
-  TCP.
-- The inbound routing details requested by the dashboard.
+- A SIP application or phone system that can receive calls over TLS or TCP.
+- A public hostname or IP address that Spectrum can reach.
+- Firewall access (network permission) for the SIP listening port and the RTP
+  audio ports used by your application.
 
 WhatsApp numbers cannot be used for Spectrum Voice.
+
+<Note>
+  If the SIP application runs on a private network, such as a laptop on home or
+  office Wi-Fi, it is not normally reachable from Spectrum. Configure port
+  forwarding and firewall rules, or run the application on a public server.
+</Note>
 
 ## Set up inbound calling
 
@@ -35,31 +42,52 @@ WhatsApp numbers cannot be used for Spectrum Voice.
     Make sure you select an iMessage line. WhatsApp numbers are not supported.
   </Step>
   <Step title="Register the inbound route">
-    Enter the SIP URI requested by the dashboard and save the registration.
-    Use a `sips:` URI for TLS or a `sip:` URI for TCP:
+    In the **SIP URI** field, enter the address that Spectrum should call. Use
+    `sips:` for encrypted TLS signaling or `sip:` for unencrypted TCP
+    signaling:
 
     ```text
     sips:agent@voice.example.com:5061
     sip:agent@voice.example.com:5060
     ```
 
-    When the URI omits its port, Spectrum uses 5061 for `sips:` and 5060 for
-    `sip:`. To use a different listening port, include it explicitly in the
-    URI. UDP is not supported.
+    Replace `agent` with the SIP username or extension expected by your
+    application, and replace `voice.example.com` with its public hostname.
+    The final number is the port on which your application listens. A port tells
+    Spectrum which network service to contact on that server.
+
+    If the application does not require a specific username or extension, omit
+    `agent@`. For example:
+
+    ```text
+    sips:voice.example.com:5061
+    ```
+
+    Port 5061 is the default for `sips:` and 5060 is the default for `sip:`.
+    These are defaults, not requirements. To use a different listening port,
+    include that port in the URI. UDP is not supported.
+
+    The dashboard also has optional **Username** and **Password** fields. Fill
+    in both fields only if your SIP application requires username-and-password
+    authentication for incoming calls. This standard SIP mechanism is called
+    SIP Digest. Otherwise, leave both fields empty.
   </Step>
   <Step title="Configure your SIP application">
-    Configure the receiving application with the inbound values shown in the
-    dashboard. The transport and listening port must match the saved SIP URI.
+    Configure the application to listen using the same transport and port as
+    the SIP URI saved in the dashboard.
 
-    For TLS, configure a certificate and private key for the endpoint hostname.
-    Use a publicly trusted certificate whose subject alternative name covers
-    that hostname. For TCP, use a `sip:` URI; 5060 is the default when the URI
-    does not include a port.
+    For TLS, the application needs a TLS certificate and its private key. For
+    production, use a publicly trusted certificate that is valid for the
+    hostname or IP address in the SIP URI. TCP does not require a TLS
+    certificate.
   </Step>
   <Step title="Keep the SIP application available">
-    Start the SIP application and keep its SIP listener reachable so it can
-    accept an incoming call. Also allow the RTP ports used by the application
-    so audio can flow in both directions.
+    Start the SIP application and make sure Spectrum can reach its public
+    hostname or IP address and SIP port.
+
+    Also allow the application's RTP port range through the firewall. RTP
+    carries the call audio and normally uses UDP; check the application's media
+    or RTP settings for its exact port range.
   </Step>
   <Step title="Place an inbound test call">
     From another phone, call the iMessage line registered in the dashboard.
@@ -86,13 +114,15 @@ an inbound route does not register the business profile.
 - The selected number is an iMessage line, not a WhatsApp number.
 - The SIP application uses the routing values shown in the dashboard.
 - The saved SIP URI uses `sips:` for TLS or `sip:` for TCP.
-- The application listens on the transport and port specified by the saved
-  route, not UDP.
-- The TLS certificate matches the endpoint hostname when using TLS.
-- The SIP application remains reachable and ready to receive calls.
+- The application listens on the transport and port specified by the saved SIP
+  URI.
+- The TLS certificate is valid for the hostname or IP address in the SIP URI
+  when using TLS.
+- Spectrum can reach the application's public hostname or IP address and SIP
+  port.
 - A test call reaches the application and has working two-way audio.
-- RTP media is allowed by the network. SIP TLS does not encrypt the RTP audio
-  stream.
+- The firewall allows the application's UDP RTP port range. SIP TLS does not
+  encrypt the RTP audio stream.
 
 ## Troubleshooting
 
@@ -101,6 +131,9 @@ an inbound route does not register the business profile.
 Check that the inbound route is saved for the exact iMessage line being called.
 Then confirm that the SIP application is running, publicly reachable, and
 listening on the transport and port specified by the saved SIP URI.
+
+If the application runs behind a router or cloud firewall, confirm that traffic
+on the SIP port is forwarded to the application.
 
 ### The wrong project or line receives the call
 
@@ -115,14 +148,17 @@ accept SIP over UDP.
 ### A TLS route does not connect
 
 Confirm that the route starts with `sips:`, the receiving application listens
-for TLS on the configured port, and its certificate covers the hostname in the
-route. Also confirm that the firewall allows inbound TCP traffic on that port.
+for TLS on the configured port, and its certificate covers the hostname or IP
+address in the route. Also confirm that the firewall allows inbound TCP traffic
+on that port.
 
 ### The call arrives but audio does not work
 
 SIP TLS protects signaling only. Audio uses RTP, so confirm that the endpoint's
-firewall and NAT configuration allow the negotiated RTP traffic in both
-directions.
+firewall allows the UDP RTP port range configured in the SIP application. If
+the application is behind a router, its NAT or port-forwarding configuration
+must also send that traffic to the application. NAT is the router feature that
+lets devices on a private network share a public internet address.
 
 ### I configured outbound calls, but inbound does not work
 

--- a/docs/providers/voice/inbound-calls.mdx.vel
+++ b/docs/providers/voice/inbound-calls.mdx.vel
@@ -15,7 +15,8 @@ You need:
 
 - A Spectrum project.
 - An iMessage line in that project.
-- A SIP client, PBX, or voice application that can receive calls over TCP.
+- A SIP client, PBX, or voice application that can receive calls over TLS or
+  TCP.
 - The inbound routing details requested by the dashboard.
 
 WhatsApp numbers cannot be used for Spectrum Voice.
@@ -34,19 +35,31 @@ WhatsApp numbers cannot be used for Spectrum Voice.
     Make sure you select an iMessage line. WhatsApp numbers are not supported.
   </Step>
   <Step title="Register the inbound route">
-    Enter the SIP routing information requested by the dashboard and save the
-    registration. The dashboard registration tells Spectrum where to send an
-    incoming call.
+    Enter the SIP URI requested by the dashboard and save the registration.
+    Use a `sips:` URI for TLS or a `sip:` URI for TCP:
+
+    ```text
+    sips:agent@voice.example.com:5061
+    sip:agent@voice.example.com:5060
+    ```
+
+    When the URI omits its port, Spectrum uses 5061 for `sips:` and 5060 for
+    `sip:`. To use a different listening port, include it explicitly in the
+    URI. UDP is not supported.
   </Step>
   <Step title="Configure your SIP application">
     Configure the receiving application with the inbound values shown in the
-    dashboard. Set the SIP transport to TCP.
+    dashboard. The transport and listening port must match the saved SIP URI.
 
-    Do not use UDP, TLS, or a `sips:` URI. They are not currently supported.
+    For TLS, configure a certificate and private key for the endpoint hostname.
+    Use a publicly trusted certificate whose subject alternative name covers
+    that hostname. For TCP, use a `sip:` URI; 5060 is the default when the URI
+    does not include a port.
   </Step>
   <Step title="Keep the SIP application available">
-    Start the SIP application and keep its connection active so it can accept
-    an incoming call.
+    Start the SIP application and keep its SIP listener reachable so it can
+    accept an incoming call. Also allow the RTP ports used by the application
+    so audio can flow in both directions.
   </Step>
   <Step title="Place an inbound test call">
     From another phone, call the iMessage line registered in the dashboard.
@@ -72,29 +85,46 @@ an inbound route does not register the business profile.
 - The inbound route is saved under the correct project.
 - The selected number is an iMessage line, not a WhatsApp number.
 - The SIP application uses the routing values shown in the dashboard.
-- The transport is TCP, not UDP or TLS.
-- The SIP application stays connected and ready to receive calls.
+- The saved SIP URI uses `sips:` for TLS or `sip:` for TCP.
+- The application listens on the transport and port specified by the saved
+  route, not UDP.
+- The TLS certificate matches the endpoint hostname when using TLS.
+- The SIP application remains reachable and ready to receive calls.
 - A test call reaches the application and has working two-way audio.
+- RTP media is allowed by the network. SIP TLS does not encrypt the RTP audio
+  stream.
 
 ## Troubleshooting
 
 ### No inbound call arrives
 
 Check that the inbound route is saved for the exact iMessage line being called.
-Then confirm that the SIP application is running and connected over TCP.
+Then confirm that the SIP application is running, publicly reachable, and
+listening on the transport and port specified by the saved SIP URI.
 
 ### The wrong project or line receives the call
 
 Open the inbound registration in the dashboard and verify both the selected
 project and iMessage line. The inbound route is tied to that selection.
 
-### The SIP application tries UDP or TLS
+### The SIP application tries UDP
 
-Select TCP explicitly in the SIP application. Automatic transport selection
-can choose a protocol that Spectrum Voice does not support.
+Select TLS or TCP explicitly in the SIP application. Spectrum Voice does not
+accept SIP over UDP.
+
+### A TLS route does not connect
+
+Confirm that the route starts with `sips:`, the receiving application listens
+for TLS on the configured port, and its certificate covers the hostname in the
+route. Also confirm that the firewall allows inbound TCP traffic on that port.
+
+### The call arrives but audio does not work
+
+SIP TLS protects signaling only. Audio uses RTP, so confirm that the endpoint's
+firewall and NAT configuration allow the negotiated RTP traffic in both
+directions.
 
 ### I configured outbound calls, but inbound does not work
 
 Outbound credentials and inbound routing are separate. Return to the dashboard
 and register the inbound route for the iMessage line.
-

--- a/docs/providers/voice/outbound-calls.mdx.vel
+++ b/docs/providers/voice/outbound-calls.mdx.vel
@@ -7,6 +7,12 @@ Outbound calling connects your SIP application to an iMessage line owned by
 your Spectrum project.
 
 <Note>
+  The ports in this guide are destination ports on Spectrum. Your SIP
+  application does not need to bind or listen on local port 5060 or 5061 to
+  initiate an outbound call; it can use an available local source port.
+</Note>
+
+<Note>
   Business profile registration is recommended for production, but it is not
   required. Outbound calls work without any business profile registration,
   although they may be flagged.
@@ -48,7 +54,7 @@ WhatsApp numbers cannot be used for Spectrum Voice.
     | Username | Your Spectrum project ID |
     | Password | Your Spectrum project secret |
     | Transport | `TLS` |
-    | Port | `5061` |
+    | Spectrum destination port | `5061` |
 
     SIP products name these fields differently. The server field might be
     called **SIP URI**, **domain**, **registrar**, **proxy**, or **host**. In
@@ -56,12 +62,13 @@ WhatsApp numbers cannot be used for Spectrum Voice.
     URI, use `sips:sip.spectrum.photon.codes:5061;transport=tls`.
   </Step>
   <Step title="Select the signaling transport">
-    Select TLS explicitly and use port 5061. Keep certificate verification
-    enabled and verify that the certificate is valid for
-    `sip.spectrum.photon.codes`.
+    Select TLS explicitly and set Spectrum's remote or server port to 5061.
+    This is the destination port, not a required local listening port. Keep
+    certificate verification enabled and verify that the certificate is valid
+    for `sip.spectrum.photon.codes`.
 
     TCP remains supported for existing integrations. To use it, select TCP on
-    port 5060, or use
+    Spectrum destination port 5060, or use
     `sip:sip.spectrum.photon.codes:5060;transport=tcp`. UDP is not supported.
   </Step>
   <Step title="Connect and authenticate">
@@ -91,6 +98,9 @@ SPECTRUM_SIP_USERNAME=your-project-id
 SPECTRUM_SIP_PASSWORD=your-project-secret
 SPECTRUM_SIP_TRANSPORT=tls
 ```
+
+`SPECTRUM_SIP_HOST` and `SPECTRUM_SIP_PORT` identify the remote Spectrum
+endpoint. They do not configure a local listening port.
 
 Keep the project secret in a secret manager or protected environment variable.
 Do not commit it to source control or send it to browser code.
@@ -126,7 +136,7 @@ but it should not be treated as a guarantee that a call will never be flagged.
 - The server is exactly `sip.spectrum.photon.codes`.
 - The username is the project ID, not the project name.
 - The password is the current project secret.
-- The transport is TLS/5061 or TCP/5060, not UDP.
+- The Spectrum destination is TLS/5061 or TCP/5060, not UDP.
 - TLS certificate verification is enabled when using TLS.
 - A test call connects and has working two-way audio.
 - RTP media is allowed by the network. SIP TLS does not encrypt the RTP audio
@@ -137,9 +147,10 @@ but it should not be treated as a guarantee that a call will never be flagged.
 
 ### The SIP application cannot connect
 
-Check the server spelling and make sure the transport and port match: TLS uses
-5061 and TCP uses 5060. Disable UDP and confirm that your network allows the SIP
-application to make the outbound TCP connection used by the selected transport.
+Check the server spelling and make sure the transport and Spectrum destination
+port match: TLS uses 5061 and TCP uses 5060. Disable UDP and confirm that your
+network allows the SIP application to make the outbound TCP connection used by
+the selected transport.
 
 ### TLS certificate verification fails
 

--- a/docs/providers/voice/outbound-calls.mdx.vel
+++ b/docs/providers/voice/outbound-calls.mdx.vel
@@ -7,9 +7,9 @@ Outbound calling connects your SIP application to an iMessage line owned by
 your Spectrum project.
 
 <Note>
-  The ports in this guide are destination ports on Spectrum. Your SIP
-  application does not need to bind or listen on local port 5060 or 5061 to
-  initiate an outbound call; it can use an available local source port.
+  Port 5061 is the **Spectrum server port**. Enter it in the server, remote, or
+  proxy port field in your SIP application. Your application does not need to
+  use 5061 as its own local or listening port.
 </Note>
 
 <Note>
@@ -25,7 +25,11 @@ You need:
 - A Spectrum project.
 - An iMessage line in that project.
 - The project's ID and secret.
-- A SIP client, PBX, or voice application that supports TLS or TCP transport.
+- A SIP application or phone system that supports TLS or TCP and
+  username-and-password authentication. This standard SIP mechanism is called
+  SIP Digest.
+- The ability to set the caller ID, sometimes called the **From** number, for
+  outbound calls.
 
 WhatsApp numbers cannot be used for Spectrum Voice.
 
@@ -50,39 +54,54 @@ WhatsApp numbers cannot be used for Spectrum Voice.
 
     | SIP setting | Value |
     |---|---|
-    | Server or URI | `sip.spectrum.photon.codes` |
+    | Server, proxy, or host | `sip.spectrum.photon.codes` |
+    | Server port | `5061` |
+    | Transport | `TLS` |
     | Username | Your Spectrum project ID |
     | Password | Your Spectrum project secret |
-    | Transport | `TLS` |
-    | Spectrum destination port | `5061` |
+    | Registration | Off (Spectrum is not a SIP registrar) |
+    | Caller ID or From number | An iMessage line owned by the project |
 
     SIP products name these fields differently. The server field might be
-    called **SIP URI**, **domain**, **registrar**, **proxy**, or **host**. In
-    each case, use `sip.spectrum.photon.codes`. If the field requires a full
-    URI, use `sips:sip.spectrum.photon.codes:5061;transport=tls`.
-  </Step>
-  <Step title="Select the signaling transport">
-    Select TLS explicitly and set Spectrum's remote or server port to 5061.
-    This is the destination port, not a required local listening port. Keep
-    certificate verification enabled and verify that the certificate is valid
+    called **SIP URI**, **domain**, **proxy**, or **host**. In each case, use
+    `sip.spectrum.photon.codes`. If the field requires one full URI, use:
+
+    ```text
+    sips:sip.spectrum.photon.codes:5061
+    ```
+
+    Keep TLS certificate verification enabled. The certificate must be valid
     for `sip.spectrum.photon.codes`.
 
     TCP remains supported for existing integrations. To use it, select TCP on
-    Spectrum destination port 5060, or use
-    `sip:sip.spectrum.photon.codes:5060;transport=tcp`. UDP is not supported.
+    Spectrum server port 5060, or use
+    `sip:sip.spectrum.photon.codes:5060;transport=tcp`. TCP does not encrypt SIP
+    signaling. UDP is not supported.
   </Step>
-  <Step title="Connect and authenticate">
-    Start the SIP application and confirm that it connects successfully.
+  <Step title="Use a trunk or no-registration mode">
+    Many SIP applications try to register with a server before making calls.
+    Spectrum works differently: it checks the project credentials when each
+    outbound call is placed, so it does not support SIP registration.
 
-    If authentication fails, check that the project ID and project secret are
-    from the same project and do not contain extra spaces or line breaks.
+    If the application has a **Register** or **Registration** setting, turn it
+    off or choose a trunk, peer, or no-registration mode.
+
+    The application must be able to place a call without first completing SIP
+    registration. A softphone that requires a successful registration is not
+    compatible with this setup.
   </Step>
   <Step title="Place a test call">
-    Place a call through the configured SIP account. Confirm that the call uses
-    an iMessage line owned by the authenticated project.
+    Set the caller ID or From number to an iMessage line owned by the project,
+    then call a phone number through the configured SIP account. Use full
+    international format, such as `+14155550123`.
 
-    Test call setup and two-way audio before using the connection in
-    production.
+    Spectrum asks the application for the project credentials when the call is
+    placed. The application should handle this automatically. If authentication
+    fails, confirm that the project ID and project secret come from the same
+    project and contain no extra spaces or line breaks.
+
+    Confirm that the receiving phone shows the expected iMessage line as the
+    caller ID and that audio works in both directions.
   </Step>
 </Steps>
 
@@ -99,8 +118,8 @@ SPECTRUM_SIP_PASSWORD=your-project-secret
 SPECTRUM_SIP_TRANSPORT=tls
 ```
 
-`SPECTRUM_SIP_HOST` and `SPECTRUM_SIP_PORT` identify the remote Spectrum
-endpoint. They do not configure a local listening port.
+`SPECTRUM_SIP_HOST` and `SPECTRUM_SIP_PORT` identify the Spectrum server. They
+do not configure a local listening port.
 
 Keep the project secret in a secret manager or protected environment variable.
 Do not commit it to source control or send it to browser code.
@@ -136,21 +155,29 @@ but it should not be treated as a guarantee that a call will never be flagged.
 - The server is exactly `sip.spectrum.photon.codes`.
 - The username is the project ID, not the project name.
 - The password is the current project secret.
-- The Spectrum destination is TLS/5061 or TCP/5060, not UDP.
+- The Spectrum server uses TLS/5061 or TCP/5060, not UDP.
+- SIP registration is disabled.
+- The caller ID or From number is an iMessage line owned by the project.
 - TLS certificate verification is enabled when using TLS.
 - A test call connects and has working two-way audio.
-- RTP media is allowed by the network. SIP TLS does not encrypt the RTP audio
-  stream.
+- The firewall allows the SIP application's UDP RTP port range. SIP TLS does
+  not encrypt the RTP audio stream.
 - The business profile has been submitted if you want to reduce flagging risk.
 
 ## Troubleshooting
 
 ### The SIP application cannot connect
 
-Check the server spelling and make sure the transport and Spectrum destination
-port match: TLS uses 5061 and TCP uses 5060. Disable UDP and confirm that your
-network allows the SIP application to make the outbound TCP connection used by
-the selected transport.
+Check the server spelling and make sure its port matches the transport: TLS
+uses 5061 and TCP uses 5060. Do not use UDP. Confirm that the network allows the
+SIP application to make an outbound connection to the selected Spectrum server
+port.
+
+### The SIP application says registration failed
+
+Spectrum does not support SIP registration. Use a trunk, peer, or
+no-registration mode and place a test call. The project ID and secret
+authenticate the call itself.
 
 ### TLS certificate verification fails
 
@@ -163,6 +190,12 @@ server certificate. Do not disable certificate verification as a workaround.
 Use the project ID as the username and the project secret as the password. Make
 sure both came from the same project. If the secret was rotated, replace the
 old value in the SIP application.
+
+### The call is rejected with 403
+
+Set the caller ID or From number to an iMessage line owned by the authenticated
+project. Spectrum rejects missing phone numbers and numbers owned by another
+project.
 
 ### The line is not available
 
@@ -178,4 +211,7 @@ days for registration to complete.
 ### The call connects but audio does not work
 
 SIP TLS protects signaling only. Audio uses RTP, so confirm that your firewall
-and NAT configuration allow the negotiated RTP traffic in both directions.
+allows the UDP RTP port range configured in the SIP application. If the
+application is behind a router, its NAT or port-forwarding configuration must
+also allow that traffic in both directions. NAT is the router feature that lets
+devices on a private network share a public internet address.

--- a/docs/providers/voice/outbound-calls.mdx.vel
+++ b/docs/providers/voice/outbound-calls.mdx.vel
@@ -19,7 +19,7 @@ You need:
 - A Spectrum project.
 - An iMessage line in that project.
 - The project's ID and secret.
-- A SIP client, PBX, or voice application that supports TCP transport.
+- A SIP client, PBX, or voice application that supports TLS or TCP transport.
 
 WhatsApp numbers cannot be used for Spectrum Voice.
 
@@ -47,18 +47,22 @@ WhatsApp numbers cannot be used for Spectrum Voice.
     | Server or URI | `sip.spectrum.photon.codes` |
     | Username | Your Spectrum project ID |
     | Password | Your Spectrum project secret |
-    | Transport | `TCP` |
+    | Transport | `TLS` |
+    | Port | `5061` |
 
     SIP products name these fields differently. The server field might be
     called **SIP URI**, **domain**, **registrar**, **proxy**, or **host**. In
-    each case, use `sip.spectrum.photon.codes`.
+    each case, use `sip.spectrum.photon.codes`. If the field requires a full
+    URI, use `sips:sip.spectrum.photon.codes:5061;transport=tls`.
   </Step>
-  <Step title="Force TCP transport">
-    Select TCP explicitly. Do not leave transport on an automatic setting if
-    your SIP application might choose UDP or TLS.
+  <Step title="Select the signaling transport">
+    Select TLS explicitly and use port 5061. Keep certificate verification
+    enabled and verify that the certificate is valid for
+    `sip.spectrum.photon.codes`.
 
-    Spectrum Voice currently supports only SIP over TCP. A `sips:` URI will
-    not work.
+    TCP remains supported for existing integrations. To use it, select TCP on
+    port 5060, or use
+    `sip:sip.spectrum.photon.codes:5060;transport=tcp`. UDP is not supported.
   </Step>
   <Step title="Connect and authenticate">
     Start the SIP application and confirm that it connects successfully.
@@ -81,10 +85,11 @@ These environment variable names are examples for your own application. They
 are not read automatically by `spectrum-ts`.
 
 ```bash
-SPECTRUM_SIP_URI=sip.spectrum.photon.codes
+SPECTRUM_SIP_HOST=sip.spectrum.photon.codes
+SPECTRUM_SIP_PORT=5061
 SPECTRUM_SIP_USERNAME=your-project-id
 SPECTRUM_SIP_PASSWORD=your-project-secret
-SPECTRUM_SIP_TRANSPORT=tcp
+SPECTRUM_SIP_TRANSPORT=tls
 ```
 
 Keep the project secret in a secret manager or protected environment variable.
@@ -121,17 +126,26 @@ but it should not be treated as a guarantee that a call will never be flagged.
 - The server is exactly `sip.spectrum.photon.codes`.
 - The username is the project ID, not the project name.
 - The password is the current project secret.
-- The transport is TCP, not UDP or TLS.
+- The transport is TLS/5061 or TCP/5060, not UDP.
+- TLS certificate verification is enabled when using TLS.
 - A test call connects and has working two-way audio.
+- RTP media is allowed by the network. SIP TLS does not encrypt the RTP audio
+  stream.
 - The business profile has been submitted if you want to reduce flagging risk.
 
 ## Troubleshooting
 
 ### The SIP application cannot connect
 
-Check the server spelling and force the transport to TCP. Disable automatic
-UDP or TLS selection. Also confirm that your network allows the SIP application
-to make an outbound TCP connection.
+Check the server spelling and make sure the transport and port match: TLS uses
+5061 and TCP uses 5060. Disable UDP and confirm that your network allows the SIP
+application to make the outbound TCP connection used by the selected transport.
+
+### TLS certificate verification fails
+
+Connect to `sip.spectrum.photon.codes`, not an IP address or unrelated alias.
+The hostname used by the SIP application must match the hostname covered by the
+server certificate. Do not disable certificate verification as a workaround.
 
 ### Authentication fails
 
@@ -149,3 +163,8 @@ are not currently supported for Spectrum Voice.
 Outbound calls can work without a registered business profile, but they may be
 flagged. Register the business profile in the dashboard and allow 1–2 business
 days for registration to complete.
+
+### The call connects but audio does not work
+
+SIP TLS protects signaling only. Audio uses RTP, so confirm that your firewall
+and NAT configuration allow the negotiated RTP traffic in both directions.


### PR DESCRIPTION
## Summary
- document SIP signaling over TLS/5061 while preserving TCP/5060 compatibility
- add `sips:` and `sip:` routing examples, certificate guidance, and transport troubleshooting
- clarify that voice media remains unencrypted RTP and SRTP is unsupported

## Rollout
The TLS implementation is already deployed and tested in staging. Merge and publish these docs after the production TLS rollout is verified.

## Validation
- `bun run check`
- `bun run --bun build`
- structural MDX checks
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to voice/SIP guides; no runtime code, auth, or API behavior is modified in this PR.
> 
> **Overview**
> Updates Spectrum Voice docs to match **SIP signaling over TLS** (recommended outbound on server port **5061**), while keeping **TCP/5060** as a compatibility path. Inbound routing is documented with **`sips:`** vs **`sip:`** URIs, listening ports, optional SIP Digest, and TLS certificate expectations.
> 
> The voice overview adds clearer inbound/outbound definitions, a signaling vs media breakdown (**RTP** supported, **SRTP** not), and removes the prior TCP-only warnings. **Outbound** and **inbound** guides expand setup steps (no SIP registration, caller ID / From, trunk mode), env examples (`tls` / 5061), and troubleshooting for TLS certs, reachability, **403** rejections, and one-way or missing audio via UDP RTP firewall/NAT.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1bc24115b6fca19057e79bffc6fa70b35aadc35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788059450&installation_model_id=19795&pr_number=226&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F226&signature=1e76b694ea40ff608149bef400154734036699150c296b55d5b5aedb665dfcc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Voice calling guidance for inbound and outbound SIP over TLS or TCP.
  * Added setup details for URI formats, ports, certificates, firewall access, reachability, and RTP audio.
  * Clarified transport, connectivity, certificate, caller ID, NAT, and no-audio troubleshooting.
  * Documented that UDP and SRTP are unsupported, with TLS on port 5061 recommended and TCP on port 5060 supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->