### PR TITLE
feat(core): add portable @spectrum-ts/core/webhook entry

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -19,6 +19,7 @@
       "includes": [
         "packages/core/src/index.ts",
         "packages/core/src/authoring.ts",
+        "packages/core/src/webhook/portable.ts",
         "packages/core/src/fusor/index.ts",
         "packages/spectrum-ts/src/index.ts",
         "packages/spectrum-ts/src/authoring.ts",

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "marked": "^18.0.5",
         "mime-types": "^3.0.1",
         "open-graph-scraper": "^6.11.0",
+        "uncrypto": "^0.1.3",
         "vcf": "^2.1.2",
         "zod": "^4.2.1",
       },
@@ -1242,6 +1243,8 @@
     "ultracite": ["ultracite@7.8.4", "", { "dependencies": { "@clack/prompts": "^1.5.1", "commander": "^15.0.0", "cross-spawn": "^7.0.6", "deepmerge": "^4.3.1", "glob": "^13.0.6", "jsonc-parser": "^3.3.1", "nypm": "^0.6.6", "yaml": "^2.9.0", "zod": "^4.4.3" }, "peerDependencies": { "oxfmt": ">=0.1.0", "oxlint": "^1.0.0" }, "optionalPeers": ["oxfmt", "oxlint"], "bin": { "ultracite": "dist/index.js" } }, "sha512-Lqd1k8sr7xT3QY+2x6qA72TFkA3r1Z7QvCUbOFBOeGAVdwBG43RPSvhTuEpZOgbdINFBcJ/v6dK2tyT4inPDTQ=="],
 
     "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
+
+    "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
     "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spectrum-ts/core",
   "version": "12.7.0",
-  "description": "The spectrum-ts runtime — Spectrum, content builders, fusor, and the provider authoring API.",
+  "description": "The spectrum-ts runtime \u2014 Spectrum, content builders, fusor, and the provider authoring API.",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/photon-hq/spectrum-ts.git",
@@ -28,6 +28,11 @@
       "bun": "./src/authoring.ts",
       "types": "./src/authoring.ts",
       "default": "./dist/authoring.js"
+    },
+    "./webhook": {
+      "bun": "./src/webhook/portable.ts",
+      "types": "./src/webhook/portable.ts",
+      "default": "./dist/webhook.js"
     }
   },
   "publishConfig": {
@@ -40,6 +45,10 @@
       "./authoring": {
         "types": "./dist/authoring.d.ts",
         "default": "./dist/authoring.js"
+      },
+      "./webhook": {
+        "types": "./dist/webhook.d.ts",
+        "default": "./dist/webhook.js"
       }
     }
   },
@@ -60,6 +69,7 @@
     "marked": "^18.0.5",
     "mime-types": "^3.0.1",
     "open-graph-scraper": "^6.11.0",
+    "uncrypto": "^0.1.3",
     "vcf": "^2.1.2",
     "zod": "^4.2.1"
   },

--- a/packages/core/src/spectrum.ts
+++ b/packages/core/src/spectrum.ts
@@ -1222,7 +1222,7 @@ export async function Spectrum<
       return webhookText(500, "webhook secret not configured");
     }
 
