### PR TITLE
iMessage: discover mid-run line changes without a restart

### DIFF
--- a/docs/providers/imessage.mdx.vel
+++ b/docs/providers/imessage.mdx.vel
@@ -47,8 +47,9 @@ import { imessage } from "@spectrum-ts/imessage";
 
 Cloud mode discovers every line owned by the project and renews its tokens
 automatically. Most applications should use the empty `imessage.config()` call.
-Lines provisioned while the app is running are picked up at the next token
-renewal — see [when line changes reach a running
+Lines provisioned while the app is running are discovered automatically within
+about a minute, or immediately via `refreshLines(app)` — see [when line changes
+reach a running
 app](/spectrum-ts/providers/imessage/connection-and-routing#when-line-changes-reach-a-running-app).
 
 ### Explicit cloud clients

--- a/docs/providers/imessage/connection-and-routing.mdx.vel
+++ b/docs/providers/imessage/connection-and-routing.mdx.vel
@@ -94,9 +94,28 @@ When traffic to a dedicated line approaches its per-line capacity, Spectrum can 
 
 ### When line changes reach a running app
 
-The SDK learns about your lines from the credentials it mints, and it re-mints them on a schedule — so a line provisioned (or deprovisioned) while your app is running is picked up at the next token renewal, not immediately.
+The SDK learns about your lines from the credentials it mints, and it keeps that set current without a restart: alongside the scheduled token renewal, it polls the project's line inventory (every 60 seconds by default) and refreshes immediately when a line was provisioned or deprovisioned mid-run. A new line is normally attached — receiving inbound messages and routable from `space.create()` — within one poll interval.
 
-Until that renewal lands, a newly provisioned line is invisible to the process: it receives no inbound messages, and `space.create()` cannot route through it. Messages sent to it in that window are not delayed, they are not delivered to your app at all. Restart the process if you need a new line to take effect right away.
+Tune or disable the poll per provider:
+
+```ts
+imessage.config({ lineDiscovery: { intervalMs: 30_000 } }); // poll faster
+imessage.config({ lineDiscovery: { enabled: false } }); // renewal-only
+```
+
+When you have just provisioned a line and don't want to wait for the poll, force a refresh from your own code — it re-mints credentials right away and resolves once the new line set is live:
+
+```ts
+import { refreshLines } from "@spectrum-ts/imessage";
+
+await refreshLines(app);
+```
+
+`refreshLines` is a no-op for explicitly-configured `clients`, which have no cloud inventory to refresh. It works uniformly whether you run one process or many — each replica discovers lines independently, so in a multi-replica deployment call it on every replica (or rely on the poll, which runs in each).
+
+<Warning>
+  Until a replica discovers a new line, that line is invisible to it: it receives no inbound messages there, and `space.create()` on that replica cannot route through it. Messages sent to the line in that window are not delayed for that process — they are not delivered to it at all. If you assign users to a line as soon as it is provisioned (e.g. from `/lines/route`), call `refreshLines` first or prefer lines old enough for every replica's poll to have seen them.
+</Warning>
 
 <Note>
   On dedicated lines, two routing behaviors change the moment a second line appears, whether that happens at startup or mid-run:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -101,6 +101,7 @@ export type {
   ProviderMessage,
   SchemaMessage,
   SpaceNamespace,
+  SpectrumLike,
 } from "./platform/types";
 export { Spectrum, type SpectrumInstance } from "./spectrum";
 export type { Message } from "./types/message";
@@ -111,6 +112,10 @@ export type {
   DedicatedTokenData,
   FusorTokenData,
   ImessageInfoData,
+  ImessageLineData,
+  LineData,
+  LinesData,
+  OtherPlatformLineData,
   PlatformStatus,
   PlatformsData,
   ProjectData,

--- a/packages/core/src/utils/cloud.ts
+++ b/packages/core/src/utils/cloud.ts
@@ -65,6 +65,35 @@ export interface FusorTokenData {
   token: string;
 }
 
+export interface ImessageLineData {
+  createdAt: string;
+  id: string;
+  phoneNumber: string;
+  platform: "imessage";
+  profile: {
+    firstName: string | null;
+    lastName: string | null;
+    avatarUrl: string | null;
+  };
+  status: "available" | "unavailable" | "unknown";
+}
+
+/**
+ * Non-iMessage members of the `lines` array (e.g. WhatsApp Business numbers,
+ * registered or still pending). Kept loose — consumers narrow on `platform`
+ * and read the fields their platform defines.
+ */
+export interface OtherPlatformLineData {
+  platform: Exclude<CloudPlatform, "imessage">;
+  [key: string]: unknown;
+}
+
+export type LineData = ImessageLineData | OtherPlatformLineData;
+
+export interface LinesData {
+  lines: LineData[];
+}
+
 /**
  * Per-project profile bag — a flexible record of project-level settings
  * defined in Spectrum Cloud. Concrete fields depend on the project; consumers
@@ -191,6 +220,18 @@ export const cloud = {
 
   getImessageInfo: (projectId: string): Promise<ImessageInfoData> =>
     request(`/projects/${projectId}/imessage/`),
+
+  listLines: (
+    projectId: string,
+    projectSecret: string,
+    platform?: CloudPlatform
+  ): Promise<LinesData> =>
+    request(
+      `/projects/${projectId}/lines/${platform ? `?platform=${platform}` : ""}`,
+      {
+        headers: { Authorization: basicAuth(projectId, projectSecret) },
+      }
+    ),
 
   issueWhatsappBusinessTokens: (
     projectId: string,

--- a/packages/core/src/utils/token-renewal.ts
+++ b/packages/core/src/utils/token-renewal.ts
@@ -11,6 +11,15 @@ export interface TokenRenewal {
   forceRefresh(): Promise<void>;
   invalidate(): void;
   refreshIfNeeded(): Promise<void>;
+  /**
+   * Like {@link forceRefresh}, but guarantees the refresh it resolves on
+   * STARTED after this call: a refresh already in flight is awaited and then
+   * one more runs. `forceRefresh` would coalesce onto the in-flight one, whose
+   * data may predate whatever the caller just changed (e.g. a line provisioned
+   * a moment ago). Concurrent callers during the same flight share the one
+   * chained refresh.
+   */
+  refreshNext(): Promise<void>;
 }
 
 export interface TokenRenewalOptions {
@@ -75,6 +84,28 @@ export const createTokenRenewal = (
     return refreshInFlight;
   };
 
+  let queuedRefresh: Promise<void> | undefined;
+
+  // `refreshInFlight` is the promise returned by `.finally()`, so by the time
+  // the chained `.then` runs it has already been cleared — the chained
+  // coalescedRefresh always starts a genuinely new refresh. The in-flight
+  // outcome is deliberately swallowed: the caller asked for the NEXT refresh,
+  // and its failure surfaces on the returned promise.
+  const refreshNext = (): Promise<void> => {
+    if (!refreshInFlight) {
+      return coalescedRefresh();
+    }
+    if (!queuedRefresh) {
+      queuedRefresh = refreshInFlight
+        .catch(() => undefined)
+        .then(() => {
+          queuedRefresh = undefined;
+          return coalescedRefresh();
+        });
+    }
+    return queuedRefresh;
+  };
+
   const runScheduledRefresh = (): void => {
     if (disposed) {
       return;
@@ -111,6 +142,7 @@ export const createTokenRenewal = (
     invalidate(): void {
       tokenExpiresAt = 0;
     },
+    refreshNext,
     async refreshIfNeeded(): Promise<void> {
       if (Date.now() < tokenExpiresAt - EXPIRY_BUFFER_MS) {
         return;

--- a/packages/core/test/utils/token-renewal.test.ts
+++ b/packages/core/test/utils/token-renewal.test.ts
@@ -165,6 +165,82 @@ describe("createTokenRenewal", () => {
     renewal.dispose();
   });
 
+  it("refreshNext chains a fresh refresh behind an in-flight one", async () => {
+    vi.useFakeTimers();
+    const resolvers: (() => void)[] = [];
+    const refresh = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve);
+        })
+    );
+    const renewal = createTokenRenewal({
+      expiresInSeconds: () => 3600,
+      name: "test",
+      refresh,
+    });
+
+    const inFlight = renewal.forceRefresh();
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    // Both callers during the same flight share the one chained refresh.
+    const next = renewal.refreshNext();
+    const nextAgain = renewal.refreshNext();
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    resolvers[0]?.();
+    await inFlight;
+    await vi.advanceTimersByTimeAsync(0);
+    expect(refresh).toHaveBeenCalledTimes(2);
+
+    resolvers[1]?.();
+    await Promise.all([next, nextAgain]);
+    expect(refresh).toHaveBeenCalledTimes(2);
+    renewal.dispose();
+  });
+
+  it("refreshNext without an in-flight refresh runs immediately", async () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn(() => Promise.resolve());
+    const renewal = createTokenRenewal({
+      expiresInSeconds: () => 3600,
+      name: "test",
+      refresh,
+    });
+
+    await renewal.refreshNext();
+    expect(refresh).toHaveBeenCalledTimes(1);
+    renewal.dispose();
+  });
+
+  it("refreshNext still runs when the in-flight refresh rejects", async () => {
+    vi.useFakeTimers();
+    let rejectStale: ((error: Error) => void) | undefined;
+    const refresh = vi
+      .fn<() => Promise<void>>()
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectStale = reject;
+          })
+      )
+      .mockResolvedValue(undefined);
+    const renewal = createTokenRenewal({
+      expiresInSeconds: () => 3600,
+      name: "test",
+      refresh,
+    });
+
+    const stale = renewal.forceRefresh();
+    const next = renewal.refreshNext();
+
+    rejectStale?.(new Error("stale refresh failed"));
+    await expect(stale).rejects.toThrow("stale refresh failed");
+    await next;
+    expect(refresh).toHaveBeenCalledTimes(2);
+    renewal.dispose();
+  });
+
   it("cancels a pending renewal timer", async () => {
     vi.useFakeTimers();
     const refresh = vi.fn(() => Promise.resolve());

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -2,6 +2,7 @@ import { createGrpcClient } from "@photon-ai/advanced-imessage/grpc";
 import {
   cloud,
   type DedicatedTokenData,
+  type LinesData,
   type SharedTokenData,
   type SpectrumLike,
 } from "@spectrum-ts/core";
@@ -29,6 +30,13 @@ const FORCE_REFRESH_MIN_INTERVAL_MS = 5000;
 // re-mint; drift triggers the same refresh the renewal timer runs.
 const DEFAULT_LINE_DISCOVERY_INTERVAL_MS = 60_000;
 
+// A drift that survives its own re-mint cannot be resolved by minting again
+// right away — e.g. a line the token service skips because its instance is
+// not resolvable yet, or stale entries after a plan change. Retry such a
+// drift only every Nth tick, so a wedged line costs one mint per damp window
+// instead of one per poll, while a NEW drift still re-mints immediately.
+const REPEAT_DRIFT_DAMP_TICKS = 5;
+
 const authLog = createLogger("spectrum.imessage.auth");
 
 export interface LineDiscoveryOptions {
@@ -53,6 +61,17 @@ const cloudAuthState = new WeakMap<RemoteClient[], CloudAuth>();
 const instanceAttrs = (instanceId: string) => ({
   "spectrum.imessage.instance": instanceId,
 });
+
+// The polled inventory reduced to the phone set discovery diffs against.
+const listedImessagePhones = (data: LinesData): Set<string> => {
+  const listed = new Set<string>();
+  for (const line of data.lines) {
+    if (line.platform === "imessage") {
+      listed.add(line.phoneNumber);
+    }
+  }
+  return listed;
+};
 
 export async function createCloudClients(
   projectId: string,
@@ -234,6 +253,10 @@ export async function createCloudClients(
   // number yet, so an id-based diff would re-mint every tick for a line that
   // cannot attach. The poll only reads; the re-mint stays the single path that
   // mutates the client set.
+  // Discovery is best-effort by contract: nothing in here may throw out of
+  // the interval, mutate the client set directly (only reconcile does that),
+  // or run once the client is disposed. Every failure mode degrades to the
+  // pre-discovery behavior — the line is picked up at the next token renewal.
   const startLineDiscovery = (): (() => void) | undefined => {
     if (options?.lineDiscovery?.enabled === false) {
       return;
@@ -241,19 +264,53 @@ export async function createCloudClients(
     const intervalMs =
       options?.lineDiscovery?.intervalMs ?? DEFAULT_LINE_DISCOVERY_INTERVAL_MS;
     let pollInFlight = false;
+    let pollFailures = 0;
+    let lastDriftSignature: string | undefined;
+    let ticksSinceDriftMint = 0;
+
+    const noteRecovered = (): void => {
+      if (pollFailures === 0) {
+        return;
+      }
+      authLog.info("imessage line discovery poll recovered", {
+        "spectrum.imessage.discovery.failures": pollFailures,
+      });
+      pollFailures = 0;
+    };
+
+    // The damp gate: a NEW drift signature mints immediately; the same one
+    // persisting across ticks mints only once per damp window.
+    const shouldMintForDrift = (signature: string): boolean => {
+      if (signature === lastDriftSignature) {
+        ticksSinceDriftMint += 1;
+        if (ticksSinceDriftMint < REPEAT_DRIFT_DAMP_TICKS) {
+          return false;
+        }
+      }
+      lastDriftSignature = signature;
+      ticksSinceDriftMint = 0;
+      return true;
+    };
 
     const poll = async (): Promise<void> => {
       const data = await cloud.listLines(projectId, projectSecret, "imessage");
-      const listed = new Set<string>();
-      for (const line of data.lines) {
-        if (line.platform === "imessage") {
-          listed.add(line.phoneNumber);
-        }
+      if (disposed) {
+        return;
       }
+      noteRecovered();
+      const listed = listedImessagePhones(data);
       const drifted =
         listed.size !== entries.length ||
         entries.some((entry) => !listed.has(entry.phone));
       if (!drifted) {
+        lastDriftSignature = undefined;
+        return;
+      }
+      const signature = `${[...listed].sort().join(",")}|${entries
+        .map((entry) => entry.phone)
+        .sort()
+        .join(",")}`;
+      if (!shouldMintForDrift(signature)) {
         return;
       }
       authLog.info("imessage line inventory drifted; re-minting tokens", {
@@ -266,15 +323,23 @@ export async function createCloudClients(
     const timer = setInterval(() => {
       // Skip the tick rather than queue behind a slow poll or refresh — the
       // next tick re-checks the same live inventory anyway.
-      if (pollInFlight) {
+      if (pollInFlight || disposed) {
         return;
       }
       pollInFlight = true;
       poll()
         .catch((error: unknown) => {
-          authLog.warn(
+          pollFailures += 1;
+          // First failure of a streak at warn, the rest at debug: an outage
+          // otherwise warn-logs once a minute for its whole duration, and the
+          // recovery log above already brackets the streak.
+          const logFailure = pollFailures === 1 ? authLog.warn : authLog.debug;
+          logFailure(
             "imessage line discovery poll failed",
-            errorAttrs(error),
+            {
+              "spectrum.imessage.discovery.failures": pollFailures,
+              ...errorAttrs(error),
+            },
             error instanceof Error ? error : undefined
           );
         })
@@ -287,19 +352,22 @@ export async function createCloudClients(
     return () => clearInterval(timer);
   };
 
+  let disposed = false;
   let stopLineDiscovery: (() => void) | undefined;
 
   const cloudAuth: CloudAuth = {
     dispose: () => {
+      disposed = true;
       stopLineDiscovery?.();
       renewal.dispose();
     },
     forceRefresh,
     // Deliberate calls (the public refreshLines) bypass the reconnect-storm
     // floor above — a user who just provisioned a line must never have the
-    // refresh silently skipped — but still coalesce with any refresh already
-    // in flight.
-    refreshLines: () => renewal.forceRefresh(),
+    // refresh silently skipped — and chain behind an in-flight refresh
+    // instead of coalescing onto it, whose payload may predate the
+    // provisioning the caller is trying to pick up.
+    refreshLines: () => renewal.refreshNext(),
   };
 
   if (tokenData.type === "shared") {

--- a/packages/imessage/src/auth.ts
+++ b/packages/imessage/src/auth.ts
@@ -3,6 +3,7 @@ import {
   cloud,
   type DedicatedTokenData,
   type SharedTokenData,
+  type SpectrumLike,
 } from "@spectrum-ts/core";
 import {
   createLogger,
@@ -15,6 +16,7 @@ import {
   notifyLineDetached,
   setLineId,
 } from "./lines";
+import { IMESSAGE_PLATFORM } from "./platform";
 import { type RemoteClient, SHARED_PHONE } from "./types";
 
 // Floor between forced re-mints so a stream reconnect storm can't hammer the
@@ -22,11 +24,28 @@ import { type RemoteClient, SHARED_PHONE } from "./types";
 // message + poll streams asking at nearly the same instant.
 const FORCE_REFRESH_MIN_INTERVAL_MS = 5000;
 
+// How often line discovery compares the cloud's line inventory against the
+// tracked client set. A matching inventory costs one authenticated GET and no
+// re-mint; drift triggers the same refresh the renewal timer runs.
+const DEFAULT_LINE_DISCOVERY_INTERVAL_MS = 60_000;
+
 const authLog = createLogger("spectrum.imessage.auth");
+
+export interface LineDiscoveryOptions {
+  /** Set `false` to turn the inventory poll off entirely. */
+  enabled?: boolean;
+  /** Poll cadence; defaults to 60 seconds. */
+  intervalMs?: number;
+}
+
+export interface CloudClientOptions {
+  lineDiscovery?: LineDiscoveryOptions;
+}
 
 interface CloudAuth {
   dispose: () => void;
   forceRefresh: () => Promise<void>;
+  refreshLines: () => Promise<void>;
 }
 
 const cloudAuthState = new WeakMap<RemoteClient[], CloudAuth>();
@@ -37,7 +56,8 @@ const instanceAttrs = (instanceId: string) => ({
 
 export async function createCloudClients(
   projectId: string,
-  projectSecret: string
+  projectSecret: string,
+  options?: CloudClientOptions
 ): Promise<RemoteClient[]> {
   let tokenData = await cloud.issueImessageTokens(projectId, projectSecret);
   let lastRefreshAt = Date.now();
@@ -207,7 +227,80 @@ export async function createCloudClients(
     await renewal.forceRefresh();
   };
 
-  const cloudAuth: CloudAuth = { dispose: renewal.dispose, forceRefresh };
+  // Poll the cloud's line inventory and re-mint when it drifts from the
+  // tracked set, so a line provisioned mid-run attaches within one poll
+  // interval instead of at the next scheduled renewal (80% of the token TTL).
+  // Compares phone numbers, not line ids: reconcile skips a line that has no
+  // number yet, so an id-based diff would re-mint every tick for a line that
+  // cannot attach. The poll only reads; the re-mint stays the single path that
+  // mutates the client set.
+  const startLineDiscovery = (): (() => void) | undefined => {
+    if (options?.lineDiscovery?.enabled === false) {
+      return;
+    }
+    const intervalMs =
+      options?.lineDiscovery?.intervalMs ?? DEFAULT_LINE_DISCOVERY_INTERVAL_MS;
+    let pollInFlight = false;
+
+    const poll = async (): Promise<void> => {
+      const data = await cloud.listLines(projectId, projectSecret, "imessage");
+      const listed = new Set<string>();
+      for (const line of data.lines) {
+        if (line.platform === "imessage") {
+          listed.add(line.phoneNumber);
+        }
+      }
+      const drifted =
+        listed.size !== entries.length ||
+        entries.some((entry) => !listed.has(entry.phone));
+      if (!drifted) {
+        return;
+      }
+      authLog.info("imessage line inventory drifted; re-minting tokens", {
+        "spectrum.imessage.lines.listed": listed.size,
+        "spectrum.imessage.lines.tracked": entries.length,
+      });
+      await renewal.forceRefresh();
+    };
+
+    const timer = setInterval(() => {
+      // Skip the tick rather than queue behind a slow poll or refresh — the
+      // next tick re-checks the same live inventory anyway.
+      if (pollInFlight) {
+        return;
+      }
+      pollInFlight = true;
+      poll()
+        .catch((error: unknown) => {
+          authLog.warn(
+            "imessage line discovery poll failed",
+            errorAttrs(error),
+            error instanceof Error ? error : undefined
+          );
+        })
+        .finally(() => {
+          pollInFlight = false;
+        });
+    }, intervalMs);
+    timer.unref?.();
+
+    return () => clearInterval(timer);
+  };
+
+  let stopLineDiscovery: (() => void) | undefined;
+
+  const cloudAuth: CloudAuth = {
+    dispose: () => {
+      stopLineDiscovery?.();
+      renewal.dispose();
+    },
+    forceRefresh,
+    // Deliberate calls (the public refreshLines) bypass the reconnect-storm
+    // floor above — a user who just provisioned a line must never have the
+    // refresh silently skipped — but still coalesce with any refresh already
+    // in flight.
+    refreshLines: () => renewal.forceRefresh(),
+  };
 
   if (tokenData.type === "shared") {
     const address =
@@ -240,6 +333,9 @@ export async function createCloudClients(
   // path building lines and one place that decides what a line needs.
   reconcile(tokenData);
 
+  // Dedicated mode only: shared-pool projects have no line inventory to watch.
+  stopLineDiscovery = startLineDiscovery();
+
   cloudAuthState.set(entries, cloudAuth);
 
   return entries;
@@ -264,4 +360,41 @@ export function getCloudRecover(
   clients: RemoteClient[]
 ): (() => Promise<void>) | undefined {
   return cloudAuthState.get(clients)?.forceRefresh;
+}
+
+/**
+ * The on-demand refresh for a cloud-backed client array: re-mints tokens
+ * immediately (coalesced with an in-flight refresh, never throttled) and
+ * reconciles the line set. Undefined for explicitly-configured (static-token)
+ * clients, which have no cloud inventory to refresh.
+ */
+export function getLineRefresh(
+  clients: RemoteClient[]
+): (() => Promise<void>) | undefined {
+  return cloudAuthState.get(clients)?.refreshLines;
+}
+
+/**
+ * Re-mint `app`'s iMessage cloud credentials right now and reconcile its line
+ * set, so a line provisioned (or removed) moments ago attaches without
+ * waiting for the scheduled token renewal or the discovery poll. Resolves once
+ * the refreshed inventory has been applied to the running client — new lines
+ * are routable and subscribed when this returns.
+ *
+ * A no-op for explicitly-configured (`clients: [...]`) providers, which have
+ * no cloud inventory to refresh. Throws when the instance has no iMessage
+ * provider registered (or has already been stopped).
+ */
+export async function refreshLines(app: SpectrumLike): Promise<void> {
+  const runtime = app.__internal.platforms.get(IMESSAGE_PLATFORM);
+  if (!runtime) {
+    throw new Error(
+      "refreshLines: no iMessage provider is registered on this Spectrum instance (or it has been stopped)"
+    );
+  }
+  const refresh = getLineRefresh(runtime.client as RemoteClient[]);
+  if (!refresh) {
+    return;
+  }
+  await refresh();
 }

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -27,6 +27,7 @@ import type { ProviderMessageRecord } from "@spectrum-ts/core/authoring";
 // compiling — prefer importing from `spectrum-ts`.
 // biome-ignore lint/performance/noBarrelFile: provider entrypoint exports its public helpers
 export { read } from "@spectrum-ts/core";
+export { type LineDiscoveryOptions, refreshLines } from "./auth";
 export { type BackgroundInput, background } from "./content/background";
 export { type ContactCard, nativeContactCard } from "./content/contact-card";
 export {
@@ -510,7 +511,9 @@ const definedIMessage = defineCorePlatform(IMESSAGE_PLATFORM, {
           }),
         }));
       } else if (projectId && projectSecret) {
-        clients = await createCloudClients(projectId, projectSecret);
+        clients = await createCloudClients(projectId, projectSecret, {
+          lineDiscovery: config.lineDiscovery,
+        });
       } else {
         throw new Error(
           "Cloud iMessage requires projectId and projectSecret. Pass credentials to Spectrum() or provide explicit clients with imessage.config({ clients: [...] }). For local Messages access, install @spectrum-ts/imessage-local and use localIMessage.config()."

--- a/packages/imessage/src/types.ts
+++ b/packages/imessage/src/types.ts
@@ -22,8 +22,22 @@ const clientEntry = z.object({
   phone: z.string(),
 });
 
+/**
+ * Mid-run line discovery. In cloud dedicated mode the SDK polls the project's
+ * line inventory and re-mints credentials as soon as it drifts from the
+ * tracked set, so a line provisioned (or removed) while the app is running
+ * attaches within one poll interval instead of at the next token renewal.
+ * Ignored for explicitly-configured `clients` and for shared-pool projects,
+ * which have no dedicated inventory to watch.
+ */
+const lineDiscoverySchema = z.strictObject({
+  enabled: z.boolean().optional(),
+  intervalMs: z.number().int().min(5000).optional(),
+});
+
 export const configSchema = z.strictObject({
   clients: clientEntry.or(z.array(clientEntry)).optional(),
+  lineDiscovery: lineDiscoverySchema.optional(),
 });
 
 /**

--- a/packages/imessage/test/auth.test.ts
+++ b/packages/imessage/test/auth.test.ts
@@ -50,6 +50,34 @@ const dedicated = (
 const issueImessageTokens = vi.fn(
   (): Promise<FakeTokenData> => Promise.resolve(initialTokenData)
 );
+
+interface FakeListedLine {
+  createdAt: string;
+  id: string;
+  phoneNumber: string;
+  platform: "imessage";
+  profile: {
+    firstName: string | null;
+    lastName: string | null;
+    avatarUrl: string | null;
+  };
+  status: "available" | "unavailable" | "unknown";
+}
+
+// One member of the polled `GET /lines` inventory, keyed by phone number —
+// the field discovery diffs against the tracked client set.
+const listedLine = (phone: string): FakeListedLine => ({
+  platform: "imessage",
+  id: `id-${phone}`,
+  phoneNumber: phone,
+  profile: { firstName: null, lastName: null, avatarUrl: null },
+  status: "available",
+  createdAt: "2026-01-01T00:00:00.000Z",
+});
+
+const listLines = vi.fn(
+  (): Promise<{ lines: FakeListedLine[] }> => Promise.resolve({ lines: [] })
+);
 const clientOptions: FakeClientOptions[] = [];
 const fakeClients: FakeClient[] = [];
 const createGrpcClient = vi.fn((options: FakeClientOptions) => {
@@ -63,16 +91,26 @@ vi.doMock("@spectrum-ts/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@spectrum-ts/core")>();
   return {
     ...actual,
-    cloud: { ...actual.cloud, issueImessageTokens },
+    cloud: { ...actual.cloud, issueImessageTokens, listLines },
   };
 });
 
 vi.doMock("@photon-ai/advanced-imessage/grpc", () => ({ createGrpcClient }));
 
-const { createCloudClients, disposeCloudAuth, getCloudRecover } = await import(
-  "@/auth"
-);
+const { createCloudClients, disposeCloudAuth, getCloudRecover, refreshLines } =
+  await import("@/auth");
 const { addLineObserver } = await import("@/lines");
+const { IMESSAGE_PLATFORM } = await import("@/platform");
+
+// Minimal SpectrumLike shape: refreshLines only reads
+// `__internal.platforms.get("imessage").client`.
+const fakeApp = (client: unknown) =>
+  ({
+    __internal: {
+      platforms: new Map([[IMESSAGE_PLATFORM, { client }]]),
+    },
+    __providers: [],
+  }) as unknown as Parameters<typeof refreshLines>[0];
 
 // The recover hook runs the same closure the renewal timer does, so it is the
 // cheapest way to drive a refresh. It is throttled to one re-mint per 5s.
@@ -103,6 +141,8 @@ describe("imessage cloud auth", () => {
   beforeEach(() => {
     issueImessageTokens.mockReset();
     issueImessageTokens.mockResolvedValue(initialTokenData);
+    listLines.mockReset();
+    listLines.mockResolvedValue({ lines: [] });
     createGrpcClient.mockClear();
     clientOptions.length = 0;
     fakeClients.length = 0;
@@ -334,5 +374,179 @@ describe("imessage cloud auth", () => {
     expect(clients).toHaveLength(2);
 
     await disposeCloudAuth(clients);
+  });
+
+  describe("line discovery", () => {
+    const DISCOVERY_INTERVAL_MS = 10_000;
+
+    const startWithDiscovery = async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      issueImessageTokens.mockResolvedValueOnce(
+        dedicated({ "instance-1": "+15550000001" })
+      );
+      return await createCloudClients("project-1", "secret-1", {
+        lineDiscovery: { intervalMs: DISCOVERY_INTERVAL_MS },
+      });
+    };
+
+    it("attaches a provisioned line at the next inventory poll", async () => {
+      const clients = await startWithDiscovery();
+      expect(clients).toHaveLength(1);
+
+      listLines.mockResolvedValue({
+        lines: [listedLine("+15550000001"), listedLine("+15550000002")],
+      });
+      issueImessageTokens.mockResolvedValueOnce(
+        dedicated({
+          "instance-1": "+15550000001",
+          "instance-2": "+15550000002",
+        })
+      );
+
+      await vi.advanceTimersByTimeAsync(DISCOVERY_INTERVAL_MS);
+
+      expect(listLines).toHaveBeenCalledWith(
+        "project-1",
+        "secret-1",
+        "imessage"
+      );
+      expect(clients).toHaveLength(2);
+      expect(clients.map((entry) => entry.phone)).toEqual([
+        "+15550000001",
+        "+15550000002",
+      ]);
+
+      await disposeCloudAuth(clients);
+    });
+
+    it("does not re-mint while the inventory matches", async () => {
+      const clients = await startWithDiscovery();
+      listLines.mockResolvedValue({ lines: [listedLine("+15550000001")] });
+
+      await vi.advanceTimersByTimeAsync(DISCOVERY_INTERVAL_MS * 2);
+
+      expect(listLines).toHaveBeenCalledTimes(2);
+      // Startup mint only — a matching poll must not touch the token endpoint.
+      expect(issueImessageTokens).toHaveBeenCalledTimes(1);
+      expect(clients).toHaveLength(1);
+
+      await disposeCloudAuth(clients);
+    });
+
+    it("recovers from a failed poll on the next tick", async () => {
+      const clients = await startWithDiscovery();
+      listLines.mockRejectedValueOnce(new Error("poll boom"));
+      await vi.advanceTimersByTimeAsync(DISCOVERY_INTERVAL_MS);
+      expect(clients).toHaveLength(1);
+
+      listLines.mockResolvedValue({
+        lines: [listedLine("+15550000001"), listedLine("+15550000002")],
+      });
+      issueImessageTokens.mockResolvedValueOnce(
+        dedicated({
+          "instance-1": "+15550000001",
+          "instance-2": "+15550000002",
+        })
+      );
+      await vi.advanceTimersByTimeAsync(DISCOVERY_INTERVAL_MS);
+
+      expect(clients).toHaveLength(2);
+
+      await disposeCloudAuth(clients);
+    });
+
+    it("stops polling once the client is disposed", async () => {
+      const clients = await startWithDiscovery();
+
+      await disposeCloudAuth(clients);
+      await vi.advanceTimersByTimeAsync(DISCOVERY_INTERVAL_MS * 3);
+
+      expect(listLines).not.toHaveBeenCalled();
+    });
+
+    it("can be disabled via config", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      issueImessageTokens.mockResolvedValueOnce(
+        dedicated({ "instance-1": "+15550000001" })
+      );
+      const clients = await createCloudClients("project-1", "secret-1", {
+        lineDiscovery: { enabled: false },
+      });
+
+      await vi.advanceTimersByTimeAsync(120_000);
+
+      expect(listLines).not.toHaveBeenCalled();
+
+      await disposeCloudAuth(clients);
+    });
+
+    it("does not poll in shared mode", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      issueImessageTokens.mockResolvedValueOnce({
+        expiresIn: 3600,
+        token: "shared-1",
+        type: "shared",
+      });
+      const clients = await createCloudClients("project-1", "secret-1", {
+        lineDiscovery: { intervalMs: DISCOVERY_INTERVAL_MS },
+      });
+
+      await vi.advanceTimersByTimeAsync(DISCOVERY_INTERVAL_MS * 3);
+
+      expect(listLines).not.toHaveBeenCalled();
+
+      await disposeCloudAuth(clients);
+    });
+  });
+
+  describe("refreshLines", () => {
+    it("re-mints immediately, even within the forced-refresh floor", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      issueImessageTokens.mockResolvedValueOnce(
+        dedicated({ "instance-1": "+15550000001" })
+      );
+      const clients = await createCloudClients("project-1", "secret-1");
+
+      // No timer advance: still inside the 5s floor that throttles the
+      // stream-recovery hook. A deliberate refresh must not be skipped.
+      issueImessageTokens.mockResolvedValueOnce(
+        dedicated({
+          "instance-1": "+15550000001",
+          "instance-2": "+15550000002",
+        })
+      );
+      await refreshLines(fakeApp(clients));
+
+      expect(clients).toHaveLength(2);
+      expect(clients.map((entry) => entry.phone)).toEqual([
+        "+15550000001",
+        "+15550000002",
+      ]);
+
+      await disposeCloudAuth(clients);
+    });
+
+    it("is a no-op for explicitly-configured clients", async () => {
+      // A static client array never passes through createCloudClients, so it
+      // has no cloud auth state to refresh.
+      await refreshLines(fakeApp([]));
+
+      expect(issueImessageTokens).not.toHaveBeenCalled();
+    });
+
+    it("throws when the instance has no iMessage provider", async () => {
+      const app = {
+        __internal: { platforms: new Map() },
+        __providers: [],
+      } as unknown as Parameters<typeof refreshLines>[0];
+
+      await expect(refreshLines(app)).rejects.toThrow(
+        "no iMessage provider is registered"
+      );
+    });
   });
 });

--- a/packages/imessage/test/auth.test.ts
+++ b/packages/imessage/test/auth.test.ts
@@ -456,6 +456,66 @@ describe("imessage cloud auth", () => {
       await disposeCloudAuth(clients);
     });
 
+    it("does not re-mint when a poll lands after dispose", async () => {
+      const clients = await startWithDiscovery();
+      let resolvePoll:
+        | ((value: { lines: FakeListedLine[] }) => void)
+        | undefined;
+      listLines.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolvePoll = resolve;
+          })
+      );
+
+      // The tick fires and the poll is in flight when the client is disposed;
+      // its late result must not trigger a mint against a torn-down client.
+      await vi.advanceTimersByTimeAsync(DISCOVERY_INTERVAL_MS);
+      await disposeCloudAuth(clients);
+      resolvePoll?.({
+        lines: [listedLine("+15550000001"), listedLine("+15550000002")],
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(issueImessageTokens).toHaveBeenCalledTimes(1);
+      expect(clients).toHaveLength(1);
+    });
+
+    it("damps re-minting while the same drift persists", async () => {
+      const clients = await startWithDiscovery();
+      // The mint keeps returning the single-line payload (the beforeEach
+      // default), so the second listed line can never attach: the exact wedged
+      // state the damp exists for.
+      listLines.mockResolvedValue({
+        lines: [listedLine("+15550000001"), listedLine("+15550000002")],
+      });
+
+      await vi.advanceTimersByTimeAsync(DISCOVERY_INTERVAL_MS);
+      // Startup + the first drift mint.
+      expect(issueImessageTokens).toHaveBeenCalledTimes(2);
+
+      // The same drift signature is damped, not re-minted every tick.
+      await vi.advanceTimersByTimeAsync(DISCOVERY_INTERVAL_MS * 4);
+      expect(issueImessageTokens).toHaveBeenCalledTimes(2);
+
+      // Damp window elapsed: one retry.
+      await vi.advanceTimersByTimeAsync(DISCOVERY_INTERVAL_MS);
+      expect(issueImessageTokens).toHaveBeenCalledTimes(3);
+
+      // A drift with a new shape re-mints immediately.
+      listLines.mockResolvedValue({
+        lines: [
+          listedLine("+15550000001"),
+          listedLine("+15550000002"),
+          listedLine("+15550000003"),
+        ],
+      });
+      await vi.advanceTimersByTimeAsync(DISCOVERY_INTERVAL_MS);
+      expect(issueImessageTokens).toHaveBeenCalledTimes(4);
+
+      await disposeCloudAuth(clients);
+    });
+
     it("stops polling once the client is disposed", async () => {
       const clients = await startWithDiscovery();
 
@@ -503,6 +563,48 @@ describe("imessage cloud auth", () => {
   });
 
   describe("refreshLines", () => {
+    it("chains behind an in-flight refresh instead of coalescing onto it", async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      issueImessageTokens.mockResolvedValueOnce(
+        dedicated({ "instance-1": "+15550000001" })
+      );
+      const clients = await createCloudClients("project-1", "secret-1");
+      const recover = getCloudRecover(clients);
+      if (!recover) {
+        throw new Error("expected cloud recovery hook");
+      }
+
+      // A refresh already in flight, minted BEFORE the new line existed.
+      let resolveStale: ((value: FakeTokenData) => void) | undefined;
+      issueImessageTokens.mockImplementationOnce(
+        () =>
+          new Promise<FakeTokenData>((resolve) => {
+            resolveStale = resolve;
+          })
+      );
+      await vi.advanceTimersByTimeAsync(5000);
+      const stale = recover();
+
+      issueImessageTokens.mockResolvedValueOnce(
+        dedicated({
+          "instance-1": "+15550000001",
+          "instance-2": "+15550000002",
+        })
+      );
+      const refreshed = refreshLines(fakeApp(clients));
+
+      resolveStale?.(dedicated({ "instance-1": "+15550000001" }));
+      await stale;
+      await refreshed;
+
+      // The stale payload alone would have left one line; refreshLines must
+      // resolve on a mint that started after the call.
+      expect(clients).toHaveLength(2);
+
+      await disposeCloudAuth(clients);
+    });
+
     it("re-mints immediately, even within the forced-refresh floor", async () => {
       vi.useFakeTimers();
       vi.setSystemTime(0);


### PR DESCRIPTION
## What

Two additions, both thin triggers for the existing `reconcile()` path in `packages/imessage/src/auth.ts` (attach/detach plumbing, coalescing, and observer notifications are all reused as-is):

**1. Inventory polling (automatic, on by default)** — in cloud dedicated mode, the SDK polls `GET /projects/:id/lines?platform=imessage` (default every 60s) and force-refreshes credentials when the listed phone-number set drifts from the tracked client set. A matching poll costs one authenticated GET and no re-mint. Diffing is by phone number, not line id, because reconcile deliberately skips number-less lines — an id diff would re-mint every tick for a line that cannot attach yet. Configurable:

```ts
imessage.config({ lineDiscovery: { intervalMs: 30_000 } })
imessage.config({ lineDiscovery: { enabled: false } })
```

**2. `refreshLines(app)` (on-demand)** — new public export from `@spectrum-ts/imessage` for "I just provisioned a line and want it now". Re-mints immediately and resolves once the new line set is live. It deliberately bypasses the 5s forced-refresh floor (that floor exists to damp stream-reconnect storms; a deliberate call must never be silently skipped) but still coalesces with any in-flight refresh. No-op for explicitly-configured `clients`; throws if no iMessage provider is registered.

Supporting changes:
- `@spectrum-ts/core`: `cloud.listLines()` (the external endpoint already exists server-side, project Basic auth) + line data types; exports `SpectrumLike` (the type `refreshLines` accepts — `SpectrumInstance` satisfies it).
- Config schema: `lineDiscovery` on `imessage.config()`.
- Docs: `connection-and-routing.mdx.vel` "When line changes reach a running app" rewritten — "restart the process" guidance replaced with discovery/`refreshLines`, plus a warning about the remaining per-replica window; overview page updated.
- Tests: 9 new cases in `packages/imessage/test/auth.test.ts` (drift-triggered attach, matching-inventory no-op, failed-poll recovery, dispose stops the poll, disable via config, shared mode never polls, `refreshLines` within the floor / static no-op / no-provider throw).

## Verification

- `packages/imessage`: 215/215 tests pass (`vitest run`)
- `packages/core`: 319/319 tests pass
- `turbo typecheck`: 13/13 packages clean
- `ultracite check`: clean

https://claude.ai/code/session_016p2BzwU46Wpt83aZBcuR8k

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790204545&installation_model_id=19795&pr_number=243&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F243&signature=2e2d08a300cd0c18f6463a0822089f63febe30514d7df7e39eabffdda26e132a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->