### PR TITLE
feat(imessage-local): surface local inbound events

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -530,7 +530,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
+    "@types/bun": ["@types/bun@1.4.2", "", { "dependencies": { "bun-types": "1.4.2" } }, "sha512-GimotNn7+ZV0uVArItBbriZsR1oNf0+WTzPkdcFrzShI7k2norL0uzEaJT8T33dWr7O/c9ZDuAFQrctKCi72oQ=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -670,7 +670,7 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
-    "bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
+    "bun-types": ["bun-types@1.4.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-bxV1FgK7yBIzjRe5zBozIM4Bem11ZJcCXSrjWRG3YWLt8yFDePu4cLjpebO8OvPeIE9trbyPF4fuj3Cia4Fj3w=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -1322,6 +1322,8 @@
 
     "protobufjs/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
+    "spectrum-ts/@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
+
     "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
@@ -1363,6 +1365,8 @@
     "cli-highlight/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "spectrum-ts/@types/bun/bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -530,7 +530,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.4.2", "", { "dependencies": { "bun-types": "1.4.2" } }, "sha512-GimotNn7+ZV0uVArItBbriZsR1oNf0+WTzPkdcFrzShI7k2norL0uzEaJT8T33dWr7O/c9ZDuAFQrctKCi72oQ=="],
+    "@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -670,7 +670,7 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
-    "bun-types": ["bun-types@1.4.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-bxV1FgK7yBIzjRe5zBozIM4Bem11ZJcCXSrjWRG3YWLt8yFDePu4cLjpebO8OvPeIE9trbyPF4fuj3Cia4Fj3w=="],
+    "bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -1322,8 +1322,6 @@
 
     "protobufjs/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
-    "spectrum-ts/@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
-
     "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
@@ -1365,8 +1363,6 @@
     "cli-highlight/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
-
-    "spectrum-ts/@types/bun/bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
 

--- a/docs/reactions-and-replies.mdx.vel
+++ b/docs/reactions-and-replies.mdx.vel
@@ -43,6 +43,17 @@ await message.react(Emoji.laugh);
 
 `reaction()` rejects reaction messages as targets — reacting to a reaction throws at build time.
 
+Inbound reaction removals use the same reaction content shape as additions,
+with `message.content.removed === true`. The field is omitted for additions,
+so existing consumers that only inspect `emoji` and `target` continue to work.
+
+```ts
+if (message.content.type === "reaction") {
+  const action = message.content.removed ? "removed" : "added";
+  console.log(action, message.content.emoji, message.content.target.id);
+}
+```
+
 The iMessage tapback aliases are:
 
 <Accordion title="Emoji" description="{{ emoji.doc.summary }}">

--- a/packages/core/src/content/reaction.ts
+++ b/packages/core/src/content/reaction.ts
@@ -18,6 +18,8 @@ const isMessage = (v: unknown): v is Message =>
 export const reactionSchema = z.object({
   type: z.literal("reaction"),
   emoji: z.string().min(1),
+  /** True when this event removes a previously applied reaction. */
+  removed: z.boolean().optional(),
   target: z.custom<Message>(isMessage, {
     message: "reaction target must be a Message",
   }),
@@ -27,6 +29,7 @@ export type Reaction = z.infer<typeof reactionSchema>;
 
 export const asReaction = (input: {
   emoji: string;
+  removed?: boolean;
   target: Message;
 }): Reaction => reactionSchema.parse({ type: "reaction", ...input });
 

--- a/packages/core/test/core/send-reaction.test.ts
+++ b/packages/core/test/core/send-reaction.test.ts
@@ -57,6 +57,16 @@ const firstMessage = async (app: Awaited<ReturnType<typeof Spectrum>>) => {
 };
 
 describe("reaction sends return a Message", () => {
+  it("preserves provider-supplied reaction removal state", () => {
+    const removed = asReaction({
+      emoji: "👍",
+      removed: true,
+      target: record("target") as unknown as Message,
+    });
+
+    expect(removed.removed).toBe(true);
+  });
+
   it("message.react resolves to the reaction Message with the built target", async () => {
     const provider = makeReactionProvider("react_ok", (content) =>
       Promise.resolve({

--- a/packages/imessage-local/README.md
+++ b/packages/imessage-local/README.md
@@ -26,3 +26,11 @@ attachment lookup through the local Messages database. Results are cached per
 client. Because `@photon-ai/imessage-kit` does not currently expose direct
 message- or attachment-GUID filters, uncached lookups use bounded pagination
 (up to 10,000 rows) and may return `undefined` for older records.
+
+## Inbound events
+
+The message stream surfaces local Tapback additions and removals as universal
+`reaction` content. Membership and group-name changes use Spectrum's universal
+`addMember`, `removeMember`, and `rename` content shapes. Poll votes contain
+only the target message id exposed by the local database, so they surface as
+`custom` content with `raw.imessage_type === "poll-vote"`.

--- a/packages/imessage-local/README.md
+++ b/packages/imessage-local/README.md
@@ -18,3 +18,11 @@ const spectrum = Spectrum({
 This package is intentionally not included in the batteries-included
 `spectrum-ts` package. Install it only on the macOS host that will access the
 local Messages database.
+
+## Local lookups
+
+The provider supports `space.getMessage(id)`, chat display-name lookup, and
+attachment lookup through the local Messages database. Results are cached per
+client. Because `@photon-ai/imessage-kit` does not currently expose direct
+message- or attachment-GUID filters, uncached lookups use bounded pagination
+(up to 10,000 rows) and may return `undefined` for older records.

--- a/packages/imessage-local/README.md
+++ b/packages/imessage-local/README.md
@@ -22,10 +22,11 @@ local Messages database.
 ## Local lookups
 
 The provider supports `space.getMessage(id)`, chat display-name lookup, and
-attachment lookup through the local Messages database. Results are cached per
-client. Because `@photon-ai/imessage-kit` does not currently expose direct
-message- or attachment-GUID filters, uncached lookups use bounded pagination
-(up to 10,000 rows) and may return `undefined` for older records.
+attachment lookup through the local Messages database. Message and attachment
+results are cached per client. Because `@photon-ai/imessage-kit` does not
+currently expose direct message- or attachment-GUID filters, uncached lookups
+use bounded pagination (up to 10,000 rows) and may return `undefined` for older
+records.
 
 ## Inbound events
 

--- a/packages/imessage-local/src/index.ts
+++ b/packages/imessage-local/src/index.ts
@@ -42,6 +42,8 @@ import { isCustomizedMiniApp } from "../../imessage/src/content/customized-mini-
 import { messageEffects } from "../../imessage/src/content/effect";
 import { chatTypeFromGuid, dmChatGuid } from "./ids";
 import {
+  getAttachment as localGetAttachment,
+  getDisplayName as localGetDisplayName,
   getMessage as localGetMessage,
   messages as localMessages,
   send as localSend,
@@ -220,8 +222,8 @@ export const localIMessage = definePlatform(PLATFORM_ID, {
     handleLocalOnlySend(client, space.id, content),
 
   actions: {
-    getMessage: async ({ client }, _space, messageId) =>
-      localGetMessage(client, messageId),
+    getMessage: async ({ client }, space, messageId) =>
+      localGetMessage(client, space.id, messageId),
     getMembers: async () =>
       unsupportedAction(
         "getMembers",
@@ -232,15 +234,11 @@ export const localIMessage = definePlatform(PLATFORM_ID, {
         "getAvatar",
         "fetching group avatars requires remote iMessage"
       ),
-    getDisplayName: async () =>
-      unsupportedAction(
-        "getDisplayName",
-        "reading chat display names requires remote iMessage"
-      ),
-    getAttachment: async (): Promise<Attachment | undefined> =>
-      unsupportedAction(
-        "getAttachment",
-        "fetching attachments by GUID requires remote iMessage"
-      ),
+    getDisplayName: async ({ client }, space) =>
+      localGetDisplayName(client, space.id),
+    getAttachment: async (
+      { client }: { client: IMessageSDK },
+      guid: string
+    ): Promise<Attachment | undefined> => localGetAttachment(client, guid),
   },
 });

--- a/packages/imessage-local/src/local/api.ts
+++ b/packages/imessage-local/src/local/api.ts
@@ -2,7 +2,7 @@ import type { IMessageSDK } from "@photon-ai/imessage-kit";
 import type { Content, ManagedStream } from "@spectrum-ts/core";
 import type { ProviderMessageRecord } from "@spectrum-ts/core/authoring";
 import type { IMessageMessage } from "../types";
-import { messages as localMessages } from "./inbound";
+import { messages as localMessages, toMessages } from "./inbound";
 import {
   getLocalAttachment,
   getLocalDisplayName,
@@ -23,7 +23,8 @@ export const getMessage = (
   client: IMessageSDK,
   spaceId: string,
   id: string
-): Promise<IMessageMessage | undefined> => getLocalMessage(client, spaceId, id);
+): Promise<IMessageMessage | undefined> =>
+  getLocalMessage(client, spaceId, id, toMessages);
 
 export const getAttachment = getLocalAttachment;
 export const getDisplayName = getLocalDisplayName;

--- a/packages/imessage-local/src/local/api.ts
+++ b/packages/imessage-local/src/local/api.ts
@@ -4,9 +4,11 @@ import type { ProviderMessageRecord } from "@spectrum-ts/core/authoring";
 import type { IMessageMessage } from "../types";
 import { messages as localMessages } from "./inbound";
 import {
-  getMessage as getLocalMessage,
-  send as sendLocalMessage,
-} from "./send";
+  getLocalAttachment,
+  getLocalDisplayName,
+  getLocalMessage,
+} from "./lookup";
+import { send as sendLocalMessage } from "./send";
 
 export const messages = (client: IMessageSDK): ManagedStream<IMessageMessage> =>
   localMessages(client);
@@ -19,5 +21,9 @@ export const send = (
 
 export const getMessage = (
   client: IMessageSDK,
+  spaceId: string,
   id: string
-): Promise<IMessageMessage | undefined> => getLocalMessage(client, id);
+): Promise<IMessageMessage | undefined> => getLocalMessage(client, spaceId, id);
+
+export const getAttachment = getLocalAttachment;
+export const getDisplayName = getLocalDisplayName;

--- a/packages/imessage-local/src/local/attachments.ts
+++ b/packages/imessage-local/src/local/attachments.ts
@@ -2,7 +2,7 @@ import { createReadStream } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { Readable } from "node:stream";
 import type { Message as LocalIMessage } from "@photon-ai/imessage-kit";
-import { type Content, fromVCard } from "@spectrum-ts/core";
+import { type Attachment, type Content, fromVCard } from "@spectrum-ts/core";
 import { asAttachment, asContact, asVoice } from "@spectrum-ts/core/authoring";
 import {
   appleAudioMimeType,
@@ -25,7 +25,9 @@ export const readLocalAttachment = async (
   return readFile(att.localPath);
 };
 
-const toAttachmentContent = (att: LocalAttachment): Content => {
+export const localAttachmentAsAttachment = (
+  att: LocalAttachment
+): Attachment => {
   const { localPath } = att;
   return asAttachment({
     id: att.id,
@@ -64,7 +66,7 @@ const toVCardContent = async (att: LocalAttachment): Promise<Content> => {
     const buf = await readLocalAttachment(att);
     return asContact(fromVCard(buf.toString("utf8")));
   } catch {
-    return toAttachmentContent(att);
+    return localAttachmentAsAttachment(att);
   }
 };
 
@@ -78,5 +80,5 @@ export const localAttachmentContent = async (
   const audioMimeType = isVoice ? appleAudioMimeType(att) : undefined;
   return audioMimeType
     ? toVoiceContent(att, audioMimeType)
-    : toAttachmentContent(att);
+    : localAttachmentAsAttachment(att);
 };

--- a/packages/imessage-local/src/local/inbound.ts
+++ b/packages/imessage-local/src/local/inbound.ts
@@ -10,11 +10,14 @@ import {
   stream,
 } from "@spectrum-ts/core";
 import {
+  addMemberSchema,
   asCustom,
   asReaction,
   asReply,
   asText,
   type ProviderMessageRecord,
+  removeMemberSchema,
+  renameSchema,
 } from "@spectrum-ts/core/authoring";
 import { appleAudioMimeType } from "../../../imessage/src/shared/audio";
 import {
@@ -188,17 +191,52 @@ const toReactionMessage = async (
 const toGroupChangeMessage = (
   message: LocalIMessage,
   base: Omit<IMessageMessage, "id" | "content">
-): IMessageMessage => ({
-  ...base,
-  id: message.id,
-  content: asCustom({
-    action: message.kind,
-    affectedParticipant: message.affectedParticipant,
-    imessage_type:
-      message.kind === "unknown" ? "message-event" : "group-change",
-    newGroupName: message.newGroupName,
-  }),
-});
+): IMessageMessage | undefined => {
+  let content: Content | undefined;
+  switch (message.kind) {
+    case "memberAdded":
+      content = message.affectedParticipant
+        ? addMemberSchema.parse({
+            members: [message.affectedParticipant],
+            type: "addMember",
+          })
+        : undefined;
+      break;
+    case "memberRemoved":
+      content = message.affectedParticipant
+        ? removeMemberSchema.parse({
+            members: [message.affectedParticipant],
+            type: "removeMember",
+          })
+        : undefined;
+      break;
+    case "nameChanged":
+      content = message.newGroupName
+        ? renameSchema.parse({
+            displayName: message.newGroupName,
+            type: "rename",
+          })
+        : undefined;
+      break;
+    default:
+      content = asCustom({
+        action: message.kind,
+        affectedParticipant: message.affectedParticipant,
+        imessage_type: "message-event",
+        newGroupName: message.newGroupName,
+      });
+  }
+
+  return content ? { ...base, content, id: message.id } : undefined;
+};
+
+const toGroupChangeMessages = (
+  message: LocalIMessage,
+  base: Omit<IMessageMessage, "id" | "content">
+): IMessageMessage[] => {
+  const event = toGroupChangeMessage(message, base);
+  return event ? [event] : [];
+};
 
 const refetchUntilAttachmentsSettle = async (
   client: IMessageSDK,
@@ -246,7 +284,7 @@ export const toMessages = async (
   }
 
   if (message.kind !== "text") {
-    return [toGroupChangeMessage(message, base)];
+    return toGroupChangeMessages(message, base);
   }
 
   if (message.retractedAt !== null) {

--- a/packages/imessage-local/src/local/inbound.ts
+++ b/packages/imessage-local/src/local/inbound.ts
@@ -3,9 +3,15 @@ import type {
   IMessageSDK,
   Message as LocalIMessage,
 } from "@photon-ai/imessage-kit";
-import { type Content, type ManagedStream, stream } from "@spectrum-ts/core";
+import {
+  type Content,
+  type ManagedStream,
+  type Message,
+  stream,
+} from "@spectrum-ts/core";
 import {
   asCustom,
+  asReaction,
   asReply,
   asText,
   type ProviderMessageRecord,
@@ -18,10 +24,20 @@ import {
 } from "../../../imessage/src/shared/inbound-parts";
 import type { IMessageMessage } from "../types";
 import { localAttachmentContent } from "./attachments";
+import { cacheLocalMessage, getLocalMessage } from "./lookup";
 
 const ATTACHMENT_JOIN_RETRY_DELAY_MS = 250;
 const ATTACHMENT_JOIN_RETRY_LIMIT = 8;
 const ATTACHMENT_JOIN_FETCH_LIMIT = 10;
+
+const TAPBACK_EMOJI: Readonly<Record<string, string>> = {
+  dislike: "👎",
+  emphasize: "‼️",
+  laugh: "😂",
+  like: "👍",
+  love: "❤️",
+  question: "❓",
+};
 
 const hasAttachmentPlaceholder = (message: LocalIMessage): boolean =>
   message.text?.includes(ATTACHMENT_PLACEHOLDER) ?? false;
@@ -76,6 +92,109 @@ const wrapReply = (
   }));
 };
 
+const messageBase = (
+  message: LocalIMessage,
+  chatId: string,
+  chatKind: Exclude<LocalIMessage["chatKind"], "unknown">
+): Omit<IMessageMessage, "id" | "content"> => ({
+  direction: message.isFromMe ? "outbound" : "inbound",
+  sender: {
+    id: message.participant ?? "",
+    ...(message.participant ? { address: message.participant } : {}),
+    ...(message.service ? { service: message.service } : {}),
+  },
+  space: {
+    id: chatId,
+    type: chatKind === "group" ? "group" : "dm",
+    phone: "",
+  },
+  timestamp: message.createdAt,
+});
+
+const stubReactionTarget = (
+  base: Omit<IMessageMessage, "id" | "content">,
+  targetId: string
+): IMessageMessage => ({
+  ...base,
+  id: targetId,
+  content: asCustom({ imessage_type: "reaction-target", stub: true }),
+});
+
+const reactionEmoji = (
+  reaction: NonNullable<LocalIMessage["reaction"]>
+): string | undefined =>
+  reaction.kind === "emoji"
+    ? (reaction.emoji ?? undefined)
+    : TAPBACK_EMOJI[reaction.kind];
+
+const toReactionMessage = async (
+  client: IMessageSDK | undefined,
+  message: LocalIMessage,
+  base: Omit<IMessageMessage, "id" | "content">
+): Promise<IMessageMessage | undefined> => {
+  const reaction = message.reaction;
+  if (!reaction?.targetMessageId) {
+    return;
+  }
+
+  if (reaction.kind === "pollVote") {
+    return {
+      ...base,
+      id: message.id,
+      content: asCustom({
+        imessage_type: "poll-vote",
+        targetMessageId: reaction.targetMessageId,
+      }),
+    };
+  }
+
+  const emoji = reactionEmoji(reaction);
+  if (!emoji) {
+    return {
+      ...base,
+      id: message.id,
+      content: asCustom({
+        imessage_type: "reaction",
+        kind: reaction.kind,
+        removed: reaction.isRemoved,
+        targetMessageId: reaction.targetMessageId,
+      }),
+    };
+  }
+
+  const target = client
+    ? await getLocalMessage(client, base.space.id, reaction.targetMessageId)
+    : undefined;
+  return {
+    ...base,
+    id: message.id,
+    content: asReaction({
+      emoji,
+      ...(reaction.isRemoved ? { removed: true } : {}),
+      target: (target ??
+        stubReactionTarget(
+          base,
+          reaction.targetMessageId
+        )) as unknown as Message,
+    }),
+  };
+};
+
+const toGroupChangeMessage = (
+  message: LocalIMessage,
+  base: Omit<IMessageMessage, "id" | "content">
+): IMessageMessage => ({
+  ...base,
+  id: message.id,
+  content: asCustom({
+    action: message.kind,
+    affectedParticipant: message.affectedParticipant,
+    imessage_type:
+      message.kind === "unknown" ? "message-event" : "group-change",
+    newGroupName: message.newGroupName,
+  }),
+});
+
 const refetchUntilAttachmentsSettle = async (
   client: IMessageSDK,
   message: LocalIMessage
@@ -106,21 +225,26 @@ const refetchUntilAttachmentsSettle = async (
 };
 
 export const toMessages = async (
-  message: LocalIMessage
+  message: LocalIMessage,
+  client?: IMessageSDK
 ): Promise<IMessageMessage[]> => {
   const { chatId, chatKind } = message;
   if (!chatId || chatKind === "unknown") {
     return [];
   }
 
-  // Drop rows spectrum's Content union cannot faithfully represent:
-  // reactions, group events, and retracts would collapse to empty or
-  // Apple-generated pseudo-text otherwise.
-  if (
-    message.reaction !== null ||
-    message.kind !== "text" ||
-    message.retractedAt !== null
-  ) {
+  const base = messageBase(message, chatId, chatKind);
+
+  if (message.reaction !== null) {
+    const reaction = await toReactionMessage(client, message, base);
+    return reaction ? [reaction] : [];
+  }
+
+  if (message.kind !== "text") {
+    return [toGroupChangeMessage(message, base)];
+  }
+
+  if (message.retractedAt !== null) {
     return [];
   }
 
@@ -128,20 +252,6 @@ export const toMessages = async (
     return [];
   }
 
-  const base: Omit<IMessageMessage, "id" | "content"> = {
-    // Local mode exposes only the participant address; no service/country.
-    sender: {
-      id: message.participant ?? "",
-      ...(message.participant ? { address: message.participant } : {}),
-    },
-    // Local mode has no concept of "which-of-my-phones"; phone is empty.
-    space: {
-      id: chatId,
-      type: chatKind === "group" ? "group" : "dm",
-      phone: "",
-    },
-    timestamp: message.createdAt,
-  };
   const targetId = replyTargetId(message);
   const audioAttachmentId = voiceAttachmentId(message);
 
@@ -212,7 +322,11 @@ export const messages = (client: IMessageSDK): ManagedStream<IMessageMessage> =>
       const stableMessage = isPendingAttachmentJoin(message)
         ? await refetchUntilAttachmentsSettle(client, message)
         : message;
-      const ms = await toMessages(stableMessage);
+      const ms = await cacheLocalMessage(
+        client,
+        stableMessage,
+        await toMessages(stableMessage, client)
+      );
       for (const m of ms) {
         await emit(m);
       }

--- a/packages/imessage-local/src/local/inbound.ts
+++ b/packages/imessage-local/src/local/inbound.ts
@@ -163,7 +163,12 @@ const toReactionMessage = async (
   }
 
   const target = client
-    ? await getLocalMessage(client, base.space.id, reaction.targetMessageId)
+    ? await getLocalMessage(
+        client,
+        base.space.id,
+        reaction.targetMessageId,
+        toMessages
+      )
     : undefined;
   return {
     ...base,

--- a/packages/imessage-local/src/local/lookup.ts
+++ b/packages/imessage-local/src/local/lookup.ts
@@ -1,0 +1,152 @@
+import type {
+  IMessageSDK,
+  Attachment as KitAttachment,
+  Message as LocalIMessage,
+} from "@photon-ai/imessage-kit";
+import type { Attachment } from "@spectrum-ts/core";
+import type { IMessageMessage } from "../types";
+import { localAttachmentAsAttachment } from "./attachments";
+import { toMessages } from "./inbound";
+
+const LOOKUP_PAGE_SIZE = 200;
+const LOOKUP_MAX_PAGES = 50;
+const MESSAGE_CACHE_LIMIT = 1000;
+const ATTACHMENT_CACHE_LIMIT = 1000;
+
+interface LocalLookupCache {
+  attachments: Map<string, Attachment>;
+  messages: Map<string, IMessageMessage>;
+}
+
+const caches = new WeakMap<IMessageSDK, LocalLookupCache>();
+
+const cacheFor = (client: IMessageSDK): LocalLookupCache => {
+  const existing = caches.get(client);
+  if (existing) {
+    return existing;
+  }
+  const created = {
+    attachments: new Map<string, Attachment>(),
+    messages: new Map<string, IMessageMessage>(),
+  };
+  caches.set(client, created);
+  return created;
+};
+
+const lruSet = <T>(
+  cache: Map<string, T>,
+  key: string,
+  value: T,
+  limit: number
+) => {
+  cache.delete(key);
+  cache.set(key, value);
+  while (cache.size > limit) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) {
+      return;
+    }
+    cache.delete(oldest);
+  }
+};
+
+const cacheAttachment = (
+  client: IMessageSDK,
+  attachment: KitAttachment
+): Attachment => {
+  const normalized = localAttachmentAsAttachment(attachment);
+  lruSet(
+    cacheFor(client).attachments,
+    attachment.id,
+    normalized,
+    ATTACHMENT_CACHE_LIMIT
+  );
+  return normalized;
+};
+
+export const cacheLocalMessage = async (
+  client: IMessageSDK,
+  source: LocalIMessage
+): Promise<IMessageMessage[]> => {
+  const normalized = await toMessages(source);
+  const cache = cacheFor(client);
+  for (const message of normalized) {
+    lruSet(cache.messages, message.id, message, MESSAGE_CACHE_LIMIT);
+  }
+  if (normalized[0]) {
+    lruSet(cache.messages, source.id, normalized[0], MESSAGE_CACHE_LIMIT);
+  }
+  for (const attachment of source.attachments) {
+    cacheAttachment(client, attachment);
+  }
+  return normalized;
+};
+
+export const getLocalMessage = async (
+  client: IMessageSDK,
+  spaceId: string,
+  messageId: string
+): Promise<IMessageMessage | undefined> => {
+  const cached = cacheFor(client).messages.get(messageId);
+  if (cached) {
+    return cached;
+  }
+
+  for (let page = 0; page < LOOKUP_MAX_PAGES; page += 1) {
+    const rows = await client.getMessages({
+      chatId: spaceId,
+      limit: LOOKUP_PAGE_SIZE,
+      offset: page * LOOKUP_PAGE_SIZE,
+    });
+    for (const row of rows) {
+      const normalized = await cacheLocalMessage(client, row);
+      const match = normalized.find((message) => message.id === messageId);
+      if (match) {
+        return match;
+      }
+      if (row.id === messageId) {
+        return normalized[0];
+      }
+    }
+    if (rows.length < LOOKUP_PAGE_SIZE) {
+      break;
+    }
+  }
+};
+
+export const getLocalAttachment = async (
+  client: IMessageSDK,
+  attachmentId: string
+): Promise<Attachment | undefined> => {
+  const cached = cacheFor(client).attachments.get(attachmentId);
+  if (cached) {
+    return cached;
+  }
+
+  for (let page = 0; page < LOOKUP_MAX_PAGES; page += 1) {
+    const rows = await client.getMessages({
+      hasAttachments: true,
+      limit: LOOKUP_PAGE_SIZE,
+      offset: page * LOOKUP_PAGE_SIZE,
+    });
+    for (const row of rows) {
+      for (const attachment of row.attachments) {
+        const normalized = cacheAttachment(client, attachment);
+        if (attachment.id === attachmentId) {
+          return normalized;
+        }
+      }
+    }
+    if (rows.length < LOOKUP_PAGE_SIZE) {
+      break;
+    }
+  }
+};
+
+export const getLocalDisplayName = async (
+  client: IMessageSDK,
+  spaceId: string
+): Promise<string | undefined> => {
+  const [chat] = await client.listChats({ chatId: spaceId, limit: 1 });
+  return chat?.name ?? undefined;
+};

--- a/packages/imessage-local/src/local/lookup.ts
+++ b/packages/imessage-local/src/local/lookup.ts
@@ -53,6 +53,16 @@ const lruSet = <T>(
   }
 };
 
+const lruGet = <T>(cache: Map<string, T>, key: string): T | undefined => {
+  const value = cache.get(key);
+  if (value === undefined) {
+    return;
+  }
+  cache.delete(key);
+  cache.set(key, value);
+  return value;
+};
+
 const cacheAttachment = (
   client: IMessageSDK,
   attachment: KitAttachment
@@ -91,7 +101,7 @@ export const getLocalMessage = async (
   messageId: string,
   normalize: LocalMessageNormalizer
 ): Promise<IMessageMessage | undefined> => {
-  const cached = cacheFor(client).messages.get(messageId);
+  const cached = lruGet(cacheFor(client).messages, messageId);
   if (cached) {
     return cached;
   }
@@ -126,7 +136,7 @@ export const getLocalAttachment = async (
   client: IMessageSDK,
   attachmentId: string
 ): Promise<Attachment | undefined> => {
-  const cached = cacheFor(client).attachments.get(attachmentId);
+  const cached = lruGet(cacheFor(client).attachments, attachmentId);
   if (cached) {
     return cached;
   }

--- a/packages/imessage-local/src/local/lookup.ts
+++ b/packages/imessage-local/src/local/lookup.ts
@@ -66,20 +66,21 @@ const cacheAttachment = (
 
 export const cacheLocalMessage = async (
   client: IMessageSDK,
-  source: LocalIMessage
+  source: LocalIMessage,
+  normalized?: IMessageMessage[]
 ): Promise<IMessageMessage[]> => {
-  const normalized = await toMessages(source);
+  const messages = normalized ?? (await toMessages(source));
   const cache = cacheFor(client);
-  for (const message of normalized) {
+  for (const message of messages) {
     lruSet(cache.messages, message.id, message, MESSAGE_CACHE_LIMIT);
   }
-  if (normalized[0]) {
-    lruSet(cache.messages, source.id, normalized[0], MESSAGE_CACHE_LIMIT);
+  if (messages[0]) {
+    lruSet(cache.messages, source.id, messages[0], MESSAGE_CACHE_LIMIT);
   }
   for (const attachment of source.attachments) {
     cacheAttachment(client, attachment);
   }
-  return normalized;
+  return messages;
 };
 
 export const getLocalMessage = async (

--- a/packages/imessage-local/src/local/lookup.ts
+++ b/packages/imessage-local/src/local/lookup.ts
@@ -6,12 +6,15 @@ import type {
 import type { Attachment } from "@spectrum-ts/core";
 import type { IMessageMessage } from "../types";
 import { localAttachmentAsAttachment } from "./attachments";
-import { toMessages } from "./inbound";
 
 const LOOKUP_PAGE_SIZE = 200;
 const LOOKUP_MAX_PAGES = 50;
 const MESSAGE_CACHE_LIMIT = 1000;
 const ATTACHMENT_CACHE_LIMIT = 1000;
+
+export type LocalMessageNormalizer = (
+  source: LocalIMessage
+) => Promise<IMessageMessage[]>;
 
 interface LocalLookupCache {
   attachments: Map<string, Attachment>;
@@ -67,26 +70,26 @@ const cacheAttachment = (
 export const cacheLocalMessage = async (
   client: IMessageSDK,
   source: LocalIMessage,
-  normalized?: IMessageMessage[]
+  normalized: IMessageMessage[]
 ): Promise<IMessageMessage[]> => {
-  const messages = normalized ?? (await toMessages(source));
   const cache = cacheFor(client);
-  for (const message of messages) {
+  for (const message of normalized) {
     lruSet(cache.messages, message.id, message, MESSAGE_CACHE_LIMIT);
   }
-  if (messages[0]) {
-    lruSet(cache.messages, source.id, messages[0], MESSAGE_CACHE_LIMIT);
+  if (normalized[0]) {
+    lruSet(cache.messages, source.id, normalized[0], MESSAGE_CACHE_LIMIT);
   }
   for (const attachment of source.attachments) {
     cacheAttachment(client, attachment);
   }
-  return messages;
+  return normalized;
 };
 
 export const getLocalMessage = async (
   client: IMessageSDK,
   spaceId: string,
-  messageId: string
+  messageId: string,
+  normalize: LocalMessageNormalizer
 ): Promise<IMessageMessage | undefined> => {
   const cached = cacheFor(client).messages.get(messageId);
   if (cached) {
@@ -100,7 +103,11 @@ export const getLocalMessage = async (
       offset: page * LOOKUP_PAGE_SIZE,
     });
     for (const row of rows) {
-      const normalized = await cacheLocalMessage(client, row);
+      const normalized = await cacheLocalMessage(
+        client,
+        row,
+        await normalize(row)
+      );
       const match = normalized.find((message) => message.id === messageId);
       if (match) {
         return match;

--- a/packages/imessage-local/src/local/send.ts
+++ b/packages/imessage-local/src/local/send.ts
@@ -6,7 +6,6 @@ import { type Content, toVCard } from "@spectrum-ts/core";
 import type { ProviderMessageRecord } from "@spectrum-ts/core/authoring";
 import { unsupportedLocalContent } from "../../../imessage/src/shared/errors";
 import { vcardFileName } from "../../../imessage/src/shared/vcard";
-import type { IMessageMessage } from "../types";
 import { DEFAULT_ATTACHMENT_NAME } from "./attachments";
 
 // v3 `IMessageSDK.send` resolves to `void`: the chat.db row id only
@@ -73,12 +72,3 @@ export const send = async (
       throw unsupportedLocalContent(content.type);
   }
 };
-
-// Local mode has no by-id SDK lookup and does not surface reactions, so it
-// has no cache to consult. `space.getMessage(id)` always resolves to
-// `undefined` on local: callers with only an id cannot materialize a Message
-// here.
-export const getMessage = async (
-  _client: IMessageSDK,
-  _id: string
-): Promise<IMessageMessage | undefined> => undefined;

--- a/packages/imessage-local/test/local/inbound.test.ts
+++ b/packages/imessage-local/test/local/inbound.test.ts
@@ -1,5 +1,8 @@
-import type { Message as LocalIMessage } from "@photon-ai/imessage-kit";
-import { describe, expect, it } from "vitest";
+import type {
+  IMessageSDK,
+  Message as LocalIMessage,
+} from "@photon-ai/imessage-kit";
+import { describe, expect, it, vi } from "vitest";
 import { toMessages } from "@/local/inbound";
 
 const CREATED_AT = new Date(1_700_000_000_000);
@@ -64,6 +67,126 @@ const summarize = (message: Awaited<ReturnType<typeof toMessages>>[number]) => {
 };
 
 describe("iMessage local toMessages", () => {
+  it("surfaces inbound tapbacks with a hydrated target", async () => {
+    const getMessages = vi.fn(() =>
+      Promise.resolve([
+        localMessage({
+          id: "target-message",
+          isFromMe: true,
+          text: "from the agent",
+        }),
+      ])
+    );
+    const client = { getMessages } as unknown as IMessageSDK;
+
+    const [message] = await toMessages(
+      localMessage({
+        id: "reaction-message",
+        reaction: {
+          emoji: null,
+          isRemoved: false,
+          kind: "like",
+          targetMessageId: "target-message",
+          textRange: { length: 14, location: 0 },
+        },
+      }),
+      client
+    );
+
+    expect(message?.content).toMatchObject({
+      emoji: "👍",
+      target: {
+        content: { text: "from the agent", type: "text" },
+        direction: "outbound",
+        id: "target-message",
+      },
+      type: "reaction",
+    });
+  });
+
+  it("preserves reaction removals", async () => {
+    const [message] = await toMessages(
+      localMessage({
+        id: "removed-reaction",
+        reaction: {
+          emoji: "🦊",
+          isRemoved: true,
+          kind: "emoji",
+          targetMessageId: "target-message",
+          textRange: { length: 0, location: 0 },
+        },
+      })
+    );
+
+    expect(message?.content).toMatchObject({
+      emoji: "🦊",
+      removed: true,
+      target: { id: "target-message" },
+      type: "reaction",
+    });
+  });
+
+  it("surfaces the coarse poll-vote data available from the local SDK", async () => {
+    const [message] = await toMessages(
+      localMessage({
+        id: "poll-vote",
+        reaction: {
+          emoji: null,
+          isRemoved: false,
+          kind: "pollVote",
+          targetMessageId: "poll-message",
+          textRange: { length: 0, location: 0 },
+        },
+      })
+    );
+
+    expect(message?.content).toEqual({
+      raw: {
+        imessage_type: "poll-vote",
+        targetMessageId: "poll-message",
+      },
+      type: "custom",
+    });
+  });
+
+  it("surfaces group membership and title changes", async () => {
+    const [memberAdded] = await toMessages(
+      localMessage({
+        affectedParticipant: "+15557654321",
+        id: "member-added",
+        kind: "memberAdded",
+        text: null,
+      })
+    );
+    const [renamed] = await toMessages(
+      localMessage({
+        id: "renamed",
+        kind: "nameChanged",
+        newGroupName: "Road trip",
+        text: null,
+      })
+    );
+
+    expect(memberAdded?.content).toEqual({
+      raw: {
+        action: "memberAdded",
+        affectedParticipant: "+15557654321",
+        imessage_type: "group-change",
+        newGroupName: undefined,
+      },
+      type: "custom",
+    });
+    expect(renamed?.content).toEqual({
+      raw: {
+        action: "nameChanged",
+        affectedParticipant: undefined,
+        imessage_type: "group-change",
+        newGroupName: "Road trip",
+      },
+      type: "custom",
+    });
+  });
+
   it("keeps plain text messages as text", async () => {
     const messages = await toMessages(localMessage({ text: "plain text" }));
 

--- a/packages/imessage-local/test/local/inbound.test.ts
+++ b/packages/imessage-local/test/local/inbound.test.ts
@@ -166,25 +166,38 @@ describe("iMessage local toMessages", () => {
         text: null,
       })
     );
+    const [memberRemoved] = await toMessages(
+      localMessage({
+        affectedParticipant: "+15550001111",
+        id: "member-removed",
+        kind: "memberRemoved",
+        text: null,
+      })
+    );
 
     expect(memberAdded?.content).toEqual({
-      raw: {
-        action: "memberAdded",
-        affectedParticipant: "+15557654321",
-        imessage_type: "group-change",
-        newGroupName: undefined,
-      },
-      type: "custom",
+      members: ["+15557654321"],
+      type: "addMember",
     });
     expect(renamed?.content).toEqual({
-      raw: {
-        action: "nameChanged",
-        affectedParticipant: undefined,
-        imessage_type: "group-change",
-        newGroupName: "Road trip",
-      },
-      type: "custom",
+      displayName: "Road trip",
+      type: "rename",
     });
+    expect(memberRemoved?.content).toEqual({
+      members: ["+15550001111"],
+      type: "removeMember",
+    });
+  });
+
+  it("drops incomplete typed group changes", async () => {
+    await expect(
+      toMessages(
+        localMessage({
+          affectedParticipant: null,
+          kind: "memberRemoved",
+        })
+      )
+    ).resolves.toEqual([]);
   });
 
   it("keeps plain text messages as text", async () => {

--- a/packages/imessage-local/test/local/lookup.test.ts
+++ b/packages/imessage-local/test/local/lookup.test.ts
@@ -7,6 +7,7 @@ import type {
 import { describe, expect, it, vi } from "vitest";
 import { toMessages } from "@/local/inbound";
 import {
+  cacheLocalMessage,
   getLocalAttachment,
   getLocalDisplayName,
   getLocalMessage,
@@ -53,6 +54,28 @@ const client = (overrides: Partial<IMessageSDK>): IMessageSDK =>
   Object.assign(Object.create(null), overrides) as IMessageSDK;
 
 describe("local iMessage lookup", () => {
+  it("promotes cache hits before evicting the least recently used message", async () => {
+    const getMessages = vi.fn(() => Promise.resolve([]));
+    const sdk = client({ getMessages });
+    const first = message("message-0");
+    await cacheLocalMessage(sdk, first, await toMessages(first));
+    for (let index = 1; index < 1000; index += 1) {
+      const row = message(`message-${index}`);
+      await cacheLocalMessage(sdk, row, await toMessages(row));
+    }
+
+    await expect(
+      getLocalMessage(sdk, "any;-;+15551234567", "message-0", toMessages)
+    ).resolves.toMatchObject({ id: "message-0" });
+
+    const overflow = message("message-1000");
+    await cacheLocalMessage(sdk, overflow, await toMessages(overflow));
+    await expect(
+      getLocalMessage(sdk, "any;-;+15551234567", "message-0", toMessages)
+    ).resolves.toMatchObject({ id: "message-0" });
+    expect(getMessages).not.toHaveBeenCalled();
+  });
+
   it("finds a message by Apple GUID within its space", async () => {
     const getMessages = vi.fn(() => Promise.resolve([message("message-1")]));
 

--- a/packages/imessage-local/test/local/lookup.test.ts
+++ b/packages/imessage-local/test/local/lookup.test.ts
@@ -1,0 +1,124 @@
+import type {
+  Chat,
+  IMessageSDK,
+  Attachment as KitAttachment,
+  Message as KitMessage,
+} from "@photon-ai/imessage-kit";
+import { describe, expect, it, vi } from "vitest";
+import {
+  getLocalAttachment,
+  getLocalDisplayName,
+  getLocalMessage,
+} from "@/local/lookup";
+
+const createdAt = new Date(1_700_000_000_000);
+
+const attachment = (id: string): KitAttachment =>
+  ({
+    createdAt,
+    fileName: `${id}.png`,
+    id,
+    isFromMe: false,
+    isSensitiveContent: false,
+    isSticker: false,
+    localPath: `/tmp/${id}.png`,
+    mimeType: "image/png",
+    sizeBytes: 123,
+    transferStatus: "complete",
+    uti: "public.png",
+  }) as KitAttachment;
+
+const message = (
+  id: string,
+  attachments: readonly KitAttachment[] = []
+): KitMessage =>
+  ({
+    attachments,
+    chatId: "any;-;+15551234567",
+    chatKind: "dm",
+    createdAt,
+    hasAttachments: attachments.length > 0,
+    id,
+    isAudioMessage: false,
+    isFromMe: false,
+    kind: "text",
+    participant: "+15551234567",
+    reaction: null,
+    retractedAt: null,
+    text: attachments.length > 0 ? undefined : "hello",
+  }) as KitMessage;
+
+const client = (overrides: Partial<IMessageSDK>): IMessageSDK =>
+  Object.assign(Object.create(null), overrides) as IMessageSDK;
+
+describe("local iMessage lookup", () => {
+  it("finds a message by Apple GUID within its space", async () => {
+    const getMessages = vi.fn(() => Promise.resolve([message("message-1")]));
+
+    const found = await getLocalMessage(
+      client({ getMessages }),
+      "any;-;+15551234567",
+      "message-1"
+    );
+
+    expect(found).toMatchObject({
+      content: { text: "hello", type: "text" },
+      id: "message-1",
+    });
+    expect(getMessages).toHaveBeenCalledWith({
+      chatId: "any;-;+15551234567",
+      limit: 200,
+      offset: 0,
+    });
+  });
+
+  it("resolves generated attachment child ids", async () => {
+    const getMessages = vi.fn(() =>
+      Promise.resolve([message("message-1", [attachment("attachment-1")])])
+    );
+
+    const found = await getLocalMessage(
+      client({ getMessages }),
+      "any;-;+15551234567",
+      "message-1:attachment-1"
+    );
+
+    expect(found).toMatchObject({
+      content: { id: "attachment-1", type: "attachment" },
+      id: "message-1:attachment-1",
+    });
+  });
+
+  it("finds an attachment by GUID", async () => {
+    const getMessages = vi.fn(() =>
+      Promise.resolve([message("message-1", [attachment("attachment-1")])])
+    );
+
+    const found = await getLocalAttachment(
+      client({ getMessages }),
+      "attachment-1"
+    );
+
+    expect(found).toMatchObject({
+      id: "attachment-1",
+      mimeType: "image/png",
+      name: "attachment-1.png",
+      size: 123,
+      type: "attachment",
+    });
+  });
+
+  it("reads a chat display name", async () => {
+    const listChats = vi.fn(() =>
+      Promise.resolve([{ name: "Family" } as Chat])
+    );
+
+    await expect(
+      getLocalDisplayName(client({ listChats }), "any;+;chat-family")
+    ).resolves.toBe("Family");
+    expect(listChats).toHaveBeenCalledWith({
+      chatId: "any;+;chat-family",
+      limit: 1,
+    });
+  });
+});

--- a/packages/imessage-local/test/local/lookup.test.ts
+++ b/packages/imessage-local/test/local/lookup.test.ts
@@ -5,6 +5,7 @@ import type {
   Message as KitMessage,
 } from "@photon-ai/imessage-kit";
 import { describe, expect, it, vi } from "vitest";
+import { toMessages } from "@/local/inbound";
 import {
   getLocalAttachment,
   getLocalDisplayName,
@@ -58,7 +59,8 @@ describe("local iMessage lookup", () => {
     const found = await getLocalMessage(
       client({ getMessages }),
       "any;-;+15551234567",
-      "message-1"
+      "message-1",
+      toMessages
     );
 
     expect(found).toMatchObject({
@@ -80,7 +82,8 @@ describe("local iMessage lookup", () => {
     const found = await getLocalMessage(
       client({ getMessages }),
       "any;-;+15551234567",
-      "message-1:attachment-1"
+      "message-1:attachment-1",
+      toMessages
     );
 
     expect(found).toMatchObject({

--- a/packages/imessage/src/remote/reactions.ts
+++ b/packages/imessage/src/remote/reactions.ts
@@ -18,9 +18,9 @@ import {
 } from "./inbound";
 import { toMessageMetadata } from "./message-metadata";
 
-type ReactionAddedEvent = Extract<
+type ReactionEvent = Extract<
   MessageEvent,
-  { type: "message.reactionAdded" }
+  { type: "message.reactionAdded" | "message.reactionRemoved" }
 >;
 
 type TapbackKind = Exclude<SettableMessageReaction["kind"], "emoji">;
@@ -41,16 +41,18 @@ const TAPBACK_TO_EMOJI: Readonly<Record<string, string>> = Object.fromEntries(
 type RawProviderMessage = Pick<IMessageMessage, "content" | "id">;
 
 const reactionEmoji = (
-  reaction: ReactionAddedEvent["reaction"]
+  reaction: ReactionEvent["reaction"]
 ): string | undefined =>
   reaction.kind === "emoji" ? reaction.emoji : TAPBACK_TO_EMOJI[reaction.kind];
 
 const asProviderReaction = (
   emoji: string,
-  target: RawProviderMessage
+  target: RawProviderMessage,
+  removed: boolean
 ): ReactionContent =>
   reactionSchema.parse({
     emoji,
+    ...(removed ? { removed: true } : {}),
     target,
     type: "reaction",
   });
@@ -90,7 +92,7 @@ const resolveReactionTarget = async (
 export const toReactionMessages = async (
   client: AdvancedIMessage,
   cache: MessageCache,
-  event: ReactionAddedEvent,
+  event: ReactionEvent,
   phone: string
 ): Promise<IMessageMessage[]> => {
   const emoji = reactionEmoji(event.reaction);
@@ -127,7 +129,11 @@ export const toReactionMessages = async (
       },
       timestamp: event.occurredAt,
       id: `${event.messageGuid}:reaction:${event.sequence}${partSuffix}`,
-      content: asProviderReaction(emoji, resolved),
+      content: asProviderReaction(
+        emoji,
+        resolved,
+        event.type === "message.reactionRemoved"
+      ),
     },
   ];
 };
@@ -174,7 +180,7 @@ export const reactToMessage = async (
   return {
     ...toMessageMetadata(sent),
     id: sent.guid,
-    content: asProviderReaction(reaction, target),
+    content: asProviderReaction(reaction, target, false),
     direction: "outbound",
     space: { id: spaceId },
     timestamp: sent.dateCreated,

--- a/packages/imessage/src/remote/stream.ts
+++ b/packages/imessage/src/remote/stream.ts
@@ -149,7 +149,10 @@ const toMessageItem = async (
     return { cursor, id: event.message.guid, values };
   }
 
-  if (event.type === "message.reactionAdded") {
+  if (
+    event.type === "message.reactionAdded" ||
+    event.type === "message.reactionRemoved"
+  ) {
     if (isEventFromCurrentAccount(event, phone)) {
       return {
         cursor,
@@ -200,8 +203,8 @@ const toMessageItem = async (
     };
   }
 
-  // Consumed for the cursor but not surfaced (edits, unsends, sticker
-  // placements, reaction removals). Logged so "the stream is alive but this
+  // Consumed for the cursor but not surfaced (edits, unsends, and sticker
+  // placements). Logged so "the stream is alive but this
   // event type never arrives" is distinguishable from "the stream is dead".
   streamLog.debug("message event consumed without mapping", {
     "spectrum.imessage.event_type": event.type,

--- a/packages/imessage/test/remote/reactions.test.ts
+++ b/packages/imessage/test/remote/reactions.test.ts
@@ -91,11 +91,14 @@ const attachment = (
     uti: undefined,
   }) as unknown as SDKMessage["content"]["attachments"][number];
 
-const reactionEvent = (
-  overrides: Partial<
-    Extract<MessageEvent, { type: "message.reactionAdded" }>
-  > = {}
-): Extract<MessageEvent, { type: "message.reactionAdded" }> =>
+const reactionEvent = <
+  T extends
+    | "message.reactionAdded"
+    | "message.reactionRemoved" = "message.reactionAdded",
+>(
+  type: T = "message.reactionAdded" as T,
+  overrides: Partial<Extract<MessageEvent, { type: T }>> = {}
+): Extract<MessageEvent, { type: T }> =>
   ({
     actor: { address: "user@example.com" },
     chatGuid: "s1",
@@ -104,9 +107,9 @@ const reactionEvent = (
     occurredAt: SENT_DATE,
     reaction: { kind: "like" },
     sequence: 1,
-    type: "message.reactionAdded",
+    type,
     ...overrides,
-  }) as unknown as Extract<MessageEvent, { type: "message.reactionAdded" }>;
+  }) as unknown as Extract<MessageEvent, { type: T }>;
 
 describe("iMessage remote reactToMessage", () => {
   it("maps a native tapback emoji and returns the tapback record", async () => {
@@ -178,6 +181,28 @@ describe("iMessage remote toReactionMessages", () => {
     }
   });
 
+  it("surfaces reaction removals without losing the target", async () => {
+    const get = vi.fn((_message: string) => Promise.resolve(sdkMessage()));
+    const remote = {
+      messages: { get },
+    } as unknown as AdvancedIMessage;
+
+    const messages = await toReactionMessages(
+      remote,
+      new MessageCache(),
+      reactionEvent("message.reactionRemoved"),
+      "+15551234567"
+    );
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.content).toMatchObject({
+      emoji: "👍",
+      removed: true,
+      target: { id: "msg-guid" },
+      type: "reaction",
+    });
+  });
+
   it("drops the reaction when the target cannot be fetched", async () => {
     // Regression guard for the shared `resolveTargetMessage` extraction: a
     // failed fetch must keep dropping the event rather than propagating.
@@ -205,7 +230,7 @@ describe("iMessage remote toReactionMessages", () => {
     const messages = await toReactionMessages(
       remote,
       new MessageCache(),
-      reactionEvent({
+      reactionEvent("message.reactionAdded", {
         actor: {
           address: "+15557654321",
           country: "ca",
@@ -256,7 +281,9 @@ describe("iMessage remote toReactionMessages", () => {
     const messages = await toReactionMessages(
       remote,
       getMessageCache(remote),
-      reactionEvent({ messageGuid: "outbound-stream-guid" }),
+      reactionEvent("message.reactionAdded", {
+        messageGuid: "outbound-stream-guid",
+      }),
       "+15551234567"
     );
 
@@ -300,7 +327,7 @@ describe("iMessage remote toReactionMessages", () => {
     const messages = await toReactionMessages(
       remote,
       new MessageCache(),
-      reactionEvent({ targetPartIndex: 5 }),
+      reactionEvent("message.reactionAdded", { targetPartIndex: 5 }),
       "+15551234567"
     );
 


### PR DESCRIPTION
## Summary

- Surface local Tapback additions and removals as universal `reaction` messages.
- Resolve reaction targets from the per-client cache or bounded local message lookup.
- Surface member additions, member removals, and group renames using Spectrum's universal content shapes.
- Surface the coarse poll-vote signal available from chat.db as custom content carrying the target message id.
- Drop incomplete typed group changes instead of fabricating participant identities.

## Dependencies

- Depends on #248 for the additive `Reaction.removed` contract.
- Depends on #249 for local target lookup and caching.

This is opened as a draft because GitHub cannot base an upstream PR on branches that exist only in the contributor fork. Until #248 and #249 merge and this branch is refreshed, the displayed diff includes those prerequisite changes.

## Local-data limitations

- Poll rows expose the target message id but not enough public data to reconstruct a typed poll-option vote.
- Unknown/group-action rows remain custom events for forward compatibility.
- This does not add edit, unsend, or ongoing delivery telemetry; those require separate lifecycle handling.

## Testing

- [x] `bun run --cwd packages/imessage-local typecheck`
- [x] Local provider tests: 3 files, 28 tests passed
- [x] Ultracite check on changed source and test files
- [x] `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791432821&installation_model_id=19795&pr_number=250&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F250&signature=51e91fd264b72af1c20e4ac6092ebe88186d0e8184499bf4dbdbfd741da99db3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->