-    const verification = verifySpectrumSignature({
+    const verification = await verifySpectrumSignature({
       rawBody: bodyBytes,
       headers,
       secret: resolvedWebhookSecret,

--- a/packages/core/src/webhook/portable.ts
+++ b/packages/core/src/webhook/portable.ts
@@ -1,0 +1,36 @@
+// Portable native-webhook primitives — the `@spectrum-ts/core/webhook` entry.
+//
+// Everything on this surface is runtime-agnostic: signature verification runs
+// on Web Crypto and the slim wire schemas are plain zod, with no Node builtins
+// anywhere in the import graph. It is what an HTTP adapter needs to verify and
+// parse a native Spectrum webhook delivery on runtimes where the Node-flavored
+// `Spectrum()` runtime can't live — Convex's V8 isolate, Cloudflare Workers,
+// Deno Deploy — and it is the single source of truth those adapters share with
+// `spectrum.webhook()` for the wire format.
+//
+// Deliberately NOT here: `webhook/deserialize.ts`. It materializes full
+// `Content` objects and pulls the Node-only content builders (`node:fs`,
+// `node:crypto`), so turning a slim envelope into a live `[space, message]`
+// pair stays a `Spectrum()` concern.
+
+export type {
+  SlimContent,
+  SlimEnvelope,
+  SlimMessage,
+  SlimMessageRef,
+  SlimSender,
+  SlimSpace,
+} from "./types";
+export {
+  slimContentSchema,
+  slimEnvelopeSchema,
+  slimMessageRefSchema,
+  slimMessageSchema,
+  slimSenderSchema,
+  slimSpaceSchema,
+} from "./types";
+export {
+  type VerifyInput,
+  type VerifyResult,
+  verifySpectrumSignature,
+} from "./verify";

--- a/packages/core/src/webhook/verify.ts
+++ b/packages/core/src/webhook/verify.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual } from "node:crypto";
+import { subtle } from "uncrypto";
 
 const SIGNATURE_HEADER = "x-spectrum-signature";
 const TIMESTAMP_HEADER = "x-spectrum-timestamp";
@@ -13,6 +13,10 @@ const SIGNATURE_SCHEME = "v0";
  */
 const REPLAY_TOLERANCE_SECONDS = 300;
 const MILLIS_PER_SECOND = 1000;
+
+const HEX_PATTERN = /^[0-9a-f]+$/i;
+const HEX_CHARS_PER_BYTE = 2;
+const HEX_RADIX = 16;
 
 export type VerifyResult =
   | { ok: true }
@@ -29,6 +33,26 @@ export interface VerifyInput {
   secret: string;
 }
 
+/** Strict hex decode; `null` (not a truncated buffer) on malformed input. */
+const hexToBytes = (hex: string): Uint8Array<ArrayBuffer> | null => {
+  if (
+    hex.length === 0 ||
+    hex.length % HEX_CHARS_PER_BYTE !== 0 ||
+    !HEX_PATTERN.test(hex)
+  ) {
+    return null;
+  }
+  const bytes = new Uint8Array(hex.length / HEX_CHARS_PER_BYTE);
+  for (let index = 0; index < bytes.length; index += 1) {
+    const offset = index * HEX_CHARS_PER_BYTE;
+    bytes[index] = Number.parseInt(
+      hex.slice(offset, offset + HEX_CHARS_PER_BYTE),
+      HEX_RADIX
+    );
+  }
+  return bytes;
+};
+
 /**
  * Verify a native Spectrum webhook signature.
  *
@@ -37,10 +61,27 @@ export interface VerifyInput {
  * is the `X-Spectrum-Timestamp` header (unix seconds). The base string is built
  * over the **exact body bytes**: never JSON-parse-then-restringify before
  * verifying, or the bytes (key order, whitespace) change and the MAC won't
- * match. The digest comparison is constant-time.
+ * match.
+ *
+ * Implemented on Web Crypto (hence async) so it runs identically on Node, Bun,
+ * and V8-isolate runtimes (Convex, Cloudflare Workers, Deno Deploy) — this is
+ * part of the portable `@spectrum-ts/core/webhook` entry. `subtle` comes from
+ * `uncrypto`, whose conditional exports pick `node:crypto`'s webcrypto under
+ * Node and `globalThis.crypto` everywhere else, so this works on Node 18 (where
+ * the global is not exposed by default) without a runtime feature check.
+ *
+ * The digest comparison is `subtle.verify`, which compares MACs in constant
+ * time.
  */
-export function verifySpectrumSignature(input: VerifyInput): VerifyResult {
+export async function verifySpectrumSignature(
+  input: VerifyInput
+): Promise<VerifyResult> {
   const { rawBody, headers, secret, now = Date.now() } = input;
+  if (!secret) {
+    // A missing secret is caller misconfiguration, not an unauthenticated
+    // request — surface it loudly instead of returning an undebuggable 401.
+    throw new Error("verifySpectrumSignature: secret must be non-empty");
+  }
   const provided = headers[SIGNATURE_HEADER];
   const timestamp = headers[TIMESTAMP_HEADER];
   if (!(provided && timestamp)) {
@@ -56,20 +97,29 @@ export function verifySpectrumSignature(input: VerifyInput): VerifyResult {
     return { ok: false, reason: "expired" };
   }
 
-  const base = Buffer.concat([
-    Buffer.from(`${SIGNATURE_SCHEME}:${timestamp}:`, "utf8"),
-    Buffer.from(rawBody),
-  ]);
-  const expected = createHmac("sha256", secret).update(base).digest();
-
   const providedHex = provided.startsWith(SIGNATURE_PREFIX)
     ? provided.slice(SIGNATURE_PREFIX.length)
     : provided;
-  const providedBytes = Buffer.from(providedHex, "hex");
-  if (
-    providedBytes.length !== expected.length ||
-    !timingSafeEqual(providedBytes, expected)
-  ) {
+  const providedBytes = hexToBytes(providedHex);
+  if (!providedBytes) {
+    return { ok: false, reason: "signature-mismatch" };
+  }
+
+  const encoder = new TextEncoder();
+  const prefix = encoder.encode(`${SIGNATURE_SCHEME}:${timestamp}:`);
+  const base = new Uint8Array(prefix.length + rawBody.length);
+  base.set(prefix, 0);
+  base.set(rawBody, prefix.length);
+
+  const key = await subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"]
+  );
+  const matches = await subtle.verify("HMAC", key, providedBytes, base);
+  if (!matches) {
     return { ok: false, reason: "signature-mismatch" };
   }
   return { ok: true };

--- a/packages/core/test/webhook/verify.test.ts
+++ b/packages/core/test/webhook/verify.test.ts
@@ -6,6 +6,7 @@ const SECRET = "whsec_unit_test_secret";
 const NOW_SECONDS = 1_700_000_000;
 const NOW_MS = NOW_SECONDS * 1000;
 const TOLERANCE_SECONDS = 300;
+const EMPTY_SECRET_ERROR = /secret must be non-empty/;
 
 const encode = (text: string): Uint8Array => new TextEncoder().encode(text);
 
@@ -28,9 +29,9 @@ const headersFor = (
 });
 
 describe("verifySpectrumSignature", () => {
-  it("accepts a correctly signed body", () => {
+  it("accepts a correctly signed body", async () => {
     const body = encode('{"event":"messages"}');
-    const result = verifySpectrumSignature({
+    const result = await verifySpectrumSignature({
       rawBody: body,
       headers: headersFor(sign(body, NOW_SECONDS), NOW_SECONDS),
       secret: SECRET,
@@ -39,10 +40,10 @@ describe("verifySpectrumSignature", () => {
     expect(result).toEqual({ ok: true });
   });
 
-  it("accepts a bare hex signature without the v0= prefix", () => {
+  it("accepts a bare hex signature without the v0= prefix", async () => {
     const body = encode("payload");
     const signature = sign(body, NOW_SECONDS).slice("v0=".length);
-    const result = verifySpectrumSignature({
+    const result = await verifySpectrumSignature({
       rawBody: body,
       headers: headersFor(signature, NOW_SECONDS),
       secret: SECRET,
@@ -51,10 +52,10 @@ describe("verifySpectrumSignature", () => {
     expect(result.ok).toBe(true);
   });
 
-  it("rejects a tampered body", () => {
+  it("rejects a tampered body", async () => {
     const signedBody = encode("original");
     const deliveredBody = encode("tampered!");
-    const result = verifySpectrumSignature({
+    const result = await verifySpectrumSignature({
       rawBody: deliveredBody,
       headers: headersFor(sign(signedBody, NOW_SECONDS), NOW_SECONDS),
       secret: SECRET,
@@ -63,9 +64,9 @@ describe("verifySpectrumSignature", () => {
     expect(result).toEqual({ ok: false, reason: "signature-mismatch" });
   });
 
-  it("rejects a wrong secret", () => {
+  it("rejects a wrong secret", async () => {
     const body = encode("payload");
-    const result = verifySpectrumSignature({
+    const result = await verifySpectrumSignature({
       rawBody: body,
       headers: headersFor(sign(body, NOW_SECONDS, "other-secret"), NOW_SECONDS),
       secret: SECRET,
@@ -74,10 +75,10 @@ describe("verifySpectrumSignature", () => {
     expect(result).toEqual({ ok: false, reason: "signature-mismatch" });
   });
 
-  it("accepts a timestamp at the edge of the tolerance window", () => {
+  it("accepts a timestamp at the edge of the tolerance window", async () => {
     const body = encode("payload");
     const timestamp = NOW_SECONDS - TOLERANCE_SECONDS;
-    const result = verifySpectrumSignature({
+    const result = await verifySpectrumSignature({
       rawBody: body,
       headers: headersFor(sign(body, timestamp), timestamp),
       secret: SECRET,
@@ -86,10 +87,10 @@ describe("verifySpectrumSignature", () => {
     expect(result.ok).toBe(true);
   });
 
-  it("rejects a timestamp just outside the tolerance window", () => {
+  it("rejects a timestamp just outside the tolerance window", async () => {
     const body = encode("payload");
     const timestamp = NOW_SECONDS - TOLERANCE_SECONDS - 1;
-    const result = verifySpectrumSignature({
+    const result = await verifySpectrumSignature({
       rawBody: body,
       headers: headersFor(sign(body, timestamp), timestamp),
       secret: SECRET,
@@ -98,9 +99,9 @@ describe("verifySpectrumSignature", () => {
     expect(result).toEqual({ ok: false, reason: "expired" });
   });
 
-  it("rejects when the signature header is missing", () => {
+  it("rejects when the signature header is missing", async () => {
     const body = encode("payload");
-    const result = verifySpectrumSignature({
+    const result = await verifySpectrumSignature({
       rawBody: body,
       headers: { "x-spectrum-timestamp": String(NOW_SECONDS) },
       secret: SECRET,
@@ -109,9 +110,9 @@ describe("verifySpectrumSignature", () => {
     expect(result).toEqual({ ok: false, reason: "missing-headers" });
   });
 
-  it("rejects when the timestamp header is missing", () => {
+  it("rejects when the timestamp header is missing", async () => {
     const body = encode("payload");
-    const result = verifySpectrumSignature({
+    const result = await verifySpectrumSignature({
       rawBody: body,
       headers: { "x-spectrum-signature": sign(body, NOW_SECONDS) },
       secret: SECRET,
@@ -120,9 +121,9 @@ describe("verifySpectrumSignature", () => {
     expect(result).toEqual({ ok: false, reason: "missing-headers" });
   });
 
-  it("rejects a non-numeric timestamp header", () => {
+  it("rejects a non-numeric timestamp header", async () => {
     const body = encode("payload");
-    const result = verifySpectrumSignature({
+    const result = await verifySpectrumSignature({
       rawBody: body,
       headers: {
         "x-spectrum-signature": sign(body, NOW_SECONDS),
@@ -134,14 +135,37 @@ describe("verifySpectrumSignature", () => {
     expect(result).toEqual({ ok: false, reason: "missing-headers" });
   });
 
-  it("rejects a non-hex / wrong-length signature without throwing", () => {
+  it("rejects a non-hex / wrong-length signature without throwing", async () => {
     const body = encode("payload");
-    const result = verifySpectrumSignature({
+    const result = await verifySpectrumSignature({
       rawBody: body,
       headers: headersFor("v0=not-hex-zzzz", NOW_SECONDS),
       secret: SECRET,
       now: NOW_MS,
     });
     expect(result).toEqual({ ok: false, reason: "signature-mismatch" });
+  });
+
+  it("rejects an odd-length hex signature without throwing", async () => {
+    const body = encode("payload");
+    const result = await verifySpectrumSignature({
+      rawBody: body,
+      headers: headersFor("v0=abc", NOW_SECONDS),
+      secret: SECRET,
+      now: NOW_MS,
+    });
+    expect(result).toEqual({ ok: false, reason: "signature-mismatch" });
+  });
+
+  it("throws on an empty secret instead of returning a 401-shaped result", async () => {
+    const body = encode("payload");
+    await expect(
+      verifySpectrumSignature({
+        rawBody: body,
+        headers: headersFor(sign(body, NOW_SECONDS), NOW_SECONDS),
+        secret: "",
+        now: NOW_MS,
+      })
+    ).rejects.toThrow(EMPTY_SECRET_ERROR);
   });
 });

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   entry: {
     index: "src/index.ts",
     authoring: "src/authoring.ts",
+    webhook: "src/webhook/portable.ts",
   },
   format: "esm",
   fixedExtension: false,


### PR DESCRIPTION
## Problem

Webhook signature verification used `node:crypto`, so it only ran on Node. That rules out receiving Spectrum webhooks on V8-isolate runtimes — Convex, Cloudflare Workers, Deno Deploy — which provide Web Crypto but no Node builtins.

It also had a latent gap on a runtime we already claim to support: `globalThis.crypto` is not exposed by default on **Node 18**, and `@spectrum-ts/imessage` declares `engines.node >= 18.17`.

## Solution

`verifySpectrumSignature` is reimplemented on Web Crypto via [`uncrypto`](https://github.com/unjs/uncrypto), whose conditional exports resolve to `node:crypto`'s webcrypto under Node and `globalThis.crypto` everywhere else. No runtime feature check needed — the Node 18 gap disappears rather than being papered over.

The function is now **async**; the single internal call site (`handleSpectrumWebhook`) is updated.

A new **`@spectrum-ts/core/webhook`** subpath exports it alongside the slim wire schemas. It deliberately **excludes** `webhook/deserialize.ts`, which pulls `node:fs` and `node:crypto` in transitively through the content builders — materializing a slim envelope into a live `[space, message]` pair stays a `Spectrum()` concern.

## Behaviour changes

Two fall out of the rewrite, both narrowing previously-loose handling:

- A malformed signature is now decoded **strictly** and returns `signature-mismatch`, rather than silently comparing a truncated buffer.
- An empty `secret` now **throws** instead of returning a 401-shaped result. That is caller misconfiguration, not an unauthenticated request; returning 401 made it undebuggable.

The wire format is unchanged: `HMAC-SHA256(secret, "v0:" + timestamp + ":" + rawBody)`, hex, `v0=` prefix, 5-minute replay window. Comparison remains constant-time (`subtle.verify`).

## Verification

`check`, `typecheck`, `test` (32/32 tasks, both Node and Bun runtimes) and `build` all pass.

Confirmed `uncrypto` stays an **external** import in the built chunk, so the *consumer's* bundler picks the condition rather than it being baked in at publish time. Bundling the new entry with esbuild:

| Target | Resolves to | `node:crypto` refs |
|---|---|---|
| `platform: browser` (Convex's V8 runtime) | `globalThis.crypto` | 0 |
| `platform: node` | `node:crypto` webcrypto | 1 |

Existing verify tests were converted to async, with two added covering the strict-hex and empty-secret paths.

## Notes

Nothing here is specific to any one host — this is the generic portable slice of the SDK. It is the first of two extractions needed by a Convex component; a follow-up PR adds `@spectrum-ts/imessage/remote`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789845950&installation_model_id=19795&pr_number=240&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F240&signature=ec3b33b12a7e0adafe7f0b01984813711be59225c281ff1cfe890f43470e69d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a portable webhook API for runtime-agnostic applications.
  - Webhook types, schemas, and signature verification are now available through a dedicated package entry point.
  - Webhook signature verification now supports asynchronous Web Crypto implementations.

- **Bug Fixes**
  - Improved handling of malformed signatures, including invalid hexadecimal and odd-length values.
  - Empty signing secrets now produce a clear error instead of an unsuccessful verification result.

- **Tests**
  - Expanded coverage for asynchronous verification and invalid signature scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->