### PR TITLE
docs: add voice call troubleshooting page

### DIFF
--- a/docs/nav.json
+++ b/docs/nav.json
@@ -140,7 +140,8 @@
     {
       "group": "Troubleshooting",
       "pages": [
-        "spectrum-ts/troubleshooting/imessage"
+        "spectrum-ts/troubleshooting/imessage",
+        "spectrum-ts/troubleshooting/voice"
       ]
     }
   ]

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -53,7 +53,8 @@
           "root": "spectrum-ts/providers/voice",
           "pages": [
             "spectrum-ts/providers/voice/outbound-calls",
-            "spectrum-ts/providers/voice/inbound-calls"
+            "spectrum-ts/providers/voice/inbound-calls",
+            "spectrum-ts/providers/voice/troubleshooting"
           ]
         },
         {
@@ -140,8 +141,7 @@
     {
       "group": "Troubleshooting",
       "pages": [
-        "spectrum-ts/troubleshooting/imessage",
-        "spectrum-ts/troubleshooting/voice"
+        "spectrum-ts/troubleshooting/imessage"
       ]
     }
   ]

--- a/docs/providers/voice/troubleshooting.mdx.vel
+++ b/docs/providers/voice/troubleshooting.mdx.vel
@@ -1,6 +1,6 @@
 ---
 title: "Voice call troubleshooting"
-sidebarTitle: "Voice"
+sidebarTitle: "Troubleshooting"
 description: "Common audio problems on Spectrum voice calls, what causes them, and how to fix them."
 ---
 

--- a/docs/troubleshooting/voice.mdx.vel
+++ b/docs/troubleshooting/voice.mdx.vel
@@ -1,0 +1,65 @@
+---
+title: "Voice call troubleshooting"
+sidebarTitle: "Voice"
+description: "Common audio problems on Spectrum voice calls, what causes them, and how to fix them."
+---
+
+If calls connect but the audio is wrong and you've ruled out your own endpoint, this page is organized by the symptom you're hearing. Find it in the headings below and follow the fix. Each section is self-contained, so you can land here from a search result and still get what you need.
+
+If your symptom isn't listed, jump to [Still stuck?](#still-stuck) for what to send us so we can trace it on our side.
+
+## Callers hear choppy or distorted AI audio
+
+The classic shape of this problem: the human caller hears the AI voice as
+choppy or warbly on every call, while the reverse direction is clean — the AI
+platform's own transcription and recording sound fine.
+
+The usual cause is the G.722 codec. Many AI voice endpoints (ElevenLabs,
+for example) select G.722 whenever it appears in the SDP offer, regardless of
+offer order. G.722 audibly degrades when the caller's leg crosses a transcode,
+which is the normal case for mobile and VoLTE callers.
+
+Spectrum no longer offers G.722 on bridged SIP legs, so new calls negotiate
+G.711 (PCMU) end-to-end and this failure mode should not occur. To confirm on
+a live call, check the negotiated codec in your endpoint's answer (the SIP
+`200 OK`): it should read `PCMU/8000` or `PCMA/8000`, not `G722/8000`.
+
+If your calls still negotiate G.722 or the audio is still choppy on G.711,
+jump to [Still stuck?](#still-stuck) — include the negotiated codec in your
+report.
+
+## Audio sounds like a regular phone call, not HD
+
+This is expected. Spectrum negotiates G.711, the codec the phone network
+itself uses, because wideband G.722 breaks down over the transcoded mobile
+legs that most callers arrive on (see the previous section). Standard
+telephone quality on every call is the deliberate trade against HD quality on
+some calls and choppy audio on the rest.
+
+## One-way or missing audio
+
+Spectrum sits in the signaling path only — RTP media flows directly between
+the carrier and your SIP endpoint. One-way or missing audio therefore almost
+always means media isn't reaching one of those two ends:
+
+- Confirm your endpoint (or its cloud provider) allows inbound RTP from the
+  carrier's media IPs, not just SIP signaling.
+- If your endpoint is behind NAT, make sure it advertises a publicly
+  reachable address in its SDP rather than a private one.
+- Check your endpoint's media logs for RTP timeout or packet-receive errors
+  on the affected call.
+
+## Still stuck?
+
+Send us:
+
+- Your project id (from `photon projects show`).
+- The SIP Call-ID (or the call time, caller number, and dialed number so we
+  can find it).
+- The direction (inbound or outbound) and which side hears the problem.
+- The negotiated codec from the `200 OK`, if you can capture it.
+- Your downstream SIP endpoint vendor (ElevenLabs, Retell, self-hosted, …).
+
+We'll trace the call on our side, including the exact SDP each leg saw. Email
+us at [help@photon.codes](mailto:help@photon.codes) or ping us in the Discord
+linked in the footer.

--- a/docs/troubleshooting/voice.mdx.vel
+++ b/docs/troubleshooting/voice.mdx.vel
@@ -15,8 +15,7 @@ is clean — the AI platform's transcription and its own recording sound fine.
 
 Spectrum uses G.711 for call audio to keep quality consistent. It's the
 codec the phone network itself runs on, and it holds up on the mobile
-networks most callers are on. Wideband codecs sound better in a demo but
-fall apart on real mobile calls, so Spectrum doesn't offer them.
+networks most callers are on.
 
 If your AI audio is choppy anyway, check the codec in your endpoint's
 `200 OK`. It should say `PCMU/8000` or `PCMA/8000` — if it says anything

--- a/docs/troubleshooting/voice.mdx.vel
+++ b/docs/troubleshooting/voice.mdx.vel
@@ -10,43 +10,43 @@ If your symptom isn't listed, jump to [Still stuck?](#still-stuck) for what to s
 
 ## Callers hear choppy or distorted AI audio
 
-The classic shape of this problem: the human caller hears the AI voice as
-choppy or warbly on every call, while the reverse direction is clean — the AI
-platform's own transcription and recording sound fine.
+The caller hears the AI voice as choppy or warbly on every call, but the
+other direction is clean — the AI platform's transcription and its own
+recording sound fine.
 
-The usual cause is the G.722 codec. Many AI voice endpoints (ElevenLabs,
-for example) select G.722 whenever it appears in the SDP offer, regardless of
-offer order. G.722 audibly degrades when the caller's leg crosses a transcode,
-which is the normal case for mobile and VoLTE callers.
+This is almost always G.722. Many AI voice endpoints (ElevenLabs, for
+example) pick G.722 whenever it appears in the SDP offer, no matter where it
+sits in the list, and G.722 handles transcoding badly. Most mobile and VoLTE
+callers reach you through at least one transcode.
 
-Spectrum no longer offers G.722 on bridged SIP legs, so new calls negotiate
-G.711 (PCMU) end-to-end and this failure mode should not occur. To confirm on
-a live call, check the negotiated codec in your endpoint's answer (the SIP
-`200 OK`): it should read `PCMU/8000` or `PCMA/8000`, not `G722/8000`.
+Spectrum no longer offers G.722 on its SIP legs, so calls negotiate G.711
+(PCMU) end to end and new calls shouldn't hit this. To check a live call,
+look at the codec in your endpoint's `200 OK`: it should say `PCMU/8000` or
+`PCMA/8000`, not `G722/8000`.
 
