### PR TITLE
fix(imessage): surface reaction removal events

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -530,7 +530,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
+    "@types/bun": ["@types/bun@1.4.2", "", { "dependencies": { "bun-types": "1.4.2" } }, "sha512-GimotNn7+ZV0uVArItBbriZsR1oNf0+WTzPkdcFrzShI7k2norL0uzEaJT8T33dWr7O/c9ZDuAFQrctKCi72oQ=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -670,7 +670,7 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
-    "bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
+    "bun-types": ["bun-types@1.4.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-bxV1FgK7yBIzjRe5zBozIM4Bem11ZJcCXSrjWRG3YWLt8yFDePu4cLjpebO8OvPeIE9trbyPF4fuj3Cia4Fj3w=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -1322,6 +1322,8 @@
 
     "protobufjs/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
+    "spectrum-ts/@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
+
     "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
@@ -1363,6 +1365,8 @@
     "cli-highlight/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "spectrum-ts/@types/bun/bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -530,7 +530,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.4.2", "", { "dependencies": { "bun-types": "1.4.2" } }, "sha512-GimotNn7+ZV0uVArItBbriZsR1oNf0+WTzPkdcFrzShI7k2norL0uzEaJT8T33dWr7O/c9ZDuAFQrctKCi72oQ=="],
+    "@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -670,7 +670,7 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
-    "bun-types": ["bun-types@1.4.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-bxV1FgK7yBIzjRe5zBozIM4Bem11ZJcCXSrjWRG3YWLt8yFDePu4cLjpebO8OvPeIE9trbyPF4fuj3Cia4Fj3w=="],
+    "bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -1322,8 +1322,6 @@
 
     "protobufjs/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
-    "spectrum-ts/@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
-
     "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
@@ -1365,8 +1363,6 @@
     "cli-highlight/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "spectrum-ts/@types/bun/bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
 

--- a/docs/reactions-and-replies.mdx.vel
+++ b/docs/reactions-and-replies.mdx.vel
@@ -43,6 +43,17 @@ await message.react(Emoji.laugh);
 
 `reaction()` rejects reaction messages as targets — reacting to a reaction throws at build time.
 
+Inbound reaction removals use the same reaction content shape as additions,
+with `message.content.removed === true`. The field is omitted for additions,
+so existing consumers that only inspect `emoji` and `target` continue to work.
+
+```ts
+if (message.content.type === "reaction") {
+  const action = message.content.removed ? "removed" : "added";
+  console.log(action, message.content.emoji, message.content.target.id);
+}
+```
+
 The iMessage tapback aliases are:
 
 <Accordion title="Emoji" description="{{ emoji.doc.summary }}">

--- a/packages/core/src/content/reaction.ts
+++ b/packages/core/src/content/reaction.ts
@@ -18,6 +18,8 @@ const isMessage = (v: unknown): v is Message =>
 export const reactionSchema = z.object({
   type: z.literal("reaction"),
   emoji: z.string().min(1),
+  /** True when this event removes a previously applied reaction. */
+  removed: z.boolean().optional(),
   target: z.custom<Message>(isMessage, {
     message: "reaction target must be a Message",
   }),
@@ -27,6 +29,7 @@ export type Reaction = z.infer<typeof reactionSchema>;
 
 export const asReaction = (input: {
   emoji: string;
+  removed?: boolean;
   target: Message;
 }): Reaction => reactionSchema.parse({ type: "reaction", ...input });
 

--- a/packages/core/test/core/send-reaction.test.ts
+++ b/packages/core/test/core/send-reaction.test.ts
@@ -57,6 +57,16 @@ const firstMessage = async (app: Awaited<ReturnType<typeof Spectrum>>) => {
 };
 
 describe("reaction sends return a Message", () => {
+  it("preserves provider-supplied reaction removal state", () => {
+    const removed = asReaction({
+      emoji: "👍",
+      removed: true,
+      target: record("target") as unknown as Message,
+    });
+
+    expect(removed.removed).toBe(true);
+  });
+
   it("message.react resolves to the reaction Message with the built target", async () => {
     const provider = makeReactionProvider("react_ok", (content) =>
       Promise.resolve({

--- a/packages/imessage/src/remote/reactions.ts
+++ b/packages/imessage/src/remote/reactions.ts
@@ -18,9 +18,9 @@ import {
 } from "./inbound";
 import { toMessageMetadata } from "./message-metadata";
 
-type ReactionAddedEvent = Extract<
+type ReactionEvent = Extract<
   MessageEvent,
-  { type: "message.reactionAdded" }
+  { type: "message.reactionAdded" | "message.reactionRemoved" }
 >;
 
 type TapbackKind = Exclude<SettableMessageReaction["kind"], "emoji">;
@@ -41,16 +41,18 @@ const TAPBACK_TO_EMOJI: Readonly<Record<string, string>> = Object.fromEntries(
 type RawProviderMessage = Pick<IMessageMessage, "content" | "id">;
 
 const reactionEmoji = (
-  reaction: ReactionAddedEvent["reaction"]
+  reaction: ReactionEvent["reaction"]
 ): string | undefined =>
   reaction.kind === "emoji" ? reaction.emoji : TAPBACK_TO_EMOJI[reaction.kind];
 
 const asProviderReaction = (
   emoji: string,
-  target: RawProviderMessage
+  target: RawProviderMessage,
+  removed: boolean
 ): ReactionContent =>
   reactionSchema.parse({
     emoji,
+    ...(removed ? { removed: true } : {}),
     target,
     type: "reaction",
   });
@@ -90,7 +92,7 @@ const resolveReactionTarget = async (
 export const toReactionMessages = async (
   client: AdvancedIMessage,
   cache: MessageCache,
-  event: ReactionAddedEvent,
+  event: ReactionEvent,
   phone: string
 ): Promise<IMessageMessage[]> => {
   const emoji = reactionEmoji(event.reaction);
@@ -127,7 +129,11 @@ export const toReactionMessages = async (
       },
       timestamp: event.occurredAt,
       id: `${event.messageGuid}:reaction:${event.sequence}${partSuffix}`,
-      content: asProviderReaction(emoji, resolved),
+      content: asProviderReaction(
+        emoji,
+        resolved,
+        event.type === "message.reactionRemoved"
+      ),
     },
   ];
 };
@@ -174,7 +180,7 @@ export const reactToMessage = async (
   return {
     ...toMessageMetadata(sent),
     id: sent.guid,
-    content: asProviderReaction(reaction, target),
+    content: asProviderReaction(reaction, target, false),
     direction: "outbound",
     space: { id: spaceId },
     timestamp: sent.dateCreated,

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -149,7 +149,10 @@ const toMessageItem = async (
     return { cursor, id: event.message.guid, values };
   }
 
-  if (event.type === "message.reactionAdded") {
+  if (
+    event.type === "message.reactionAdded" ||
+    event.type === "message.reactionRemoved"
+  ) {
     if (isEventFromCurrentAccount(event, phone)) {
       return {
         cursor,
@@ -200,8 +203,8 @@ const toMessageItem = async (
     };
   }
 
-  // Consumed for the cursor but not surfaced (edits, unsends, sticker
-  // placements, reaction removals). Logged so "the stream is alive but this
+  // Consumed for the cursor but not surfaced (edits, unsends, and sticker
+  // placements). Logged so "the stream is alive but this
   // event type never arrives" is distinguishable from "the stream is dead".
   streamLog.debug("message event consumed without mapping", {
     "spectrum.imessage.event_type": event.type,

--- a/packages/imessage/test/remote/reactions.test.ts
+++ b/packages/imessage/test/remote/reactions.test.ts
@@ -91,11 +91,14 @@ const attachment = (
     uti: undefined,
   }) as unknown as SDKMessage["content"]["attachments"][number];
 
-const reactionEvent = (
-  overrides: Partial<
-    Extract<MessageEvent, { type: "message.reactionAdded" }>
-  > = {}
-): Extract<MessageEvent, { type: "message.reactionAdded" }> =>
+const reactionEvent = <
+  T extends
+    | "message.reactionAdded"
+    | "message.reactionRemoved" = "message.reactionAdded",
+>(
+  type: T = "message.reactionAdded" as T,
+  overrides: Partial<Extract<MessageEvent, { type: T }>> = {}
+): Extract<MessageEvent, { type: T }> =>
   ({
     actor: { address: "user@example.com" },
     chatGuid: "s1",
@@ -104,9 +107,9 @@ const reactionEvent = (
     occurredAt: SENT_DATE,
     reaction: { kind: "like" },
     sequence: 1,
-    type: "message.reactionAdded",
+    type,
     ...overrides,
-  }) as unknown as Extract<MessageEvent, { type: "message.reactionAdded" }>;
+  }) as unknown as Extract<MessageEvent, { type: T }>;
 
 describe("iMessage remote reactToMessage", () => {
   it("maps a native tapback emoji and returns the tapback record", async () => {
@@ -178,6 +181,28 @@ describe("iMessage remote toReactionMessages", () => {
     }
   });
 
+  it("surfaces reaction removals without losing the target", async () => {
+    const get = vi.fn((_message: string) => Promise.resolve(sdkMessage()));
+    const remote = {
+      messages: { get },
+    } as unknown as AdvancedIMessage;
+
+    const messages = await toReactionMessages(
+      remote,
+      new MessageCache(),
+      reactionEvent("message.reactionRemoved"),
+      "+15551234567"
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.content).toMatchObject({
+      emoji: "👍",
+      removed: true,
+      target: { id: "msg-guid" },
+      type: "reaction",
+    });
+  });
+
   it("drops the reaction when the target cannot be fetched", async () => {
     // Regression guard for the shared `resolveTargetMessage` extraction: a
     // failed fetch must keep dropping the event rather than propagating.
@@ -205,7 +230,7 @@ describe("iMessage remote toReactionMessages", () => {
     const messages = await toReactionMessages(
       remote,
       new MessageCache(),
-      reactionEvent({
+      reactionEvent("message.reactionAdded", {
         actor: {
           address: "+15557654321",
           country: "ca",
@@ -256,7 +281,9 @@ describe("iMessage remote toReactionMessages", () => {
     const messages = await toReactionMessages(
       remote,
       getMessageCache(remote),
-      reactionEvent({ messageGuid: "outbound-stream-guid" }),
+      reactionEvent("message.reactionAdded", {
+        messageGuid: "outbound-stream-guid",
+      }),
       "+15551234567"
     );
 
@@ -300,7 +327,7 @@ describe("iMessage remote toReactionMessages", () => {
     const messages = await toReactionMessages(
       remote,
       new MessageCache(),
-      reactionEvent({ targetPartIndex: 5 }),
+      reactionEvent("message.reactionAdded", { targetPartIndex: 5 }),
       "+15551234567"
     );
 


### PR DESCRIPTION
## Summary

- Add an optional `removed` flag to universal reaction content.
- Route advanced-iMessage `message.reactionRemoved` events through the existing reaction mapper and message stream.
- Preserve target resolution, actor attribution, part-index handling, and stable event ids for both additions and removals.
- Document how consumers distinguish inbound reaction additions from removals.

## Compatibility

The new field is additive and omitted for reaction additions, so consumers that only inspect `emoji` and `target` retain their existing behavior.

## Testing

- [x] `bun run --cwd packages/core typecheck`
- [x] `bun run --cwd packages/imessage typecheck`
- [x] Core reaction tests: 10 passed
- [x] Remote iMessage reaction tests: 9 passed
- [x] Ultracite check on changed source and test files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791432779&installation_model_id=19795&pr_number=248&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F248&signature=b1655cf820de36f41da4db5931be67fd01356d4df9366c21678cb1561b82d8e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reaction removal events are now supported and clearly marked with a `removed` indicator.
  * Removed reactions retain their emoji and target message details, allowing apps to distinguish removals from newly added reactions.
  * Reaction handling now covers both added and removed events.

* **Documentation**
  * Added guidance and examples for identifying reaction removals.

* **Tests**
  * Added coverage to verify that reaction removal state and associated message details are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->