### PR TITLE
feat(imessage-local): implement local lookups

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -530,7 +530,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
+    "@types/bun": ["@types/bun@1.4.2", "", { "dependencies": { "bun-types": "1.4.2" } }, "sha512-GimotNn7+ZV0uVArItBbriZsR1oNf0+WTzPkdcFrzShI7k2norL0uzEaJT8T33dWr7O/c9ZDuAFQrctKCi72oQ=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -670,7 +670,7 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
-    "bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
+    "bun-types": ["bun-types@1.4.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-bxV1FgK7yBIzjRe5zBozIM4Bem11ZJcCXSrjWRG3YWLt8yFDePu4cLjpebO8OvPeIE9trbyPF4fuj3Cia4Fj3w=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -1322,6 +1322,8 @@
 
     "protobufjs/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
+    "spectrum-ts/@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
+
     "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
@@ -1363,6 +1365,8 @@
     "cli-highlight/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "spectrum-ts/@types/bun/bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -530,7 +530,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.4.2", "", { "dependencies": { "bun-types": "1.4.2" } }, "sha512-GimotNn7+ZV0uVArItBbriZsR1oNf0+WTzPkdcFrzShI7k2norL0uzEaJT8T33dWr7O/c9ZDuAFQrctKCi72oQ=="],
+    "@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -670,7 +670,7 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
-    "bun-types": ["bun-types@1.4.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-bxV1FgK7yBIzjRe5zBozIM4Bem11ZJcCXSrjWRG3YWLt8yFDePu4cLjpebO8OvPeIE9trbyPF4fuj3Cia4Fj3w=="],
+    "bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -1322,8 +1322,6 @@
 
     "protobufjs/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
-    "spectrum-ts/@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
-
     "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
@@ -1365,8 +1363,6 @@
     "cli-highlight/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "spectrum-ts/@types/bun/bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
 

--- a/packages/imessage-local/README.md
+++ b/packages/imessage-local/README.md
@@ -18,3 +18,11 @@ const spectrum = Spectrum({
 This package is intentionally not included in the batteries-included
 `spectrum-ts` package. Install it only on the macOS host that will access the
 local Messages database.
+
+## Local lookups
+
+The provider supports `space.getMessage(id)`, chat display-name lookup, and
+attachment lookup through the local Messages database. Results are cached per
+client. Because `@photon-ai/imessage-kit` does not currently expose direct
+message- or attachment-GUID filters, uncached lookups use bounded pagination
+(up to 10,000 rows) and may return `undefined` for older records.

--- a/packages/imessage-local/README.md
+++ b/packages/imessage-local/README.md
@@ -22,7 +22,8 @@ local Messages database.
 ## Local lookups
 
 The provider supports `space.getMessage(id)`, chat display-name lookup, and
-attachment lookup through the local Messages database. Results are cached per
-client. Because `@photon-ai/imessage-kit` does not currently expose direct
-message- or attachment-GUID filters, uncached lookups use bounded pagination
-(up to 10,000 rows) and may return `undefined` for older records.
+attachment lookup through the local Messages database. Message and attachment
+results are cached per client. Because `@photon-ai/imessage-kit` does not
+currently expose direct message- or attachment-GUID filters, uncached lookups
+use bounded pagination (up to 10,000 rows) and may return `undefined` for older
+records.

--- a/packages/imessage-local/src/index.ts
+++ b/packages/imessage-local/src/index.ts
@@ -42,6 +42,8 @@ import { isCustomizedMiniApp } from "../../imessage/src/content/customized-mini-
 import { messageEffects } from "../../imessage/src/content/effect";
 import { chatTypeFromGuid, dmChatGuid } from "./ids";
 import {
+  getAttachment as localGetAttachment,
+  getDisplayName as localGetDisplayName,
   getMessage as localGetMessage,
   messages as localMessages,
   send as localSend,
@@ -220,8 +222,8 @@ export const localIMessage = definePlatform(PLATFORM_ID, {
     handleLocalOnlySend(client, space.id, content),
 
   actions: {
-    getMessage: async ({ client }, _space, messageId) =>
-      localGetMessage(client, messageId),
+    getMessage: async ({ client }, space, messageId) =>
+      localGetMessage(client, space.id, messageId),
     getMembers: async () =>
       unsupportedAction(
         "getMembers",
@@ -232,15 +234,11 @@ export const localIMessage = definePlatform(PLATFORM_ID, {
         "getAvatar",
         "fetching group avatars requires remote iMessage"
       ),
-    getDisplayName: async () =>
-      unsupportedAction(
-        "getDisplayName",
-        "reading chat display names requires remote iMessage"
-      ),
-    getAttachment: async (): Promise<Attachment | undefined> =>
-      unsupportedAction(
-        "getAttachment",
-        "fetching attachments by GUID requires remote iMessage"
-      ),
+    getDisplayName: async ({ client }, space) =>
+      localGetDisplayName(client, space.id),
+    getAttachment: async (
+      { client }: { client: IMessageSDK },
+      guid: string
+    ): Promise<Attachment | undefined> => localGetAttachment(client, guid),
   },
 });

--- a/packages/imessage-local/src/local/api.ts
+++ b/packages/imessage-local/src/local/api.ts
@@ -2,7 +2,7 @@ import type { IMessageSDK } from "@photon-ai/imessage-kit";
 import type { Content, ManagedStream } from "@spectrum-ts/core";
 import type { ProviderMessageRecord } from "@spectrum-ts/core/authoring";
 import type { IMessageMessage } from "../types";
-import { messages as localMessages } from "./inbound";
+import { messages as localMessages, toMessages } from "./inbound";
 import {
   getLocalAttachment,
   getLocalDisplayName,
@@ -23,7 +23,8 @@ export const getMessage = (
   client: IMessageSDK,
   spaceId: string,
   id: string
-): Promise<IMessageMessage | undefined> => getLocalMessage(client, spaceId, id);
+): Promise<IMessageMessage | undefined> =>
+  getLocalMessage(client, spaceId, id, toMessages);
 
 export const getAttachment = getLocalAttachment;
 export const getDisplayName = getLocalDisplayName;

--- a/packages/imessage-local/src/local/api.ts
+++ b/packages/imessage-local/src/local/api.ts
@@ -4,9 +4,11 @@ import type { ProviderMessageRecord } from "@spectrum-ts/core/authoring";
 import type { IMessageMessage } from "../types";
 import { messages as localMessages } from "./inbound";
 import {
-  getMessage as getLocalMessage,
-  send as sendLocalMessage,
-} from "./send";
+  getLocalAttachment,
+  getLocalDisplayName,
+  getLocalMessage,
+} from "./lookup";
+import { send as sendLocalMessage } from "./send";
 
 export const messages = (client: IMessageSDK): ManagedStream<IMessageMessage> =>
   localMessages(client);
@@ -19,5 +21,9 @@ export const send = (
 
 export const getMessage = (
   client: IMessageSDK,
+  spaceId: string,
   id: string
-): Promise<IMessageMessage | undefined> => getLocalMessage(client, id);
+): Promise<IMessageMessage | undefined> => getLocalMessage(client, spaceId, id);
+
+export const getAttachment = getLocalAttachment;
+export const getDisplayName = getLocalDisplayName;

--- a/packages/imessage-local/src/local/attachments.ts
+++ b/packages/imessage-local/src/local/attachments.ts
@@ -2,7 +2,7 @@ import { createReadStream } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { Readable } from "node:stream";
 import type { Message as LocalIMessage } from "@photon-ai/imessage-kit";
-import { type Content, fromVCard } from "@spectrum-ts/core";
+import { type Attachment, type Content, fromVCard } from "@spectrum-ts/core";
 import { asAttachment, asContact, asVoice } from "@spectrum-ts/core/authoring";
 import {
   appleAudioMimeType,
@@ -25,7 +25,9 @@ export const readLocalAttachment = async (
   return readFile(att.localPath);
 };
 
-const toAttachmentContent = (att: LocalAttachment): Content => {
+export const localAttachmentAsAttachment = (
+  att: LocalAttachment
+): Attachment => {
   const { localPath } = att;
   return asAttachment({
     id: att.id,
@@ -64,7 +66,7 @@ const toVCardContent = async (att: LocalAttachment): Promise<Content> => {
     const buf = await readLocalAttachment(att);
     return asContact(fromVCard(buf.toString("utf8")));
   } catch {
-    return toAttachmentContent(att);
+    return localAttachmentAsAttachment(att);
   }
 };
 
@@ -78,5 +80,5 @@ export const localAttachmentContent = async (
   const audioMimeType = isVoice ? appleAudioMimeType(att) : undefined;
   return audioMimeType
     ? toVoiceContent(att, audioMimeType)
-    : toAttachmentContent(att);
+    : localAttachmentAsAttachment(att);
 };

--- a/packages/imessage-local/src/local/lookup.ts
+++ b/packages/imessage-local/src/local/lookup.ts
@@ -1,0 +1,152 @@
+import type {
+  IMessageSDK,
+  Attachment as KitAttachment,
+  Message as LocalIMessage,
+} from "@photon-ai/imessage-kit";
+import type { Attachment } from "@spectrum-ts/core";
+import type { IMessageMessage } from "../types";
+import { localAttachmentAsAttachment } from "./attachments";
+import { toMessages } from "./inbound";
+
+const LOOKUP_PAGE_SIZE = 200;
+const LOOKUP_MAX_PAGES = 50;
+const MESSAGE_CACHE_LIMIT = 1000;
+const ATTACHMENT_CACHE_LIMIT = 1000;
+
+interface LocalLookupCache {
+  attachments: Map<string, Attachment>;
+  messages: Map<string, IMessageMessage>;
+}
+
+const caches = new WeakMap<IMessageSDK, LocalLookupCache>();
+
+const cacheFor = (client: IMessageSDK): LocalLookupCache => {
+  const existing = caches.get(client);
+  if (existing) {
+    return existing;
+  }
+  const created = {
+    attachments: new Map<string, Attachment>(),
+    messages: new Map<string, IMessageMessage>(),
+  };
+  caches.set(client, created);
+  return created;
+};
+
+const lruSet = <T>(
+  cache: Map<string, T>,
+  key: string,
+  value: T,
+  limit: number
+) => {
+  cache.delete(key);
+  cache.set(key, value);
+  while (cache.size > limit) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) {
+      return;
+    }
+    cache.delete(oldest);
+  }
+};
+
+const cacheAttachment = (
+  client: IMessageSDK,
+  attachment: KitAttachment
+): Attachment => {
+  const normalized = localAttachmentAsAttachment(attachment);
+  lruSet(
+    cacheFor(client).attachments,
+    attachment.id,
+    normalized,
+    ATTACHMENT_CACHE_LIMIT
+  );
+  return normalized;
+};
+
+export const cacheLocalMessage = async (
+  client: IMessageSDK,
+  source: LocalIMessage
+): Promise<IMessageMessage[]> => {
+  const normalized = await toMessages(source);
+  const cache = cacheFor(client);
+  for (const message of normalized) {
+    lruSet(cache.messages, message.id, message, MESSAGE_CACHE_LIMIT);
+  }
+  if (normalized[0]) {
+    lruSet(cache.messages, source.id, normalized[0], MESSAGE_CACHE_LIMIT);
+  }
+  for (const attachment of source.attachments) {
+    cacheAttachment(client, attachment);
+  }
+  return normalized;
+};
+
+export const getLocalMessage = async (
+  client: IMessageSDK,
+  spaceId: string,
+  messageId: string
+): Promise<IMessageMessage | undefined> => {
+  const cached = cacheFor(client).messages.get(messageId);
+  if (cached) {
+    return cached;
+  }
+
+  for (let page = 0; page < LOOKUP_MAX_PAGES; page += 1) {
+    const rows = await client.getMessages({
+      chatId: spaceId,
+      limit: LOOKUP_PAGE_SIZE,
+      offset: page * LOOKUP_PAGE_SIZE,
+    });
+    for (const row of rows) {
+      const normalized = await cacheLocalMessage(client, row);
+      const match = normalized.find((message) => message.id === messageId);
+      if (match) {
+        return match;
+      }
+      if (row.id === messageId) {
+        return normalized[0];
+      }
+    }
+    if (rows.length < LOOKUP_PAGE_SIZE) {
+      break;
+    }
+  }
+};
+
+export const getLocalAttachment = async (
+  client: IMessageSDK,
+  attachmentId: string
+): Promise<Attachment | undefined> => {
+  const cached = cacheFor(client).attachments.get(attachmentId);
+  if (cached) {
+    return cached;
+  }
+
+  for (let page = 0; page < LOOKUP_MAX_PAGES; page += 1) {
+    const rows = await client.getMessages({
+      hasAttachments: true,
+      limit: LOOKUP_PAGE_SIZE,
+      offset: page * LOOKUP_PAGE_SIZE,
+    });
+    for (const row of rows) {
+      for (const attachment of row.attachments) {
+        const normalized = cacheAttachment(client, attachment);
+        if (attachment.id === attachmentId) {
+          return normalized;
+        }
+      }
+    }
+    if (rows.length < LOOKUP_PAGE_SIZE) {
+      break;
+    }
+  }
+};
+
+export const getLocalDisplayName = async (
+  client: IMessageSDK,
+  spaceId: string
+): Promise<string | undefined> => {
+  const [chat] = await client.listChats({ chatId: spaceId, limit: 1 });
+  return chat?.name ?? undefined;
+};

--- a/packages/imessage-local/src/local/lookup.ts
+++ b/packages/imessage-local/src/local/lookup.ts
@@ -6,12 +6,15 @@ import type {
 import type { Attachment } from "@spectrum-ts/core";
 import type { IMessageMessage } from "../types";
 import { localAttachmentAsAttachment } from "./attachments";
-import { toMessages } from "./inbound";
 
 const LOOKUP_PAGE_SIZE = 200;
 const LOOKUP_MAX_PAGES = 50;
 const MESSAGE_CACHE_LIMIT = 1000;
 const ATTACHMENT_CACHE_LIMIT = 1000;
+
+export type LocalMessageNormalizer = (
+  source: LocalIMessage
+) => Promise<IMessageMessage[]>;
 
 interface LocalLookupCache {
   attachments: Map<string, Attachment>;
@@ -66,9 +69,9 @@ const cacheAttachment = (
 
 export const cacheLocalMessage = async (
   client: IMessageSDK,
-  source: LocalIMessage
+  source: LocalIMessage,
+  normalized: IMessageMessage[]
 ): Promise<IMessageMessage[]> => {
-  const normalized = await toMessages(source);
   const cache = cacheFor(client);
   for (const message of normalized) {
     lruSet(cache.messages, message.id, message, MESSAGE_CACHE_LIMIT);
@@ -85,7 +88,8 @@ export const cacheLocalMessage = async (
 export const getLocalMessage = async (
   client: IMessageSDK,
   spaceId: string,
-  messageId: string
+  messageId: string,
+  normalize: LocalMessageNormalizer
 ): Promise<IMessageMessage | undefined> => {
   const cached = cacheFor(client).messages.get(messageId);
   if (cached) {
@@ -99,7 +103,11 @@ export const getLocalMessage = async (
       offset: page * LOOKUP_PAGE_SIZE,
     });
     for (const row of rows) {
-      const normalized = await cacheLocalMessage(client, row);
+      const normalized = await cacheLocalMessage(
+        client,
+        row,
+        await normalize(row)
+      );
       const match = normalized.find((message) => message.id === messageId);
       if (match) {
         return match;

--- a/packages/imessage-local/src/local/lookup.ts
+++ b/packages/imessage-local/src/local/lookup.ts
@@ -53,6 +53,16 @@ const lruSet = <T>(
   }
 };
 
+const lruGet = <T>(cache: Map<string, T>, key: string): T | undefined => {
+  const value = cache.get(key);
+  if (value === undefined) {
+    return;
+  }
+  cache.delete(key);
+  cache.set(key, value);
+  return value;
+};
+
 const cacheAttachment = (
   client: IMessageSDK,
   attachment: KitAttachment
@@ -91,7 +101,7 @@ export const getLocalMessage = async (
   messageId: string,
   normalize: LocalMessageNormalizer
 ): Promise<IMessageMessage | undefined> => {
-  const cached = cacheFor(client).messages.get(messageId);
+  const cached = lruGet(cacheFor(client).messages, messageId);
   if (cached) {
     return cached;
   }
@@ -126,7 +136,7 @@ export const getLocalAttachment = async (
   client: IMessageSDK,
   attachmentId: string
 ): Promise<Attachment | undefined> => {
-  const cached = cacheFor(client).attachments.get(attachmentId);
+  const cached = lruGet(cacheFor(client).attachments, attachmentId);
   if (cached) {
     return cached;
   }

--- a/packages/imessage-local/src/local/send.ts
+++ b/packages/imessage-local/src/local/send.ts
@@ -6,7 +6,6 @@ import { type Content, toVCard } from "@spectrum-ts/core";
 import type { ProviderMessageRecord } from "@spectrum-ts/core/authoring";
 import { unsupportedLocalContent } from "../../../imessage/src/shared/errors";
 import { vcardFileName } from "../../../imessage/src/shared/vcard";
-import type { IMessageMessage } from "../types";
 import { DEFAULT_ATTACHMENT_NAME } from "./attachments";
 
 // v3 `IMessageSDK.send` resolves to `void`: the chat.db row id only
@@ -73,12 +72,3 @@ export const send = async (
       throw unsupportedLocalContent(content.type);
   }
 };
-
-// Local mode has no by-id SDK lookup and does not surface reactions, so it
-// has no cache to consult. `space.getMessage(id)` always resolves to
-// `undefined` on local: callers with only an id cannot materialize a Message
-// here.
-export const getMessage = async (
-  _client: IMessageSDK,
-  _id: string
-): Promise<IMessageMessage | undefined> => undefined;

--- a/packages/imessage-local/test/local/lookup.test.ts
+++ b/packages/imessage-local/test/local/lookup.test.ts
@@ -7,6 +7,7 @@ import type {
 import { describe, expect, it, vi } from "vitest";
 import { toMessages } from "@/local/inbound";
 import {
+  cacheLocalMessage,
   getLocalAttachment,
   getLocalDisplayName,
   getLocalMessage,
@@ -53,6 +54,28 @@ const client = (overrides: Partial<IMessageSDK>): IMessageSDK =>
   Object.assign(Object.create(null), overrides) as IMessageSDK;
 
 describe("local iMessage lookup", () => {
+  it("promotes cache hits before evicting the least recently used message", async () => {
+    const getMessages = vi.fn(() => Promise.resolve([]));
+    const sdk = client({ getMessages });
+    const first = message("message-0");
+    await cacheLocalMessage(sdk, first, await toMessages(first));
+    for (let index = 1; index < 1000; index += 1) {
+      const row = message(`message-${index}`);
+      await cacheLocalMessage(sdk, row, await toMessages(row));
+    }
+
+    await expect(
+      getLocalMessage(sdk, "any;-;+15551234567", "message-0", toMessages)
+    ).resolves.toMatchObject({ id: "message-0" });
+
+    const overflow = message("message-1000");
+    await cacheLocalMessage(sdk, overflow, await toMessages(overflow));
+    await expect(
+      getLocalMessage(sdk, "any;-;+15551234567", "message-0", toMessages)
+    ).resolves.toMatchObject({ id: "message-0" });
+    expect(getMessages).not.toHaveBeenCalled();
+  });
+
   it("finds a message by Apple GUID within its space", async () => {
     const getMessages = vi.fn(() => Promise.resolve([message("message-1")]));
 

--- a/packages/imessage-local/test/local/lookup.test.ts
+++ b/packages/imessage-local/test/local/lookup.test.ts
@@ -1,0 +1,124 @@
+import type {
+  Chat,
+  IMessageSDK,
+  Attachment as KitAttachment,
+  Message as KitMessage,
+} from "@photon-ai/imessage-kit";
+import { describe, expect, it, vi } from "vitest";
+import {
+  getLocalAttachment,
+  getLocalDisplayName,
+  getLocalMessage,
+} from "@/local/lookup";
+
+const createdAt = new Date(1_700_000_000_000);
+
+const attachment = (id: string): KitAttachment =>
+  ({
+    createdAt,
+    fileName: `${id}.png`,
+    id,
+    isFromMe: false,
+    isSensitiveContent: false,
+    isSticker: false,
+    localPath: `/tmp/${id}.png`,
+    mimeType: "image/png",
+    sizeBytes: 123,
+    transferStatus: "complete",
+    uti: "public.png",
+  }) as KitAttachment;
+
+const message = (
+  id: string,
+  attachments: readonly KitAttachment[] = []
+): KitMessage =>
+  ({
+    attachments,
+    chatId: "any;-;+15551234567",
+    chatKind: "dm",
+    createdAt,
+    hasAttachments: attachments.length > 0,
+    id,
+    isAudioMessage: false,
+    isFromMe: false,
+    kind: "text",
+    participant: "+15551234567",
+    reaction: null,
+    retractedAt: null,
+    text: attachments.length > 0 ? undefined : "hello",
+  }) as KitMessage;
+
+const client = (overrides: Partial<IMessageSDK>): IMessageSDK =>
+  Object.assign(Object.create(null), overrides) as IMessageSDK;
+
+describe("local iMessage lookup", () => {
+  it("finds a message by Apple GUID within its space", async () => {
+    const getMessages = vi.fn(() => Promise.resolve([message("message-1")]));
+
+    const found = await getLocalMessage(
+      client({ getMessages }),
+      "any;-;+15551234567",
+      "message-1"
+    );
+
+    expect(found).toMatchObject({
+      content: { text: "hello", type: "text" },
+      id: "message-1",
+    });
+    expect(getMessages).toHaveBeenCalledWith({
+      chatId: "any;-;+15551234567",
+      limit: 200,
+      offset: 0,
+    });
+  });
+
+  it("resolves generated attachment child ids", async () => {
+    const getMessages = vi.fn(() =>
+      Promise.resolve([message("message-1", [attachment("attachment-1")])])
+    );
+
+    const found = await getLocalMessage(
+      client({ getMessages }),
+      "any;-;+15551234567",
+      "message-1:attachment-1"
+    );
+
+    expect(found).toMatchObject({
+      content: { id: "attachment-1", type: "attachment" },
+      id: "message-1:attachment-1",
+    });
+  });
+
+  it("finds an attachment by GUID", async () => {
+    const getMessages = vi.fn(() =>
+      Promise.resolve([message("message-1", [attachment("attachment-1")])])
+    );
+
+    const found = await getLocalAttachment(
+      client({ getMessages }),
+      "attachment-1"
+    );
+
+    expect(found).toMatchObject({
+      id: "attachment-1",
+      mimeType: "image/png",
+      name: "attachment-1.png",
+      size: 123,
+      type: "attachment",
+    });
+  });
+
+  it("reads a chat display name", async () => {
+    const listChats = vi.fn(() =>
+      Promise.resolve([{ name: "Family" } as Chat])
+    );
+
+    await expect(
+      getLocalDisplayName(client({ listChats }), "any;+;chat-family")
+    ).resolves.toBe("Family");
+    expect(listChats).toHaveBeenCalledWith({
+      chatId: "any;+;chat-family",
+      limit: 1,
+    });
+  });
+});

--- a/packages/imessage-local/test/local/lookup.test.ts
+++ b/packages/imessage-local/test/local/lookup.test.ts
@@ -5,6 +5,7 @@ import type {
   Message as KitMessage,
 } from "@photon-ai/imessage-kit";
 import { describe, expect, it, vi } from "vitest";
+import { toMessages } from "@/local/inbound";
 import {
   getLocalAttachment,
   getLocalDisplayName,
@@ -58,7 +59,8 @@ describe("local iMessage lookup", () => {
     const found = await getLocalMessage(
       client({ getMessages }),
       "any;-;+15551234567",
-      "message-1"
+      "message-1",
+      toMessages
     );
 
     expect(found).toMatchObject({
@@ -80,7 +82,8 @@ describe("local iMessage lookup", () => {
     const found = await getLocalMessage(
       client({ getMessages }),
       "any;-;+15551234567",
-      "message-1:attachment-1"
+      "message-1:attachment-1",
+      toMessages
     );
 
     expect(found).toMatchObject({


### PR DESCRIPTION
## Summary

- Implement local `space.getMessage(id)` support using `@photon-ai/imessage-kit` message queries.
- Add local chat display-name and attachment lookup actions.
- Preserve generated child ids for multipart and attachment messages.
- Cache normalized messages and attachments per SDK client with bounded LRU storage.
- Keep lookup independent of inbound normalization by injecting the message normalizer.

## Behavior

The current open-source SDK does not expose direct message- or attachment-GUID filters. Uncached lookups therefore paginate at most 10,000 rows and return `undefined` when a record is outside that window. This bound and the caching behavior are documented in the local-provider README.

## Testing

- [x] `bun run --cwd packages/imessage-local typecheck`
- [x] Local provider tests: 3 files, 23 tests passed
- [x] Ultracite check on changed source and test files
- [x] `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791432798&installation_model_id=19795&pr_number=249&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F249&signature=7c85ca6da42258097c88504a1fd5f47970b1acd93c054303302815cf0fdb8b1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local iMessage lookups for messages, attachments, and chat display names.
  * Added support for converting local attachments into standard attachment results.
  * Added bounded caching for message and attachment lookup results to improve repeated lookups.

* **Documentation**
  * Documented local lookup behavior, caching scope, pagination limits, and cases where older records may not be found.

* **Tests**
  * Added coverage for message, attachment, chat name, and cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->