-If your calls still negotiate G.722 or the audio is still choppy on G.711,
-jump to [Still stuck?](#still-stuck) — include the negotiated codec in your
+If the answer still says G.722, or the audio is still choppy on G.711, jump
+to [Still stuck?](#still-stuck) and include the negotiated codec in your
 report.
 
 ## Audio sounds like a regular phone call, not HD
 
-This is expected. Spectrum negotiates G.711, the codec the phone network
-itself uses, because wideband G.722 breaks down over the transcoded mobile
-legs that most callers arrive on (see the previous section). Standard
-telephone quality on every call is the deliberate trade against HD quality on
-some calls and choppy audio on the rest.
+That's expected. Spectrum negotiates G.711, the same codec the phone network
+uses. Wideband G.722 sounds better in ideal conditions, but it breaks down
+over the transcoded mobile legs most callers arrive on, so we ship standard
+call quality on every call instead of HD on some and garbled audio on the
+rest.
 
 ## One-way or missing audio
 
-Spectrum sits in the signaling path only — RTP media flows directly between
-the carrier and your SIP endpoint. One-way or missing audio therefore almost
-always means media isn't reaching one of those two ends:
+Spectrum only handles signaling. The audio itself (RTP) flows directly
+between the carrier and your SIP endpoint, so when sound is missing in one
+direction the problem is usually at one of those two ends:
 
-- Confirm your endpoint (or its cloud provider) allows inbound RTP from the
-  carrier's media IPs, not just SIP signaling.
-- If your endpoint is behind NAT, make sure it advertises a publicly
-  reachable address in its SDP rather than a private one.
-- Check your endpoint's media logs for RTP timeout or packet-receive errors
+- Make sure your endpoint (or its cloud provider) accepts inbound RTP from
+  the carrier's media IPs, not just SIP signaling.
+- If your endpoint sits behind NAT, it needs to advertise a publicly
+  reachable address in its SDP, not a private one.
+- Check your endpoint's media logs for RTP timeouts or packet-receive errors
   on the affected call.
 
 ## Still stuck?
@@ -54,8 +54,8 @@ always means media isn't reaching one of those two ends:
 Send us:
 
 - Your project id (from `photon projects show`).
-- The SIP Call-ID (or the call time, caller number, and dialed number so we
-  can find it).
+- The SIP Call-ID, or the call time, caller number, and dialed number so we
+  can find it.
 - The direction (inbound or outbound) and which side hears the problem.
 - The negotiated codec from the `200 OK`, if you can capture it.
 - Your downstream SIP endpoint vendor (ElevenLabs, Retell, self-hosted, …).

--- a/docs/troubleshooting/voice.mdx.vel
+++ b/docs/troubleshooting/voice.mdx.vel
@@ -10,30 +10,23 @@ If your symptom isn't listed, jump to [Still stuck?](#still-stuck) for what to s
 
 ## Callers hear choppy or distorted AI audio
 
-The caller hears the AI voice as choppy or warbly on every call, but the
-other direction is clean — the AI platform's transcription and its own
-recording sound fine.
+The caller hears the AI voice as choppy or warbly, but the other direction
+is clean — the AI platform's transcription and its own recording sound fine.
 
-This is almost always G.722. Many AI voice endpoints (ElevenLabs, for
-example) pick G.722 whenever it appears in the SDP offer, no matter where it
-sits in the list, and G.722 handles transcoding badly. Most mobile and VoLTE
-callers reach you through at least one transcode.
+Spectrum uses G.711 for call audio to keep quality consistent. It's the
+codec the phone network itself runs on, and it holds up on the mobile
+networks most callers are on. Wideband codecs sound better in a demo but
+fall apart on real mobile calls, so Spectrum doesn't offer them.
 
-Spectrum uses G.711 on its SIP legs — G.722 isn't in the offer, so your
-endpoint can't select it. To check a live call, look at the codec in your
-endpoint's `200 OK`: it should say `PCMU/8000` or `PCMA/8000`.
-
-If it says `G722/8000`, or the audio is still choppy on G.711, jump to
-[Still stuck?](#still-stuck) and include the negotiated codec in your
-report.
+If your AI audio is choppy anyway, check the codec in your endpoint's
+`200 OK`. It should say `PCMU/8000` or `PCMA/8000` — if it says anything
+else, or it's choppy even on those, jump to [Still stuck?](#still-stuck)
+and include the codec in your report.
 
 ## Audio sounds like a regular phone call, not HD
 
-That's expected. Spectrum negotiates G.711, the same codec the phone network
-uses. Wideband G.722 sounds better in ideal conditions, but it breaks down
-over the transcoded mobile legs most callers arrive on, so we ship standard
-call quality on every call instead of HD on some and garbled audio on the
-rest.
+That's expected — G.711 is standard telephone quality. Consistent audio on
+every call beats HD on some and garbled audio on the rest.
 
 ## One-way or missing audio
 

--- a/docs/troubleshooting/voice.mdx.vel
+++ b/docs/troubleshooting/voice.mdx.vel
@@ -19,13 +19,12 @@ example) pick G.722 whenever it appears in the SDP offer, no matter where it
 sits in the list, and G.722 handles transcoding badly. Most mobile and VoLTE
 callers reach you through at least one transcode.
 
-Spectrum no longer offers G.722 on its SIP legs, so calls negotiate G.711
-(PCMU) end to end and new calls shouldn't hit this. To check a live call,
-look at the codec in your endpoint's `200 OK`: it should say `PCMU/8000` or
-`PCMA/8000`, not `G722/8000`.
+Spectrum uses G.711 on its SIP legs — G.722 isn't in the offer, so your
+endpoint can't select it. To check a live call, look at the codec in your
+endpoint's `200 OK`: it should say `PCMU/8000` or `PCMA/8000`.
 
-If the answer still says G.722, or the audio is still choppy on G.711, jump
-to [Still stuck?](#still-stuck) and include the negotiated codec in your
+If it says `G722/8000`, or the audio is still choppy on G.711, jump to
+[Still stuck?](#still-stuck) and include the negotiated codec in your
 report.
 
 ## Audio sounds like a regular phone call, not HD


### PR DESCRIPTION
Covers choppy AI audio (G.722 over transcoded mobile legs as Spectrum no longer offers G.722 on bridged SIP legs), the narrowband-by-design trade-off, and one-way audio checks. Mirrors the iMessage troubleshooting page format.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788552495&installation_model_id=19795&pr_number=230&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F230&signature=0b09bd34497d6caca15954150f8792ee6a18a9a9a5e8292c7fb9efa693a9d1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, API, or security impact.
> 
> **Overview**
> Adds a **Voice troubleshooting** doc under Providers → Voice, linked in `nav.json` next to inbound/outbound call guides.
> 
> The new page is symptom-based: choppy or distorted AI audio (G.711 / `PCMU/8000` or `PCMA/8000` in the `200 OK`), why audio sounds like narrowband phone quality by design, and one-way or missing audio (direct RTP between carrier and SIP endpoint, firewall/NAT/SDP checks). It ends with a **Still stuck?** checklist for support (project id, Call-ID, codec, vendor, etc.), in the same style as the iMessage troubleshooting page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8b09b492b7ad31fb34828c74b49ca95df4cf61a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Voice provider troubleshooting guide covering choppy, missing, or one-way audio.
  * Documented expected G.711 audio quality and troubleshooting steps for codecs, RTP, NAT, and logging.
  * Added guidance for identifying calls and escalating unresolved issues.
  * Updated Voice provider navigation to include the new guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->