### PR TITLE
feat(imessage): map inbound mini app cards to app content

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -133,7 +133,7 @@
       "version": "12.8.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.14.4",
-        "@photon-ai/advanced-imessage": "^2.0.2",
+        "@photon-ai/advanced-imessage": "^2.1.0",
         "@photon-ai/otel": "^3.3.0",
         "lru-cache": "^11.0.0",
         "marked": "^18.0.5",
@@ -404,7 +404,7 @@
 
     "@parseaple/typedstream": ["@parseaple/typedstream@2.0.2", "", { "dependencies": { "@parseaple/bplist": "1.0.1" } }, "sha512-bzKNZjiBtZN2T2U7Nqq/hhv+EezkPnaWoB5WvPuBwNpQvOr3EI0XrDTkFnAzsA9DKdu57es/gcb1d2ctd1u8xw=="],
 
-    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@2.0.2", "", { "dependencies": { "@bufbuild/protobuf": "^2.11.0" }, "peerDependencies": { "@grpc/grpc-js": "^1.12.6", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2" }, "optionalPeers": ["@grpc/grpc-js", "nice-grpc", "nice-grpc-common"] }, "sha512-2BbK2mUXPivgaeiHpN8hwF6tKW0AIeEyNiIOOYXc7h42SiPsBmlMEuKHdmCGbI+8mVb090a16HZJLOySDcg7Ug=="],
+    "@photon-ai/advanced-imessage": ["@photon-ai/advanced-imessage@2.1.0", "", { "dependencies": { "@bufbuild/protobuf": "^2.11.0" }, "peerDependencies": { "@grpc/grpc-js": "^1.12.6", "nice-grpc": "^2.1.11", "nice-grpc-common": "^2.0.2" }, "optionalPeers": ["@grpc/grpc-js", "nice-grpc", "nice-grpc-common"] }, "sha512-KT/aCBWcq667alyKe8DclqDUa/0fUuW2ZYDCxfIKuQBm08U4JcNG56fCdNUd69MFkKkzZgW35j59EYsx5DnLcQ=="],
 
     "@photon-ai/imessage-kit": ["@photon-ai/imessage-kit@3.0.0", "", { "dependencies": { "@parseaple/typedstream": "^2.0.0" }, "optionalDependencies": { "better-sqlite3": "^12.5.0" } }, "sha512-GGDETlRbrPXP5eaRvswaead7MCBGQkm8f7d3aVbx8+rXhB4GEyPiw7Q1/yz5ix53rmxqKRevWywOfG7n+kZDBw=="],
 
