### PR TITLE
docs: clarify iMessage contact photo rendering

### DIFF
--- a/docs/content/contacts.mdx.vel
+++ b/docs/content/contacts.mdx.vel
@@ -50,6 +50,35 @@ Use `contact()` to share contact cards. The builder takes either a structured <T
 {% set contactType = symbol("ts:spectrum-ts#Contact") %}
 `fromVCard(vcf)` parses a vCard string into a <TypeTooltip name="ContactInput" type={`{{ contactInput.signature }}`} />. `toVCard(contact)` serializes a resolved <TypeTooltip name="Contact" type={`{{ contactType.signature }}`} /> back to vCard.
 
+<Warning>
+  The `photo` field embeds the original image bytes in the vCard, but the
+  receiving app decides whether to show them in its contact-card preview.
+  Apple Messages currently renders initials for arbitrary iMessage vCard
+  attachments even when the embedded photo is delivered and available to
+  Contacts. [`nativeContactCard()`](/spectrum-ts/providers/imessage/messaging-features/contact-card-sharing)
+  uses Apple's separate Name & Photo mechanism and can only share the bot
+  account's own profile.
+</Warning>
+
+If the image must be visible in the conversation, send it alongside the contact
+card. On iMessage this becomes a multipart message with a normal image preview
+and a separate contact attachment:
+
+```ts
+import { attachment, contact, group } from "spectrum-ts";
+
+await space.send(group(
+  attachment(avatarBytes, {
+    name: "ada-lovelace.jpg",
+    mimeType: "image/jpeg",
+  }),
+  contact({
+    name: { first: "Ada", last: "Lovelace" },
+    phones: [{ value: "+15551234567", type: "mobile" }],
+  }),
+));
+```
+
 <Accordion title="ContactInput" description="The fields you can populate on a contact card. All fields are optional except where the receiving platform requires at least one identifying field.">
   | Field | Type | Description |
   |---|---|---|
@@ -62,6 +91,6 @@ Use `contact()` to share contact cards. The builder takes either a structured <T
   | `urls` | `string[]` | Associated URLs. |
   | `birthday` | `string` | ISO date. |
   | `note` | `string` | Free-form note. |
-  | `photo` | `{ mimeType, read() }` | Profile photo bytes. |
+  | `photo` | `{ mimeType, read() }` | Image bytes embedded in the vCard. Preview rendering is controlled by the receiving app. |
   | `raw` | `unknown` | Provider-specific extras passed through untouched. |
 </Accordion>

--- a/docs/providers/imessage/messaging-features/contact-card-sharing.mdx.vel
+++ b/docs/providers/imessage/messaging-features/contact-card-sharing.mdx.vel
@@ -32,6 +32,14 @@ This shares the bot's own contact card as it appears in iMessage. Recipients
 can tap it to save the contact. Use it in onboarding flows where you want users
 to add your bot to their contacts.
 
+<Warning>
+  `nativeContactCard()` has no name or photo input. It always shares the sending
+  iMessage account's current Apple Name & Photo profile. To send an arbitrary
+  person's details, use [`contact()`](/spectrum-ts/content/contacts); any
+  embedded photo remains vCard data, and Apple Messages may render initials in
+  the attachment preview.
+</Warning>
+
 {% set unsupportedError = symbol("ts:spectrum-ts#UnsupportedError") %}
 <Note>
   Native contact card sharing requires `@spectrum-ts/imessage`. With

--- a/packages/core/test/utils/vcard.test.ts
+++ b/packages/core/test/utils/vcard.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { asContact } from "@/content/contact";
+import { fromVCard, toVCard } from "@/utils/vcard";
+
+describe("contact photo vCards", () => {
+  it("round-trips embedded photo bytes", async () => {
+    const photoBytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]);
+    const vcard = await toVCard(
+      asContact({
+        name: { first: "Example", last: "Tester" },
+        photo: {
+          mimeType: "image/jpeg",
+          read: async () => photoBytes,
+        },
+      })
+    );
+
+    expect(vcard).toContain("PHOTO;ENCODING=b;TYPE=JPEG:");
+
+    const parsed = fromVCard(vcard);
+    expect(parsed.photo?.mimeType).toBe("image/jpeg");
+    await expect(parsed.photo?.read()).resolves.toEqual(photoBytes);
+  });
+});


### PR DESCRIPTION
## What changed

- document that `contact().photo` embeds image bytes in the vCard while preview rendering remains client-controlled
- distinguish arbitrary vCard contacts from `nativeContactCard()`, which shares only the sending iMessage account's Apple Name & Photo
- show the supported image-plus-contact multipart fallback when an in-conversation image must be visible
- add a core regression test proving embedded photo bytes survive the vCard serialize/parse round trip

## Root cause

ENG-2248 was not a serialization or transport loss. Live testing showed that Spectrum delivered the complete vCard, the downloaded JPEG bytes matched the original SHA-256, and macOS Contacts parsed the card with image data available. Apple Messages still rendered initials in the arbitrary contact attachment preview.

The advanced iMessage server's separate `ShareContactInfo` RPC accepts only a chat GUID and force-shares the sender account's current global Name & Photo profile; it cannot carry an arbitrary contact name or avatar.

## Impact

The public guidance now matches the behavior users actually see and gives them a visible-image fallback without changing the existing contact-card wire format or account-level profile state.

## Validation

- `bun run check`
- `bun run typecheck`
- `bun run build`
- `packages/core: bun run test:node` — 318 passed
- `packages/core: bun run test:bun` — 318 passed

Linear: ENG-2248

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789027903&installation_model_id=19795&pr_number=235&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F235&signature=804682e194b6bfd2614e4ce6abb4647510d96b9a2ed16c0085d3f895cefc7124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->