### PR TITLE
docs: add Eve iMessage integration

### DIFF
--- a/docs/integrations/chat-sdk.mdx.vel
+++ b/docs/integrations/chat-sdk.mdx.vel
@@ -8,7 +8,7 @@ The iMessage adapter (`chat-adapter-imessage`) connects [Chat SDK](https://chat-
 <Note>
   Building an agent with [eve](https://vercel.com/eve)? Follow the [eve
   integration guide](/integrations/eve) to provision Photon and add
-  iMessage as an Eve channel.
+  iMessage as an eve channel.
 </Note>
 
 - **Cloud** (recommended) — connects to [Spectrum Cloud](https://app.photon.codes) with a project ID and secret. Runs anywhere, including serverless.

--- a/docs/integrations/chat-sdk.mdx.vel
+++ b/docs/integrations/chat-sdk.mdx.vel
@@ -5,6 +5,12 @@ description: "Add iMessage to a Chat SDK bot with the iMessage adapter"
 
 The iMessage adapter (`chat-adapter-imessage`) connects [Chat SDK](https://chat-sdk.dev/docs) bots to iMessage. It's built on [`spectrum-ts`](/spectrum-ts/introduction), so the same bot code reaches iMessage through any of three modes:
 
+<Note>
+  Building an agent with [eve](https://vercel.com/eve)? Follow the [eve
+  integration guide](/integrations/eve) to provision Photon and add
+  iMessage as an Eve channel.
+</Note>
+
 - **Cloud** (recommended) — connects to [Spectrum Cloud](https://app.photon.codes) with a project ID and secret. Runs anywhere, including serverless.
 - **Self-hosted** — connects to your own `@photon-ai/advanced-imessage` gRPC endpoint.
 - **Local** — reads the on-device Messages database and sends through Apple's native APIs. macOS only.

--- a/docs/integrations/eve.mdx.vel
+++ b/docs/integrations/eve.mdx.vel
@@ -4,7 +4,6 @@ description: "Connect an eve agent to iMessage through Photon"
 ---
 
 {% set webhookRoute = "/eve/v1/photon" %}
-{% set exampleConnectorId = "photon/my-agent" %}
 {% set env = {
   projectId: "IMESSAGE_PROJECT_ID",
   projectSecret: "IMESSAGE_PROJECT_SECRET",
@@ -13,7 +12,6 @@ description: "Connect an eve agent to iMessage through Photon"
 {% set spectrumInstance = symbol("ts:spectrum-ts#SpectrumInstance") %}
 {% set chatMessage = symbol("ts:chat#Message") %}
 {% set chatThread = symbol("ts:chat#Thread") %}
-{% set channelOptions = symbol("ts:eve/channels/photon#PhotonIMessageChannelConfig") %}
 
 [eve](https://vercel.com/eve) can expose an agent over iMessage with
 `photonIMessageChannel`. The channel wraps [Photon's Chat SDK iMessage
@@ -26,18 +24,21 @@ The channel receives authenticated Photon webhook deliveries at
 `{{ webhookRoute }}`, keeps each iMessage conversation in one eve session, and
 marks accepted messages as read. If another accepted message arrives while the
 agent is replying, it cooperatively cancels the active turn and steers its
-replacement instead of starting a second independent reply.
+replacement instead of starting a second independent reply. Replies are sent
+as complete messages rather than token-by-token streams because iMessage does
+not support Chat SDK streaming.
+
+This guide covers the Photon side of the integration: provisioning,
+credentials, and webhook verification. The channel's TypeScript surface —
+imports, configuration options, and callback signatures — is still evolving,
+so it is documented upstream in the [eve Photon channel
+reference](https://eve.dev/docs/channels/photon) rather than duplicated here.
 
 ## Add the Photon channel
 
-If you do not have an eve agent yet, create one first:
-
-```bash
-npx eve@latest init my-agent
-cd my-agent
-```
-
-From the agent directory, add the Photon iMessage channel:
+If you do not have an eve agent yet, create one first with the
+[eve docs](https://eve.dev/docs). From the agent directory, add the Photon
+iMessage channel:
 
 ```bash
 eve add channel/photon-imessage
@@ -48,58 +49,25 @@ The setup wizard:
 1. Creates a Photon project or connects an existing one.
 2. Registers your iMessage phone number with the project.
 3. Lets you choose Vercel Connect or portable environment credentials.
-4. Writes `agent/channels/photon.ts`.
+4. Scaffolds the channel file in your agent.
 
 ## Vercel Connect
 
 Choose **Set up Vercel Connect** when the agent will run on Vercel. The wizard
 links the Vercel project, creates a Photon connector, configures the Photon
-webhook, and scaffolds a channel like this:
+webhook, and scaffolds a channel that resolves the Photon project ID and
+secret through Vercel Connect when the channel initializes. Keep the connector
+ID the wizard writes into the generated file.
 
-```ts
-import { connectPhotonCredentials } from "@vercel/connect/eve";
-import { photonIMessageChannel } from "eve/channels/photon";
-
-export default photonIMessageChannel({
-  credentials: connectPhotonCredentials("{{ exampleConnectorId }}"),
-});
-```
-
-`connectPhotonCredentials` resolves the project ID and secret only when the
-channel initializes. Forwarded webhooks are verified with same-project Vercel
-OIDC by default, so this path does not require an
-`{{ env.webhookSecret }}` environment variable.
-
-<Note>
-  The connector name in your generated file can differ from
-  `{{ exampleConnectorId }}`. Keep the value written by the setup wizard.
-</Note>
+Forwarded webhooks are verified with same-project Vercel OIDC by default, so
+this path does not require an `{{ env.webhookSecret }}` environment variable.
 
 ## Portable credentials
 
 Choose **Use portable credentials** for another host. The wizard writes
 `{{ env.projectId }}` and `{{ env.projectSecret }}` to `.env.local` and
-scaffolds an environment-backed credential provider:
-
-```ts
-import { photonIMessageChannel } from "eve/channels/photon";
-
-const photonCredentials = async () => {
-  const projectId = process.env.{{ env.projectId }};
-  const projectSecret = process.env.{{ env.projectSecret }};
-
-  if (!projectId || !projectSecret) {
-    throw new Error("Photon project credentials are required.");
-  }
-
-  return { projectId, projectSecret };
-};
-
-export default photonIMessageChannel({
-  credentials: photonCredentials,
-  webhookSecret: process.env.{{ env.webhookSecret }},
-});
-```
+scaffolds a credential provider that reads them from the environment, along
+with a webhook signing secret read from `{{ env.webhookSecret }}`.
 
 After deploying the agent:
 
@@ -125,51 +93,20 @@ After deploying the agent:
 </Warning>
 
 For a direct Photon webhook, the signing secret replaces the default Vercel
-OIDC verifier. An explicitly configured `webhookVerifier` takes precedence over
-the signing secret.
+OIDC verifier. A custom webhook verifier configured on the channel takes
+precedence over the signing secret.
 
 ## Filter and enrich inbound messages
 
-Use `onMessage` to decide which messages reach the agent and to add private
-context to the turn. Return `null` to ignore a message:
+The channel's `onMessage` callback decides which inbound messages reach the
+agent and can attach private context to the turn — for example, ignoring
+messages from other bots, or telling the agent who the sender is. The
+callback receives the Chat SDK {{ chatMessage | typeRef }}, and its context
+exposes the low-level {{ chatThread | typeRef }} for advanced iMessage
+operations.
 
-```ts
-import { connectPhotonCredentials } from "@vercel/connect/eve";
-import { photonIMessageChannel } from "eve/channels/photon";
-
-export default photonIMessageChannel({
-  credentials: connectPhotonCredentials("{{ exampleConnectorId }}"),
-  onMessage(_context, message) {
-    if (message.author.isBot) {
-      return null;
-    }
-
-    return {
-      auth: null,
-      context: [`The sender is ${message.author.fullName}.`],
-    };
-  },
-});
-```
-
-Returning `{ auth: null }` accepts the message without attaching an
-application-specific authenticated identity. The callback receives
-a {{ chatMessage | typeRef }}, and its context exposes the low-level
-{{ chatThread | typeRef }} for advanced iMessage operations.
-
-## Channel options
-
-The {{ channelOptions | typeRef }} interface is the source of truth for channel
-configuration:
-
-| Option | Type | Required | Description |
-|---|---|---|---|
-{% for option in channelOptions.members -%}
-| `{{ option.name }}` | {{ option.type | cell | safe }} | {% if option.optional %}No{% else %}Yes{% endif %} | {{ option.doc.summary }} |
-{% endfor %}
-
-The channel sends complete replies rather than token-by-token streams because
-iMessage does not support Chat SDK streaming.
+See the [eve Photon channel reference](https://eve.dev/docs/channels/photon)
+for the current callback signature and return shape.
 
 ## Next steps
 

--- a/docs/integrations/eve.mdx.vel
+++ b/docs/integrations/eve.mdx.vel
@@ -1,0 +1,183 @@
+---
+title: "eve"
+description: "Connect an eve agent to iMessage through Photon"
+---
+
+{% set webhookRoute = "/eve/v1/photon" %}
+{% set exampleConnectorId = "photon/my-agent" %}
+{% set env = {
+  projectId: "IMESSAGE_PROJECT_ID",
+  projectSecret: "IMESSAGE_PROJECT_SECRET",
+  webhookSecret: "IMESSAGE_WEBHOOK_SECRET"
+} %}
+{% set spectrumInstance = symbol("ts:spectrum-ts#SpectrumInstance") %}
+{% set chatMessage = symbol("ts:chat#Message") %}
+{% set chatThread = symbol("ts:chat#Thread") %}
+{% set channelOptions = symbol("ts:eve/channels/photon#PhotonIMessageChannelConfig") %}
+
+[eve](https://vercel.com/eve) can expose an agent over iMessage with
+`photonIMessageChannel`. The channel wraps [Photon's Chat SDK iMessage
+adapter](https://github.com/photon-hq/vercel-chat-adapter-imessage), which is
+built on `spectrum-ts`. You configure an eve channel; you do not need to
+construct a Chat SDK `Chat` instance or initialize the underlying
+{{ spectrumInstance | typeRef }} yourself.
+
+The channel receives authenticated Photon webhook deliveries at
+`{{ webhookRoute }}`, keeps each iMessage conversation in one eve session, and
+marks accepted messages as read. If another accepted message arrives while the
+agent is replying, it cooperatively cancels the active turn and steers its
+replacement instead of starting a second independent reply.
+
+## Add the Photon channel
+
+If you do not have an eve agent yet, create one first:
+
+```bash
+npx eve@latest init my-agent
+cd my-agent
+```
+
+From the agent directory, add the Photon iMessage channel:
+
+```bash
+eve add channel/photon-imessage
+```
+
+The setup wizard:
+
+1. Creates a Photon project or connects an existing one.
+2. Registers your iMessage phone number with the project.
+3. Lets you choose Vercel Connect or portable environment credentials.
+4. Writes `agent/channels/photon.ts`.
+
+## Vercel Connect
+
+Choose **Set up Vercel Connect** when the agent will run on Vercel. The wizard
+links the Vercel project, creates a Photon connector, configures the Photon
+webhook, and scaffolds a channel like this:
+
+```ts
+import { connectPhotonCredentials } from "@vercel/connect/eve";
+import { photonIMessageChannel } from "eve/channels/photon";
+
+export default photonIMessageChannel({
+  credentials: connectPhotonCredentials("{{ exampleConnectorId }}"),
+});
+```
+
+`connectPhotonCredentials` resolves the project ID and secret only when the
+channel initializes. Forwarded webhooks are verified with same-project Vercel
+OIDC by default, so this path does not require an
+`{{ env.webhookSecret }}` environment variable.
+
+<Note>
+  The connector name in your generated file can differ from
+  `{{ exampleConnectorId }}`. Keep the value written by the setup wizard.
+</Note>
+
+## Portable credentials
+
+Choose **Use portable credentials** for another host. The wizard writes
+`{{ env.projectId }}` and `{{ env.projectSecret }}` to `.env.local` and
+scaffolds an environment-backed credential provider:
+
+```ts
+import { photonIMessageChannel } from "eve/channels/photon";
+
+const photonCredentials = async () => {
+  const projectId = process.env.{{ env.projectId }};
+  const projectSecret = process.env.{{ env.projectSecret }};
+
+  if (!projectId || !projectSecret) {
+    throw new Error("Photon project credentials are required.");
+  }
+
+  return { projectId, projectSecret };
+};
+
+export default photonIMessageChannel({
+  credentials: photonCredentials,
+  webhookSecret: process.env.{{ env.webhookSecret }},
+});
+```
+
+After deploying the agent:
+
+<Steps>
+  <Step title="Register the webhook">
+    In the [Photon dashboard](https://app.photon.codes), create a webhook that
+    points to your public `https://your-host.example{{ webhookRoute }}` URL.
+  </Step>
+  <Step title="Store the signing secret">
+    Copy the webhook signing secret to `{{ env.webhookSecret }}` in your
+    host's encrypted environment variables.
+  </Step>
+  <Step title="Add the project credentials">
+    Add `{{ env.projectId }}` and `{{ env.projectSecret }}` to the same
+    environment, then redeploy the agent.
+  </Step>
+</Steps>
+
+<Warning>
+  Keep the project secret and webhook signing secret out of source control.
+  They are different credentials: the project secret authorizes Photon API
+  access, while the webhook secret authenticates inbound deliveries.
+</Warning>
+
+For a direct Photon webhook, the signing secret replaces the default Vercel
+OIDC verifier. An explicitly configured `webhookVerifier` takes precedence over
+the signing secret.
+
+## Filter and enrich inbound messages
+
+Use `onMessage` to decide which messages reach the agent and to add private
+context to the turn. Return `null` to ignore a message:
+
+```ts
+import { connectPhotonCredentials } from "@vercel/connect/eve";
+import { photonIMessageChannel } from "eve/channels/photon";
+
+export default photonIMessageChannel({
+  credentials: connectPhotonCredentials("{{ exampleConnectorId }}"),
+  onMessage(_context, message) {
+    if (message.author.isBot) {
+      return null;
+    }
+
+    return {
+      auth: null,
+      context: [`The sender is ${message.author.fullName}.`],
+    };
+  },
+});
+```
+
+Returning `{ auth: null }` accepts the message without attaching an
+application-specific authenticated identity. The callback receives
+a {{ chatMessage | typeRef }}, and its context exposes the low-level
+{{ chatThread | typeRef }} for advanced iMessage operations.
+
+## Channel options
+
+The {{ channelOptions | typeRef }} interface is the source of truth for channel
+configuration:
+
+| Option | Type | Required | Description |
+|---|---|---|---|
+{% for option in channelOptions.members -%}
+| `{{ option.name }}` | {{ option.type | cell | safe }} | {% if option.optional %}No{% else %}Yes{% endif %} | {{ option.doc.summary }} |
+{% endfor %}
+
+The channel sends complete replies rather than token-by-token streams because
+iMessage does not support Chat SDK streaming.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="eve Photon channel" icon="comment" href="https://eve.dev/docs/channels/photon">
+    Read the upstream eve reference for the Photon channel.
+  </Card>
+  <Card title="Chat SDK adapter" icon="code" href="https://github.com/photon-hq/vercel-chat-adapter-imessage">
+    Use the adapter directly or review its iMessage capability matrix.
+  </Card>
+</CardGroup>

--- a/docs/nav.json
+++ b/docs/nav.json
@@ -125,7 +125,8 @@
     {
       "group": "Integrations",
       "pages": [
-        "integrations/chat-sdk"
+        "integrations/chat-sdk",
+        "integrations/eve"
       ]
     },
     {


### PR DESCRIPTION
## Summary

- add a standalone Eve integration page alongside Chat SDK
- document Photon channel setup for Vercel Connect and portable credentials
- extract Chat SDK types through Vellum; backlink eve interface details to the eve docs
- add cross-navigation from the Chat SDK page

## Why

Eve now supports Photon-powered iMessage through `photonIMessageChannel`. This gives users one Photon-owned guide covering provisioning, credentials, webhook verification, and inbound filtering.

Interface-specific details (imports, channel options, callback signatures) are backlinked to the eve docs rather than duplicated, since eve's integration surface is still iterating.

## Validation

- `bun install --frozen-lockfile`
- `bun run check`
- `bun run typecheck`
- `bun run test`
- `bun run build`
- central docs generation with Vellum 0.3 (662 symbols, 86 templates)
- Mintlify local preview with no console errors

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788555505&installation_model_id=19795&pr_number=231&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F231&signature=57404bbd7be9ab6cae0b1afd5c9d8f4adbcc950519579c26d84dbc597e170eff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Mintlify/Vellum docs and navigation; no runtime or security-sensitive code paths.
> 
> **Overview**
> Adds a new **Integrations → eve** page that documents connecting an eve agent to iMessage via `photonIMessageChannel`: wizard setup (`eve add channel/photon-imessage`), **Vercel Connect** vs **portable credentials**, webhook URL at `/eve/v1/photon`, and how project vs webhook secrets differ. It explains Photon-owned behavior (session-per-conversation, cooperative cancel/steer on new messages, non-streaming replies) and points evolving TypeScript APIs to [eve’s Photon channel reference](https://eve.dev/docs/channels/photon).
> 
> The page uses Vellum `symbol()` refs for `spectrum-ts#SpectrumInstance` and Chat SDK `Message`/`Thread` in the `onMessage` section. **Chat SDK** integration doc gains a `<Note>` directing eve users to this guide. **`docs/nav.json`** registers `integrations/eve` next to `integrations/chat-sdk`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43891cec349d9e4009af2a9bdfaef576b5901938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an integration guide for connecting an eve agent to iMessage through Photon.
  * Documented setup options, webhook registration and verification, credential handling, and message processing.
  * Added links to related channel and adapter references.
  * Added the new guide to the Integrations navigation.
  * Added a note linking eve users to the integration guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->