@@ -530,7 +530,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
+    "@types/bun": ["@types/bun@1.4.2", "", { "dependencies": { "bun-types": "1.4.2" } }, "sha512-GimotNn7+ZV0uVArItBbriZsR1oNf0+WTzPkdcFrzShI7k2norL0uzEaJT8T33dWr7O/c9ZDuAFQrctKCi72oQ=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -670,7 +670,7 @@
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 
-    "bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
+    "bun-types": ["bun-types@1.4.2", "", { "dependencies": { "@types/node": "*" } }, "sha512-bxV1FgK7yBIzjRe5zBozIM4Bem11ZJcCXSrjWRG3YWLt8yFDePu4cLjpebO8OvPeIE9trbyPF4fuj3Cia4Fj3w=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -1322,6 +1322,8 @@
 
     "protobufjs/@types/node": ["@types/node@25.0.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA=="],
 
+    "spectrum-ts/@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
+
     "strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
@@ -1363,6 +1365,8 @@
     "cli-highlight/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
 
     "protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "spectrum-ts/@types/bun/bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "vite/rolldown/@oxc-project/types": ["@oxc-project/types@0.138.0", "", {}, "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA=="],
 

--- a/packages/core/src/authoring.ts
+++ b/packages/core/src/authoring.ts
@@ -36,6 +36,7 @@ export {
   setLogLevel,
 } from "@photon-ai/otel";
 // Content factories, schemas, and the inbound-record type (from `content/`).
+export { asApp } from "./content/app";
 export { asAttachment } from "./content/attachment";
 export { avatarSchema } from "./content/avatar";
 export { asContact } from "./content/contact";

--- a/packages/core/src/content/app.ts
+++ b/packages/core/src/content/app.ts
@@ -89,6 +89,13 @@ export type AppUrl =
 
 /** Optional rendering behavior for an app card. */
 export interface AppOptions {
+  /**
+   * Layout to use verbatim instead of deriving one from the URL's link
+   * metadata. A provider mapping an inbound card already holds the layout the
+   * sender wrote; refetching it would cost a network round-trip and overwrite
+   * the sender's own text with whatever the link happens to advertise.
+   */
+  layout?: AppLayout;
   /** Render the installed app extension's live UI when the platform supports it. */
   live?: boolean;
 }
@@ -164,12 +171,17 @@ const buildLayout = (
  * description → subcaption, og:image → JPEG-transcoded image) using the same
  * machinery as `richlink`. A single metadata fetch is shared and memoized
  * across `url()` / `layout()`; fetch / parse failures resolve to a host-only
- * caption (no throw, no retry).
+ * caption (no throw, no retry). Pass `options.layout` to supply an
+ * already-decoded layout and skip the fetch entirely.
  */
 export const asApp = (url: AppUrl, options: AppOptions = {}): App => {
+  const { layout: knownLayout, ...rest } = options;
   const getUrl = resolveUrl(url);
   const getMetadata = memoize(async () => fetchLinkMetadata(await getUrl()));
   const getLayout = memoize(async (): Promise<AppLayout> => {
+    if (knownLayout) {
+      return knownLayout;
+    }
     const resolvedUrl = await getUrl();
     const metadata = await getMetadata();
     let image: Uint8Array | undefined;
@@ -188,7 +200,7 @@ export const asApp = (url: AppUrl, options: AppOptions = {}): App => {
     type: "app",
     url: getUrl,
     layout: getLayout,
-    ...options,
+    ...rest,
   });
 };
 

--- a/packages/imessage/package.json
+++ b/packages/imessage/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.14.4",
-    "@photon-ai/advanced-imessage": "^2.0.2",
+    "@photon-ai/advanced-imessage": "^2.1.0",
     "@photon-ai/otel": "^3.3.0",
     "lru-cache": "^11.0.0",
     "marked": "^18.0.5",

--- a/packages/imessage/src/index.ts
+++ b/packages/imessage/src/index.ts
@@ -41,6 +41,8 @@ export type {
   IMessageAttachmentMetadata,
   IMessageMention,
   IMessageMessage,
+  IMessageMiniApp,
+  IMessageMiniAppLayout,
   IMessagePlacedSticker,
   IMessageReaction,
   IMessageReactionRecord,

--- a/packages/imessage/src/remote/inbound.ts
+++ b/packages/imessage/src/remote/inbound.ts
@@ -2,11 +2,19 @@ import {
   type AdvancedIMessage,
   type ChatServiceType,
   type MessageEvent,
+  type MiniAppContent,
   NotFoundError,
   type SingleServiceAddressInfo,
 } from "@photon-ai/advanced-imessage/grpc";
-import { type Content, fromVCard, type Group } from "@spectrum-ts/core";
 import {
+  type AppLayout,
+  appLayoutSchema,
+  type Content,
+  fromVCard,
+  type Group,
+} from "@spectrum-ts/core";
+import {
+  asApp,
   asAttachment,
   asContact,
   asCustom,
@@ -252,6 +260,50 @@ const buildOrderedPartMessage = async (
 const unsupportedMessageContent = (): Content =>
   asCustom({ imessage_type: "unsupported-message" });
 
+/**
+ * Fold an inbound app card's decoded slots into an `AppLayout`.
+ *
+ * `imageTitle` / `imageSubtitle` are deliberately dropped: both are only valid
+ * alongside the JPEG bytes, and an inbound card carries no image. They stay
+ * reachable on `miniApp` in the native metadata.
+ *
+ * `summary` is Apple's fallback string for surfaces that cannot draw the card,
+ * so it stands in for a missing `caption` rather than leaving the bubble blank.
+ */
+const toAppLayout = (miniApp: MiniAppContent): AppLayout | undefined => {
+  const { layout } = miniApp;
+  const parsed = appLayoutSchema.safeParse({
+    caption: layout?.caption ?? layout?.summary ?? miniApp.appName,
+    subcaption: layout?.subcaption,
+    summary: layout?.summary,
+    trailingCaption: layout?.trailingCaption,
+    trailingSubcaption: layout?.trailingSubcaption,
+  });
+  return parsed.success ? parsed.data : undefined;
+};
+
+/**
+ * Map a third-party iMessage app card to `app` content.
+ *
+ * The card's layout is already decoded, so it is handed to `asApp` verbatim —
+ * deriving one from the URL would fetch link metadata for an opaque
+ * session URL and overwrite what the sending extension actually wrote.
+ *
+ * Returns `undefined` whenever the card cannot be represented faithfully (no
+ * URL, an unparseable one, or no text slot at all); the caller then keeps its
+ * existing fallback. The URL is validated here rather than left to `asApp`
+ * because `url()` is a lazy accessor — an invalid one would not throw until a
+ * consumer awaited it.
+ */
+const toAppCardContent = (message: AppleMessage): Content | undefined => {
+  const miniApp = message.content.miniApp;
+  if (!(miniApp?.url && URL.canParse(miniApp.url))) {
+    return;
+  }
+  const layout = toAppLayout(miniApp);
+  return layout && asApp(miniApp.url, { layout, live: miniApp.live });
+};
+
 const buildUnwrappedContentMessage = async (
   client: AdvancedIMessage,
   base: RemoteMessageBase,
@@ -264,6 +316,13 @@ const buildUnwrappedContentMessage = async (
     : undefined;
 
   if (attachments.length === 0) {
+    // An app card wins over `text`: on a balloon row Apple's text is only the
+    // fallback string shown where the card cannot be drawn, so preferring it
+    // would hand the caller the summary of a card it never receives.
+    const card = toAppCardContent(message);
+    if (card) {
+      return { ...base, id: messageGuidStr, content: card };
+    }
     const text = message.content.text;
     return {
       ...base,

--- a/packages/imessage/src/remote/message-metadata.ts
+++ b/packages/imessage/src/remote/message-metadata.ts
@@ -5,6 +5,8 @@ import type {
   MessageMention,
   MessagePlacedSticker,
   MessageReaction,
+  MiniAppContent,
+  MiniAppLayoutInfo,
   SingleServiceAddressInfo,
   StickerPlacement,
   TextFormat,
@@ -13,6 +15,8 @@ import type {
   IMessageAppliedReaction,
   IMessageAttachmentMetadata,
   IMessageMention,
+  IMessageMiniApp,
+  IMessageMiniAppLayout,
   IMessageNativeMessageMetadata,
   IMessagePlacedSticker,
   IMessageReaction,
@@ -27,6 +31,33 @@ const toTextFormat = (format: TextFormat): IMessageTextFormat => ({
   start: format.start,
   type: format.type,
 });
+
+const toMiniAppLayout = (layout: MiniAppLayoutInfo): IMessageMiniAppLayout => ({
+  caption: layout.caption,
+  imageSubtitle: layout.imageSubtitle,
+  imageTitle: layout.imageTitle,
+  subcaption: layout.subcaption,
+  summary: layout.summary,
+  trailingCaption: layout.trailingCaption,
+  trailingSubcaption: layout.trailingSubcaption,
+});
+
+// The visible slots also reach the caller as `app` content; the card is kept
+// whole here so one object holds everything Apple decoded for the balloon,
+// alongside the native-only ids that have no cross-provider equivalent.
+const toMiniApp = (
+  miniApp: MiniAppContent | undefined
+): IMessageMiniApp | undefined =>
+  miniApp && {
+    appName: miniApp.appName,
+    appStoreId: miniApp.appStoreId,
+    extensionBundleId: miniApp.extensionBundleId,
+    layout: miniApp.layout && toMiniAppLayout(miniApp.layout),
+    live: miniApp.live,
+    sessionId: miniApp.sessionId,
+    teamId: miniApp.teamId,
+    url: miniApp.url,
+  };
 
 const toMention = (mention: MessageMention): IMessageMention => ({
   address: mention.address,
@@ -138,6 +169,7 @@ export const toMessageMetadata = (
   mentions: native.content?.mentions?.map(toMention) ?? [],
   subject: native.subject,
   balloonBundleId: native.content?.balloonBundleId,
+  miniApp: toMiniApp(native.content?.miniApp),
   expressiveSendStyleId: native.content?.expressiveSendStyleId,
   attachmentMetadata:
     native.content?.attachments?.map(toAttachmentMetadata) ?? [],

--- a/packages/imessage/src/types.ts
+++ b/packages/imessage/src/types.ts
@@ -162,6 +162,39 @@ const reactionRecordSchema = z
   })
   .readonly();
 
+/** The card's text slots exactly as Apple decoded them from the balloon. */
+const miniAppLayoutSchema = z
+  .object({
+    caption: z.string().optional(),
+    imageSubtitle: z.string().optional(),
+    imageTitle: z.string().optional(),
+    subcaption: z.string().optional(),
+    summary: z.string().optional(),
+    trailingCaption: z.string().optional(),
+    trailingSubcaption: z.string().optional(),
+  })
+  .readonly();
+
+/**
+ * Everything Apple's balloon payload carries for an inbound third-party app
+ * card. The visible slots also surface as `app` content; these are the native
+ * details that have no place in the cross-provider union — most usefully
+ * `sessionId`, which is shared by every update to the same card and is how a
+ * run of updates (a game's moves, say) is correlated back to one session.
+ */
+const miniAppSchema = z
+  .object({
+    appName: z.string().optional(),
+    appStoreId: z.number().int().optional(),
+    extensionBundleId: z.string(),
+    layout: miniAppLayoutSchema.optional(),
+    live: z.boolean(),
+    sessionId: z.string().optional(),
+    teamId: z.string(),
+    url: z.string().optional(),
+  })
+  .readonly();
+
 export const nativeMessageMetadataSchema = z.object({
   dateDelivered: z.date().optional(),
   dateEdited: z.date().optional(),
@@ -182,6 +215,7 @@ export const nativeMessageMetadataSchema = z.object({
   mentions: z.array(mentionSchema).readonly(),
   subject: z.string().optional(),
   balloonBundleId: z.string().optional(),
+  miniApp: miniAppSchema.optional(),
   expressiveSendStyleId: z.string().optional(),
   attachmentMetadata: z.array(attachmentMetadataSchema).readonly(),
 
@@ -231,6 +265,8 @@ export type IMessageAttachmentMetadata = z.infer<
   typeof attachmentMetadataSchema
 >;
 export type IMessageMention = z.infer<typeof mentionSchema>;
+export type IMessageMiniApp = z.infer<typeof miniAppSchema>;
+export type IMessageMiniAppLayout = z.infer<typeof miniAppLayoutSchema>;
 export type IMessageNativeMessageMetadata = z.infer<
   typeof nativeMessageMetadataSchema
 >;

--- a/packages/imessage/test/remote/inbound-app-card.test.ts
+++ b/packages/imessage/test/remote/inbound-app-card.test.ts
@@ -1,0 +1,220 @@
+import type {
+  AdvancedIMessage,
+  MessageEvent,
+  MiniAppContent,
+  Message as SDKMessage,
+} from "@photon-ai/advanced-imessage/grpc";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MessageCache } from "@/cache";
+import { type ReceivedEvent, toInboundMessages } from "@/remote/inbound";
+
+const CREATED_AT = new Date("2026-02-03T04:05:06.000Z");
+
+// Shape and values taken from a real GamePigeon "Four in a Row" session: a
+// move arrives with no text of its own, carrying everything it displays in the
+// balloon payload.
+const GAME_URL = "https://gamepigeonapp.com/?ver=52&data=oB0cet0ELMle0C23";
+const SESSION_ID = "2385D202-E40E-4D47-86F7-E9C3FDE818EA";
+
+const gamePigeon = (
+  overrides: Partial<MiniAppContent> = {}
+): MiniAppContent => ({
+  appName: "GamePigeon",
+  extensionBundleId: "com.gamerdelights.gamepigeon.ext",
+  layout: { caption: "Your move." },
+  live: true,
+  sessionId: SESSION_ID,
+  teamId: "EWFNLB79LQ",
+  url: GAME_URL,
+  ...overrides,
+});
+
+const nativeMessage = (
+  miniApp: MiniAppContent | undefined,
+  text?: string
+): SDKMessage =>
+  ({
+    appliedReactions: [],
+    chatGuids: ["iMessage;-;+15550000001"],
+    content: {
+      attachments: [],
+      balloonBundleId:
+        "com.apple.messages.MSMessageExtensionBalloonPlugin" +
+        ":EWFNLB79LQ:com.gamerdelights.gamepigeon.ext",
+      formatting: [],
+      mentions: [],
+      miniApp,
+      text,
+    },
+    dataDetectorResultsPresent: false,
+    dateCreated: CREATED_AT,
+    didNotifyRecipient: true,
+    guid: "gamepigeon-move-1",
+    isArchived: false,
+    isAudioMessage: false,
+    isAutoReply: false,
+    isCorrupt: false,
+    isDelayed: false,
+    isDelivered: true,
+    isDeliveredQuietly: false,
+    isExpirable: false,
+    isForward: false,
+    isFromMe: false,
+    isSent: true,
+    isServiceMessage: false,
+    isSpam: false,
+    isSystemMessage: false,
+    itemType: "normal",
+    placedStickers: [],
+    sendErrorCode: 0,
+    sender: { address: "+15550000001", country: "US", service: "iMessage" },
+  }) as unknown as SDKMessage;
+
+const inbound = async (miniApp: MiniAppContent | undefined, text?: string) => {
+  const [message] = await toInboundMessages(
+    { messages: {} } as unknown as AdvancedIMessage,
+    new MessageCache(),
+    {
+      chatGuid: "iMessage;-;+15550000001",
+      isFromMe: false,
+      message: nativeMessage(miniApp, text),
+      occurredAt: CREATED_AT,
+      sequence: 1,
+      type: "message.received",
+    } as Extract<MessageEvent, { type: "message.received" }> as ReceivedEvent,
+    "+15550000000"
+  );
+  if (!message) {
+    throw new Error("expected an inbound message");
+  }
+  return message;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("inbound app cards", () => {
+  it("maps a third-party app card to app content", async () => {
+    const message = await inbound(gamePigeon());
+
+    expect(message.content.type).toBe("app");
+    if (message.content.type !== "app") {
+      throw new Error("expected app content");
+    }
+    expect(await message.content.url()).toBe(GAME_URL);
+    expect(await message.content.layout()).toEqual({ caption: "Your move." });
+    expect(message.content.live).toBe(true);
+  });
+
+  it("uses the sender's layout without fetching link metadata", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+    const message = await inbound(gamePigeon());
+    if (message.content.type !== "app") {
+      throw new Error("expected app content");
+    }
+    await message.content.layout();
+    await message.content.url();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("prefers the card over Apple's fallback text", async () => {
+    const message = await inbound(gamePigeon(), "Four in a Row");
+
+    expect(message.content.type).toBe("app");
+    expect(message.nativeText).toBe("Four in a Row");
+  });
+
+  it("falls back to summary when the card has no caption", async () => {
+    const message = await inbound(
+      gamePigeon({ layout: { summary: "Your move!" } })
+    );
+
+    if (message.content.type !== "app") {
+      throw new Error("expected app content");
+    }
+    expect(await message.content.layout()).toEqual({
+      caption: "Your move!",
+      summary: "Your move!",
+    });
+  });
+
+  it("falls back to the app name when the card has no text at all", async () => {
+    const message = await inbound(gamePigeon({ layout: undefined }));
+
+    if (message.content.type !== "app") {
+      throw new Error("expected app content");
+    }
+    expect(await message.content.layout()).toEqual({ caption: "GamePigeon" });
+  });
+
+  it("drops image slots that would need image bytes the card never carries", async () => {
+    const message = await inbound(
+      gamePigeon({
+        layout: {
+          caption: "Your move.",
+          imageSubtitle: "tap to play",
+          imageTitle: "GamePigeon",
+        },
+      })
+    );
+
+    if (message.content.type !== "app") {
+      throw new Error("expected app content");
+    }
+    expect(await message.content.layout()).toEqual({ caption: "Your move." });
+    expect(message.miniApp?.layout).toMatchObject({
+      imageSubtitle: "tap to play",
+      imageTitle: "GamePigeon",
+    });
+  });
+
+  it("surfaces the native card details on message metadata", async () => {
+    const message = await inbound(gamePigeon());
+
+    expect(message.miniApp).toEqual({
+      appName: "GamePigeon",
+      appStoreId: undefined,
+      extensionBundleId: "com.gamerdelights.gamepigeon.ext",
+      layout: {
+        caption: "Your move.",
+        imageSubtitle: undefined,
+        imageTitle: undefined,
+        subcaption: undefined,
+        summary: undefined,
+        trailingCaption: undefined,
+        trailingSubcaption: undefined,
+      },
+      live: true,
+      sessionId: SESSION_ID,
+      teamId: "EWFNLB79LQ",
+      url: GAME_URL,
+    });
+  });
+
+  it("keeps the unsupported fallback when the card has no url", async () => {
+    const message = await inbound(gamePigeon({ url: undefined }));
+
+    expect(message.content).toEqual({
+      raw: { imessage_type: "unsupported-message" },
+      type: "custom",
+    });
+  });
+
+  it("keeps the unsupported fallback when the url cannot be parsed", async () => {
+    const message = await inbound(gamePigeon({ url: "not a url" }));
+
+    expect(message.content).toEqual({
+      raw: { imessage_type: "unsupported-message" },
+      type: "custom",
+    });
+  });
+
+  it("leaves ordinary messages on the text path", async () => {
+    const message = await inbound(undefined, "Hello");
+
+    expect(message.content.type).toBe("text");
+  });
+});

--- a/packages/spectrum-ts/test/imessage-package-boundary.test.ts
+++ b/packages/spectrum-ts/test/imessage-package-boundary.test.ts
@@ -39,7 +39,7 @@ describe("iMessage package boundary", () => {
 
     expect(manifest.dependencies).toMatchObject({
       "@grpc/grpc-js": "^1.14.4",
-      "@photon-ai/advanced-imessage": "^2.0.2",
+      "@photon-ai/advanced-imessage": "^2.1.0",
       "nice-grpc": "^2.1.16",
       "nice-grpc-common": "^2.0.3",
     });


### PR DESCRIPTION
## Problem

An inbound third-party iMessage app card never reached the caller as an app card.

Apple delivers these as balloon rows: a GamePigeon board, an Apple Cash request, any `MSMessageExtension` payload. The advanced-imessage server decodes the balloon and hands us the result on `message.content.miniApp` — app name, team id, session id, the visible text slots, and the URL the extension is opened with. `toInboundMessages` did not read that field. It fell through to the `text` branch, and on a balloon row Apple's `text` is only the fallback string shown where the card cannot be drawn, which for a game move is empty. The message surfaced as `custom / unsupported-message`.

The practical symptom: the peer plays a move inside GamePigeon, and the app driving Spectrum gets no usable signal that anything happened.

This is the SDK half of a fix whose server half is photon-hq/advanced-imessage-server-v2#158 — there, a third-party card's session updates were being dropped as if they were Apple's own status rows. With #158 deployed the update reaches the SDK; without this PR the SDK still throws it away.

## Solution

`toAppCardContent` maps `content.miniApp` to `app` content, ahead of `text` in the no-attachment branch. The card wins over the text: preferring the text would hand the caller the summary of a card it never receives.

The sender's layout is passed through verbatim rather than derived from the URL. `asApp` normally fetches link metadata to build a layout, which is wrong twice over here — a mini-app URL is an opaque session blob (`data:?ver=52&data=…`), so the fetch is a wasted round-trip, and whatever it scraped would overwrite the text the sending extension actually wrote. `AppOptions` gains an optional `layout` for this; supplying it skips the fetch entirely.

`imageTitle` / `imageSubtitle` are dropped from the layout. Both are only valid alongside JPEG bytes, and an inbound card carries no image; they stay reachable on the native metadata.

The mapping returns `undefined` — leaving the existing fallback in place — when the card cannot be represented faithfully: no URL, an unparseable URL, or no text slot at all. The URL is validated here rather than left to `asApp` because `url()` is a lazy accessor, so an invalid one would not throw until a consumer awaited it.

Alongside the content, the decoded card is surfaced whole on `message.miniApp`. This is not decoration. Nothing in the cross-provider `content` identifies *which* card an update belongs to: the URL blob changes completely between moves, the layout is identical on every move ("Your move." / "Gomoku"), and `message.id` is new each time. `miniApp.sessionId` is the only correlation key, and two games running in one conversation are indistinguishable without it. `teamId`, `extensionBundleId` and `appStoreId` come along from the same object at no extra cost.

`@photon-ai/advanced-imessage` moves to `^2.1.0`, which is where `MiniAppContent` is introduced.

## Verification

A live round against a real device, rather than synthesized rows. staging2 sent a board, a physical iPhone played the move in GamePigeon, and the move arrived at a `Spectrum()` instance subscribed to the same server:

| # | Board sent | Move played | Received | `sessionId` |
|---|---|---|---|---|
| 1 | 14:56:47 | 14:57:02 | 14:56:59 | `74009EC7-…` |
| 2 | 15:00:24 | 15:00:42 | 15:00:39 | `DDFDABCC-…` |
| 3 | 15:05:08 | 15:05:17 | 15:05:14 | `19AD8DA5-…` |

Each arrived as `app` content with the sender's own caption intact and its session id attached. In `chat.db` the board row is `amt=3` self-referential and the move row is `amt=2` pointing back at it — the shape #158 previously discarded.

Against a stashed control the same rows produced `custom / unsupported-message`.

`test` (32/32 tasks, Node and Bun), `typecheck` and `check` all pass. Ten new cases cover the mapping, the no-fetch guarantee, card-over-text precedence, both caption fallbacks, dropped image slots, the metadata, the two malformed-URL fallbacks, and that ordinary messages stay on the text path. Their fixtures are the shape of a real GamePigeon session.

## Notes

Requires photon-hq/advanced-imessage-server-v2#158 on the server side to receive anything.

Two boundaries left as they are:

- A card arriving with attachments is not mapped; it stays on the attachment path. Balloon payloads carry their image inline rather than as attachment rows, and no such sample exists, so handling it would be speculation about extension behaviour.
- Outbound `customizedMiniApp()` still exposes no `image`, so a card we send renders as the extension's generic cover. Unrelated to this path, noted because it is the obvious next question.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/photon-hq/codesmith/spectrum-ts/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791445297&installation_model_id=19795&pr_number=251&repository=photon-hq%2Fspectrum-ts&return_to=https%3A%2F%2Fgithub.com%2Fphoton-hq%2Fspectrum-ts%2Fpull%2F251&signature=9b0a687e301f3326e85aa205536974c1a61ddd539ded97c6a68fa468c777e5e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for receiving and displaying third-party mini-app cards in iMessage messages.
  * Preserved app-provided layouts and URLs when available, with fallbacks for incomplete card data.
  * Added mini-app details and layout information to iMessage message metadata.
  * Added public app-content authoring support for integrations.
* **Bug Fixes**
  * Improved handling of app cards without attachments, ensuring card content takes precedence over plain text when appropriate.
  * Preserved standard text-message behavior for messages without supported app content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->